### PR TITLE
Database file locking — prevent concurrent access (#155)

### DIFF
--- a/src/Typhon.Engine/Errors/DatabaseLockedException.cs
+++ b/src/Typhon.Engine/Errors/DatabaseLockedException.cs
@@ -1,0 +1,40 @@
+using JetBrains.Annotations;
+using System;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Thrown when a database file is already locked by another process.
+/// </summary>
+[PublicAPI]
+public class DatabaseLockedException : StorageException
+{
+    public DatabaseLockedException(string databasePath, int ownerPid, string ownerMachine, DateTimeOffset startedAt) : base(TyphonErrorCode.DatabaseLocked,
+            $"Database '{databasePath}' is locked by process {ownerPid} on '{ownerMachine}' (started {startedAt:u}). " +
+            $"Close the other process or delete the .lock file if the process has crashed.")
+    {
+        OwnerPid = ownerPid;
+        OwnerMachine = ownerMachine;
+        StartedAt = startedAt;
+    }
+
+    public DatabaseLockedException(string databasePath, int ownerPid, string ownerMachine, DateTimeOffset startedAt, Exception innerException) : 
+        base(TyphonErrorCode.DatabaseLocked,
+            $"Database '{databasePath}' is locked by process {ownerPid} on '{ownerMachine}' (started {startedAt:u}). " +
+            $"Close the other process or delete the .lock file if the process has crashed.",
+            innerException)
+    {
+        OwnerPid = ownerPid;
+        OwnerMachine = ownerMachine;
+        StartedAt = startedAt;
+    }
+
+    /// <summary>PID of the process that holds the lock.</summary>
+    public int OwnerPid { get; }
+
+    /// <summary>Machine name of the process that holds the lock.</summary>
+    public string OwnerMachine { get; }
+
+    /// <summary>When the owning process started.</summary>
+    public DateTimeOffset StartedAt { get; }
+}

--- a/src/Typhon.Engine/Errors/ThrowHelper.cs
+++ b/src/Typhon.Engine/Errors/ThrowHelper.cs
@@ -66,6 +66,11 @@ internal static class ThrowHelper
 
     [DoesNotReturn]
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowDatabaseLocked(string databasePath, int ownerPid, string ownerMachine, DateTimeOffset startedAt)
+        => throw new DatabaseLockedException(databasePath, ownerPid, ownerMachine, startedAt);
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static void ThrowPageCacheBackpressureTimeout(int dirtyPageCount, int epochProtectedCount, TimeSpan waitDuration)
         => throw new PageCacheBackpressureTimeoutException(dirtyPageCount, epochProtectedCount, waitDuration);
 

--- a/src/Typhon.Engine/Errors/TyphonErrorCode.cs
+++ b/src/Typhon.Engine/Errors/TyphonErrorCode.cs
@@ -6,35 +6,36 @@ namespace Typhon.Engine;
 /// Codes within a range are assigned sequentially as needed; gaps are intentional
 /// to allow insertion without renumbering.
 /// </summary>
-public enum TyphonErrorCode : int
+public enum TyphonErrorCode
 {
     // 0 — Unspecified / generic
-    Unspecified                 = 0,
+    Unspecified                     = 0,
 
     // 1xxx — Transaction
-    TransactionTimeout          = 1002,
+    TransactionTimeout              = 1002,
 
     // 2xxx — Storage
-    DataCorruption              = 2003,
-    StorageCapacityExceeded     = 2004,
-    PageChecksumMismatch        = 2005,
-    PageCacheBackpressureTimeout = 2006,
+    DataCorruption                  = 2003,
+    StorageCapacityExceeded         = 2004,
+    PageChecksumMismatch            = 2005,
+    PageCacheBackpressureTimeout    = 2006,
+    DatabaseLocked                  = 2007,
 
     // 3xxx — Component
-    SchemaValidation            = 3001,
-    SchemaMigration             = 3002,
+    SchemaValidation                = 3001,
+    SchemaMigration                 = 3002,
 
     // 4xxx — Index
-    UniqueConstraintViolation   = 4001,
+    UniqueConstraintViolation       = 4001,
     // 5xxx — Query (reserved)
 
     // 6xxx — Resource
-    ResourceExhausted           = 6001,
-    LockTimeout                 = 6003,
+    ResourceExhausted               = 6001,
+    LockTimeout                     = 6003,
 
     // 7xxx — Durability
-    WalBackPressureTimeout      = 7001,
-    WalClaimTooLarge            = 7002,
-    WalWriteFailure             = 7003,
-    WalSegmentError             = 7004,
+    WalBackPressureTimeout          = 7001,
+    WalClaimTooLarge                = 7002,
+    WalWriteFailure                 = 7003,
+    WalSegmentError                 = 7004,
 }

--- a/src/Typhon.Engine/Storage/PagedMMF.cs
+++ b/src/Typhon.Engine/Storage/PagedMMF.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -150,6 +151,7 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
     
     private SafeFileHandle _fileHandle;
     private long _fileSize;
+    private string _lockFilePath;
     private readonly IPageCacheBackpressureStrategy _backpressureStrategy;
 
     /// <summary>
@@ -249,6 +251,10 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
 
         try
         {
+            // Acquire advisory lock file before opening the database
+            _lockFilePath = BuildLockFilePath();
+            AcquireLockFile();
+
             // Init or load the file
             var filePathName = Options.BuildDatabasePathFileName();
             var fi = new FileInfo(filePathName);
@@ -262,6 +268,12 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
                 LoadFile();
             }
             Logger.LogInformation("Virtual Disk Manager service initialized successfully");
+        }
+        catch (DatabaseLockedException)
+        {
+            // Lock violation — propagate without wrapping for clear diagnostics
+            ReleaseLockFile();
+            throw;
         }
         catch (Exception e)
         {
@@ -280,12 +292,136 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
         }
     }
 
+    #region Lock File
+
+    private string BuildLockFilePath() => Path.Combine(Options.DatabaseDirectory, $"{Options.DatabaseName}.lock");
+
+    /// <summary>
+    /// Checks for an existing advisory lock file and creates a new one.
+    /// If a stale lock file is found (dead PID), it is deleted with a warning.
+    /// If a live lock file is found, throws <see cref="DatabaseLockedException"/>.
+    /// </summary>
+    private void AcquireLockFile()
+    {
+        if (File.Exists(_lockFilePath))
+        {
+            try
+            {
+                var json = File.ReadAllText(_lockFilePath);
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                var pid = root.GetProperty("pid").GetInt32();
+                var machineName = root.GetProperty("machineName").GetString() ?? "unknown";
+                var startedAt = root.TryGetProperty("startedAt", out var ts) ? 
+                    DateTimeOffset.Parse(ts.GetString() ?? string.Empty) : DateTimeOffset.MinValue;
+
+                if (!string.Equals(machineName, Environment.MachineName, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Different machine — cannot verify PID remotely, treat as live
+                    ThrowHelper.ThrowDatabaseLocked(Options.BuildDatabasePathFileName(), pid, machineName, startedAt);
+                }
+
+                if (IsProcessAlive(pid))
+                {
+                    ThrowHelper.ThrowDatabaseLocked(Options.BuildDatabasePathFileName(), pid, machineName, startedAt);
+                }
+
+                // Stale lock — process is dead, delete and proceed
+                Logger.LogWarning("Stale lock file detected for PID {Pid} (started {StartedAt:u}). Previous process may have crashed. Removing lock file",
+                    pid, startedAt);
+                DeleteFileAndWait(_lockFilePath);
+            }
+            catch (DatabaseLockedException)
+            {
+                throw; // Re-throw lock exceptions
+            }
+            catch (Exception ex)
+            {
+                // Corrupt or unreadable lock file — delete and proceed with a warning
+                Logger.LogWarning(ex, "Lock file '{LockFilePath}' is corrupt or unreadable. Removing it", _lockFilePath);
+                try { DeleteFileAndWait(_lockFilePath); } catch { /* best effort */ }
+            }
+        }
+
+        // Write new lock file
+        try
+        {
+            var lockContent = JsonSerializer.Serialize(new
+            {
+                pid = Environment.ProcessId,
+                startedAt = DateTimeOffset.UtcNow.ToString("o"),
+                machineName = Environment.MachineName
+            });
+            File.WriteAllText(_lockFilePath, lockContent);
+        }
+        catch (Exception ex)
+        {
+            // Lock file creation failed — log warning but proceed (OS file share is the real protection)
+            Logger.LogWarning(ex, "Failed to create lock file '{LockFilePath}'. OS-level file sharing will still prevent concurrent access", _lockFilePath);
+        }
+    }
+
+    /// <summary>
+    /// Deletes the advisory lock file if it exists.
+    /// </summary>
+    private void ReleaseLockFile()
+    {
+        try
+        {
+            if (_lockFilePath != null)
+            {
+                DeleteFileAndWait(_lockFilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to delete lock file '{LockFilePath}'", _lockFilePath);
+        }
+    }
+
+    private static bool IsProcessAlive(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            // Process does not exist
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Deletes a file and polls until the NTFS pending-delete completes.
+    /// On Windows, <see cref="File.Delete"/> returns immediately but the directory entry removal is deferred — <see cref="File.Exists"/> can return true
+    /// briefly after deletion.
+    /// Without polling, a subsequent <see cref="File.WriteAllText"/> to the same path can fail with <see cref="IOException"/>.
+    /// </summary>
+    private static void DeleteFileAndWait(string path, int maxWaitMs = 500)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        File.Delete(path);
+        var sw = Stopwatch.StartNew();
+        while (File.Exists(path) && sw.ElapsedMilliseconds < maxWaitMs)
+        {
+            Thread.Sleep(1);
+        }
+    }
+
+    #endregion
+
     private void CreateFile()
     {
         // Create the Files
         var filePathName = Options.BuildDatabasePathFileName();
 
-        _fileHandle = File.OpenHandle(filePathName, FileMode.Create, FileAccess.ReadWrite, FileShare.None, FileOptions.Asynchronous | FileOptions.RandomAccess);
+        _fileHandle = File.OpenHandle(filePathName, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, FileOptions.Asynchronous | FileOptions.RandomAccess);
         _fileSize = 0L;
 
         Logger.LogInformation("Create Database '{DatabaseName}' in file '{FilePathName}'", Options.DatabaseName, filePathName);
@@ -303,7 +439,7 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
     {
         // Create the Files
         var filePathName = Options.BuildDatabasePathFileName();
-        _fileHandle = File.OpenHandle(filePathName, FileMode.Open, FileAccess.ReadWrite, FileShare.None, FileOptions.Asynchronous|FileOptions.RandomAccess);
+        _fileHandle = File.OpenHandle(filePathName, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, FileOptions.Asynchronous | FileOptions.RandomAccess);
         {
             var fi = new FileInfo(filePathName);
             _fileSize = fi.Length;
@@ -337,7 +473,9 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
                 _fileHandle.Dispose();
                 _fileHandle = null;
             }
-        
+
+            ReleaseLockFile();
+
             _memPagesInfo = null;
             _memPagesAddr = null;
             _backpressureStrategy.Dispose();
@@ -714,28 +852,25 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
                         }
                     }
 
-                    if (!found)
+                    ++_metrics.BackpressureWaitCount;
+
+                    Logger.LogWarning(
+                        "Page cache backpressure: wait#{WaitCount} dirty={DirtyCount} epoch={EpochCount} retry={RetryCount} remaining={RemainingMs}ms",
+                        _metrics.BackpressureWaitCount, dirtyCount, epochCount, bpCtx.RetryCount, bpCtx.WaitContext.Remaining.TotalMilliseconds);
+
+                    // Demand-driven flush: wake the checkpoint manager immediately so dirty pages get written to
+                    // disk → DecrementDirty → SignalPageAvailable → waiter wakes.
+                    // Idempotent — safe to call on every retry iteration.
+                    OnBackpressure?.Invoke();
+
+                    if (!_backpressureStrategy.OnPressure(ref bpCtx, dirtyCount, epochCount))
                     {
-                        ++_metrics.BackpressureWaitCount;
-
-                        Logger.LogWarning(
-                            "Page cache backpressure: wait#{WaitCount} dirty={DirtyCount} epoch={EpochCount} retry={RetryCount} remaining={RemainingMs}ms",
-                            _metrics.BackpressureWaitCount, dirtyCount, epochCount, bpCtx.RetryCount, bpCtx.WaitContext.Remaining.TotalMilliseconds);
-
-                        // Demand-driven flush: wake the checkpoint manager immediately so dirty pages get written to
-                        // disk → DecrementDirty → SignalPageAvailable → waiter wakes.
-                        // Idempotent — safe to call on every retry iteration.
-                        OnBackpressure?.Invoke();
-
-                        if (!_backpressureStrategy.OnPressure(ref bpCtx, dirtyCount, epochCount))
-                        {
-                            ThrowHelper.ThrowPageCacheBackpressureTimeout(
-                                dirtyCount, epochCount,
-                                TimeoutOptions.Current.PageCacheBackpressureTimeout - bpCtx.WaitContext.Remaining);
-                        }
-
-                        continue;
+                        ThrowHelper.ThrowPageCacheBackpressureTimeout(
+                            dirtyCount, epochCount,
+                            TimeoutOptions.Current.PageCacheBackpressureTimeout - bpCtx.WaitContext.Remaining);
                     }
+
+                    continue;
                 }
             }
 
@@ -1034,7 +1169,7 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
                     FilePageIndex = filePageIndex,
                     SegmentId = 0,
                     ChangeRevision = headerAddr->ChangeRevision,
-                    UncompressedSize = (ushort)PageSize,
+                    UncompressedSize = PageSize,
                     CompressionAlgo = useCompression ? FpiCompression.AlgoLZ4 : FpiCompression.AlgoNone,
                     Reserved = 0,
                 };

--- a/src/Typhon.Engine/Storage/PagedMMFOptions.cs
+++ b/src/Typhon.Engine/Storage/PagedMMFOptions.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace Typhon.Engine;
 
@@ -39,14 +40,35 @@ public class PagedMMFOptions
         try
         {
             var pfn = BuildDatabasePathFileName();
-            if (File.Exists(pfn))
-            {
-                File.Delete(pfn);
-            }
+            DeleteAndWait(pfn);
+
+            var lockPath = Path.Combine(DatabaseDirectory, $"{DatabaseName}.lock");
+            DeleteAndWait(lockPath);
         }
         catch (Exception)
         {
             // ignored
+        }
+    }
+
+    /// <summary>
+    /// Deletes a file and polls until the NTFS pending-delete completes.
+    /// On Windows, <see cref="File.Delete"/> returns immediately but the directory entry
+    /// removal is deferred — subsequent operations on the same path can fail without this wait.
+    /// </summary>
+    private static void DeleteAndWait(string path, int maxWaitMs = 500)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        File.Delete(path);
+        var sw = new System.Diagnostics.Stopwatch();
+        sw.Start();
+        while (File.Exists(path) && sw.ElapsedMilliseconds < maxWaitMs)
+        {
+            Thread.Sleep(1);
         }
     }
     

--- a/test/Typhon.Engine.Tests/Storage/DatabaseFileLockingTests.cs
+++ b/test/Typhon.Engine.Tests/Storage/DatabaseFileLockingTests.cs
@@ -1,0 +1,285 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using Serilog;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+namespace Typhon.Engine.Tests;
+
+class DatabaseFileLockingTests
+{
+    private string _testDir;
+
+    [SetUp]
+    public void Setup()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "Typhon.Tests", nameof(DatabaseFileLockingTests));
+        Directory.CreateDirectory(_testDir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Log.CloseAndFlush();
+
+        // Clean up test files — best effort
+        try
+        {
+            if (Directory.Exists(_testDir))
+            {
+                foreach (var file in Directory.GetFiles(_testDir))
+                {
+                    try { File.Delete(file); } catch { }
+                }
+            }
+        }
+        catch { }
+    }
+
+    /// <summary>
+    /// Creates a DI service provider configured for the given database name.
+    /// Calls EnsureFileDeleted to start clean.
+    /// </summary>
+    private IServiceProvider BuildServiceProvider(string dbName)
+    {
+        var sc = new ServiceCollection();
+        sc.AddLogging(builder =>
+            {
+                builder.AddSimpleConsole(options =>
+                {
+                    options.SingleLine = true;
+                    options.IncludeScopes = true;
+                    options.TimestampFormat = "mm:ss.fff ";
+                });
+                builder.SetMinimumLevel(LogLevel.Information);
+            })
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddHighResolutionSharedTimer()
+            .AddDeadlineWatchdog()
+            .AddScopedManagedPagedMemoryMappedFile(options =>
+            {
+                options.DatabaseName = dbName;
+                options.DatabaseDirectory = _testDir;
+                options.DatabaseCacheSize = PagedMMF.MinimumCacheSize;
+            })
+            .AddScopedDatabaseEngine(_ => { });
+
+        var sp = sc.BuildServiceProvider();
+        sp.EnsureFileDeleted<ManagedPagedMMFOptions>();
+        return sp;
+    }
+
+    [Test]
+    public void LockFile_Created_Deleted()
+    {
+        var dbName = "lock_create";
+        var lockPath = Path.Combine(_testDir, $"{dbName}.lock");
+
+        var sp = BuildServiceProvider(dbName);
+        var dbe = sp.GetRequiredService<DatabaseEngine>();
+
+        // Lock file should exist while database is open
+        Assert.That(File.Exists(lockPath), Is.True, "Lock file should be created on database open");
+
+        // Verify lock file content
+        var json = File.ReadAllText(lockPath);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.That(root.GetProperty("pid").GetInt32(), Is.EqualTo(Environment.ProcessId));
+        Assert.That(root.GetProperty("machineName").GetString(), Is.EqualTo(Environment.MachineName));
+        Assert.That(root.TryGetProperty("startedAt", out _), Is.True);
+
+        // Dispose — lock file should be deleted
+        (sp as IDisposable)?.Dispose();
+        Assert.That(File.Exists(lockPath), Is.False, "Lock file should be deleted on database close");
+    }
+
+    [Test]
+    public void StaleLock_DeadPid()
+    {
+        var dbName = "lock_stale";
+        var lockPath = Path.Combine(_testDir, $"{dbName}.lock");
+
+        // Build provider first (cleans up), then plant lock file before engine creation
+        var sp = BuildServiceProvider(dbName);
+
+        // Find a dead PID
+        var deadPid = 99999;
+        while (IsProcessAlive(deadPid))
+        {
+            deadPid++;
+        }
+
+        // Plant stale lock file AFTER EnsureFileDeleted but BEFORE engine creation
+        File.WriteAllText(lockPath, JsonSerializer.Serialize(new
+        {
+            pid = deadPid,
+            startedAt = DateTimeOffset.UtcNow.AddHours(-1).ToString("o"),
+            machineName = Environment.MachineName
+        }));
+
+        // Opening database should succeed (stale lock detected and removed)
+        var dbe = sp.GetRequiredService<DatabaseEngine>();
+
+        // New lock file should have current PID
+        var json = File.ReadAllText(lockPath);
+        using var doc = JsonDocument.Parse(json);
+        Assert.That(doc.RootElement.GetProperty("pid").GetInt32(), Is.EqualTo(Environment.ProcessId));
+
+        (sp as IDisposable)?.Dispose();
+    }
+
+    [Test]
+    public void LiveLock_Throws()
+    {
+        var dbName = "lock_live";
+        var lockPath = Path.Combine(_testDir, $"{dbName}.lock");
+
+        // Build provider first, then plant lock file
+        var sp = BuildServiceProvider(dbName);
+
+        File.WriteAllText(lockPath, JsonSerializer.Serialize(new
+        {
+            pid = Environment.ProcessId,
+            startedAt = DateTimeOffset.UtcNow.ToString("o"),
+            machineName = Environment.MachineName
+        }));
+
+        // Opening database should throw DatabaseLockedException
+        var ex = Assert.Throws<DatabaseLockedException>(() => sp.GetRequiredService<DatabaseEngine>());
+        Assert.That(ex.OwnerPid, Is.EqualTo(Environment.ProcessId));
+        Assert.That(ex.OwnerMachine, Is.EqualTo(Environment.MachineName));
+
+        (sp as IDisposable)?.Dispose();
+
+        // Clean up
+        if (File.Exists(lockPath))
+        {
+            File.Delete(lockPath);
+        }
+    }
+
+    [Test]
+    public void CrossMachineLock_Throws()
+    {
+        var dbName = "lock_remote";
+        var lockPath = Path.Combine(_testDir, $"{dbName}.lock");
+
+        // Build provider first, then plant lock file
+        var sp = BuildServiceProvider(dbName);
+
+        File.WriteAllText(lockPath, JsonSerializer.Serialize(new
+        {
+            pid = 1,
+            startedAt = DateTimeOffset.UtcNow.ToString("o"),
+            machineName = "REMOTE-SERVER-42"
+        }));
+
+        // Opening database should throw — can't verify remote PID, treat as live
+        var ex = Assert.Throws<DatabaseLockedException>(() => sp.GetRequiredService<DatabaseEngine>());
+        Assert.That(ex.OwnerMachine, Is.EqualTo("REMOTE-SERVER-42"));
+
+        (sp as IDisposable)?.Dispose();
+
+        // Clean up
+        if (File.Exists(lockPath))
+        {
+            File.Delete(lockPath);
+        }
+    }
+
+    [Test]
+    public void CorruptLockFile_Removed()
+    {
+        var dbName = "lock_corrupt";
+        var lockPath = Path.Combine(_testDir, $"{dbName}.lock");
+
+        // Build provider first, then plant corrupt lock file
+        var sp = BuildServiceProvider(dbName);
+        File.WriteAllText(lockPath, "this is not valid json {{{");
+
+        // Opening database should succeed (corrupt lock file removed with warning)
+        var dbe = sp.GetRequiredService<DatabaseEngine>();
+
+        // New lock file should have current PID
+        var json = File.ReadAllText(lockPath);
+        using var doc = JsonDocument.Parse(json);
+        Assert.That(doc.RootElement.GetProperty("pid").GetInt32(), Is.EqualTo(Environment.ProcessId));
+
+        (sp as IDisposable)?.Dispose();
+    }
+
+    [Test]
+    public void FileShare_AllowsRead()
+    {
+        var dbName = "lock_share_r";
+        var dbPath = Path.Combine(_testDir, $"{dbName}.bin");
+
+        var sp = BuildServiceProvider(dbName);
+        var dbe = sp.GetRequiredService<DatabaseEngine>();
+
+        // Another reader should be able to open the file for reading
+        using var readHandle = File.OpenHandle(dbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        Assert.That(readHandle.IsInvalid, Is.False, "Read-only access should succeed while database is open");
+
+        (sp as IDisposable)?.Dispose();
+    }
+
+    [Test]
+    public void FileShare_PreventsWrite()
+    {
+        var dbName = "lock_share_w";
+        var dbPath = Path.Combine(_testDir, $"{dbName}.bin");
+
+        var sp = BuildServiceProvider(dbName);
+        var dbe = sp.GetRequiredService<DatabaseEngine>();
+
+        // Another writer should be blocked
+        Assert.Throws<IOException>(() =>
+        {
+            using var writeHandle = File.OpenHandle(dbPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+        });
+
+        (sp as IDisposable)?.Dispose();
+    }
+
+    [Test]
+    public void EnsureDeleted_RemovesLock()
+    {
+        var dbName = "lock_ensure";
+        var lockPath = Path.Combine(_testDir, $"{dbName}.lock");
+        var dbPath = Path.Combine(_testDir, $"{dbName}.bin");
+
+        // Create both files manually
+        File.WriteAllText(dbPath, "dummy");
+        File.WriteAllText(lockPath, "dummy");
+
+        var options = new PagedMMFOptions
+        {
+            DatabaseName = dbName,
+            DatabaseDirectory = _testDir
+        };
+        options.EnsureFileDeleted();
+
+        Assert.That(File.Exists(dbPath), Is.False, "Database file should be deleted");
+        Assert.That(File.Exists(lockPath), Is.False, "Lock file should be deleted");
+    }
+
+    private static bool IsProcessAlive(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **OS-level `FileShare.Read`**: Changed from `FileShare.None` to `FileShare.Read` in `PagedMMF.CreateFile()` and `LoadFile()`. Backup tools can read while database is open; concurrent writers get `IOException` from the OS kernel.
- **Advisory `.lock` file**: JSON lock file (`pid`, `startedAt`, `machineName`) created on database open, deleted on close. Provides clear error messages and handles stale-lock-after-crash via PID liveness check. Cross-machine locks (different `machineName`) are treated as live (conservative).
- **`DatabaseLockedException`**: New `StorageException` subclass (error code `DatabaseLocked = 2007`) that propagates unwrapped for clear diagnostics.
- **Windows NTFS pending-delete**: `DeleteFileAndWait` polls after `File.Delete` until the directory entry is actually removed, preventing `IOException` on subsequent `WriteAllText` to the same path.

## Changed Files (6 files, +530 / -42)

- `PagedMMF.cs` — `FileShare.Read`, lock file acquire/release, `DeleteFileAndWait`, `DatabaseLockedException` passthrough in constructor
- `PagedMMFOptions.cs` — `EnsureFileDeleted` also removes `.lock` file, `DeleteAndWait` for NTFS
- `DatabaseLockedException.cs` — New exception with PID, machine name, timestamp
- `TyphonErrorCode.cs` — `DatabaseLocked = 2007`
- `ThrowHelper.cs` — `ThrowDatabaseLocked(...)` 
- `DatabaseFileLockingTests.cs` — 8 tests (lock create/delete, stale PID, live PID, cross-machine, corrupt, FileShare read/write, EnsureDeleted)

## Test Plan

- [x] Lock file created on open, deleted on close
- [x] Stale lock (dead PID) detected and cleaned up
- [x] Live lock (current process PID) throws `DatabaseLockedException`
- [x] Cross-machine lock throws (cannot verify remote PID)
- [x] Corrupt lock file removed gracefully
- [x] `FileShare.Read` allows read-only access by other processes
- [x] `FileShare.Read` prevents concurrent write access
- [x] `EnsureFileDeleted` removes both `.bin` and `.lock` files

Closes #155