### PR TITLE
Versioned Secondary Indexes — HEAD/TAIL buffer for MVCC isolation

### DIFF
--- a/src/Typhon.Engine/Data/ComponentTable.cs
+++ b/src/Typhon.Engine/Data/ComponentTable.cs
@@ -168,7 +168,9 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IContentionTar
     public ChunkBasedSegment CompRevTableSegment { get; private set; }
     public ChunkBasedSegment DefaultIndexSegment { get; private set; }
     public ChunkBasedSegment String64IndexSegment { get; private set; }
+    public ChunkBasedSegment TailIndexSegment { get; private set; }
     public BTree<long> PrimaryKeyIndex { get; private set; }
+    internal VariableSizedBufferSegment<VersionedIndexEntry> TailVSBS { get; private set; }
     public int ComponentStorageSize => Definition.ComponentStorageSize;
     public DBComponentDefinition Definition { get; private set; }
 
@@ -232,13 +234,15 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IContentionTar
             ComponentSegment.AllocatedChunkCount +
             CompRevTableSegment.AllocatedChunkCount +
             DefaultIndexSegment.AllocatedChunkCount +
-            (String64IndexSegment?.AllocatedChunkCount ?? 0);
+            (String64IndexSegment?.AllocatedChunkCount ?? 0) +
+            (TailIndexSegment?.AllocatedChunkCount ?? 0);
 
         long totalCapacityChunks =
             ComponentSegment.ChunkCapacity +
             CompRevTableSegment.ChunkCapacity +
             DefaultIndexSegment.ChunkCapacity +
-            (String64IndexSegment?.ChunkCapacity ?? 0);
+            (String64IndexSegment?.ChunkCapacity ?? 0) +
+            (TailIndexSegment?.ChunkCapacity ?? 0);
 
         writer.WriteCapacity(totalAllocatedChunks, totalCapacityChunks);
 
@@ -288,6 +292,13 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IContentionTar
             props["String64IndexSegment.Capacity"] = String64IndexSegment.ChunkCapacity;
         }
 
+        // TailIndexSegment (may be null if no AllowMultiple secondary indexes)
+        if (TailIndexSegment != null)
+        {
+            props["TailIndexSegment.AllocatedChunks"] = TailIndexSegment.AllocatedChunkCount;
+            props["TailIndexSegment.Capacity"] = TailIndexSegment.ChunkCapacity;
+        }
+
         return props;
     }
 
@@ -317,6 +328,13 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IContentionTar
             PrimaryKeyIndex = new LongSingleBTree(DefaultIndexSegment, stableId: -1, changeSet: changeSet);
         }
 
+        // Allocate TAIL version-history segment for AllowMultiple secondary indexes
+        if (Definition.MultipleIndicesCount > 0)
+        {
+            TailIndexSegment = mmf.AllocateChunkBasedSegment(PageBlockType.None, MainIndexSegmentStartingSize, 512, changeSet);
+            TailVSBS = new VariableSizedBufferSegment<VersionedIndexEntry>(TailIndexSegment);
+        }
+
         BuildIndexedFieldInfo(false, changeSet);
         BuildComponentCollectionInfo(changeSet);
     }
@@ -325,8 +343,8 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IContentionTar
     /// Load constructor: restores a ComponentTable from previously persisted segment root page indices.
     /// Used during database reopen to reconnect to existing on-disk data instead of allocating fresh segments.
     /// </summary>
-    internal ComponentTable(DatabaseEngine dbe, DBComponentDefinition definition, IResource parent, int componentSPI, int versionSPI, int defaultIndexSPI, 
-        int string64IndexSPI, ExhaustionPolicy exhaustionPolicy = ExhaustionPolicy.None) : 
+    internal ComponentTable(DatabaseEngine dbe, DBComponentDefinition definition, IResource parent, int componentSPI, int versionSPI, int defaultIndexSPI,
+        int string64IndexSPI, int tailIndexSPI = 0, ExhaustionPolicy exhaustionPolicy = ExhaustionPolicy.None) :
         base($"ComponentTable_{definition.Name}", ResourceType.ComponentTable, parent, exhaustionPolicy)
     {
         DBE = dbe;
@@ -338,9 +356,16 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IContentionTar
         DefaultIndexSegment  = mmf.LoadChunkBasedSegment(defaultIndexSPI, sizeof(Index64Chunk));
         String64IndexSegment = mmf.LoadChunkBasedSegment(string64IndexSPI, sizeof(IndexString64Chunk));
 
-        PrimaryKeyIndex = definition.AllowMultiple ? 
-            new LongMultipleBTree(DefaultIndexSegment, load: true, stableId: -1) : 
+        PrimaryKeyIndex = definition.AllowMultiple ?
+            new LongMultipleBTree(DefaultIndexSegment, load: true, stableId: -1) :
             new LongSingleBTree(DefaultIndexSegment, load: true, stableId: -1);
+
+        // Restore TAIL version-history segment for AllowMultiple secondary indexes
+        if (Definition.MultipleIndicesCount > 0)
+        {
+            TailIndexSegment = mmf.LoadChunkBasedSegment(tailIndexSPI, 512);
+            TailVSBS = new VariableSizedBufferSegment<VersionedIndexEntry>(TailIndexSegment);
+        }
 
         BuildIndexedFieldInfo(true);
 
@@ -423,6 +448,7 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IContentionTar
 
         if (disposing)
         {
+            TailIndexSegment?.Dispose();
             String64IndexSegment?.Dispose();
             DefaultIndexSegment.Dispose();
             CompRevTableSegment.Dispose();

--- a/src/Typhon.Engine/Data/DatabaseEngine.cs
+++ b/src/Typhon.Engine/Data/DatabaseEngine.cs
@@ -51,6 +51,7 @@ public struct ComponentR1
     public int VersionSPI;
     public int DefaultIndexSPI;
     public int String64IndexSPI;
+    public int TailIndexSPI;
 
     public ComponentCollection<FieldR1> Fields;
 }
@@ -420,11 +421,13 @@ public class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropertiesProvi
             });
 
     unsafe internal ChunkBasedSegment GetComponentCollectionSegment<T>() where T : unmanaged =>
-        _componentCollectionSegmentByStride.GetOrAdd(RoundToStandardStride(sizeof(T) * 8),
+        _componentCollectionSegmentByStride.GetOrAdd(
+            RoundToStandardStride(Math.Max(sizeof(T) * ComponentCollectionItemCountPerChunk, sizeof(VariableSizedBufferRootHeader))),
             stride => MMF.AllocateChunkBasedSegment(PageBlockType.None, ComponentCollectionSegmentStartingSize, stride));
 
-    internal ChunkBasedSegment GetComponentCollectionSegment(int itemSize, ChangeSet changeSet = null) =>
-        _componentCollectionSegmentByStride.GetOrAdd(RoundToStandardStride(itemSize * 8),
+    unsafe internal ChunkBasedSegment GetComponentCollectionSegment(int itemSize, ChangeSet changeSet = null) =>
+        _componentCollectionSegmentByStride.GetOrAdd(
+            RoundToStandardStride(Math.Max(itemSize * ComponentCollectionItemCountPerChunk, sizeof(VariableSizedBufferRootHeader))),
             stride => MMF.AllocateChunkBasedSegment(PageBlockType.None, ComponentCollectionSegmentStartingSize, stride, changeSet));
 
     internal long GetNewPrimaryKey() => Interlocked.Increment(ref _curPrimaryKey);
@@ -494,6 +497,7 @@ public class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropertiesProvi
             VersionSPI          = table.CompRevTableSegment.RootPageIndex,
             DefaultIndexSPI     = table.DefaultIndexSegment.RootPageIndex,
             String64IndexSPI    = table.String64IndexSegment.RootPageIndex,
+            TailIndexSPI        = table.TailIndexSegment?.RootPageIndex ?? 0,
         };
 
         {
@@ -673,7 +677,7 @@ public class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropertiesProvi
         {
             // Load path: restore from saved SPIs
             componentTable = new ComponentTable(this, definition, this, persisted.ComponentSPI, persisted.VersionSPI,
-                persisted.DefaultIndexSPI, persisted.String64IndexSPI);
+                persisted.DefaultIndexSPI, persisted.String64IndexSPI, persisted.TailIndexSPI);
 
             // Update _curPrimaryKey from loaded PK index
             if (componentTable.PrimaryKeyIndex.EntryCount > 0)

--- a/src/Typhon.Engine/Data/Index/BTree.NodeWrapper.cs
+++ b/src/Typhon.Engine/Data/Index/BTree.NodeWrapper.cs
@@ -137,6 +137,7 @@ public abstract partial class BTree<TKey>
                 {
                     var bufferId = _storage.CreateBuffer(ref accessor);
                     args.ElementId = _storage.Append(bufferId, value, ref accessor);
+                    args.BufferRootId = bufferId;
                     value = bufferId;
                 }
                 var item = new KeyValueItem(args.Key, value); // item to add
@@ -222,6 +223,7 @@ public abstract partial class BTree<TKey>
                 {
                     var curItem = GetItem(index, ref accessor);
                     args.ElementId = _storage.Append(curItem.Value, args.GetValue(), ref accessor);
+                    args.BufferRootId = curItem.Value;
                 }
                 // Unique index: GetValue() not called, so Added stays false.
                 // AddOrUpdateCore detects !Added && !AllowMultiple and throws UniqueConstraintViolationException.

--- a/src/Typhon.Engine/Data/Index/BTree.cs
+++ b/src/Typhon.Engine/Data/Index/BTree.cs
@@ -124,17 +124,16 @@ public interface IBTree
     bool AllowMultiple { get; }
     int EntryCount { get; }
     unsafe int Add(void* keyAddr, int value, ref ChunkAccessor accessor);
+    unsafe int Add(void* keyAddr, int value, ref ChunkAccessor accessor, out int bufferRootId);
     unsafe bool Remove(void* keyAddr, out int value, ref ChunkAccessor accessor);
     unsafe Result<int, BTreeLookupStatus> TryGet(void* keyAddr, ref ChunkAccessor accessor);
-    unsafe bool RemoveValue(void* keyAddr, int elementId, int value, ref ChunkAccessor accessor);
+    unsafe bool RemoveValue(void* keyAddr, int elementId, int value, ref ChunkAccessor accessor, bool preserveEmptyBuffer = false);
     unsafe VariableSizedBufferAccessor<int> TryGetMultiple(void* keyAddr, ref ChunkAccessor accessor);
     void CheckConsistency(ref ChunkAccessor accessor);
 }
 
 public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged 
 {
-    const int ChunkRandomAccessorPagedCount = 8;
-
     [DebuggerDisplay("Key: {Key}, Value: {Value}")]
     [StructLayout(LayoutKind.Sequential)]
     public struct KeyValueItem
@@ -175,6 +174,7 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
         public bool Added { get; private set; }
 
         public int ElementId;
+        public int BufferRootId;
 
         public ref ChunkAccessor Accessor;
 
@@ -593,15 +593,19 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
         return (1 + adjusted / entriesPerChunk, (adjusted % entriesPerChunk) * BTreeDirectoryEntry.Size);
     }
 
-    public unsafe int Add(void* keyAddr, int value, ref ChunkAccessor accessor) => Add(Unsafe.AsRef<TKey>(keyAddr), value, ref accessor);
+    public unsafe int Add(void* keyAddr, int value, ref ChunkAccessor accessor) => Add(Unsafe.AsRef<TKey>(keyAddr), value, ref accessor, out _);
+    public unsafe int Add(void* keyAddr, int value, ref ChunkAccessor accessor, out int bufferRootId)
+        => Add(Unsafe.AsRef<TKey>(keyAddr), value, ref accessor, out bufferRootId);
     public unsafe bool Remove(void* keyAddr, out int value, ref ChunkAccessor accessor) => Remove(Unsafe.AsRef<TKey>(keyAddr), out value, ref accessor);
     public unsafe Result<int, BTreeLookupStatus> TryGet(void* keyAddr, ref ChunkAccessor accessor) => TryGet(Unsafe.AsRef<TKey>(keyAddr), ref accessor);
-    public unsafe bool RemoveValue(void* keyAddr, int elementId, int value, ref ChunkAccessor accessor) 
-        => RemoveValue(Unsafe.AsRef<TKey>(keyAddr), elementId, value, ref accessor);
+    public unsafe bool RemoveValue(void* keyAddr, int elementId, int value, ref ChunkAccessor accessor, bool preserveEmptyBuffer = false)
+        => RemoveValue(Unsafe.AsRef<TKey>(keyAddr), elementId, value, ref accessor, preserveEmptyBuffer);
     public unsafe VariableSizedBufferAccessor<int> TryGetMultiple(void* keyAddr, ref ChunkAccessor accessor)
         => TryGetMultiple(Unsafe.AsRef<TKey>(keyAddr), ref accessor);
 
-    public int Add(TKey key, int value, ref ChunkAccessor accessor)
+    public int Add(TKey key, int value, ref ChunkAccessor accessor) => Add(key, value, ref accessor, out _);
+
+    public int Add(TKey key, int value, ref ChunkAccessor accessor, out int bufferRootId)
     {
         Activity activity = null;
         if (TelemetryConfig.BTreeActive)
@@ -620,6 +624,7 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
             AddOrUpdateCore(ref args);
             SyncHeader(ref accessor);
             activity?.SetTag(TyphonSpanAttributes.IndexOperation, "insert");
+            bufferRootId = args.BufferRootId;
             return args.ElementId;
         }
         finally
@@ -773,7 +778,7 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
         }
     }
 
-    public bool RemoveValue(TKey key, int elementId, int value, ref ChunkAccessor accessor)
+    public bool RemoveValue(TKey key, int elementId, int value, ref ChunkAccessor accessor, bool preserveEmptyBuffer = false)
     {
         Activity activity = null;
         if (TelemetryConfig.BTreeActive)
@@ -804,8 +809,10 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
                 return false;
             }
 
-            // Remove the key if we no longer have values stored there
-            if (res == 0)
+            // Remove the key if we no longer have values stored there.
+            // When preserveEmptyBuffer is true, keep the BTree key and empty HEAD buffer alive so that linked TAIL version-history buffers remain reachable
+            // for temporal queries.
+            if (res == 0 && !preserveEmptyBuffer)
             {
                 var args = new RemoveArguments(key, Comparer, ref accessor);
                 RemoveCore(ref args);
@@ -950,6 +957,7 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
             {
                 var bufferId = _storage.CreateBuffer(ref accessor);
                 args.ElementId = _storage.Append(bufferId, args.GetValue(), ref accessor);
+                args.BufferRootId = bufferId;
                 value = bufferId;
             }
             else
@@ -965,7 +973,9 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
         {
             if (AllowMultiple)
             {
-                args.ElementId = _storage.Append(GetLast(ref accessor).Value, args.GetValue(), ref accessor);
+                var bufferRootId = GetLast(ref accessor).Value;
+                args.ElementId = _storage.Append(bufferRootId, args.GetValue(), ref accessor);
+                args.BufferRootId = bufferRootId;
             }
             else
             {
@@ -983,6 +993,7 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
             {
                 var bufferId = _storage.CreateBuffer(ref accessor);
                 args.ElementId = _storage.Append(bufferId, args.GetValue(), ref accessor);
+                args.BufferRootId = bufferId;
                 value = bufferId;
             }
             else
@@ -998,7 +1009,9 @@ public abstract partial class BTree<TKey> : IBTree where TKey : unmanaged
         {
             if (AllowMultiple)
             {
-                args.ElementId = _storage.Append(GetFirst(ref accessor).Value, args.GetValue(), ref accessor);
+                var bufferRootId = GetFirst(ref accessor).Value;
+                args.ElementId = _storage.Append(bufferRootId, args.GetValue(), ref accessor);
+                args.BufferRootId = bufferRootId;
             }
             else
             {

--- a/src/Typhon.Engine/Data/Index/L16BTree.cs
+++ b/src/Typhon.Engine/Data/Index/L16BTree.cs
@@ -716,7 +716,7 @@ public class L16MultipleBTree<TKey> : L16BTree<TKey> where TKey : unmanaged
         internal override void Initialize(BTree<TKey> owner, ChunkBasedSegment segment)
         {
             base.Initialize(owner, segment);
-            _valueStore = new VariableSizedBufferSegment<int>(segment);
+            _valueStore = new VariableSizedBufferSegment<int, IndexBufferExtraHeader>(segment);
         }
 
         public override int Append(int bufferId, int value, ref ChunkAccessor accessor) => _valueStore.AddElement(bufferId, value, ref accessor);

--- a/src/Typhon.Engine/Data/Index/L32BTree.cs
+++ b/src/Typhon.Engine/Data/Index/L32BTree.cs
@@ -716,7 +716,7 @@ public class L32MultipleBTree<TKey> : L32BTree<TKey> where TKey : unmanaged
         internal override void Initialize(BTree<TKey> owner, ChunkBasedSegment segment)
         {
             base.Initialize(owner, segment);
-            _valueStore = new VariableSizedBufferSegment<int>(segment);
+            _valueStore = new VariableSizedBufferSegment<int, IndexBufferExtraHeader>(segment);
 
         }
 

--- a/src/Typhon.Engine/Data/Index/L64BTree.cs
+++ b/src/Typhon.Engine/Data/Index/L64BTree.cs
@@ -716,7 +716,7 @@ public class L64MultipleBTree<TKey> : L64BTree<TKey> where TKey : unmanaged
         internal override void Initialize(BTree<TKey> owner, ChunkBasedSegment segment)
         {
             base.Initialize(owner, segment);
-            _valueStore = new VariableSizedBufferSegment<int>(segment);
+            _valueStore = new VariableSizedBufferSegment<int, IndexBufferExtraHeader>(segment);
 
         }
 

--- a/src/Typhon.Engine/Data/Index/String64BTree.cs
+++ b/src/Typhon.Engine/Data/Index/String64BTree.cs
@@ -735,7 +735,7 @@ public class String64MultipleBTree : String64BTree
         internal override void Initialize(BTree<String64> owner, ChunkBasedSegment segment)
         {
             base.Initialize(owner, segment);
-            _valueStore = new VariableSizedBufferSegment<int>(segment);
+            _valueStore = new VariableSizedBufferSegment<int, IndexBufferExtraHeader>(segment);
 
         }
 

--- a/src/Typhon.Engine/Data/Index/TailGarbageCollector.cs
+++ b/src/Typhon.Engine/Data/Index/TailGarbageCollector.cs
@@ -1,0 +1,137 @@
+// unset
+
+using System.Collections.Generic;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Garbage collector for TAIL version-history buffers. Removes entries that are no longer needed for snapshot isolation because all active
+/// transactions have TSN > retentionTSN.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For each ChainId, the pruning algorithm keeps one "boundary sentinel" — the entry with the highest TSN &lt;= retentionTSN. This sentinel is needed because
+/// a reader at exactly retentionTSN must still be able to determine the state of that chain.
+/// </para>
+/// <para>
+/// A ChainId is fully removed (including the sentinel) when:
+/// 1. The sentinel is a Tombstone (entity is gone at the retention point), AND
+/// 2. No entries with TSN &gt; retentionTSN exist for that ChainId (no future state to preserve).
+/// </para>
+/// <para>
+/// Integration: Hook into deferred cleanup flow when MinTSN advances (requires #46/#47).
+/// </para>
+/// <para>
+/// <b>Zombie BTree key cleanup:</b> After Prune empties a TAIL buffer, if the HEAD buffer for that key is also empty (due to preserveEmptyBuffer), the BTree
+/// key is a zombie that serves no purpose. The caller (GC integration layer) should detect this case and remove the BTree key entirely using
+/// <c>IBTree.Remove</c>. This is NOT handled inside Prune because it requires access to the BTree, which is outside the TAIL segment's scope.
+/// </para>
+/// </remarks>
+internal static class TailGarbageCollector
+{
+    /// <summary>
+    /// Prune TAIL entries older than <paramref name="retentionTSN"/>, keeping one boundary sentinel per ChainId.
+    /// </summary>
+    /// <param name="tailVSBS">The TAIL VSBS containing version history entries.</param>
+    /// <param name="tailBufferId">The root chunk ID of the TAIL buffer to prune.</param>
+    /// <param name="retentionTSN">Entries with TSN below this may be pruned (oldest active transaction TSN).</param>
+    /// <param name="accessor">ChunkAccessor for the TailIndexSegment.</param>
+    /// <param name="newTailBufferId">Return the ID of the new TAIL VSBS buffer</param>
+    /// <returns>Number of entries removed.</returns>
+    internal static int Prune(VariableSizedBufferSegment<VersionedIndexEntry> tailVSBS, int tailBufferId, long retentionTSN, ref ChunkAccessor accessor, 
+        out int newTailBufferId)
+    {
+        // Phase 1: Scan all entries and group by ChainId
+        // For each ChainId, track: boundary sentinel (highest TSN <= retentionTSN),
+        // older entries (to discard), and whether future entries exist (TSN > retentionTSN).
+        var chainData = new Dictionary<int, ChainPruneState>();
+
+        var allEntries = new List<VersionedIndexEntry>();
+        foreach (ref readonly var entry in tailVSBS.EnumerateBuffer(tailBufferId))
+        {
+            allEntries.Add(entry);
+
+            var chainId = entry.ChainId;
+            if (!chainData.TryGetValue(chainId, out var state))
+            {
+                state = new ChainPruneState();
+                chainData[chainId] = state;
+            }
+
+            if (entry.TSN > retentionTSN)
+            {
+                state.HasFutureEntries = true;
+            }
+            else if (state.BoundarySentinel == null || entry.TSN > state.BoundarySentinel.Value.TSN)
+            {
+                // This entry becomes the new boundary sentinel; previous sentinel (if any) is older and can be discarded
+                state.BoundarySentinel = entry;
+            }
+            else
+            {
+                // Entry is older than current boundary sentinel — will be discarded in Phase 2
+            }
+        }
+
+        // Phase 2: Determine which entries to keep
+        var keptEntries = new List<VersionedIndexEntry>();
+        int removedCount = 0;
+
+        foreach (var entry in allEntries)
+        {
+            var chainId = entry.ChainId;
+            var state = chainData[chainId];
+
+            if (entry.TSN > retentionTSN)
+            {
+                // Future entry: always keep
+                keptEntries.Add(entry);
+                continue;
+            }
+
+            // Is this the boundary sentinel?
+            if (state.BoundarySentinel != null && entry.TSN == state.BoundarySentinel.Value.TSN
+                && entry.SignedChainId == state.BoundarySentinel.Value.SignedChainId)
+            {
+                // Keep the sentinel UNLESS it's a tombstone with no future entries
+                if (state.BoundarySentinel.Value.IsTombstone && !state.HasFutureEntries)
+                {
+                    removedCount++;
+                }
+                else
+                {
+                    keptEntries.Add(entry);
+                }
+            }
+            else
+            {
+                // Older than boundary sentinel: discard
+                removedCount++;
+            }
+        }
+
+        if (removedCount == 0)
+        {
+            newTailBufferId = tailBufferId;
+            return 0;
+        }
+
+        // Phase 3: Compact — delete the old buffer and rewrite with kept entries only.
+        // IMPORTANT: The new buffer ID will differ from the old one. The caller must update// the HEAD root header's TailBufferId to point to the new buffer.
+        tailVSBS.DeleteBuffer(tailBufferId, ref accessor);
+
+        newTailBufferId = tailVSBS.AllocateBuffer(ref accessor);
+        foreach (var entry in keptEntries)
+        {
+            tailVSBS.AddElement(newTailBufferId, entry, ref accessor);
+        }
+
+        return removedCount;
+    }
+
+    private class ChainPruneState
+    {
+        public VersionedIndexEntry? BoundarySentinel;
+        public bool HasFutureEntries;
+    }
+}

--- a/src/Typhon.Engine/Data/Index/TemporalIndexQuery.cs
+++ b/src/Typhon.Engine/Data/Index/TemporalIndexQuery.cs
@@ -1,0 +1,125 @@
+// unset
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Provides temporal (point-in-time) index lookup for AllowMultiple secondary indexes. Scans the TAIL version-history buffer to determine which chain IDs
+/// were active for a given key at a specific target TSN.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Current-state queries (HEAD path) are completely unchanged — this class is only invoked for historical/snapshot queries where the caller needs to see the
+/// index state at an older TSN.
+/// </para>
+/// <para>
+/// Algorithm: For each unique ChainId in the TAIL buffer, find the entry with the highest TSN that is &lt;= targetTSN. If that entry is Active, the ChainId
+/// is included in the result. If it's a Tombstone (or no entry exists), it's excluded.
+/// </para>
+/// </remarks>
+internal static unsafe class TemporalIndexQuery
+{
+    /// <summary>
+    /// Returns chain IDs that were active for <paramref name="fieldValueAddr"/> at <paramref name="targetTSN"/>.
+    /// </summary>
+    /// <param name="ifi">The indexed field info (contains the B+Tree index).</param>
+    /// <param name="fieldValueAddr">Pointer to the field value to look up in the B+Tree.</param>
+    /// <param name="targetTSN">The snapshot TSN to query at.</param>
+    /// <param name="tailVSBS">The TAIL VSBS containing version history entries.</param>
+    /// <param name="changeSet">ChangeSet for page tracking.</param>
+    /// <returns>List of chain IDs active at the target TSN (empty if none or key not found).</returns>
+    internal static List<int> Query(IndexedFieldInfo ifi, byte* fieldValueAddr, long targetTSN, VariableSizedBufferSegment<VersionedIndexEntry> tailVSBS, 
+        ChangeSet changeSet)
+    {
+        var result = new List<int>(4);
+
+        // Step 1: Look up the key in the B+Tree to get the HEAD buffer ID
+        var accessor = ifi.Index.Segment.CreateChunkAccessor(changeSet);
+        var headResult = ifi.Index.TryGet(fieldValueAddr, ref accessor);
+        if (headResult.IsFailure)
+        {
+            accessor.Dispose();
+            return result;
+        }
+
+        var headBufferId = headResult.Value;
+
+        // Step 2: Read TailBufferId from HEAD root header's extra header
+        var chunkAddr = accessor.GetChunkAddress(headBufferId);
+        var tailBufferId = IndexBufferExtraHeader.FromChunkAddress(chunkAddr).TailBufferId;
+        accessor.Dispose();
+
+        // Step 3: If no TAIL buffer exists, fall back to HEAD (all current entries are valid)
+        if (tailBufferId == 0)
+        {
+            return QueryHeadOnly(ifi, fieldValueAddr, changeSet);
+        }
+
+        // Step 4: Scan TAIL buffer entries, tracking the latest state per ChainId at targetTSN
+        // Pre-sized for typical small chain counts to reduce heap pressure
+        var chainStates = new Dictionary<int, (bool IsActive, long TSN)>(4);
+
+        foreach (ref readonly var entry in tailVSBS.EnumerateBuffer(tailBufferId))
+        {
+            // Only consider entries at or before our target snapshot
+            if (entry.TSN > targetTSN)
+            {
+                continue;
+            }
+
+            var chainId = entry.ChainId;
+            if (chainStates.TryGetValue(chainId, out var existing))
+            {
+                // Keep the entry with the highest TSN <= targetTSN
+                if (entry.TSN > existing.TSN)
+                {
+                    chainStates[chainId] = (entry.IsActive, entry.TSN);
+                }
+            }
+            else
+            {
+                chainStates[chainId] = (entry.IsActive, entry.TSN);
+            }
+        }
+
+        // Step 5: Collect ChainIds whose latest state is Active
+        foreach (var kvp in chainStates)
+        {
+            if (kvp.Value.IsActive)
+            {
+                result.Add(kvp.Key);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Fallback: when no TAIL buffer exists, return all current chain IDs from the HEAD buffer.
+    /// </summary>
+    private static List<int> QueryHeadOnly(IndexedFieldInfo ifi, byte* fieldValueAddr, ChangeSet changeSet)
+    {
+        var result = new List<int>(4);
+        var accessor = ifi.Index.Segment.CreateChunkAccessor(changeSet);
+        using var bufferAccessor = ifi.Index.TryGetMultiple(fieldValueAddr, ref accessor);
+        accessor.Dispose();
+
+        if (!bufferAccessor.IsValid)
+        {
+            return result;
+        }
+
+        do
+        {
+            var elements = bufferAccessor.Elements;
+            for (int i = 0; i < elements.Length; i++)
+            {
+                result.Add(elements[i]);
+            }
+        } while (bufferAccessor.NextChunk());
+
+        return result;
+    }
+}

--- a/src/Typhon.Engine/Data/Index/VersionedIndexEntry.cs
+++ b/src/Typhon.Engine/Data/Index/VersionedIndexEntry.cs
@@ -1,0 +1,85 @@
+// unset
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Entry in the TAIL version-history buffer for AllowMultiple secondary indexes.
+/// Encodes a chain-ID with an Active/Tombstone flag via the sign of <see cref="SignedChainId"/>, plus the TSN at which this state was established.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Positive <see cref="SignedChainId"/> → Active (entity is indexed under this key at this TSN).
+/// Negative <see cref="SignedChainId"/> → Tombstone (entity was removed from this key at this TSN).
+/// </para>
+/// <para>
+/// Layout: 12 bytes (4 + 8), Pack=4 for natural alignment inside VSBS chunks.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Sequential, Pack = 4)]
+internal struct VersionedIndexEntry : IEquatable<VersionedIndexEntry>
+{
+    /// <summary>
+    /// Sign-encoded chain ID. Positive = Active, Negative = Tombstone.
+    /// <c>Math.Abs(SignedChainId)</c> yields the actual chain ID.
+    /// </summary>
+    public int SignedChainId;
+
+    /// <summary>
+    /// The TSN (Transaction Sequence Number) at which this entry was written.
+    /// </summary>
+    public long TSN;
+
+    /// <summary>Creates an Active entry (entity is present under this key at this TSN).</summary>
+    public static VersionedIndexEntry Active(int chainId, long tsn)
+    {
+        Debug.Assert(chainId > 0, "ChainId must be positive for sign-encoding to work");
+        return new VersionedIndexEntry { SignedChainId = chainId, TSN = tsn };
+    }
+
+    /// <summary>Creates a Tombstone entry (entity was removed from this key at this TSN).</summary>
+    public static VersionedIndexEntry Tombstone(int chainId, long tsn)
+    {
+        Debug.Assert(chainId > 0, "ChainId must be positive for sign-encoding to work");
+        return new VersionedIndexEntry { SignedChainId = -chainId, TSN = tsn };
+    }
+
+    /// <summary>True if this entry represents an active mapping.</summary>
+    public bool IsActive => SignedChainId > 0;
+
+    /// <summary>True if this entry represents a removal.</summary>
+    public bool IsTombstone => SignedChainId < 0;
+
+    /// <summary>The chain ID (always positive, regardless of Active/Tombstone state).</summary>
+    public int ChainId => Math.Abs(SignedChainId);
+
+    public bool Equals(VersionedIndexEntry other) => SignedChainId == other.SignedChainId && TSN == other.TSN;
+    public override bool Equals(object obj) => obj is VersionedIndexEntry other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(SignedChainId, TSN);
+    public override string ToString() => $"{(IsActive ? "Active" : "Tombstone")}(ChainId={ChainId}, TSN={TSN})";
+}
+
+/// <summary>
+/// Extra header appended after <see cref="VariableSizedBufferRootHeader"/> in AllowMultiple index HEAD buffers.
+/// Links the HEAD buffer to its corresponding TAIL version-history buffer.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct IndexBufferExtraHeader
+{
+    /// <summary>
+    /// Links this HEAD buffer to its corresponding TAIL version-history buffer (in TailVSBS).
+    /// 0 = no TAIL buffer allocated yet (lazy allocation on first versioned write).
+    /// </summary>
+    public int TailBufferId;
+
+    /// <summary>
+    /// Gets a ref to the extra header at the given chunk address, offset past the standard root header.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static unsafe ref IndexBufferExtraHeader FromChunkAddress(byte* chunkAddr)
+        => ref Unsafe.AsRef<IndexBufferExtraHeader>(chunkAddr + sizeof(VariableSizedBufferRootHeader));
+}

--- a/src/Typhon.Engine/Data/Transaction/IndexMaintainer.cs
+++ b/src/Typhon.Engine/Data/Transaction/IndexMaintainer.cs
@@ -1,12 +1,13 @@
 // unset
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Typhon.Engine;
 
 internal static unsafe class IndexMaintainer
 {
-    internal static void UpdateIndices(long pk, ComponentInfo info, ComponentInfo.CompRevInfo compRevInfo, int prevCompChunkId, ChangeSet changeSet)
+    internal static void UpdateIndices(long pk, ComponentInfo info, ComponentInfo.CompRevInfo compRevInfo, int prevCompChunkId, ChangeSet changeSet, long tsn)
     {
         // If there's a previous revision, we need to update the indices if some indexed fields changed
         var startChunkId = compRevInfo.CompRevTableFirstChunkId;
@@ -28,8 +29,39 @@ internal static unsafe class IndexMaintainer
                     var accessor = ifi.Index.Segment.CreateChunkAccessor(changeSet);
                     if (ifi.Index.AllowMultiple)
                     {
-                        ifi.Index.RemoveValue(&prev[ifi.OffsetToField], *(int*)&prev[ifi.OffsetToIndexElementId], startChunkId, ref accessor);
+                        var tailVSBS = info.ComponentTable.TailVSBS;
+
+                        // When TAIL tracking is active, preserve the BTree key even if the HEAD buffer empties.
+                        // This keeps the TAIL version-history buffer reachable for temporal queries.
+                        ifi.Index.RemoveValue(&prev[ifi.OffsetToField], *(int*)&prev[ifi.OffsetToIndexElementId], startChunkId, ref accessor,
+                            preserveEmptyBuffer: tailVSBS != null);
                         *(int*)&cur[ifi.OffsetToIndexElementId] = ifi.Index.Add(&cur[ifi.OffsetToField], startChunkId, ref accessor);
+
+                        // TAIL: append Tombstone to old key, Active to new key.
+                        // Since preserveEmptyBuffer keeps the old key alive, we can TryGet after RemoveValue
+                        // and use GetOrCreateTailBuffer which properly links the TAIL to the HEAD root header.
+                        if (tailVSBS != null)
+                        {
+                            var tailAccessor = tailVSBS.Segment.CreateChunkAccessor(changeSet);
+
+                            // Tombstone on old key's TAIL buffer
+                            var oldHeadResult = ifi.Index.TryGet(&prev[ifi.OffsetToField], ref accessor);
+                            if (oldHeadResult.IsSuccess)
+                            {
+                                var oldTailBufferId = GetOrCreateTailBuffer(oldHeadResult.Value, tailVSBS, ref accessor, ref tailAccessor);
+                                tailVSBS.AddElement(oldTailBufferId, VersionedIndexEntry.Tombstone(startChunkId, tsn), ref tailAccessor);
+                            }
+
+                            // Active on new key's TAIL buffer
+                            var newHeadResult = ifi.Index.TryGet(&cur[ifi.OffsetToField], ref accessor);
+                            if (newHeadResult.IsSuccess)
+                            {
+                                var newTailBufferId = GetOrCreateTailBuffer(newHeadResult.Value, tailVSBS, ref accessor, ref tailAccessor);
+                                tailVSBS.AddElement(newTailBufferId, VersionedIndexEntry.Active(startChunkId, tsn), ref tailAccessor);
+                            }
+
+                            tailAccessor.Dispose();
+                        }
                     }
                     else
                     {
@@ -68,7 +100,17 @@ internal static unsafe class IndexMaintainer
                 var accessor = ifi.Index.Segment.CreateChunkAccessor(changeSet);
                 if (ifi.Index.AllowMultiple)
                 {
-                    *(int*)&cur[ifi.OffsetToIndexElementId] = ifi.Index.Add(&cur[ifi.OffsetToField], startChunkId, ref accessor);
+                    *(int*)&cur[ifi.OffsetToIndexElementId] = ifi.Index.Add(&cur[ifi.OffsetToField], startChunkId, ref accessor, out var headBufferId);
+
+                    // TAIL: append Active entry for newly created entity
+                    var tailVSBS = info.ComponentTable.TailVSBS;
+                    if (tailVSBS != null)
+                    {
+                        var tailAccessor = tailVSBS.Segment.CreateChunkAccessor(changeSet);
+                        var tailBufferId = GetOrCreateTailBuffer(headBufferId, tailVSBS, ref accessor, ref tailAccessor);
+                        tailVSBS.AddElement(tailBufferId, VersionedIndexEntry.Active(startChunkId, tsn), ref tailAccessor);
+                        tailAccessor.Dispose();
+                    }
                 }
                 else
                 {
@@ -79,7 +121,7 @@ internal static unsafe class IndexMaintainer
         }
     }
 
-    internal static void RemoveSecondaryIndices(ComponentInfo info, int prevCompChunkId, int startChunkId, ChangeSet changeSet)
+    internal static void RemoveSecondaryIndices(ComponentInfo info, int prevCompChunkId, int startChunkId, ChangeSet changeSet, long tsn)
     {
         var prev = info.CompContentAccessor.GetChunkAddress(prevCompChunkId);
         var indexedFieldInfos = info.ComponentTable.IndexedFieldInfos;
@@ -89,7 +131,27 @@ internal static unsafe class IndexMaintainer
             var accessor = ifi.Index.Segment.CreateChunkAccessor(changeSet);
             if (ifi.Index.AllowMultiple)
             {
-                ifi.Index.RemoveValue(&prev[ifi.OffsetToField], *(int*)&prev[ifi.OffsetToIndexElementId], startChunkId, ref accessor);
+                var tailVSBS = info.ComponentTable.TailVSBS;
+
+                // When TAIL tracking is active, preserve the BTree key even if the HEAD buffer empties.
+                // This keeps the TAIL version-history buffer reachable for temporal queries.
+                ifi.Index.RemoveValue(&prev[ifi.OffsetToField], *(int*)&prev[ifi.OffsetToIndexElementId], startChunkId, ref accessor,
+                    preserveEmptyBuffer: tailVSBS != null);
+
+                // TAIL: append Tombstone for the deleted entity.
+                // Since preserveEmptyBuffer keeps the key alive, we can TryGet after RemoveValue
+                // and use GetOrCreateTailBuffer which properly links the TAIL to the HEAD root header.
+                if (tailVSBS != null)
+                {
+                    var tailAccessor = tailVSBS.Segment.CreateChunkAccessor(changeSet);
+                    var headResult = ifi.Index.TryGet(&prev[ifi.OffsetToField], ref accessor);
+                    if (headResult.IsSuccess)
+                    {
+                        var tailBufId = GetOrCreateTailBuffer(headResult.Value, tailVSBS, ref accessor, ref tailAccessor);
+                        tailVSBS.AddElement(tailBufId, VersionedIndexEntry.Tombstone(startChunkId, tsn), ref tailAccessor);
+                    }
+                    tailAccessor.Dispose();
+                }
             }
             else
             {
@@ -97,5 +159,29 @@ internal static unsafe class IndexMaintainer
             }
             accessor.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Gets the existing TAIL buffer ID or lazily allocates a new one, storing the link in the HEAD root header's extra header.
+    /// </summary>
+    /// <param name="headBufferId">Root chunk ID of the HEAD buffer.</param>
+    /// <param name="tailVSBS">The TAIL VSBS for VersionedIndexEntry storage.</param>
+    /// <param name="headAccessor">ChunkAccessor for the BTree's segment (to read/write HEAD root header).</param>
+    /// <param name="tailAccessor">ChunkAccessor for the TailIndexSegment.</param>
+    /// <returns>The TAIL buffer ID (existing or newly allocated).</returns>
+    private static int GetOrCreateTailBuffer(int headBufferId, VariableSizedBufferSegment<VersionedIndexEntry> tailVSBS,
+        ref ChunkAccessor headAccessor, ref ChunkAccessor tailAccessor)
+    {
+        var chunkAddr = headAccessor.GetChunkAddress(headBufferId, true);
+        ref var extra = ref IndexBufferExtraHeader.FromChunkAddress(chunkAddr);
+        if (extra.TailBufferId != 0)
+        {
+            return extra.TailBufferId;
+        }
+
+        // Allocate a new TAIL buffer and link it in the extra header
+        var tailBufferId = tailVSBS.AllocateBuffer(ref tailAccessor);
+        extra.TailBufferId = tailBufferId;
+        return tailBufferId;
     }
 }

--- a/src/Typhon.Engine/Data/Transaction/Transaction.cs
+++ b/src/Typhon.Engine/Data/Transaction/Transaction.cs
@@ -1221,11 +1221,11 @@ public unsafe class Transaction : IDisposable
             // Commit the revision: update indices, clear IsolationFlag, update LastCommitRevisionIndex
             if (compRevInfo.CurCompContentChunkId != 0)
             {
-                IndexMaintainer.UpdateIndices(pk, info, compRevInfo, readCompChunkId, _changeSet);
+                IndexMaintainer.UpdateIndices(pk, info, compRevInfo, readCompChunkId, _changeSet, TSN);
             }
             else if (readCompChunkId != 0)
             {
-                IndexMaintainer.RemoveSecondaryIndices(info, readCompChunkId, compRevInfo.CompRevTableFirstChunkId, _changeSet);
+                IndexMaintainer.RemoveSecondaryIndices(info, readCompChunkId, compRevInfo.CompRevTableFirstChunkId, _changeSet, TSN);
             }
 
             elementHandle.Commit(TSN);

--- a/src/Typhon.Engine/Storage/Segments/VariableSizedBufferSegment.cs
+++ b/src/Typhon.Engine/Storage/Segments/VariableSizedBufferSegment.cs
@@ -37,16 +37,21 @@ public unsafe class VariableSizedBufferSegmentBase
     private readonly int _elementSize;
     protected internal readonly int ElementCountRootChunk;
     protected readonly int ElementCountPerChunk;
+    protected internal readonly int RootHeaderTotalSize;
     public readonly ChunkBasedSegment Segment;
 
-    protected VariableSizedBufferSegmentBase(ChunkBasedSegment segment, int elementSize)
+    protected VariableSizedBufferSegmentBase(ChunkBasedSegment segment, int elementSize) : this(segment, elementSize, sizeof(VariableSizedBufferRootHeader))
+    {
+    }
+
+    protected VariableSizedBufferSegmentBase(ChunkBasedSegment segment, int elementSize, int rootHeaderTotalSize)
     {
         _elementSize = elementSize;
+        RootHeaderTotalSize = rootHeaderTotalSize;
         var stride = segment.Stride;
-        var headerSize = sizeof(VariableSizedBufferRootHeader);
-        Debug.Assert(headerSize <= stride, $"Error, stride is too small, should be at least, {headerSize} bytes.");
-        
-        ElementCountRootChunk = (stride - headerSize) / _elementSize;
+        Debug.Assert(rootHeaderTotalSize <= stride, $"Error, stride is too small, should be at least, {rootHeaderTotalSize} bytes.");
+
+        ElementCountRootChunk = (stride - rootHeaderTotalSize) / _elementSize;
         ElementCountPerChunk = (stride - sizeof(VariableSizedBufferChunkHeader)) / _elementSize;
         Segment = segment;
     }
@@ -56,7 +61,8 @@ public unsafe class VariableSizedBufferSegmentBase
         // Allocate and initialize the first chunk of the Buffer
         var segment = accessor.Segment;
         var chunkId = segment.AllocateChunk(false);
-        ref var rh = ref Unsafe.AsRef<VariableSizedBufferRootHeader>(accessor.GetChunkAddress(chunkId, true));
+        var addr = accessor.GetChunkAddress(chunkId, true);
+        ref var rh = ref Unsafe.AsRef<VariableSizedBufferRootHeader>(addr);
         rh.Lock.Reset();
         rh.FirstFreeChunkId = 0;
         rh.FirstStoredChunkId = chunkId;
@@ -65,6 +71,14 @@ public unsafe class VariableSizedBufferSegmentBase
         rh.RefCounter = 1;
         rh.Header.NextChunkId = 0;
         rh.Header.ElementCount = 0;
+
+        // Zero-initialize any extra header bytes beyond the standard root header
+        var extraSize = RootHeaderTotalSize - sizeof(VariableSizedBufferRootHeader);
+        if (extraSize > 0)
+        {
+            Unsafe.InitBlockUnaligned(addr + sizeof(VariableSizedBufferRootHeader), 0, (uint)extraSize);
+        }
+
         return chunkId;
     }
 
@@ -187,6 +201,10 @@ public class VariableSizedBufferSegment<T> : VariableSizedBufferSegmentBase wher
     {
     }
 
+    unsafe protected VariableSizedBufferSegment(ChunkBasedSegment segment, int rootHeaderTotalSize) : base(segment, sizeof(T), rootHeaderTotalSize)
+    {
+    }
+
     unsafe public int AddElement(int bufferId, T value, ref ChunkAccessor accessor)
     {
         // Fetch the root chunk — epoch protects page lifetime
@@ -240,7 +258,7 @@ public class VariableSizedBufferSegment<T> : VariableSizedBufferSegmentBase wher
             }
 
             // Add our element to the chunk
-            var baseElementAddr = (T*)(curChunkAddr + (isRoot ? sizeof(VariableSizedBufferRootHeader) : sizeof(VariableSizedBufferChunkHeader)));
+            var baseElementAddr = (T*)(curChunkAddr + (isRoot ? RootHeaderTotalSize : sizeof(VariableSizedBufferChunkHeader)));
             baseElementAddr[curChunkHeader.ElementCount++] = value;
                 
             ++rh.TotalCount;
@@ -309,7 +327,7 @@ public class VariableSizedBufferSegment<T> : VariableSizedBufferSegmentBase wher
                 }
 
                 var copyLength = Math.Min(chunkCapacity - curChunkHeader.ElementCount, itemsLeftToCopy);
-                var dstSpan = new Span<T>((curChunkAddr + (isRoot ? sizeof(VariableSizedBufferRootHeader) : sizeof(VariableSizedBufferChunkHeader))),
+                var dstSpan = new Span<T>((curChunkAddr + (isRoot ? RootHeaderTotalSize : sizeof(VariableSizedBufferChunkHeader))),
                     chunkCapacity);
                 items.Slice(curSourceIndex, copyLength).CopyTo(dstSpan.Slice(curChunkHeader.ElementCount));
                 
@@ -337,7 +355,7 @@ public class VariableSizedBufferSegment<T> : VariableSizedBufferSegmentBase wher
             var elementChunk = accessor.GetChunkAddress(elementId, true);
             ref var elementChunkHeader = ref Unsafe.AsRef<VariableSizedBufferChunkHeader>(elementChunk);
             var isRoot = bufferId == elementId;
-            var baseElementAddr = (T*)(elementChunk + (isRoot ? sizeof(VariableSizedBufferRootHeader) : sizeof(VariableSizedBufferChunkHeader)));
+            var baseElementAddr = (T*)(elementChunk + (isRoot ? RootHeaderTotalSize : sizeof(VariableSizedBufferChunkHeader)));
 
             // Look for our element
             var count = elementChunkHeader.ElementCount;
@@ -388,6 +406,20 @@ public class VariableSizedBufferSegment<T> : VariableSizedBufferSegmentBase wher
         } while (source.NextChunk());
 
         return destBufferId;
+    }
+}
+
+/// <summary>
+/// Extended VSBS that appends a typed extra header after the standard <see cref="VariableSizedBufferRootHeader"/>.
+/// The extra header is automatically zeroed on buffer allocation.
+/// </summary>
+/// <typeparam name="T">The unmanaged element type stored in the buffer.</typeparam>
+/// <typeparam name="TExtraHeader">The unmanaged struct appended after the root header in the root chunk.</typeparam>
+[PublicAPI]
+public class VariableSizedBufferSegment<T, TExtraHeader> : VariableSizedBufferSegment<T> where T : unmanaged where TExtraHeader : unmanaged
+{
+    public unsafe VariableSizedBufferSegment(ChunkBasedSegment segment) : base(segment, sizeof(VariableSizedBufferRootHeader) + sizeof(TExtraHeader))
+    {
     }
 }
 
@@ -466,6 +498,7 @@ public ref struct VariableSizedBufferAccessor<T> : IDisposable where T : unmanag
 {
     private readonly VariableSizedBufferSegment<T> _owner;
     private readonly ChunkBasedSegment _segment;
+    private readonly int _rootHeaderTotalSize;
 
     private int _rootChunkId;
     private unsafe byte* _rootChunkAddr;
@@ -504,6 +537,7 @@ public ref struct VariableSizedBufferAccessor<T> : IDisposable where T : unmanag
     {
         _owner = owner;
         _segment = owner.Segment;
+        _rootHeaderTotalSize = owner.RootHeaderTotalSize;
         _rootChunkId = rootChunkId;
 
         _accessor = _segment.CreateChunkAccessor(changeSet);
@@ -523,7 +557,7 @@ public ref struct VariableSizedBufferAccessor<T> : IDisposable where T : unmanag
         _curChunkId = _rootChunkId;
         _curChunkAddr = _accessor.GetChunkAddress(_curChunkId);
 
-        _elementAddr = _curChunkAddr + (_curChunkId==rootChunkId ? sizeof(VariableSizedBufferRootHeader) : sizeof(VariableSizedBufferChunkHeader));
+        _elementAddr = _curChunkAddr + (_curChunkId==rootChunkId ? _rootHeaderTotalSize : sizeof(VariableSizedBufferChunkHeader));
         _elementCount = ((VariableSizedBufferChunkHeader*)_curChunkAddr)->ElementCount;
 
         if (_elementCount == 0) NextChunk();
@@ -630,7 +664,7 @@ public ref struct VariableSizedBufferAccessor<T> : IDisposable where T : unmanag
 
         _curChunkId = nextChunkId;
         _curChunkAddr = _accessor.GetChunkAddress(_curChunkId);
-        _elementAddr = _curChunkAddr + (_curChunkId == _rootChunkId ? sizeof(VariableSizedBufferRootHeader) : sizeof(VariableSizedBufferChunkHeader));
+        _elementAddr = _curChunkAddr + (_curChunkId == _rootChunkId ? _rootHeaderTotalSize : sizeof(VariableSizedBufferChunkHeader));
         _elementCount = ((VariableSizedBufferChunkHeader*)_curChunkAddr)->ElementCount;
 
         return true;

--- a/test/Typhon.Engine.Tests/Data/BTreeTests.cs
+++ b/test/Typhon.Engine.Tests/Data/BTreeTests.cs
@@ -5,7 +5,6 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Typhon.Engine.BPTree;
 
 namespace Typhon.Engine.Tests;

--- a/test/Typhon.Engine.Tests/Data/CompRevStorageElementTests.cs
+++ b/test/Typhon.Engine.Tests/Data/CompRevStorageElementTests.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using System.Runtime.CompilerServices;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Data/DeferredCleanupTests.cs
+++ b/test/Typhon.Engine.Tests/Data/DeferredCleanupTests.cs
@@ -1,7 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using Serilog;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/test/Typhon.Engine.Tests/Data/VersionedIndexTests.cs
+++ b/test/Typhon.Engine.Tests/Data/VersionedIndexTests.cs
@@ -1,0 +1,538 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Typhon.Engine.Tests;
+
+class VersionedIndexTests : TestBase<VersionedIndexTests>
+{
+    #region Phase 1 — Infrastructure Tests
+
+    [Test]
+    public void VersionedIndexEntry_StructSize_Is12Bytes()
+    {
+        unsafe
+        {
+            Assert.That(sizeof(VersionedIndexEntry), Is.EqualTo(12), "VersionedIndexEntry should be exactly 12 bytes (4 + 8)");
+        }
+    }
+
+    [Test]
+    public void VersionedIndexEntry_Active_CorrectProperties()
+    {
+        var entry = VersionedIndexEntry.Active(42, 100);
+
+        Assert.That(entry.IsActive, Is.True);
+        Assert.That(entry.IsTombstone, Is.False);
+        Assert.That(entry.ChainId, Is.EqualTo(42));
+        Assert.That(entry.TSN, Is.EqualTo(100));
+        Assert.That(entry.SignedChainId, Is.EqualTo(42));
+    }
+
+    [Test]
+    public void VersionedIndexEntry_Tombstone_CorrectProperties()
+    {
+        var entry = VersionedIndexEntry.Tombstone(42, 200);
+
+        Assert.That(entry.IsActive, Is.False);
+        Assert.That(entry.IsTombstone, Is.True);
+        Assert.That(entry.ChainId, Is.EqualTo(42));
+        Assert.That(entry.TSN, Is.EqualTo(200));
+        Assert.That(entry.SignedChainId, Is.EqualTo(-42));
+    }
+
+    [Test]
+    public void VersionedIndexEntry_Equality()
+    {
+        var a = VersionedIndexEntry.Active(1, 100);
+        var b = VersionedIndexEntry.Active(1, 100);
+        var c = VersionedIndexEntry.Tombstone(1, 100);
+
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(a.Equals(c), Is.False);
+    }
+
+    [Test]
+    public unsafe void TailBufferId_DefaultsToZero()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        var ct = dbe.GetComponentTable<CompD>();
+        Assert.That(ct.TailVSBS, Is.Not.Null, "CompD has AllowMultiple indexes, should have TailVSBS");
+        Assert.That(ct.TailIndexSegment, Is.Not.Null, "CompD has AllowMultiple indexes, should have TailIndexSegment");
+    }
+
+    [Test]
+    public void ComponentTable_NoAllowMultiple_NoTailVSBS()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        var ct = dbe.GetComponentTable<CompA>();
+        Assert.That(ct.TailVSBS, Is.Null, "CompA has no AllowMultiple indexes, should not have TailVSBS");
+        Assert.That(ct.TailIndexSegment, Is.Null, "CompA has no AllowMultiple indexes, should not have TailIndexSegment");
+    }
+
+    [Test]
+    public unsafe void AllocateTailBuffer_AddAndReadEntry()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var tailVSBS = ct.TailVSBS;
+
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var accessor = tailVSBS.Segment.CreateChunkAccessor();
+
+        // Allocate a TAIL buffer and add an entry
+        var bufferId = tailVSBS.AllocateBuffer(ref accessor);
+        Assert.That(bufferId, Is.GreaterThan(0));
+
+        var entry = VersionedIndexEntry.Active(10, 500);
+        tailVSBS.AddElement(bufferId, entry, ref accessor);
+
+        // Read it back
+        using var ba = tailVSBS.GetReadOnlyAccessor(bufferId);
+        Assert.That(ba.TotalCount, Is.EqualTo(1));
+        var elements = ba.ReadOnlyElements;
+        Assert.That(elements.Length, Is.GreaterThanOrEqualTo(1));
+        Assert.That(elements[0].SignedChainId, Is.EqualTo(10));
+        Assert.That(elements[0].TSN, Is.EqualTo(500));
+
+        accessor.Dispose();
+    }
+
+    #endregion
+
+    #region Phase 2 — Write Path Tests
+
+    [Test]
+    public void Create_WithAllowMultipleIndex_TailHasActiveEntry()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        long entityId;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(1.0f, 10, 2.0);
+            entityId = t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        // Verify TAIL buffer was written for AllowMultiple indexes
+        var ct = dbe.GetComponentTable<CompD>();
+        var tailVSBS = ct.TailVSBS;
+        Assert.That(tailVSBS, Is.Not.Null);
+
+        // Look up the HEAD buffer for field A (first AllowMultiple index)
+        var ifi = ct.IndexedFieldInfos[0]; // Field A (float, AllowMultiple)
+        Assert.That(ifi.Index.AllowMultiple, Is.True, "First indexed field should be AllowMultiple");
+
+        unsafe
+        {
+            using var guard = EpochGuard.Enter(dbe.EpochManager);
+            float key = 1.0f;
+            var accessor = ifi.Index.Segment.CreateChunkAccessor();
+            var headResult = ifi.Index.TryGet(&key, ref accessor);
+            Assert.That(headResult.IsSuccess, Is.True, "Key should exist in HEAD index");
+
+            var headBufferId = headResult.Value;
+            var tailBufferId = IndexBufferExtraHeader.FromChunkAddress(accessor.GetChunkAddress(headBufferId)).TailBufferId;
+            accessor.Dispose();
+
+            Assert.That(tailBufferId, Is.GreaterThan(0), "TAIL buffer should have been allocated");
+
+            // Read TAIL entries
+            var entries = CollectTailEntries(tailVSBS, tailBufferId);
+            Assert.That(entries.Count, Is.GreaterThanOrEqualTo(1), "Should have at least one TAIL entry");
+
+            var activeEntry = entries.Find(e => e.IsActive);
+            Assert.That(activeEntry.IsActive, Is.True, "Should have an Active entry");
+            Assert.That(activeEntry.TSN, Is.GreaterThan(0), "Active entry should have a valid TSN");
+        }
+    }
+
+    [Test]
+    public void Update_IndexedField_TailHasTombstoneAndActive()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        long entityId;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(1.0f, 10, 2.0);
+            entityId = t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        // Update field A from 1.0f to 5.0f
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(5.0f, 10, 2.0);
+            t.UpdateEntity(entityId, ref d);
+            t.Commit();
+        }
+
+        // Verify TAIL has Tombstone on old key (1.0f) and Active on new key (5.0f)
+        var ct = dbe.GetComponentTable<CompD>();
+        var tailVSBS = ct.TailVSBS;
+        var ifi = ct.IndexedFieldInfos[0]; // Field A
+
+        unsafe
+        {
+            using var guard = EpochGuard.Enter(dbe.EpochManager);
+
+            // Check old key (1.0f) — preserved by preserveEmptyBuffer even though HEAD buffer is empty
+            float oldKey = 1.0f;
+            var accessor = ifi.Index.Segment.CreateChunkAccessor();
+            var oldHeadResult = ifi.Index.TryGet(&oldKey, ref accessor);
+            Assert.That(oldHeadResult.IsSuccess, Is.True, "Old key should be preserved in BTree (preserveEmptyBuffer)");
+
+            var oldTailBufferId = IndexBufferExtraHeader.FromChunkAddress(accessor.GetChunkAddress(oldHeadResult.Value)).TailBufferId;
+            Assert.That(oldTailBufferId, Is.GreaterThan(0), "Old key should have TAIL buffer linked");
+
+            var oldEntries = CollectTailEntries(tailVSBS, oldTailBufferId);
+            Assert.That(oldEntries.Exists(e => e.IsTombstone), Is.True, "Old key's TAIL should have a Tombstone");
+
+            // Check new key (5.0f) — should have Active entry
+            float newKey = 5.0f;
+            var newHeadResult = ifi.Index.TryGet(&newKey, ref accessor);
+            Assert.That(newHeadResult.IsSuccess, Is.True, "New key should exist in HEAD index");
+
+            var newTailBufferId = IndexBufferExtraHeader.FromChunkAddress(accessor.GetChunkAddress(newHeadResult.Value)).TailBufferId;
+            Assert.That(newTailBufferId, Is.GreaterThan(0), "New key should have TAIL buffer");
+
+            var newEntries = CollectTailEntries(tailVSBS, newTailBufferId);
+            Assert.That(newEntries.Exists(e => e.IsActive), Is.True, "New key's TAIL should have an Active entry");
+            accessor.Dispose();
+        }
+    }
+
+    [Test]
+    public void Delete_Entity_TailHasTombstone()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        long entityId;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(3.0f, 10, 4.0);
+            entityId = t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        // Capture TAIL buffer ID before delete (since BTree key may be removed)
+        var ct = dbe.GetComponentTable<CompD>();
+        var tailVSBS = ct.TailVSBS;
+        var ifi = ct.IndexedFieldInfos[0]; // Field A
+
+        int tailBufferIdBeforeDelete;
+        unsafe
+        {
+            using var guard = EpochGuard.Enter(dbe.EpochManager);
+            float key = 3.0f;
+            var accessor = ifi.Index.Segment.CreateChunkAccessor();
+            var headResult = ifi.Index.TryGet(&key, ref accessor);
+            Assert.That(headResult.IsSuccess, Is.True);
+            tailBufferIdBeforeDelete = IndexBufferExtraHeader.FromChunkAddress(accessor.GetChunkAddress(headResult.Value)).TailBufferId;
+            accessor.Dispose();
+        }
+
+        // Delete the entity
+        {
+            using var t = dbe.CreateQuickTransaction();
+            t.DeleteEntity<CompD>(entityId);
+            t.Commit();
+        }
+
+        // Verify TAIL has Tombstone (need epoch scope for EnumerateBuffer)
+        if (tailBufferIdBeforeDelete > 0)
+        {
+            using var guard2 = EpochGuard.Enter(dbe.EpochManager);
+            var entries = CollectTailEntries(tailVSBS, tailBufferIdBeforeDelete);
+            Assert.That(entries.Exists(e => e.IsTombstone), Is.True, "TAIL should have a Tombstone after delete");
+        }
+    }
+
+    [Test]
+    public void ExistingTests_NoRegression_HeadPathUnchanged()
+    {
+        // Verify that normal CRUD on CompD still works (HEAD path unchanged)
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        long e1;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(1.0f, 10, 2.0);
+            e1 = t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var res = t.ReadEntity(e1, out CompD read);
+            Assert.That(res, Is.True);
+            Assert.That(read.A, Is.EqualTo(1.0f));
+            Assert.That(read.B, Is.EqualTo(10));
+            Assert.That(read.C, Is.EqualTo(2.0));
+        }
+
+        // Update and verify
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(5.0f, 20, 6.0);
+            t.UpdateEntity(e1, ref d);
+            t.Commit();
+        }
+
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var res = t.ReadEntity(e1, out CompD read);
+            Assert.That(res, Is.True);
+            Assert.That(read.A, Is.EqualTo(5.0f));
+            Assert.That(read.B, Is.EqualTo(20));
+            Assert.That(read.C, Is.EqualTo(6.0));
+        }
+    }
+
+    #endregion
+
+    #region Phase 3 — Temporal Query Tests
+
+    [Test]
+    public unsafe void TemporalQuery_BeforeCreate_ReturnsEmpty()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        var tsnBeforeCreate = dbe.TransactionChain.NextFreeId;
+
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(1.0f, 10, 2.0);
+            t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var ifi = ct.IndexedFieldInfos[0]; // Field A
+        float key = 1.0f;
+
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var result = TemporalIndexQuery.Query(ifi, (byte*)&key, tsnBeforeCreate, ct.TailVSBS, null);
+        Assert.That(result.Count, Is.EqualTo(0), "No entities should be visible before creation TSN");
+    }
+
+    [Test]
+    public unsafe void TemporalQuery_AtCreate_ReturnsEntity()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        long tsnAtCreate;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            tsnAtCreate = t.TSN;
+            var d = new CompD(1.0f, 10, 2.0);
+            t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var ifi = ct.IndexedFieldInfos[0]; // Field A
+        float key = 1.0f;
+
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var result = TemporalIndexQuery.Query(ifi, (byte*)&key, tsnAtCreate, ct.TailVSBS, null);
+        Assert.That(result.Count, Is.EqualTo(1), "Entity should be visible at creation TSN");
+    }
+
+    [Test]
+    public unsafe void TemporalQuery_OldKey_AfterUpdate_SingleEntity_StillVisible()
+    {
+        // Single entity moves from key 1.0f to 5.0f. The old key's BTree entry is preserved
+        // (empty HEAD buffer) so that the TAIL version-history remains reachable.
+        // A temporal query at the creation TSN should still find the entity under the old key.
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        long entityId;
+        long tsnAtCreate;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            tsnAtCreate = t.TSN;
+            var d = new CompD(1.0f, 10, 2.0);
+            entityId = t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        // Update field A from 1.0f to 5.0f — last entity leaves the old key
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(5.0f, 10, 2.0);
+            t.UpdateEntity(entityId, ref d);
+            t.Commit();
+        }
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var ifi = ct.IndexedFieldInfos[0]; // Field A
+
+        // Query old key at creation TSN — entity should still be visible through TAIL
+        float oldKey = 1.0f;
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var result = TemporalIndexQuery.Query(ifi, (byte*)&oldKey, tsnAtCreate, ct.TailVSBS, null);
+        Assert.That(result.Count, Is.EqualTo(1), "Entity should be visible under old key at creation TSN through TAIL");
+    }
+
+    [Test]
+    public unsafe void TemporalQuery_OldKey_AfterUpdate_MultiEntity_CorrectCount()
+    {
+        // Two entities share key A=1.0f, then one moves to A=5.0f.
+        // A temporal query at the "both created" TSN should see 2 chain IDs for key 1.0f.
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        long entity1;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(1.0f, 10, 2.0);
+            entity1 = t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        long tsnAfterBothCreated;
+        {
+            using var t = dbe.CreateQuickTransaction();
+            tsnAfterBothCreated = t.TSN;
+            var d = new CompD(1.0f, 20, 3.0); // Same A=1.0f key (AllowMultiple), different B (unique index)
+            t.CreateEntity(ref d);
+            t.Commit();
+        }
+
+        // Update entity1's A from 1.0f to 5.0f
+        {
+            using var t = dbe.CreateQuickTransaction();
+            var d = new CompD(5.0f, 10, 2.0);
+            t.UpdateEntity(entity1, ref d);
+            t.Commit();
+        }
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var ifi = ct.IndexedFieldInfos[0]; // Field A
+
+        // Query old key at tsnAfterBothCreated — both entities should be visible
+        float oldKey = 1.0f;
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var result = TemporalIndexQuery.Query(ifi, (byte*)&oldKey, tsnAfterBothCreated, ct.TailVSBS, null);
+        Assert.That(result.Count, Is.EqualTo(2), "Both entities should be visible under old key at the TSN when both existed");
+    }
+
+    #endregion
+
+    #region Phase 5 — GC Tests
+
+    [Test]
+    public void TailGC_PruneOldEntries_KeepsBoundarySentinel()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var tailVSBS = ct.TailVSBS;
+
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var accessor = tailVSBS.Segment.CreateChunkAccessor();
+
+        // Manually create a TAIL buffer with entries at different TSNs
+        var bufferId = tailVSBS.AllocateBuffer(ref accessor);
+
+        tailVSBS.AddElement(bufferId, VersionedIndexEntry.Active(1, 100), ref accessor);   // Old
+        tailVSBS.AddElement(bufferId, VersionedIndexEntry.Tombstone(1, 200), ref accessor); // Boundary sentinel at retention
+        tailVSBS.AddElement(bufferId, VersionedIndexEntry.Active(1, 300), ref accessor);    // Future
+
+        // Prune with retentionTSN = 250 (should remove TSN=100, keep TSN=200 as sentinel, keep TSN=300)
+        var removed = TailGarbageCollector.Prune(tailVSBS, bufferId, 250, ref accessor, out var newBufferId);
+
+        Assert.That(removed, Is.EqualTo(1), "Should remove 1 old entry (TSN=100)");
+        Assert.That(newBufferId, Is.GreaterThan(0), "New buffer should have been allocated");
+
+        // Verify remaining entries: boundary sentinel (TSN=200) + future (TSN=300)
+        var remaining = CollectTailEntries(tailVSBS, newBufferId);
+        Assert.That(remaining.Count, Is.EqualTo(2), "Should have sentinel + future entry");
+        Assert.That(remaining.Exists(e => e.TSN == 200 && e.IsTombstone), Is.True, "Boundary sentinel should be kept");
+        Assert.That(remaining.Exists(e => e.TSN == 300 && e.IsActive), Is.True, "Future entry should be kept");
+
+        accessor.Dispose();
+    }
+
+    [Test]
+    public void TailGC_DeadChain_FullyRemoved()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var tailVSBS = ct.TailVSBS;
+
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var accessor = tailVSBS.Segment.CreateChunkAccessor();
+
+        // Chain with only old entries ending in Tombstone (dead chain)
+        var bufferId = tailVSBS.AllocateBuffer(ref accessor);
+        tailVSBS.AddElement(bufferId, VersionedIndexEntry.Active(1, 100), ref accessor);
+        tailVSBS.AddElement(bufferId, VersionedIndexEntry.Tombstone(1, 200), ref accessor);
+
+        // Prune with retentionTSN = 300 (both entries are old, sentinel is Tombstone, no future entries)
+        var removed = TailGarbageCollector.Prune(tailVSBS, bufferId, 300, ref accessor, out _);
+
+        Assert.That(removed, Is.EqualTo(2), "Dead chain should be fully removed (Active + Tombstone)");
+
+        accessor.Dispose();
+    }
+
+    [Test]
+    public void TailGC_NoOldEntries_NothingPruned()
+    {
+        using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        RegisterComponents(dbe);
+
+        var ct = dbe.GetComponentTable<CompD>();
+        var tailVSBS = ct.TailVSBS;
+
+        using var guard = EpochGuard.Enter(dbe.EpochManager);
+        var accessor = tailVSBS.Segment.CreateChunkAccessor();
+
+        var bufferId = tailVSBS.AllocateBuffer(ref accessor);
+        tailVSBS.AddElement(bufferId, VersionedIndexEntry.Active(1, 500), ref accessor);
+
+        // Prune with retentionTSN = 100 (all entries are in the future)
+        var removed = TailGarbageCollector.Prune(tailVSBS, bufferId, 100, ref accessor, out var newBufferId);
+        Assert.That(newBufferId, Is.EqualTo(bufferId), "Buffer ID should be unchanged when nothing is pruned");
+
+        Assert.That(removed, Is.EqualTo(0), "No entries should be removed when all are in the future");
+
+        accessor.Dispose();
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static List<VersionedIndexEntry> CollectTailEntries(VariableSizedBufferSegment<VersionedIndexEntry> tailVSBS, int tailBufferId)
+    {
+        var entries = new List<VersionedIndexEntry>();
+        foreach (ref readonly var entry in tailVSBS.EnumerateBuffer(tailBufferId))
+        {
+            entries.Add(entry);
+        }
+        return entries;
+    }
+
+    #endregion
+}

--- a/test/Typhon.Engine.Tests/Durability/PageCrcVerificationTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/PageCrcVerificationTests.cs
@@ -1,10 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
-using System;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Durability/SeqlockProtocolTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/SeqlockProtocolTests.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Typhon.Engine.Tests;

--- a/test/Typhon.Engine.Tests/Durability/WalRecoveryTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/WalRecoveryTests.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Storage/ManagedPagedMMFTests.cs
+++ b/test/Typhon.Engine.Tests/Storage/ManagedPagedMMFTests.cs
@@ -488,13 +488,13 @@ public class ManagedPagedMMFTests
             var id0 = vsb.AllocateBuffer(ref accessor);
             var elIdList = new int[15];
 
-            // 15 is spread into 3 chunks: 4, 7, 4
+            // 15 is spread into 3 chunks: 4, 7, 4 (root chunk has fewer due to header overhead)
             for (int i = 0; i < 15; i++)
             {
                 elIdList[i] = vsb.AddElement(id0, i, ref accessor);
             }
 
-            // Delete all the elements of the second chunk
+            // Delete all the elements of the second chunk (values 4-10)
             for (int i = 4; i < 11; i++)
             {
                 Assert.That(vsb.DeleteElement(id0, elIdList[i], i, ref accessor), Is.Not.EqualTo(-1));


### PR DESCRIPTION
## Summary

- Introduces TAIL version-history buffers for AllowMultiple secondary indexes, fixing two MVCC snapshot isolation bugs (stale reads and phantom reads)
- Adds `VersionedIndexEntry` struct (Active/Tombstone sign-encoded entries) and `IndexBufferExtraHeader` for typed HEAD→TAIL linkage
- Extends `VariableSizedBufferSegment` with generic `<T, TExtraHeader>` subclass for domain-specific extra headers without polluting the general-purpose root header
- Implements write path (TAIL appends on create/update/delete), read path (`TemporalIndexQuery`), and GC (`TailGarbageCollector`)
- Adds `IBTree.Add` overload with `out bufferRootId` to avoid redundant TryGet on create path

Closes #58, closes #59

## Test plan

- [x] 1450 existing tests pass with 0 failures
- [x] 18 new versioned index tests covering all phases (infrastructure, write path, temporal query, GC)
- [x] `VariableSizedBufferRootHeader` back to 32 bytes — non-index VSBS users unaffected
- [x] `ManagedPagedMMFTests` deletion range verified for restored root header size