### PR TITLE
Runtime profiler: trace format, file/live inspectors, viewer UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ x64/
 x86/
 bld/
 [Bb]in/
-[Tt]ools/
 [Oo]bj/
 [Ll]og/
 

--- a/Typhon.slnx
+++ b/Typhon.slnx
@@ -14,6 +14,7 @@
         <Project Path="src/Typhon.Client/Typhon.Client.csproj" />
         <Project Path="src/Typhon.Shell/Typhon.Shell.csproj" />
         <Project Path="src/Typhon.Shell.Extensibility/Typhon.Shell.Extensibility.csproj" />
+        <Project Path="src/Typhon.Profiler/Typhon.Profiler.csproj" />
     </Folder>
     <Folder Name="/test/">
         <Project Path="test/AntHill/AntHill.csproj">
@@ -25,5 +26,8 @@
         <Project Path="test/Typhon.Client.Tests/Typhon.Client.Tests.csproj" />
         <Project Path="test/Typhon.Engine.Tests/Typhon.Engine.Tests.csproj" />
         <Project Path="test/Typhon.MonitoringDemo/Typhon.MonitoringDemo.csproj" />
+    </Folder>
+    <Folder Name="/tools/">
+        <Project Path="tools/Typhon.Profiler.Server/Typhon.Profiler.Server.csproj" />
     </Folder>
 </Solution>

--- a/src/Typhon.Engine/Data/SpatialIndex/SpatialRTree.Query.cs
+++ b/src/Typhon.Engine/Data/SpatialIndex/SpatialRTree.Query.cs
@@ -493,7 +493,9 @@ internal unsafe partial class SpatialRTree<TStore>
                 aabb[d] = center[d] - radius;
                 aabb[d + halfCoord] = center[d] + radius;
             }
+#pragma warning disable CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
             _inner = new AABBQueryEnumerator(tree, aabb, changeSet, categoryMask);
+#pragma warning restore CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
         }
 
         public SpatialQueryResult Current => _inner.Current;

--- a/src/Typhon.Engine/Observability/TelemetryConfig.cs
+++ b/src/Typhon.Engine/Observability/TelemetryConfig.cs
@@ -285,6 +285,13 @@ public static class TelemetryConfig
     /// </summary>
     public static readonly bool SchedulerActive;
 
+    /// <summary>
+    /// Whether deep trace recording is enabled (per-chunk, per-worker events written to <c>.typhon-trace</c> file).
+    /// When true, the scheduler emits <see cref="IRuntimeInspector"/> callbacks for every system ready/chunk start/chunk end event.
+    /// Overhead: ~20-30 ns per event (~3-4 µs per tick for a 20-system DAG). Default: false.
+    /// </summary>
+    public static readonly bool SchedulerDeepTrace;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // CONFIGURATION SOURCE TRACKING (for diagnostics)
     // ═══════════════════════════════════════════════════════════════════════════
@@ -367,6 +374,7 @@ public static class TelemetryConfig
         SchedulerTrackTransitionLatency = schedSection.GetValue("TrackTransitionLatency", true);
         SchedulerTrackWorkerUtilization = schedSection.GetValue("TrackWorkerUtilization", true);
         SchedulerTrackStragglerGap = schedSection.GetValue("TrackStragglerGap", true);
+        SchedulerDeepTrace = schedSection.GetValue("DeepTrace", false);
         SchedulerActive = Enabled && SchedulerEnabled;
     }
 
@@ -454,7 +462,8 @@ public static class TelemetryConfig
 
            Scheduler: Active={SchedulerActive}
              Enabled={SchedulerEnabled}, TransitionLatency={SchedulerTrackTransitionLatency},
-             WorkerUtilization={SchedulerTrackWorkerUtilization}, StragglerGap={SchedulerTrackStragglerGap}
+             WorkerUtilization={SchedulerTrackWorkerUtilization}, StragglerGap={SchedulerTrackStragglerGap},
+             DeepTrace={SchedulerDeepTrace}
          """;
 
     /// <summary>

--- a/src/Typhon.Engine/Runtime/DagScheduler.Inspector.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.Inspector.cs
@@ -1,0 +1,110 @@
+using System.Runtime.CompilerServices;
+
+namespace Typhon.Engine;
+
+public partial class DagScheduler
+{
+    /// <summary>
+    /// Sets the runtime inspector for deep tracing. Must be called before <see cref="Start"/>.
+    /// Only effective when <see cref="TelemetryConfig.SchedulerDeepTrace"/> is true.
+    /// </summary>
+    internal void SetInspector(IRuntimeInspector inspector)
+    {
+        if (!TelemetryConfig.SchedulerDeepTrace)
+        {
+            return;
+        }
+
+        _inspector = inspector;
+        _inspector.OnSchedulerStarted(Systems, _workerCount, _options.BaseTickRate);
+    }
+
+    /// <summary>Notify inspector that a tick has started.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorTickStart(long tickNumber, long timestamp)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnTickStart(tickNumber, timestamp);
+        }
+    }
+
+    /// <summary>Notify inspector that a tick has ended.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorTickEnd(long tickNumber, long timestamp)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnTickEnd(tickNumber, timestamp);
+        }
+    }
+
+    /// <summary>Notify inspector that a system became ready.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorSystemReady(int sysIdx, long timestamp)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnSystemReady(sysIdx, timestamp);
+        }
+    }
+
+    /// <summary>Notify inspector that a system was skipped.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorSystemSkipped(int sysIdx, SkipReason reason, long timestamp)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnSystemSkipped(sysIdx, reason, timestamp);
+        }
+    }
+
+    /// <summary>Notify inspector that a chunk started executing.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorChunkStart(int sysIdx, int chunkIndex, int workerId, long timestamp, int totalChunks)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnChunkStart(sysIdx, chunkIndex, workerId, timestamp, totalChunks);
+        }
+    }
+
+    /// <summary>Notify inspector that a chunk finished executing.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorChunkEnd(int sysIdx, int chunkIndex, int workerId, long timestamp, int entitiesProcessed)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnChunkEnd(sysIdx, chunkIndex, workerId, timestamp, entitiesProcessed);
+        }
+    }
+
+    /// <summary>Notify inspector of a phase transition.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorPhaseStart(TickPhase phase, long timestamp)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnPhaseStart(phase, timestamp);
+        }
+    }
+
+    /// <summary>Notify inspector of a phase end.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void InspectorPhaseEnd(TickPhase phase, long timestamp)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnPhaseEnd(phase, timestamp);
+        }
+    }
+
+    /// <summary>Flush inspector data and notify shutdown.</summary>
+    private void InspectorShutdown()
+    {
+        if (TelemetryConfig.SchedulerDeepTrace)
+        {
+            _inspector?.OnSchedulerStopping();
+        }
+    }
+}

--- a/src/Typhon.Engine/Runtime/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.cs
@@ -101,6 +101,9 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     private readonly long[] _workerActiveTicks;
     private readonly long[] _workerIdleTicks;
 
+    // Deep trace inspector (optional, guarded by TelemetryConfig.SchedulerDeepTrace)
+    private IRuntimeInspector _inspector;
+
     // ═══════════════════════════════════════════════════════════════
     // Tick lifecycle hooks (set by TyphonRuntime)
     // ═══════════════════════════════════════════════════════════════
@@ -318,6 +321,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     public void Shutdown()
     {
         LogShutdownRequested();
+        InspectorShutdown();
 
         // Signal workers to exit
         _workerShutdown = 1;
@@ -391,16 +395,19 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
         // 2. Tick start hook (TyphonRuntime creates UoW)
         TickStartCallback?.Invoke(this);
+        InspectorTickStart(_currentTickNumber, tickStartTimestamp);
 
         // 3. Mark root systems ready (evaluate runIf and ReactiveSkip for roots before waking workers)
         var readyNow = Stopwatch.GetTimestamp();
         foreach (var root in _rootSystems)
         {
             _currentTickSystemMetrics[root].ReadyTick = readyNow;
+            InspectorSystemReady(root, readyNow);
             var sys = Systems[root];
             if (sys.RunIf != null && !sys.RunIf())
             {
                 _currentTickSystemMetrics[root].SkipReason = SkipReason.RunIfFalse;
+                InspectorSystemSkipped(root, SkipReason.RunIfFalse, Stopwatch.GetTimestamp());
                 // Skip root — dispatch its successors immediately.
                 // Safe to call here: workers haven't woken yet.
                 OnSystemComplete(root, -1, false);
@@ -408,6 +415,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             else if (sys.ReactiveSkip != null && sys.ReactiveSkip())
             {
                 _currentTickSystemMetrics[root].SkipReason = SkipReason.EmptyInput;
+                InspectorSystemSkipped(root, SkipReason.EmptyInput, Stopwatch.GetTimestamp());
                 OnSystemComplete(root, -1, false);
             }
             else
@@ -416,6 +424,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                 if (overloadSkip != SkipReason.NotSkipped)
                 {
                     _currentTickSystemMetrics[root].SkipReason = overloadSkip;
+                    InspectorSystemSkipped(root, overloadSkip, Stopwatch.GetTimestamp());
                     OnSystemComplete(root, -1, false);
                 }
                 else if (sys.IsParallelQuery)
@@ -450,6 +459,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         TickEndCallback?.Invoke(this);
 
         var tickEndTimestamp = Stopwatch.GetTimestamp();
+        InspectorTickEnd(_currentTickNumber, tickEndTimestamp);
 
         // 6. Record telemetry
         //    Note: _nextTickTimestamp is updated by GetNextTick() which the base timer loop
@@ -479,6 +489,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
         // Tick start hook
         TickStartCallback?.Invoke(this);
+        InspectorTickStart(_currentTickNumber, tickStartTimestamp);
 
         // Execute in topological order
         for (var i = 0; i < _topologicalOrder.Length; i++)
@@ -488,11 +499,13 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
             var readyTick = Stopwatch.GetTimestamp();
             _currentTickSystemMetrics[sysIdx].ReadyTick = readyTick;
+            InspectorSystemReady(sysIdx, readyTick);
 
             // Check if a predecessor failed
             if (_systemFailed[sysIdx])
             {
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.DependencyFailed;
+                InspectorSystemSkipped(sysIdx, SkipReason.DependencyFailed, Stopwatch.GetTimestamp());
                 // Propagate failure to successors
                 foreach (var succ in sys.Successors)
                 {
@@ -506,12 +519,14 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             if (sys.RunIf != null && !sys.RunIf())
             {
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.RunIfFalse;
+                InspectorSystemSkipped(sysIdx, SkipReason.RunIfFalse, Stopwatch.GetTimestamp());
                 continue;
             }
 
             if (sys.ReactiveSkip != null && sys.ReactiveSkip())
             {
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.EmptyInput;
+                InspectorSystemSkipped(sysIdx, SkipReason.EmptyInput, Stopwatch.GetTimestamp());
                 continue;
             }
 
@@ -520,6 +535,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                 if (overloadSkip != SkipReason.NotSkipped)
                 {
                     _currentTickSystemMetrics[sysIdx].SkipReason = overloadSkip;
+                    InspectorSystemSkipped(sysIdx, overloadSkip, Stopwatch.GetTimestamp());
                     continue;
                 }
             }
@@ -622,6 +638,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         TickEndCallback?.Invoke(this);
 
         var tickEndTimestamp = Stopwatch.GetTimestamp();
+        InspectorTickEnd(_currentTickNumber, tickEndTimestamp);
         ComputeAndRecordTelemetry(tickStartTimestamp, tickEndTimestamp);
     }
 
@@ -777,6 +794,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         var ctx = SystemStartCallback?.Invoke(sysIdx) ?? new TickContext { TickNumber = _currentTickNumber, DeltaTime = 0f };
         var workStart = Stopwatch.GetTimestamp();
         RecordFirstChunkGrab(sysIdx, workStart);
+        InspectorChunkStart(sysIdx, 0, workerId, workStart, 1);
 
         var success = true;
         try
@@ -796,6 +814,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             SystemEndCallback?.Invoke(sysIdx, success);
 
             var workEnd = Stopwatch.GetTimestamp();
+            InspectorChunkEnd(sysIdx, 0, workerId, workEnd, _currentTickSystemMetrics[sysIdx].EntitiesProcessed);
             if (trackUtilization)
             {
                 _workerActiveTicks[workerId] += workEnd - workStart;
@@ -833,6 +852,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             }
 
             var workStart = Stopwatch.GetTimestamp();
+            InspectorChunkStart(sysIdx, chunk, workerId, workStart, sys.TotalChunks);
             try
             {
                 sys.PipelineChunkAction(chunk, sys.TotalChunks);
@@ -845,6 +865,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             }
 
             var workEnd = Stopwatch.GetTimestamp();
+            InspectorChunkEnd(sysIdx, chunk, workerId, workEnd, 0);
 
             if (trackUtilization)
             {
@@ -893,6 +914,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             }
 
             var workStart = Stopwatch.GetTimestamp();
+            InspectorChunkStart(sysIdx, chunk, workerId, workStart, sys.TotalChunks);
             try
             {
                 ParallelQueryChunkCallback?.Invoke(sysIdx, chunk, sys.TotalChunks, workerId);
@@ -905,6 +927,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             }
 
             var workEnd = Stopwatch.GetTimestamp();
+            InspectorChunkEnd(sysIdx, chunk, workerId, workEnd, _currentTickSystemMetrics[sysIdx].EntitiesProcessed);
 
             if (trackUtilization)
             {
@@ -983,13 +1006,16 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             var depsLeft = Interlocked.Decrement(ref _remainingDeps[succIdx].Value);
             if (depsLeft == 0)
             {
-                _currentTickSystemMetrics[succIdx].ReadyTick = Stopwatch.GetTimestamp();
+                var readyTs = Stopwatch.GetTimestamp();
+                _currentTickSystemMetrics[succIdx].ReadyTick = readyTs;
+                InspectorSystemReady(succIdx, readyTs);
                 var succ = Systems[succIdx];
 
                 // Check if any predecessor failed — skip this system entirely
                 if (_systemFailed[succIdx])
                 {
                     _currentTickSystemMetrics[succIdx].SkipReason = SkipReason.DependencyFailed;
+                    InspectorSystemSkipped(succIdx, SkipReason.DependencyFailed, Stopwatch.GetTimestamp());
                     OnSystemComplete(succIdx, workerId, trackUtilization);
                 }
                 // Evaluate runIf here — before any worker can grab chunks.
@@ -997,11 +1023,13 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                 else if (succ.RunIf != null && !succ.RunIf())
                 {
                     _currentTickSystemMetrics[succIdx].SkipReason = SkipReason.RunIfFalse;
+                    InspectorSystemSkipped(succIdx, SkipReason.RunIfFalse, Stopwatch.GetTimestamp());
                     OnSystemComplete(succIdx, workerId, trackUtilization);
                 }
                 else if (succ.ReactiveSkip != null && succ.ReactiveSkip())
                 {
                     _currentTickSystemMetrics[succIdx].SkipReason = SkipReason.EmptyInput;
+                    InspectorSystemSkipped(succIdx, SkipReason.EmptyInput, Stopwatch.GetTimestamp());
                     OnSystemComplete(succIdx, workerId, trackUtilization);
                 }
                 else
@@ -1010,6 +1038,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                     if (overloadSkip != SkipReason.NotSkipped)
                     {
                         _currentTickSystemMetrics[succIdx].SkipReason = overloadSkip;
+                        InspectorSystemSkipped(succIdx, overloadSkip, Stopwatch.GetTimestamp());
                         OnSystemComplete(succIdx, workerId, trackUtilization);
                     }
                     else if (succ.IsParallelQuery)
@@ -1037,6 +1066,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         var ctx = SystemStartCallback?.Invoke(sysIdx) ?? new TickContext { TickNumber = _currentTickNumber, DeltaTime = 0f };
         var workStart = Stopwatch.GetTimestamp();
         RecordFirstChunkGrab(sysIdx, workStart);
+        InspectorChunkStart(sysIdx, 0, workerId, workStart, 1);
 
         var success = true;
         try
@@ -1055,6 +1085,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             SystemEndCallback?.Invoke(sysIdx, success);
 
             var workEnd = Stopwatch.GetTimestamp();
+            InspectorChunkEnd(sysIdx, 0, workerId, workEnd, _currentTickSystemMetrics[sysIdx].EntitiesProcessed);
             if (trackUtilization)
             {
                 _workerActiveTicks[workerId] += workEnd - workStart;

--- a/src/Typhon.Engine/Runtime/EventPipeSampler.cs
+++ b/src/Typhon.Engine/Runtime/EventPipeSampler.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Manages CPU sampling by launching <c>dotnet-trace</c> as an external process.
+/// Produces a <c>.nettrace</c> file alongside the <c>.typhon-trace</c> file with full symbol resolution (method names, module names).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why external process: self-connected EventPipe sessions have a known limitation where rundown events (needed for mapping instruction pointers to method names)
+/// are not properly captured. The <c>dotnet-trace</c> tool handles this correctly because it connects from an external process via the diagnostic IPC port.
+/// </para>
+/// <para>
+/// Overhead: The runtime's <c>Microsoft-DotNETCore-SampleProfiler</c> provider suspends the execution engine ~1000 times per second. Each suspension
+/// takes ~3-5 µs, adding ~0.3-0.5% overhead. The external <c>dotnet-trace</c> process consumes minimal additional resources (just draining the IPC pipe to disk).
+/// </para>
+/// </remarks>
+public sealed class EventPipeSampler : IDisposable
+{
+    private Process _traceProcess;
+    private bool _disposed;
+
+    /// <summary>Path to the <c>.nettrace</c> file being written.</summary>
+    public string NetTracePath { get; private set; }
+
+    /// <summary>
+    /// QPC timestamp captured just before <c>dotnet-trace</c> attaches.
+    /// Used to correlate EventPipe relative timestamps with trace file absolute timestamps.
+    /// </summary>
+    public long SessionStartQpc { get; private set; }
+
+    /// <summary>
+    /// Starts CPU sampling by launching <c>dotnet-trace collect</c> targeting the current process.
+    /// </summary>
+    /// <param name="traceFilePath">Path to the main <c>.typhon-trace</c> file. The <c>.nettrace</c> is placed alongside it.</param>
+    /// <param name="durationSeconds">
+    /// How long to collect samples. <c>dotnet-trace</c> stops itself after this duration, which ensures proper session termination including rundown events
+    /// (needed for method name resolution).
+    /// Default: 15 seconds.
+    /// </param>
+    public void Start(string traceFilePath, int durationSeconds = 15)
+    {
+        NetTracePath = Path.ChangeExtension(traceFilePath, ".nettrace");
+        SessionStartQpc = Stopwatch.GetTimestamp();
+
+        var pid = Process.GetCurrentProcess().Id;
+        var duration = TimeSpan.FromSeconds(durationSeconds);
+
+        // Launch dotnet-trace as external process with fixed duration.
+        // Using --duration ensures clean session termination with full rundown (method name resolution requires the rundown events at session end).
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet-trace",
+            ArgumentList =
+            {
+                "collect",
+                "-p", pid.ToString(),
+                "--profile", "dotnet-sampled-thread-time",
+                "--duration", duration.ToString(@"hh\:mm\:ss"),
+                "-o", NetTracePath,
+                "--format", "NetTrace"
+            },
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        _traceProcess = Process.Start(psi);
+
+        if (_traceProcess == null)
+        {
+            throw new InvalidOperationException("Failed to start dotnet-trace. Ensure dotnet-trace is installed: dotnet tool install -g dotnet-trace");
+        }
+
+        // Wait briefly for dotnet-trace to attach
+        Thread.Sleep(500);
+    }
+
+    /// <summary>
+    /// Stops the <c>dotnet-trace</c> process gracefully by closing its stdin (which signals it to stop collection).
+    /// </summary>
+    public void Stop()
+    {
+        if (_traceProcess == null || _traceProcess.HasExited)
+        {
+            return;
+        }
+
+        try
+        {
+            // Wait for dotnet-trace to finish naturally (it will stop at the configured duration).
+            // The rundown events that map instruction pointers to method names are emitted at session end.
+            if (!_traceProcess.WaitForExit(TimeSpan.FromSeconds(30)))
+            {
+                _traceProcess.Kill();
+            }
+        }
+        catch
+        {
+            try { _traceProcess.Kill(); } catch { }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Stop();
+        _traceProcess?.Dispose();
+    }
+}

--- a/src/Typhon.Engine/Runtime/IRuntimeInspector.cs
+++ b/src/Typhon.Engine/Runtime/IRuntimeInspector.cs
@@ -1,0 +1,53 @@
+using JetBrains.Annotations;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Interface for deep runtime inspection. When set on <see cref="RuntimeOptions.Inspector"/>, the <see cref="DagScheduler"/> calls these methods at
+/// each instrumentation point.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations must be thread-safe: <see cref="OnChunkStart"/> and <see cref="OnChunkEnd"/> are called from worker threads concurrently.
+/// All other methods are called from the scheduler's timer thread (single-threaded).
+/// </para>
+/// <para>
+/// Performance contract: each callback should complete in &lt; 30 ns. The recommended pattern is to write a blittable struct to a per-thread ring buffer
+/// and defer all processing to a background thread.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public interface IRuntimeInspector
+{
+    /// <summary>Called when a tick begins. Single-threaded (timer thread).</summary>
+    /// <param name="tickNumber">Monotonic tick number.</param>
+    /// <param name="timestampTicks">High-resolution timestamp (<c>Stopwatch.GetTimestamp()</c>).</param>
+    void OnTickStart(long tickNumber, long timestampTicks);
+
+    /// <summary>Called when a tick phase starts. Single-threaded.</summary>
+    void OnPhaseStart(TickPhase phase, long timestampTicks);
+
+    /// <summary>Called when a tick phase ends. Single-threaded.</summary>
+    void OnPhaseEnd(TickPhase phase, long timestampTicks);
+
+    /// <summary>Called when a system becomes ready (all predecessors completed). Can be called from any worker.</summary>
+    void OnSystemReady(int systemIndex, long timestampTicks);
+
+    /// <summary>Called when a system chunk starts executing on a worker thread. Called from the worker thread.</summary>
+    void OnChunkStart(int systemIndex, int chunkIndex, int workerId, long timestampTicks, int totalChunks);
+
+    /// <summary>Called when a system chunk finishes executing. Called from the worker thread.</summary>
+    void OnChunkEnd(int systemIndex, int chunkIndex, int workerId, long timestampTicks, int entitiesProcessed);
+
+    /// <summary>Called when a system is skipped. Can be called from any worker.</summary>
+    void OnSystemSkipped(int systemIndex, SkipReason reason, long timestampTicks);
+
+    /// <summary>Called when a tick ends. Single-threaded (timer thread).</summary>
+    void OnTickEnd(long tickNumber, long timestampTicks);
+
+    /// <summary>Called once at scheduler startup with the full system definitions. Single-threaded.</summary>
+    void OnSchedulerStarted(SystemDefinition[] systems, int workerCount, float baseTickRate);
+
+    /// <summary>Called when the scheduler is stopping. Flush all buffered data.</summary>
+    void OnSchedulerStopping();
+}

--- a/src/Typhon.Engine/Runtime/RuntimeOptions.cs
+++ b/src/Typhon.Engine/Runtime/RuntimeOptions.cs
@@ -48,6 +48,13 @@ public class RuntimeOptions
     public int ParallelQueryMinChunkSize { get; set; } = 64;
 
     /// <summary>
+    /// Optional deep runtime inspector. When set, the scheduler calls <see cref="IRuntimeInspector"/> methods
+    /// at each instrumentation point (tick start/end, system ready/chunk start/chunk end, phase transitions).
+    /// Set to null (default) for no inspection overhead. Only active when <see cref="TelemetryConfig.SchedulerDeepTrace"/> is also true.
+    /// </summary>
+    public IRuntimeInspector Inspector { get; set; }
+
+    /// <summary>
     /// Resolves the effective worker count, applying the auto-detect formula if <see cref="WorkerCount"/> is -1.
     /// </summary>
     internal int ResolveWorkerCount() => WorkerCount == -1 ? Math.Max(1, Environment.ProcessorCount - 4) : WorkerCount;

--- a/src/Typhon.Engine/Runtime/TcpStreamInspector.Logging.cs
+++ b/src/Typhon.Engine/Runtime/TcpStreamInspector.Logging.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Logging;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Source-generated log messages for <see cref="TcpStreamInspector"/>. The <c>[LoggerMessage]</c> generator emits code that checks <c>IsEnabled</c>
+/// before formatting, avoiding any allocation or boxing when the level is filtered out.
+/// </summary>
+public sealed partial class TcpStreamInspector
+{
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "TcpStreamInspector listening on port {Port} ({WorkerCount} workers, {BaseTickRate:F0} Hz)")]
+    private partial void LogListenerStarted(int port, int workerCount, float baseTickRate);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "TcpStreamInspector: profiler client connected from {RemoteEndPoint}")]
+    private partial void LogClientConnected(string remoteEndPoint);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "TcpStreamInspector: profiler client disconnected ({DroppedFrames} frames dropped during session)")]
+    private partial void LogClientDisconnected(long droppedFrames);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "TcpStreamInspector: INIT frame delivery failed, closing connection ({Reason})")]
+    private partial void LogInitFailed(string reason);
+
+    [LoggerMessage(Level = LogLevel.Debug,
+        Message = "TcpStreamInspector: rejected duplicate connection from {RemoteEndPoint} (single-client only)")]
+    private partial void LogDuplicateRejected(string remoteEndPoint);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "TcpStreamInspector shutting down ({DroppedFrames} frames dropped total)")]
+    private partial void LogShuttingDown(long droppedFrames);
+}

--- a/src/Typhon.Engine/Runtime/TcpStreamInspector.cs
+++ b/src/Typhon.Engine/Runtime/TcpStreamInspector.cs
@@ -1,0 +1,497 @@
+using System;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using K4os.Compression.LZ4;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Typhon.Profiler;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// <see cref="IRuntimeInspector"/> implementation that streams trace events over TCP to the profiler server in real time.
+/// Inherits the SPSC buffer + flush pipeline from <see cref="TraceEventCaptureBase"/>; this class owns the TCP listener, non-blocking send path, and INIT framing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The inspector listens on a TCP port and accepts exactly one client (the profiler server). On connection, it sends an INIT frame with the trace header,
+/// system definitions, and current span names. On each tick end, the base class flushes per-thread buffers and calls <see cref="FlushBlock"/>, which
+/// delta-encodes, LZ4-compresses, and sends a TICK_EVENTS frame.
+/// </para>
+/// <para>
+/// The socket is switched to non-blocking mode after the INIT frame. <see cref="FlushBlock"/> uses <c>Send(..., out SocketError)</c> and treats
+/// <c>WouldBlock</c> as a drop — the timer thread never blocks on I/O. A partial send closes the socket because the receiver would be mid-frame.
+/// </para>
+/// </remarks>
+public sealed partial class TcpStreamInspector : TraceEventCaptureBase
+{
+    private readonly int _port;
+    private readonly ILogger _logger;
+
+    // TCP state
+    private TcpListener _listener;
+    private volatile Socket _client;
+    private Thread _acceptThread;
+    private volatile bool _shutdown;
+    private byte[] _initPayload;
+    private int _initPayloadSpanTableOffset;  // offset of SpanNameTableMagic in _initPayload
+    private long _droppedFrames;
+
+    // Compression + frame buffers (reused per tick)
+    private byte[] _rawBuffer;
+    private byte[] _frameBuffer;
+
+    /// <summary>First span ID that has NOT yet been sent to the client. Advanced after a successful SPAN_NAMES send.</summary>
+    private int _lastSentSpanId;
+
+    /// <summary>Number of frames dropped because the socket was not write-ready or partial send.</summary>
+    public long DroppedFrames => Interlocked.Read(ref _droppedFrames);
+
+    public TcpStreamInspector(int port = LiveStreamProtocol.DefaultPort, ILogger logger = null)
+    {
+        _port = port;
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Subclass hooks
+    // ═══════════════════════════════════════════════════════════════
+
+    protected override void InitializeOutput(SystemDefinition[] systems, int workerCount, float baseTickRate)
+    {
+        // Allocate raw buffer for event serialization + delta encoding
+        var rawBufferSize = MaxEventsPerBlock * TraceBlockEncoder.EventSize;
+        _rawBuffer = new byte[rawBufferSize];
+
+        // Frame buffer: frame envelope + block header + worst-case LZ4 output (compresses in-place into the frame buffer)
+        var maxCompressedSize = LZ4Codec.MaximumOutputSize(rawBufferSize);
+        _frameBuffer = new byte[LiveStreamProtocol.FrameHeaderSize + TraceBlockEncoder.BlockHeaderSize + maxCompressedSize];
+
+        // Pre-serialize INIT payload: header + system defs + empty span names
+        _initPayload = BuildInitPayload(systems, workerCount, baseTickRate);
+
+        // Start TCP listener + accept thread
+        _listener = new TcpListener(IPAddress.Any, _port);
+        _listener.Start(1);
+
+        _acceptThread = new Thread(AcceptLoop)
+        {
+            Name = "TcpStreamInspector.Accept",
+            IsBackground = true
+        };
+        _acceptThread.Start();
+
+        LogListenerStarted(_port, workerCount, baseTickRate);
+    }
+
+    protected override bool OnBeforeFlush()
+    {
+        var client = _client;
+        if (client == null)
+        {
+            return false; // No client — base class will skip all FlushBlock calls
+        }
+
+        return SendIncrementalSpanNames(client);
+    }
+
+    protected override bool FlushBlock(ReadOnlySpan<TraceEvent> events)
+    {
+        var client = _client;
+        if (client == null)
+        {
+            return false;
+        }
+
+        // Build the frame in _frameBuffer: [5B frame header][12B block header][LZ4 data]
+        // TraceBlockEncoder compresses directly into the frame buffer — no intermediate copy.
+        var fb = _frameBuffer.AsSpan();
+        var blockHeader = fb.Slice(LiveStreamProtocol.FrameHeaderSize, TraceBlockEncoder.BlockHeaderSize);
+        var compressedSlot = fb[(LiveStreamProtocol.FrameHeaderSize + TraceBlockEncoder.BlockHeaderSize)..];
+
+        var compressedSize = TraceBlockEncoder.EncodeBlock(events, _rawBuffer, compressedSlot, blockHeader);
+
+        var payloadSize = TraceBlockEncoder.BlockHeaderSize + compressedSize;
+        var frameSize = LiveStreamProtocol.FrameHeaderSize + payloadSize;
+        LiveStreamProtocol.WriteFrameHeader(fb, LiveFrameType.TickEvents, payloadSize);
+
+        return TrySendAll(client, _frameBuffer, 0, frameSize);
+    }
+
+    protected override void CloseOutput()
+    {
+        LogShuttingDown(Interlocked.Read(ref _droppedFrames));
+
+        // Send shutdown frame using the non-blocking send path
+        var client = _client;
+        if (client != null)
+        {
+            var shutdownFrame = new byte[LiveStreamProtocol.FrameHeaderSize];
+            LiveStreamProtocol.WriteFrameHeader(shutdownFrame, LiveFrameType.Shutdown, 0);
+            TrySendAll(client, shutdownFrame, 0, shutdownFrame.Length);
+        }
+
+        // Shut down the accept loop and join it so no new connection can race dispose
+        _shutdown = true;
+        try { _listener?.Stop(); } catch { }
+        _acceptThread?.Join(500);
+    }
+
+    public override void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        base.Dispose();
+        _shutdown = true;
+
+        // Swap _client to null before closing to avoid concurrent use by stragglers
+        var client = Interlocked.Exchange(ref _client, null);
+        if (client != null)
+        {
+            try { client.Shutdown(SocketShutdown.Both); } catch { }
+            try { client.Close(); } catch { }
+        }
+
+        try { _listener?.Stop(); } catch { }
+        _acceptThread?.Join(2000);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Non-blocking TCP send
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Attempts to send all <paramref name="length"/> bytes on a non-blocking socket.
+    /// Returns true if the full frame was sent, false otherwise (caller should give up on this client).
+    /// On WouldBlock, increments the drop counter and returns false.
+    /// On partial send or any other error, closes the socket (the peer is now mid-frame and cannot recover).
+    /// </summary>
+    private bool TrySendAll(Socket client, byte[] buffer, int offset, int length)
+    {
+        try
+        {
+            var sent = client.Send(buffer, offset, length, SocketFlags.None, out var error);
+
+            if (error == SocketError.Success && sent == length)
+            {
+                return true;
+            }
+
+            if (error == SocketError.WouldBlock)
+            {
+                Interlocked.Increment(ref _droppedFrames);
+                return false;
+            }
+
+            // Any other error, or partial send — tear down
+            Interlocked.Increment(ref _droppedFrames);
+            DisposeClient(client);
+            return false;
+        }
+        catch (SocketException)
+        {
+            DisposeClient(client);
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            _client = null;
+            return false;
+        }
+    }
+
+    /// <summary>Closes the given socket if it is still the current client. Uses CompareExchange to avoid leaking a replacement on concurrent failure.</summary>
+    private void DisposeClient(Socket expected)
+    {
+        if (Interlocked.CompareExchange(ref _client, null, expected) == expected)
+        {
+            try { expected.Close(); } catch { }
+            LogClientDisconnected(Interlocked.Read(ref _droppedFrames));
+        }
+    }
+
+    /// <summary>
+    /// Sends any newly-interned span names as a SPAN_NAMES frame. Returns true if nothing to send, or if the send succeeded. Returns false if the socket died.
+    /// </summary>
+    private bool SendIncrementalSpanNames(Socket client)
+    {
+        int nextId;
+        int sendFromId;
+        int countToSend;
+
+        lock (_spanNameToId)
+        {
+            nextId = _nextSpanNameId;
+            sendFromId = _lastSentSpanId;
+            countToSend = nextId - sendFromId;
+            if (countToSend <= 0)
+            {
+                return true;
+            }
+        }
+
+        // Serialize: [uint16 count] [foreach: uint16 id, uint8 nameLen, UTF8 bytes]
+        // Max per-name size is 2 + 1 + 255 = 258 bytes. If the batch fits in the reusable frame buffer, use it; otherwise fall back to a one-off allocation.
+        var maxPayloadSize = 2 + countToSend * 258;
+        var usesFrameBuffer = maxPayloadSize <= _frameBuffer.Length - LiveStreamProtocol.FrameHeaderSize;
+        var scratch = usesFrameBuffer
+            ? _frameBuffer.AsSpan(LiveStreamProtocol.FrameHeaderSize)
+            : new byte[maxPayloadSize].AsSpan();
+
+        var pos = 0;
+        BinaryPrimitives.WriteUInt16LittleEndian(scratch[pos..], (ushort)countToSend);
+        pos += 2;
+
+        lock (_spanNameToId)
+        {
+            for (var id = sendFromId; id < nextId; id++)
+            {
+                if (!_spanIdToName.TryGetValue(id, out var name))
+                {
+                    continue;
+                }
+
+                BinaryPrimitives.WriteUInt16LittleEndian(scratch[pos..], (ushort)id);
+                pos += 2;
+
+                var nameByteCount = Encoding.UTF8.GetByteCount(name);
+                var clamped = Math.Min(nameByteCount, 255);
+                scratch[pos++] = (byte)clamped;
+
+                var written = Encoding.UTF8.GetBytes(name.AsSpan(), scratch.Slice(pos, clamped));
+                pos += written;
+            }
+        }
+
+        var payloadSize = pos;
+
+        if (usesFrameBuffer)
+        {
+            LiveStreamProtocol.WriteFrameHeader(_frameBuffer.AsSpan(), LiveFrameType.SpanNames, payloadSize);
+            if (!TrySendAll(client, _frameBuffer, 0, LiveStreamProtocol.FrameHeaderSize + payloadSize))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            var tmp = new byte[LiveStreamProtocol.FrameHeaderSize + payloadSize];
+            LiveStreamProtocol.WriteFrameHeader(tmp.AsSpan(), LiveFrameType.SpanNames, payloadSize);
+            scratch[..payloadSize].CopyTo(tmp.AsSpan(LiveStreamProtocol.FrameHeaderSize));
+            if (!TrySendAll(client, tmp, 0, tmp.Length))
+            {
+                return false;
+            }
+        }
+
+        lock (_spanNameToId)
+        {
+            _lastSentSpanId = nextId;
+        }
+
+        return true;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // TCP accept loop
+    // ═══════════════════════════════════════════════════════════════
+
+    private void AcceptLoop()
+    {
+        while (!_shutdown)
+        {
+            Socket socket;
+            try
+            {
+                socket = _listener.AcceptSocket();
+            }
+            catch (SocketException) when (_shutdown)
+            {
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+
+            socket.NoDelay = true;
+            // Enable TCP keepalive so a half-closed peer eventually frees the slot instead of lingering
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+            var remoteEp = socket.RemoteEndPoint?.ToString() ?? "<unknown>";
+
+            // Single client only — reject additional connections
+            if (_client != null)
+            {
+                LogDuplicateRejected(remoteEp);
+                try { socket.Close(); } catch { }
+                continue;
+            }
+
+            // Send INIT frame with current state. INIT is sent in BLOCKING mode on the accept thread — we need to guarantee delivery of session metadata
+            // before flipping the socket to non-blocking for the timer thread's hot-path sends.
+            try
+            {
+                byte[] currentInit;
+                int currentSpanCount;
+                lock (_spanNameToId)
+                {
+                    currentSpanCount = _nextSpanNameId;
+                    currentInit = currentSpanCount > 0
+                        ? RebuildInitPayloadWithSpanNames()
+                        : _initPayload;
+                }
+
+                var frameBuffer = new byte[LiveStreamProtocol.FrameHeaderSize + currentInit.Length];
+                LiveStreamProtocol.WriteFrameHeader(frameBuffer.AsSpan(), LiveFrameType.Init, currentInit.Length);
+                currentInit.CopyTo(frameBuffer.AsSpan(LiveStreamProtocol.FrameHeaderSize));
+
+                socket.SendTimeout = 5000; // generous timeout for the one-shot INIT write
+                socket.Send(frameBuffer);
+
+                // Flip to non-blocking for the timer-thread send loop
+                socket.Blocking = false;
+
+                lock (_spanNameToId)
+                {
+                    _lastSentSpanId = currentSpanCount;
+                }
+
+                _client = socket;
+                LogClientConnected(remoteEp);
+            }
+            catch (SocketException ex)
+            {
+                LogInitFailed(ex.SocketErrorCode.ToString());
+                try { socket.Close(); } catch { }
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // INIT payload serialization
+    // ═══════════════════════════════════════════════════════════════
+
+    private byte[] BuildInitPayload(SystemDefinition[] systems, int workerCount, float baseTickRate)
+    {
+        using var ms = new MemoryStream();
+
+        // Write header (64 bytes, same as file format)
+        var header = new TraceFileHeader
+        {
+            Magic = TraceFileHeader.MagicValue,
+            Version = TraceFileHeader.CurrentVersion,
+            Flags = 0,
+            TimestampFrequency = Stopwatch.Frequency,
+            BaseTickRate = baseTickRate,
+            WorkerCount = (byte)workerCount,
+            SystemCount = (ushort)systems.Length,
+            CreatedUtcTicks = DateTime.UtcNow.Ticks,
+            SamplingSessionStartQpc = 0
+        };
+        ms.Write(MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(in header, 1)));
+
+        // Write system definitions (same binary format as TraceFileWriter)
+        using var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true);
+        var records = BuildSystemRecords(systems);
+
+        bw.Write((ushort)records.Length);
+        foreach (var sys in records)
+        {
+            bw.Write(sys.Index);
+
+            var nameBytes = Encoding.UTF8.GetBytes(sys.Name);
+            bw.Write((byte)Math.Min(nameBytes.Length, 255));
+            bw.Write(nameBytes, 0, Math.Min(nameBytes.Length, 255));
+
+            bw.Write(sys.Type);
+            bw.Write(sys.Priority);
+            bw.Write(sys.IsParallel);
+            bw.Write(sys.TierFilter);
+
+            bw.Write((byte)sys.Predecessors.Length);
+            foreach (var pred in sys.Predecessors)
+            {
+                bw.Write(pred);
+            }
+
+            bw.Write((byte)sys.Successors.Length);
+            foreach (var succ in sys.Successors)
+            {
+                bw.Write(succ);
+            }
+        }
+
+        // Record the exact offset of the span name table so we can replace it deterministically on reconnect without scanning for the magic
+        // (which could collide with bytes inside a system name like "SpawnManager").
+        bw.Flush();
+        _initPayloadSpanTableOffset = (int)ms.Position;
+
+        // Write empty span name table (magic + count=0)
+        bw.Write(TraceFileWriter.SpanNameTableMagic);
+        bw.Write((ushort)0);
+
+        bw.Flush();
+        return ms.ToArray();
+    }
+
+    /// <summary>Re-serialize the INIT payload with the current span name table. Caller must hold the <c>_spanNameToId</c> lock.</summary>
+    private byte[] RebuildInitPayloadWithSpanNames()
+    {
+        using var ms = new MemoryStream();
+
+        // Copy header + system defs verbatim (everything before the span table)
+        ms.Write(_initPayload.AsSpan(0, _initPayloadSpanTableOffset));
+
+        // Write the current span name table
+        using var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true);
+        bw.Write(TraceFileWriter.SpanNameTableMagic);
+        bw.Write((ushort)_spanIdToName.Count);
+        foreach (var kv in _spanIdToName)
+        {
+            bw.Write((ushort)kv.Key);
+            var nameBytes = Encoding.UTF8.GetBytes(kv.Value);
+            bw.Write((byte)Math.Min(nameBytes.Length, 255));
+            bw.Write(nameBytes, 0, Math.Min(nameBytes.Length, 255));
+        }
+
+        bw.Flush();
+        return ms.ToArray();
+    }
+
+    private static SystemDefinitionRecord[] BuildSystemRecords(SystemDefinition[] systems)
+    {
+        var records = new SystemDefinitionRecord[systems.Length];
+        for (var i = 0; i < systems.Length; i++)
+        {
+            var sys = systems[i];
+            var predecessors = systems
+                .Where(s => s.Successors.Contains(sys.Index))
+                .Select(s => (ushort)s.Index)
+                .ToArray();
+
+            records[i] = new SystemDefinitionRecord
+            {
+                Index = (ushort)sys.Index,
+                Name = sys.Name,
+                Type = (byte)sys.Type,
+                Priority = (byte)sys.Priority,
+                IsParallel = sys.IsParallelQuery,
+                TierFilter = (byte)sys.TierFilter,
+                Predecessors = predecessors,
+                Successors = sys.Successors.Select(s => (ushort)s).ToArray()
+            };
+        }
+
+        return records;
+    }
+}

--- a/src/Typhon.Engine/Runtime/TickPhase.cs
+++ b/src/Typhon.Engine/Runtime/TickPhase.cs
@@ -1,0 +1,29 @@
+using JetBrains.Annotations;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Identifies a phase within a tick's lifecycle, used by <see cref="IRuntimeInspector"/>
+/// to report phase transitions.
+/// </summary>
+[PublicAPI]
+public enum TickPhase : byte
+{
+    /// <summary>System dispatch phase — the DAG scheduler is running systems.</summary>
+    SystemDispatch = 0,
+
+    /// <summary>UoW flush — deferred writes becoming durable (WAL write).</summary>
+    UowFlush = 1,
+
+    /// <summary>Write tick fence — dirty bitmap snapshot, shadow entry processing, spatial index update.</summary>
+    WriteTickFence = 2,
+
+    /// <summary>Subscription output — refresh published Views, compute deltas, push to clients.</summary>
+    OutputPhase = 3,
+
+    /// <summary>Tier index rebuild — rebuild per-archetype tier cluster indexes at tick start.</summary>
+    TierIndexRebuild = 4,
+
+    /// <summary>Dormancy sweep — advance sleep counters, transition idle clusters.</summary>
+    DormancySweep = 5
+}

--- a/src/Typhon.Engine/Runtime/TraceEventCaptureBase.cs
+++ b/src/Typhon.Engine/Runtime/TraceEventCaptureBase.cs
@@ -1,0 +1,438 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Typhon.Profiler;
+using ProfilerTraceEventType = Typhon.Profiler.TraceEventType;
+using ProfilerTickPhase = Typhon.Profiler.TickPhase;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Base class for <see cref="IRuntimeInspector"/> implementations that capture trace events via per-thread SPSC ring buffers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Architecture (inspired by Tracy Profiler and UE5 Insights):
+/// <list type="bullet">
+///   <item>Each worker thread writes to its own <see cref="ThreadTraceBuffer"/> via [ThreadStatic] — zero contention</item>
+///   <item>The timer thread (single-writer for tick/phase events) uses buffer index 0</item>
+///   <item>At tick end, the consumer drains all per-thread buffers, sorts them by timestamp, and hands them to <see cref="FlushBlock"/></item>
+///   <item>Subclasses override <see cref="InitializeOutput"/>, <see cref="FlushBlock"/>, and <see cref="CloseOutput"/> to send events to a file, TCP socket, etc.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Thread safety: <see cref="OnChunkStart"/>/<see cref="OnChunkEnd"/> are called from worker threads. All other methods are called from the timer thread.
+/// The per-thread buffers ensure no contention on the hot path.
+/// </para>
+/// </remarks>
+public abstract class TraceEventCaptureBase : IRuntimeInspector, IDisposable
+{
+    /// <summary>Per-thread trace buffer capacity (events). Power of 2 for fast masking.</summary>
+    protected const int BufferCapacity = 2048;
+
+    /// <summary>Max events to merge per tick before writing blocks.</summary>
+    protected const int MergeBufferCapacity = 8192;
+
+    /// <summary>Max events per output block. Matches <c>TraceFileWriter.MaxEventsPerBlock</c>. A tick with more events is split across multiple blocks.</summary>
+    protected const int MaxEventsPerBlock = 4096;
+
+    // Per-thread buffers
+    protected ThreadTraceBuffer[] _buffers;
+    protected readonly TraceEvent[] _mergeBuffer;
+    protected int _workerCount;
+    protected int _currentTickNumber;
+
+    // Span name interning — accessed from any worker thread via the lock
+    protected readonly Dictionary<string, int> _spanNameToId = new();
+    protected readonly Dictionary<int, string> _spanIdToName = new();
+    protected int _nextSpanNameId;
+
+    // OTel capture
+    private ActivityListener _activityListener;
+
+    protected bool _disposed;
+
+    [ThreadStatic]
+    private static int t_bufferIndex;
+
+    [ThreadStatic]
+    private static bool t_bufferIndexInitialized;
+
+    /// <summary>Cached comparer so <c>Array.Sort</c> doesn't allocate a fresh comparer per flush.</summary>
+    protected static readonly IComparer<TraceEvent> TimestampComparer =
+        Comparer<TraceEvent>.Create(static (a, b) => a.TimestampTicks.CompareTo(b.TimestampTicks));
+
+    protected TraceEventCaptureBase()
+    {
+        _mergeBuffer = new TraceEvent[MergeBufferCapacity];
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Subclass hooks
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Initialize the subclass-specific output (open file, start TCP listener, etc.). Called after buffers are allocated but before the ActivityListener is attached.
+    /// </summary>
+    protected abstract void InitializeOutput(SystemDefinition[] systems, int workerCount, float baseTickRate);
+
+    /// <summary>
+    /// Write a single block of up to <see cref="MaxEventsPerBlock"/> events. Events are already sorted by timestamp in ascending order.
+    /// Return <c>false</c> to abort the current flush (e.g., the socket died). No further blocks will be attempted this tick.
+    /// </summary>
+    protected abstract bool FlushBlock(ReadOnlySpan<TraceEvent> events);
+
+    /// <summary>
+    /// Optional pre-flush hook called once per tick before any <see cref="FlushBlock"/> invocations. Useful for sending ancillary data like
+    /// incremental span names that should precede the event frames. Return <c>false</c> to abort the flush entirely.
+    /// </summary>
+    protected virtual bool OnBeforeFlush() => true;
+
+    /// <summary>
+    /// Close the subclass-specific output. Called from <see cref="OnSchedulerStopping"/> after the final flush and before the ActivityListener is disposed.
+    /// </summary>
+    protected abstract void CloseOutput();
+
+    // ═══════════════════════════════════════════════════════════════
+    // IRuntimeInspector — lifecycle
+    // ═══════════════════════════════════════════════════════════════
+
+    public virtual void OnSchedulerStarted(SystemDefinition[] systems, int workerCount, float baseTickRate)
+    {
+        _workerCount = workerCount;
+
+        // Buffer 0 = timer thread, buffers 1..workerCount = worker threads
+        _buffers = new ThreadTraceBuffer[workerCount + 1];
+        for (var i = 0; i < _buffers.Length; i++)
+        {
+            _buffers[i] = new ThreadTraceBuffer(BufferCapacity);
+        }
+
+        // Timer thread claims buffer 0
+        t_bufferIndex = 0;
+        t_bufferIndexInitialized = true;
+
+        // Let the subclass prepare its output before we start capturing
+        InitializeOutput(systems, workerCount, baseTickRate);
+
+        // Set up ActivityListener to capture OTel spans from Typhon.Engine
+        _activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Typhon.Engine",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = OnActivityStarted,
+            ActivityStopped = OnActivityStopped
+        };
+        ActivitySource.AddActivityListener(_activityListener);
+    }
+
+    public virtual void OnSchedulerStopping()
+    {
+        FlushBuffers();
+
+        _activityListener?.Dispose();
+        _activityListener = null;
+
+        CloseOutput();
+    }
+
+    public virtual void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _activityListener?.Dispose();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // IRuntimeInspector — event callbacks (identical across subclasses)
+    // ═══════════════════════════════════════════════════════════════
+
+    public void OnTickStart(long tickNumber, long timestampTicks)
+    {
+        _currentTickNumber = (int)tickNumber;
+        Emit(new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = (int)tickNumber,
+            EventType = ProfilerTraceEventType.TickStart
+        });
+    }
+
+    public void OnPhaseStart(TickPhase phase, long timestampTicks)
+    {
+        Emit(new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = _currentTickNumber,
+            EventType = ProfilerTraceEventType.PhaseStart,
+            Phase = (ProfilerTickPhase)(byte)phase
+        });
+    }
+
+    public void OnPhaseEnd(TickPhase phase, long timestampTicks)
+    {
+        Emit(new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = _currentTickNumber,
+            EventType = ProfilerTraceEventType.PhaseEnd,
+            Phase = (ProfilerTickPhase)(byte)phase
+        });
+    }
+
+    public void OnSystemReady(int systemIndex, long timestampTicks)
+    {
+        Emit(new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = _currentTickNumber,
+            SystemIndex = (ushort)systemIndex,
+            EventType = ProfilerTraceEventType.SystemReady
+        });
+    }
+
+    public void OnChunkStart(int systemIndex, int chunkIndex, int workerId, long timestampTicks, int totalChunks)
+    {
+        EnsureWorkerBuffer(workerId);
+        EmitToBuffer(workerId + 1, new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = _currentTickNumber,
+            SystemIndex = (ushort)systemIndex,
+            ChunkIndex = (ushort)chunkIndex,
+            WorkerId = (byte)workerId,
+            EventType = ProfilerTraceEventType.ChunkStart,
+            Payload = totalChunks
+        });
+    }
+
+    public void OnChunkEnd(int systemIndex, int chunkIndex, int workerId, long timestampTicks, int entitiesProcessed)
+    {
+        EmitToBuffer(workerId + 1, new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = _currentTickNumber,
+            SystemIndex = (ushort)systemIndex,
+            ChunkIndex = (ushort)chunkIndex,
+            WorkerId = (byte)workerId,
+            EventType = ProfilerTraceEventType.ChunkEnd,
+            EntitiesProcessed = entitiesProcessed
+        });
+    }
+
+    public void OnSystemSkipped(int systemIndex, SkipReason reason, long timestampTicks)
+    {
+        Emit(new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = _currentTickNumber,
+            SystemIndex = (ushort)systemIndex,
+            EventType = ProfilerTraceEventType.SystemSkipped,
+            SkipReason = (byte)reason
+        });
+    }
+
+    public void OnTickEnd(long tickNumber, long timestampTicks)
+    {
+        Emit(new TraceEvent
+        {
+            TimestampTicks = timestampTicks,
+            TickNumber = (int)tickNumber,
+            EventType = ProfilerTraceEventType.TickEnd
+        });
+
+        FlushBuffers();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Emit helpers
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>Emit an event to the current thread's buffer (timer thread uses buffer 0).</summary>
+    protected void Emit(in TraceEvent evt)
+    {
+        if (!t_bufferIndexInitialized)
+        {
+            t_bufferIndex = 0;
+            t_bufferIndexInitialized = true;
+        }
+
+        _buffers[t_bufferIndex].Write(in evt);
+    }
+
+    /// <summary>Emit an event to a specific buffer index (for worker threads).</summary>
+    protected void EmitToBuffer(int bufferIndex, in TraceEvent evt) => _buffers[bufferIndex].Write(in evt);
+
+    /// <summary>Set up a worker thread's buffer index on first emit.</summary>
+    protected void EnsureWorkerBuffer(int workerId)
+    {
+        if (!t_bufferIndexInitialized)
+        {
+            t_bufferIndex = workerId + 1;
+            t_bufferIndexInitialized = true;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Flush orchestration
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Drains all per-thread buffers into the merge buffer, sorts them by timestamp, and invokes <see cref="FlushBlock"/> in chunks of <see cref="MaxEventsPerBlock"/>.
+    /// Called from the timer thread at tick end — single-threaded, no contention with workers (workers are idle between ticks).
+    /// </summary>
+    protected void FlushBuffers()
+    {
+        var totalEvents = 0;
+
+        for (var i = 0; i < _buffers.Length; i++)
+        {
+            var buffer = _buffers[i];
+            while (buffer.TryRead(out var evt) && totalEvents < MergeBufferCapacity)
+            {
+                _mergeBuffer[totalEvents++] = evt;
+            }
+        }
+
+        if (totalEvents == 0)
+        {
+            return;
+        }
+
+        // Sort by timestamp for correct delta encoding (uses cached comparer — no allocation)
+        Array.Sort(_mergeBuffer, 0, totalEvents, TimestampComparer);
+
+        if (!OnBeforeFlush())
+        {
+            return;
+        }
+
+        // Emit events in chunks of MaxEventsPerBlock so large ticks don't get silently truncated
+        var sent = 0;
+        while (sent < totalEvents)
+        {
+            var count = Math.Min(totalEvents - sent, MaxEventsPerBlock);
+            if (!FlushBlock(new ReadOnlySpan<TraceEvent>(_mergeBuffer, sent, count)))
+            {
+                return;
+            }
+            sent += count;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Span name interning (shared between OTel capture and subclass access)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>Get or create an interned span name ID. Thread-safe — called from any worker thread via the ActivityListener.</summary>
+    protected int InternSpanName(string name)
+    {
+        lock (_spanNameToId)
+        {
+            if (_spanNameToId.TryGetValue(name, out var id))
+            {
+                return id;
+            }
+
+            id = _nextSpanNameId++;
+            _spanNameToId[name] = id;
+            _spanIdToName[id] = name;
+            return id;
+        }
+    }
+
+    private void OnActivityStarted(Activity activity)
+    {
+        var nameId = InternSpanName(activity.OperationName);
+        Emit(new TraceEvent
+        {
+            TimestampTicks = Stopwatch.GetTimestamp(),
+            TickNumber = _currentTickNumber,
+            EventType = ProfilerTraceEventType.SpanStart,
+            Payload = nameId,
+            WorkerId = (byte)(t_bufferIndexInitialized ? t_bufferIndex : 0)
+        });
+    }
+
+    private void OnActivityStopped(Activity activity)
+    {
+        var nameId = InternSpanName(activity.OperationName);
+        Emit(new TraceEvent
+        {
+            TimestampTicks = Stopwatch.GetTimestamp(),
+            TickNumber = _currentTickNumber,
+            EventType = ProfilerTraceEventType.SpanEnd,
+            Payload = nameId,
+            WorkerId = (byte)(t_bufferIndexInitialized ? t_bufferIndex : 0)
+        });
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Per-thread SPSC ring buffer
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Per-thread SPSC (single-producer, single-consumer) ring buffer for trace events.
+    /// The producer is the owning thread; the consumer is the timer thread at tick end.
+    /// </summary>
+    /// <remarks>
+    /// Volatile on <c>_head</c>/<c>_tail</c> provides release/acquire ordering, not atomicity — without it, the JIT or CPU could reorder the
+    /// event-slot write past the head publish, letting the consumer see an advanced head with garbage in the slot. This is why we keep
+    /// <c>Volatile.Read</c>/<c>Volatile.Write</c> here despite the project rule against them on <c>≤64</c>-bit fields (that rule is about atomicity, not ordering).
+    /// </remarks>
+    protected sealed class ThreadTraceBuffer
+    {
+        private readonly TraceEvent[] _events;
+        private readonly int _mask;
+        private int _head; // written by producer (owning thread)
+        private int _tail; // written by consumer (timer thread)
+
+        public ThreadTraceBuffer(int capacity)
+        {
+            if ((capacity & (capacity - 1)) != 0)
+            {
+                throw new ArgumentException("Capacity must be a power of 2", nameof(capacity));
+            }
+
+            _events = new TraceEvent[capacity];
+            _mask = capacity - 1;
+        }
+
+        /// <summary>Write an event. Called from the owning thread only.</summary>
+        public void Write(in TraceEvent evt)
+        {
+            var head = _head;
+            var next = (head + 1) & _mask;
+
+            // If full, drop the event (better than blocking the hot path)
+            if (next == Volatile.Read(ref _tail))
+            {
+                return;
+            }
+
+            _events[head] = evt;
+            Volatile.Write(ref _head, next);
+        }
+
+        /// <summary>Read an event. Called from the consumer thread only.</summary>
+        public bool TryRead(out TraceEvent evt)
+        {
+            var tail = _tail;
+
+            if (tail == Volatile.Read(ref _head))
+            {
+                evt = default;
+                return false;
+            }
+
+            evt = _events[tail];
+            Volatile.Write(ref _tail, (tail + 1) & _mask);
+            return true;
+        }
+    }
+}

--- a/src/Typhon.Engine/Runtime/TraceFileInspector.cs
+++ b/src/Typhon.Engine/Runtime/TraceFileInspector.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Typhon.Profiler;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// <see cref="IRuntimeInspector"/> implementation that records trace events to a <c>.typhon-trace</c> file.
+/// Inherits the SPSC buffer + flush pipeline from <see cref="TraceEventCaptureBase"/>; only the output (file writer + optional CPU sampler) is specialized here.
+/// </summary>
+public sealed class TraceFileInspector : TraceEventCaptureBase
+{
+    private readonly string _filePath;
+    private readonly bool _enableCpuSampling;
+    private TraceFileWriter _writer;
+    private EventPipeSampler _sampler;
+
+    /// <summary>
+    /// Creates a new trace file inspector.
+    /// </summary>
+    /// <param name="filePath">Path for the <c>.typhon-trace</c> file.</param>
+    /// <param name="enableCpuSampling">
+    /// When true, also starts an EventPipe CPU sampling session (~1 KHz managed stack capture).
+    /// A companion <c>.nettrace</c> file is created alongside the trace file.
+    /// Adds ~0.3-0.5% overhead from periodic EE suspensions.
+    /// </param>
+    public TraceFileInspector(string filePath, bool enableCpuSampling = false)
+    {
+        _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+        _enableCpuSampling = enableCpuSampling;
+    }
+
+    protected override void InitializeOutput(SystemDefinition[] systems, int workerCount, float baseTickRate)
+    {
+        // Start CPU sampling FIRST (so we have the session start QPC for the header)
+        long samplingStartQpc = 0;
+        if (_enableCpuSampling)
+        {
+            _sampler = new EventPipeSampler();
+            _sampler.Start(_filePath);
+            samplingStartQpc = _sampler.SessionStartQpc;
+        }
+
+        // Open file and write header + system definitions
+        var stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.Read, bufferSize: 64 * 1024);
+        _writer = new TraceFileWriter(stream);
+
+        var header = new TraceFileHeader
+        {
+            Magic = TraceFileHeader.MagicValue,
+            Version = TraceFileHeader.CurrentVersion,
+            Flags = 0,
+            TimestampFrequency = Stopwatch.Frequency,
+            BaseTickRate = baseTickRate,
+            WorkerCount = (byte)workerCount,
+            SystemCount = (ushort)systems.Length,
+            CreatedUtcTicks = DateTime.UtcNow.Ticks,
+            SamplingSessionStartQpc = samplingStartQpc
+        };
+        _writer.WriteHeader(in header);
+
+        // Convert SystemDefinition[] to SystemDefinitionRecord[]
+        var records = new SystemDefinitionRecord[systems.Length];
+        for (var i = 0; i < systems.Length; i++)
+        {
+            var sys = systems[i];
+
+            // Build predecessors list from successors of other systems
+            var predecessors = systems
+                .Where(s => s.Successors.Contains(sys.Index))
+                .Select(s => (ushort)s.Index)
+                .ToArray();
+
+            records[i] = new SystemDefinitionRecord
+            {
+                Index = (ushort)sys.Index,
+                Name = sys.Name,
+                Type = (byte)sys.Type,
+                Priority = (byte)sys.Priority,
+                IsParallel = sys.IsParallelQuery,
+                TierFilter = (byte)sys.TierFilter,
+                Predecessors = predecessors,
+                Successors = sys.Successors.Select(s => (ushort)s).ToArray()
+            };
+        }
+
+        _writer.WriteSystemDefinitions(records);
+
+        // Write empty span name table (will be updated at shutdown with all interned names)
+        _writer.WriteSpanNames(_spanIdToName);
+    }
+
+    protected override bool FlushBlock(ReadOnlySpan<TraceEvent> events)
+    {
+        _writer.WriteEvents(events);
+        return true;
+    }
+
+    protected override void CloseOutput()
+    {
+        // Write the span name table at the end of the file (reader scans for it after event blocks)
+        _writer?.WriteSpanNames(_spanIdToName);
+        _writer?.Flush();
+        _sampler?.Stop();
+    }
+
+    public override void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        base.Dispose();
+        _sampler?.Dispose();
+        _writer?.Dispose();
+    }
+}

--- a/src/Typhon.Engine/Runtime/TyphonRuntime.cs
+++ b/src/Typhon.Engine/Runtime/TyphonRuntime.cs
@@ -209,6 +209,12 @@ public sealed class TyphonRuntime : IDisposable
         };
 
         Scheduler.OnCriticalOverloadCallback = () => OnCriticalOverload?.Invoke(this);
+
+        // Wire deep trace inspector (if configured and enabled)
+        if (_options.Inspector != null)
+        {
+            Scheduler.SetInspector(_options.Inspector);
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -270,6 +276,9 @@ public sealed class TyphonRuntime : IDisposable
         {
             _parallelAccessors[i]?.Dispose();
         }
+
+        // Dispose deep trace inspector (flushes remaining data to file)
+        (_options.Inspector as IDisposable)?.Dispose();
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -1738,20 +1747,23 @@ public sealed class TyphonRuntime : IDisposable
         // for persistent cluster content mutation.
         //
         // See debate decision Q1 in the Phase 3 design notes, and claude/design/spatial-tiers/01-spatial-clusters.md §"Migration fence WAL atomicity".
-        Engine.WriteTickFence(scheduler.CurrentTickNumber);
+        InspectorPhase(TickPhase.WriteTickFence, () => Engine.WriteTickFence(scheduler.CurrentTickNumber));
 
         // Flush the UoW to make all Deferred writes (including the tick fence publishes above) durable, then dispose. UoW.Flush in WAL mode calls
         // WalManager.RequestFlush + WaitForDurable(currentLsn), where currentLsn is captured at the moment of the call — so it includes every publish made
         // in WriteTickFence.
-        try
+        InspectorPhase(TickPhase.UowFlush, () =>
         {
-            _currentUow?.Flush();
-        }
-        finally
-        {
-            _currentUow?.Dispose();
-            _currentUow = null;
-        }
+            try
+            {
+                _currentUow?.Flush();
+            }
+            finally
+            {
+                _currentUow?.Dispose();
+                _currentUow = null;
+            }
+        });
 
         // Issue #234: compute per-tier budget metrics from this tick's system telemetry, for the next tick's TickContext.
         ComputeTierBudgetMetrics();
@@ -1761,7 +1773,26 @@ public sealed class TyphonRuntime : IDisposable
         //   1. Ring buffer has ALL entries (commit-time + shadow-time) for correct View membership
         //   2. PreviousTickDirtyBitmap has this tick's dirty chunks for Modified detection
         //   3. All state is quiescent (no concurrent writers)
-        _subscriptionOutputPhase?.Execute(scheduler.CurrentTickNumber, Scheduler.CurrentOverloadLevel);
+        InspectorPhase(TickPhase.OutputPhase, () => _subscriptionOutputPhase?.Execute(scheduler.CurrentTickNumber, Scheduler.CurrentOverloadLevel));
+    }
+
+    /// <summary>
+    /// Wraps a tick phase in inspector PhaseStart/PhaseEnd calls when deep tracing is active.
+    /// When tracing is disabled, this compiles to a direct call (JIT eliminates the guard).
+    /// </summary>
+    private void InspectorPhase(TickPhase phase, Action action)
+    {
+        if (TelemetryConfig.SchedulerDeepTrace && _options.Inspector != null)
+        {
+            var start = Stopwatch.GetTimestamp();
+            _options.Inspector.OnPhaseStart(phase, start);
+            action();
+            _options.Inspector.OnPhaseEnd(phase, Stopwatch.GetTimestamp());
+        }
+        else
+        {
+            action();
+        }
     }
 
     /// <summary>

--- a/src/Typhon.Engine/Typhon.Engine.csproj
+++ b/src/Typhon.Engine/Typhon.Engine.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
         <PackageReference Include="MemoryPack" Version="1.21.4" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
@@ -38,6 +38,7 @@
         <!-- Reference the Roslyn analyzer for ChunkAccessor enforcement -->
         <ProjectReference Include="..\Typhon.Analyzers\Typhon.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
         <ProjectReference Include="..\Typhon.Generators\Typhon.Generators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+        <ProjectReference Include="..\Typhon.Profiler\Typhon.Profiler.csproj" />
         <ProjectReference Include="..\Typhon.Protocol\Typhon.Protocol.csproj" />
         <ProjectReference Include="..\Typhon.Schema.Definition\Typhon.Schema.Definition.csproj" />
     </ItemGroup>

--- a/src/Typhon.Profiler/ChromeTraceExporter.cs
+++ b/src/Typhon.Profiler/ChromeTraceExporter.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Exports a <c>.typhon-trace</c> file to Chrome Trace JSON format, viewable in <c>chrome://tracing</c> or <a href="https://ui.perfetto.dev">Perfetto UI</a>.
+/// </summary>
+/// <remarks>
+/// Mapping:
+/// <list type="bullet">
+///   <item>Each worker thread → a separate <c>tid</c></item>
+///   <item>Each tick → process (<c>pid</c>) = 1, with tick boundaries as instant events</item>
+///   <item>Each system chunk → a complete event (<c>ph: "X"</c>) with duration</item>
+///   <item>Tick phases → complete events on a dedicated "Phases" thread</item>
+///   <item>Typhon-specific data (entities, skip reason, tier) → <c>args</c> dict</item>
+/// </list>
+/// </remarks>
+public static class ChromeTraceExporter
+{
+    /// <summary>
+    /// Exports a trace file to Chrome Trace JSON format.
+    /// </summary>
+    /// <param name="traceFilePath">Path to the <c>.typhon-trace</c> file.</param>
+    /// <param name="outputStream">Stream to write JSON output to.</param>
+    public static void Export(string traceFilePath, Stream outputStream)
+    {
+        using var reader = new TraceFileReader(File.OpenRead(traceFilePath));
+        var header = reader.ReadHeader();
+        var systems = reader.ReadSystemDefinitions();
+        var events = reader.ReadAllEvents();
+
+        Export(header, systems, events, outputStream);
+    }
+
+    /// <summary>
+    /// Exports pre-loaded trace data to Chrome Trace JSON format.
+    /// </summary>
+    public static void Export(TraceFileHeader header, IReadOnlyList<SystemDefinitionRecord> systems, IReadOnlyList<TraceEvent> events, Stream outputStream)
+    {
+        var ticksPerUs = header.TimestampFrequency / 1_000_000.0;
+
+        using var writer = new Utf8JsonWriter(outputStream, new JsonWriterOptions { Indented = false });
+        writer.WriteStartObject();
+        writer.WriteStartArray("traceEvents");
+
+        // Write process and thread metadata
+        WriteMetadata(writer, header, systems);
+
+        // Track phase starts for computing durations
+        var phaseStarts = new Dictionary<TickPhase, long>();
+
+        // Track chunk starts for computing durations: key = (systemIndex, chunkIndex, workerId)
+        var chunkStarts = new Dictionary<(ushort, ushort, byte), long>();
+
+        foreach (var evt in events)
+        {
+            var timestampUs = evt.TimestampTicks / ticksPerUs;
+
+            switch (evt.EventType)
+            {
+                case TraceEventType.TickStart:
+                    // Instant event marking tick boundary
+                    WriteInstant(writer, "TickStart", timestampUs, 0, 0,
+                        w => w.WriteNumber("tickNumber", evt.TickNumber));
+                    phaseStarts.Clear();
+                    chunkStarts.Clear();
+                    break;
+
+                case TraceEventType.TickEnd:
+                    var overloadLevel = evt.Payload & 0xFF;
+                    var tickMultiplier = (evt.Payload >> 8) & 0xFF;
+                    WriteInstant(writer, "TickEnd", timestampUs, 0, 0, w =>
+                    {
+                        w.WriteNumber("tickNumber", evt.TickNumber);
+                        w.WriteNumber("overloadLevel", overloadLevel);
+                        w.WriteNumber("tickMultiplier", tickMultiplier);
+                    });
+                    break;
+
+                case TraceEventType.PhaseStart:
+                    phaseStarts[evt.Phase] = evt.TimestampTicks;
+                    break;
+
+                case TraceEventType.PhaseEnd:
+                    if (phaseStarts.TryGetValue(evt.Phase, out var phaseStart))
+                    {
+                        var durationUs = (evt.TimestampTicks - phaseStart) / ticksPerUs;
+                        // Phases rendered on thread ID = workerCount + 1 (dedicated "Phases" lane)
+                        WriteComplete(writer, evt.Phase.ToString(), timestampUs - durationUs, durationUs,
+                            1, header.WorkerCount + 1, null);
+                    }
+
+                    break;
+
+                case TraceEventType.SystemReady:
+                    WriteInstant(writer, GetSystemName(systems, evt.SystemIndex) + " Ready",
+                        timestampUs, 1, header.WorkerCount + 2, null);
+                    break;
+
+                case TraceEventType.ChunkStart:
+                    chunkStarts[(evt.SystemIndex, evt.ChunkIndex, evt.WorkerId)] = evt.TimestampTicks;
+                    break;
+
+                case TraceEventType.ChunkEnd:
+                    var key = (evt.SystemIndex, evt.ChunkIndex, evt.WorkerId);
+                    if (chunkStarts.TryGetValue(key, out var chunkStart))
+                    {
+                        var durationUs2 = (evt.TimestampTicks - chunkStart) / ticksPerUs;
+                        var sysName = GetSystemName(systems, evt.SystemIndex);
+                        var name = evt.ChunkIndex > 0 || IsParallel(systems, evt.SystemIndex)
+                            ? $"{sysName}[{evt.ChunkIndex}]"
+                            : sysName;
+
+                        WriteComplete(writer, name, timestampUs - durationUs2, durationUs2,
+                            1, evt.WorkerId, w =>
+                            {
+                                w.WriteNumber("systemIndex", evt.SystemIndex);
+                                w.WriteNumber("chunkIndex", evt.ChunkIndex);
+                                w.WriteNumber("entities", evt.EntitiesProcessed);
+                                if (IsParallel(systems, evt.SystemIndex))
+                                {
+                                    w.WriteNumber("totalChunks", evt.Payload);
+                                }
+                            });
+                    }
+
+                    break;
+
+                case TraceEventType.SystemSkipped:
+                    WriteInstant(writer, GetSystemName(systems, evt.SystemIndex) + " [SKIPPED]",
+                        timestampUs, 1, header.WorkerCount + 2,
+                        w => w.WriteString("reason", ((SkipReasonCode)evt.SkipReason).ToString()));
+                    break;
+            }
+        }
+
+        writer.WriteEndArray(); // traceEvents
+
+        // Write metadata
+        writer.WriteString("displayTimeUnit", "us");
+        writer.WriteEndObject();
+        writer.Flush();
+    }
+
+    private static void WriteMetadata(Utf8JsonWriter writer, TraceFileHeader header, IReadOnlyList<SystemDefinitionRecord> systems)
+    {
+        // Process name
+        WriteMetadataEvent(writer, "process_name", 1, 0, w => w.WriteString("name", "Typhon Runtime"));
+
+        // Thread names for each worker
+        for (var i = 0; i < header.WorkerCount; i++)
+        {
+            WriteMetadataEvent(writer, "thread_name", 1, i,
+                w => w.WriteString("name", $"Worker {i}"));
+        }
+
+        // Phases thread
+        WriteMetadataEvent(writer, "thread_name", 1, header.WorkerCount + 1,
+            w => w.WriteString("name", "Tick Phases"));
+
+        // DAG events thread
+        WriteMetadataEvent(writer, "thread_name", 1, header.WorkerCount + 2,
+            w => w.WriteString("name", "DAG Events"));
+    }
+
+    private static void WriteComplete(Utf8JsonWriter writer, string name, double timestampUs, double durationUs, int pid, int tid, Action<Utf8JsonWriter> writeArgs)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("ph", "X");
+        writer.WriteString("name", name);
+        writer.WriteNumber("ts", Math.Round(timestampUs, 3));
+        writer.WriteNumber("dur", Math.Round(durationUs, 3));
+        writer.WriteNumber("pid", pid);
+        writer.WriteNumber("tid", tid);
+
+        if (writeArgs != null)
+        {
+            writer.WriteStartObject("args");
+            writeArgs(writer);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteInstant(Utf8JsonWriter writer, string name, double timestampUs, int pid, int tid, Action<Utf8JsonWriter> writeArgs)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("ph", "i");
+        writer.WriteString("name", name);
+        writer.WriteNumber("ts", Math.Round(timestampUs, 3));
+        writer.WriteNumber("pid", pid);
+        writer.WriteNumber("tid", tid);
+        writer.WriteString("s", "t"); // thread scope
+
+        if (writeArgs != null)
+        {
+            writer.WriteStartObject("args");
+            writeArgs(writer);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteMetadataEvent(Utf8JsonWriter writer, string name, int pid, int tid, Action<Utf8JsonWriter> writeArgs)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("ph", "M");
+        writer.WriteString("name", name);
+        writer.WriteNumber("pid", pid);
+        writer.WriteNumber("tid", tid);
+
+        writer.WriteStartObject("args");
+        writeArgs(writer);
+        writer.WriteEndObject();
+
+        writer.WriteEndObject();
+    }
+
+    private static string GetSystemName(IReadOnlyList<SystemDefinitionRecord> systems, ushort index) =>
+        index < systems.Count ? systems[index].Name : $"System[{index}]";
+
+    private static bool IsParallel(IReadOnlyList<SystemDefinitionRecord> systems, ushort index) => index < systems.Count && systems[index].IsParallel;
+
+    /// <summary>
+    /// Mirror of Typhon.Engine's SkipReason enum for display purposes.
+    /// </summary>
+    private enum SkipReasonCode : byte
+    {
+        NotSkipped = 0,
+        RunIfFalse = 1,
+        EmptyInput = 2,
+        EmptyEvents = 3,
+        Throttled = 4,
+        Shed = 5,
+        Exception = 6,
+        DependencyFailed = 7
+    }
+}

--- a/src/Typhon.Profiler/LiveStreamProtocol.cs
+++ b/src/Typhon.Profiler/LiveStreamProtocol.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Buffers.Binary;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Frame types for the live streaming TCP protocol between the engine and profiler server.
+/// </summary>
+public enum LiveFrameType : byte
+{
+    /// <summary>Session initialization: TraceFileHeader + SystemDefinitionTable + SpanNameTable.</summary>
+    Init = 0x01,
+
+    /// <summary>Compressed event block (identical to .typhon-trace file block format).</summary>
+    TickEvents = 0x02,
+
+    /// <summary>Incremental span name entries (only newly interned names since last send).</summary>
+    SpanNames = 0x03,
+
+    /// <summary>Graceful shutdown signal (empty payload).</summary>
+    Shutdown = 0xFF
+}
+
+/// <summary>
+/// Wire protocol helpers for the live streaming framed binary protocol.
+/// Frame envelope: <c>[1B FrameType] [4B PayloadLength] [PayloadLength bytes Payload]</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Endianness:</b> all multi-byte integers are little-endian. This applies to the 4-byte payload length
+/// in the frame header, the 12-byte block header inside TICK_EVENTS frames, and the <see cref="TraceFileHeader"/>
+/// struct inside the INIT payload. Supported architectures (x86/x64/ARM64) are all little-endian natively, so
+/// <see cref="System.Runtime.InteropServices.MemoryMarshal.Read{T}"/> on blittable structs reinterprets the bytes
+/// correctly. Running on big-endian hardware (s390x, some MIPS) is unsupported and will produce corrupted output.
+/// </para>
+/// <para>
+/// <b>Framing model:</b> unidirectional (engine → server). The engine never reads from the socket. A single client
+/// is accepted at a time; additional connections are rejected. On disconnect, the engine drops all buffered events
+/// until a new client connects and receives a fresh INIT frame.
+/// </para>
+/// </remarks>
+public static class LiveStreamProtocol
+{
+    /// <summary>Size of the frame envelope header in bytes (1 type + 4 length).</summary>
+    public const int FrameHeaderSize = 5;
+
+    /// <summary>Default TCP port for the live stream listener.</summary>
+    public const int DefaultPort = 9001;
+
+    /// <summary>Writes a frame header into the destination span.</summary>
+    public static void WriteFrameHeader(Span<byte> dest, LiveFrameType type, int payloadLength)
+    {
+        dest[0] = (byte)type;
+        BinaryPrimitives.WriteInt32LittleEndian(dest[1..], payloadLength);
+    }
+
+    /// <summary>Reads a frame header from the source span.</summary>
+    public static (LiveFrameType Type, int PayloadLength) ReadFrameHeader(ReadOnlySpan<byte> source) 
+        => ((LiveFrameType)source[0], BinaryPrimitives.ReadInt32LittleEndian(source[1..]));
+}

--- a/src/Typhon.Profiler/SystemDefinitionRecord.cs
+++ b/src/Typhon.Profiler/SystemDefinitionRecord.cs
@@ -1,0 +1,32 @@
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Describes a system in the DAG, stored in the system definition table of a <c>.typhon-trace</c> file.
+/// Variable-length record (name is UTF-8 encoded).
+/// </summary>
+public sealed class SystemDefinitionRecord
+{
+    /// <summary>System index in the DAG array.</summary>
+    public ushort Index { get; init; }
+
+    /// <summary>Display name of the system.</summary>
+    public string Name { get; init; }
+
+    /// <summary>Execution model (Pipeline = 0, Query = 1, Callback = 2).</summary>
+    public byte Type { get; init; }
+
+    /// <summary>Priority for overload management (Normal = 0, Low = 1, High = 2, Critical = 3).</summary>
+    public byte Priority { get; init; }
+
+    /// <summary>Whether this system uses parallel chunk dispatch.</summary>
+    public bool IsParallel { get; init; }
+
+    /// <summary>Simulation tier filter (SimTier flags byte). 0x0F = All.</summary>
+    public byte TierFilter { get; init; }
+
+    /// <summary>Indices of predecessor systems in the DAG.</summary>
+    public ushort[] Predecessors { get; init; } = [];
+
+    /// <summary>Indices of successor systems in the DAG.</summary>
+    public ushort[] Successors { get; init; } = [];
+}

--- a/src/Typhon.Profiler/TickPhase.cs
+++ b/src/Typhon.Profiler/TickPhase.cs
@@ -1,0 +1,25 @@
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Identifies a phase within a tick's lifecycle.
+/// </summary>
+public enum TickPhase : byte
+{
+    /// <summary>System dispatch phase — the DAG scheduler is running systems.</summary>
+    SystemDispatch = 0,
+
+    /// <summary>UoW flush — deferred writes becoming durable (WAL write).</summary>
+    UowFlush = 1,
+
+    /// <summary>Write tick fence — dirty bitmap snapshot, shadow entry processing, spatial index update.</summary>
+    WriteTickFence = 2,
+
+    /// <summary>Subscription output — refresh published Views, compute deltas, push to clients.</summary>
+    OutputPhase = 3,
+
+    /// <summary>Tier index rebuild — rebuild per-archetype tier cluster indexes at tick start.</summary>
+    TierIndexRebuild = 4,
+
+    /// <summary>Dormancy sweep — advance sleep counters, transition idle clusters.</summary>
+    DormancySweep = 5
+}

--- a/src/Typhon.Profiler/TraceBlockEncoder.cs
+++ b/src/Typhon.Profiler/TraceBlockEncoder.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using K4os.Compression.LZ4;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Shared block encoder/decoder for the <c>.typhon-trace</c> on-disk format and the TCP live-stream protocol.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A block consists of a 12-byte header followed by LZ4-compressed, delta-encoded events:
+/// <code>
+/// [4B uncompressedSize] [4B compressedSize] [4B eventCount] [compressedSize bytes LZ4 data]
+/// </code>
+/// </para>
+/// <para>
+/// Both the file writer and the TCP live-stream inspector use this encoder so they emit byte-identical block bodies. Changes to the delta-encoding
+/// or compression scheme are made in one place.
+/// </para>
+/// </remarks>
+public static class TraceBlockEncoder
+{
+    /// <summary>Size of the block header in bytes.</summary>
+    public const int BlockHeaderSize = 12;
+
+    /// <summary>Size of one <see cref="TraceEvent"/> in bytes (blittable; 32 bytes).</summary>
+    public static readonly int EventSize = Unsafe.SizeOf<TraceEvent>();
+
+    /// <summary>
+    /// Delta-encodes a span of events into <paramref name="rawBuffer"/>, LZ4-compresses into <paramref name="compressedBuffer"/>,
+    /// and writes the 12-byte block header to <paramref name="blockHeader"/>.
+    /// </summary>
+    /// <param name="events">Events to encode (absolute timestamps).</param>
+    /// <param name="rawBuffer">Scratch buffer, must be at least <c>events.Length * EventSize</c> bytes.</param>
+    /// <param name="compressedBuffer">Output buffer for compressed data, must be at least <c>LZ4Codec.MaximumOutputSize(events.Length * EventSize)</c> bytes.</param>
+    /// <param name="blockHeader">Destination for the 12-byte block header; must be exactly 12 bytes.</param>
+    /// <returns>Number of bytes written to <paramref name="compressedBuffer"/>.</returns>
+    public static int EncodeBlock(
+        ReadOnlySpan<TraceEvent> events,
+        Span<byte> rawBuffer,
+        Span<byte> compressedBuffer,
+        Span<byte> blockHeader)
+    {
+        if (blockHeader.Length < BlockHeaderSize)
+        {
+            throw new ArgumentException($"blockHeader must be at least {BlockHeaderSize} bytes", nameof(blockHeader));
+        }
+
+        var rawSize = events.Length * EventSize;
+        var rawSpan = rawBuffer[..rawSize];
+        var eventDest = MemoryMarshal.Cast<byte, TraceEvent>(rawSpan);
+
+        events.CopyTo(eventDest);
+
+        // Apply delta encoding in reverse order so we don't overwrite source data
+        for (var i = eventDest.Length - 1; i > 0; i--)
+        {
+            eventDest[i].TimestampTicks -= eventDest[i - 1].TimestampTicks;
+        }
+
+        var compressedSize = LZ4Codec.Encode(rawSpan, compressedBuffer);
+
+        BinaryPrimitives.WriteInt32LittleEndian(blockHeader, rawSize);
+        BinaryPrimitives.WriteInt32LittleEndian(blockHeader[4..], compressedSize);
+        BinaryPrimitives.WriteInt32LittleEndian(blockHeader[8..], events.Length);
+
+        return compressedSize;
+    }
+
+    /// <summary>
+    /// Reads a block header and returns its fields.
+    /// </summary>
+    public static (int UncompressedSize, int CompressedSize, int EventCount) ReadBlockHeader(ReadOnlySpan<byte> blockHeader)
+    {
+        if (blockHeader.Length < BlockHeaderSize)
+        {
+            throw new ArgumentException($"blockHeader must be at least {BlockHeaderSize} bytes", nameof(blockHeader));
+        }
+
+        var uncompressedSize = BinaryPrimitives.ReadInt32LittleEndian(blockHeader);
+        var compressedSize = BinaryPrimitives.ReadInt32LittleEndian(blockHeader[4..]);
+        var eventCount = BinaryPrimitives.ReadInt32LittleEndian(blockHeader[8..]);
+        return (uncompressedSize, compressedSize, eventCount);
+    }
+
+    /// <summary>
+    /// Decompresses a block's LZ4 payload and restores absolute timestamps by undoing delta encoding.
+    /// </summary>
+    /// <param name="compressedData">LZ4-compressed payload (exactly <c>compressedSize</c> bytes from the header).</param>
+    /// <param name="uncompressedSize">Expected decompressed size in bytes (from the header).</param>
+    /// <param name="eventCount">Number of events in the block (from the header).</param>
+    /// <param name="rawBuffer">Scratch buffer for decompression, must be at least <paramref name="uncompressedSize"/> bytes.</param>
+    /// <param name="eventsOut">Destination for decoded events; must hold at least <paramref name="eventCount"/> elements.</param>
+    /// <exception cref="InvalidDataException">If LZ4 decoding produces an unexpected size.</exception>
+    public static void DecodeBlock(
+        ReadOnlySpan<byte> compressedData,
+        int uncompressedSize,
+        int eventCount,
+        Span<byte> rawBuffer,
+        Span<TraceEvent> eventsOut)
+    {
+        var decoded = LZ4Codec.Decode(compressedData, rawBuffer[..uncompressedSize]);
+        if (decoded != uncompressedSize)
+        {
+            throw new InvalidDataException($"LZ4 decompression size mismatch: expected {uncompressedSize}, got {decoded}");
+        }
+
+        var rawEvents = MemoryMarshal.Cast<byte, TraceEvent>(rawBuffer[..uncompressedSize]);
+        rawEvents[..eventCount].CopyTo(eventsOut);
+
+        // Undo delta encoding: cumulative sum of timestamps
+        for (var i = 1; i < eventCount; i++)
+        {
+            eventsOut[i].TimestampTicks += eventsOut[i - 1].TimestampTicks;
+        }
+    }
+}

--- a/src/Typhon.Profiler/TraceEvent.cs
+++ b/src/Typhon.Profiler/TraceEvent.cs
@@ -1,0 +1,62 @@
+using System.Runtime.InteropServices;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// A single trace event captured during runtime profiling. Fixed 32-byte blittable struct written to per-thread SPSC ring buffers with minimal
+/// overhead (~5-8 ns per write).
+/// </summary>
+/// <remarks>
+/// Design choices (inspired by Tracy Profiler's 32-byte QueueItem):
+/// <list type="bullet">
+///   <item>Fixed size — no variable-length data, no GC pressure, memcpy-friendly</item>
+///   <item>Blittable — can be written directly to memory-mapped files or unmanaged buffers</item>
+///   <item>Pack(1) — no padding waste, maximizes cache utilization</item>
+///   <item>Fields are unioned by event type — e.g., <see cref="SkipReason"/> only meaningful for
+///         <see cref="TraceEventType.SystemSkipped"/>, <see cref="EntitiesProcessed"/> only for
+///         <see cref="TraceEventType.ChunkEnd"/></item>
+/// </list>
+/// </remarks>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct TraceEvent
+{
+    /// <summary>High-resolution timestamp from <c>Stopwatch.GetTimestamp()</c>.</summary>
+    public long TimestampTicks;
+
+    /// <summary>Monotonic tick number (wraps at int.MaxValue — ~414 days at 60 Hz).</summary>
+    public int TickNumber;
+
+    /// <summary>System index in the DAG (max 65,535 systems).</summary>
+    public ushort SystemIndex;
+
+    /// <summary>Chunk index within a parallel system dispatch (0 for sequential systems).</summary>
+    public ushort ChunkIndex;
+
+    /// <summary>Worker thread ID that produced this event (0-255).</summary>
+    public byte WorkerId;
+
+    /// <summary>Type of event. Determines which other fields are meaningful.</summary>
+    public TraceEventType EventType;
+
+    /// <summary>Tick phase identifier (for <see cref="TraceEventType.PhaseStart"/>/<see cref="TraceEventType.PhaseEnd"/>).</summary>
+    public TickPhase Phase;
+
+    /// <summary>Skip reason (for <see cref="TraceEventType.SystemSkipped"/>).</summary>
+    public byte SkipReason;
+
+    /// <summary>Entity count (for <see cref="TraceEventType.ChunkEnd"/>).</summary>
+    public int EntitiesProcessed;
+
+    /// <summary>
+    /// General-purpose payload. Interpretation depends on <see cref="EventType"/>:
+    /// <list type="bullet">
+    ///   <item><see cref="TraceEventType.TickEnd"/>: overload level (byte) | tick multiplier (byte) in low 16 bits</item>
+    ///   <item><see cref="TraceEventType.ChunkStart"/>: total chunks for this system dispatch</item>
+    ///   <item><see cref="TraceEventType.SystemReady"/>: predecessor count that was satisfied</item>
+    /// </list>
+    /// </summary>
+    public int Payload;
+
+    /// <summary>Reserved for future use (alignment to 32 bytes).</summary>
+    public int Reserved;
+}

--- a/src/Typhon.Profiler/TraceEventType.cs
+++ b/src/Typhon.Profiler/TraceEventType.cs
@@ -1,0 +1,37 @@
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Identifies the type of a <see cref="TraceEvent"/> in the profiling stream.
+/// </summary>
+public enum TraceEventType : byte
+{
+    /// <summary>Tick has started. <see cref="TraceEvent.TickNumber"/> is set.</summary>
+    TickStart = 0,
+
+    /// <summary>Tick has ended. <see cref="TraceEvent.TickNumber"/> and <see cref="TraceEvent.Payload"/> (overload level) are set.</summary>
+    TickEnd = 1,
+
+    /// <summary>A tick phase has started. <see cref="TraceEvent.Phase"/> identifies which phase.</summary>
+    PhaseStart = 2,
+
+    /// <summary>A tick phase has ended. <see cref="TraceEvent.Phase"/> identifies which phase.</summary>
+    PhaseEnd = 3,
+
+    /// <summary>A system became ready (all predecessors completed). <see cref="TraceEvent.SystemIndex"/> is set.</summary>
+    SystemReady = 4,
+
+    /// <summary>A system (or chunk of a parallel system) started executing on a worker.</summary>
+    ChunkStart = 5,
+
+    /// <summary>A system (or chunk of a parallel system) finished executing. <see cref="TraceEvent.EntitiesProcessed"/> is set.</summary>
+    ChunkEnd = 6,
+
+    /// <summary>A system was skipped. <see cref="TraceEvent.SkipReason"/> is set.</summary>
+    SystemSkipped = 7,
+
+    /// <summary>An OTel Activity/span started. <see cref="TraceEvent.Payload"/> contains the interned span name ID.</summary>
+    SpanStart = 8,
+
+    /// <summary>An OTel Activity/span ended. <see cref="TraceEvent.Payload"/> contains the interned span name ID.</summary>
+    SpanEnd = 9
+}

--- a/src/Typhon.Profiler/TraceFileHeader.cs
+++ b/src/Typhon.Profiler/TraceFileHeader.cs
@@ -1,0 +1,51 @@
+using System.Runtime.InteropServices;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Fixed 64-byte header at the start of a <c>.typhon-trace</c> file.
+/// Contains metadata needed to interpret the trace events that follow.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct TraceFileHeader
+{
+    /// <summary>File magic: ASCII "TYTR" (0x52_54_59_54 little-endian).</summary>
+    public uint Magic;
+
+    /// <summary>Format version. Current: 1.</summary>
+    public ushort Version;
+
+    /// <summary>Flags (reserved for future use).</summary>
+    public ushort Flags;
+
+    /// <summary><c>Stopwatch.Frequency</c> — needed to convert timestamp ticks to real time.</summary>
+    public long TimestampFrequency;
+
+    /// <summary>Target tick rate in Hz (e.g., 60.0 for 60 fps).</summary>
+    public float BaseTickRate;
+
+    /// <summary>Number of worker threads in the DagScheduler.</summary>
+    public byte WorkerCount;
+
+    /// <summary>Number of systems in the DAG.</summary>
+    public ushort SystemCount;
+
+    /// <summary>UTC timestamp when the trace was started (DateTime.UtcNow.Ticks).</summary>
+    public long CreatedUtcTicks;
+
+    /// <summary>
+    /// QPC timestamp (<c>Stopwatch.GetTimestamp()</c>) when the EventPipe sampling session started.
+    /// Used to correlate <c>.nettrace</c> relative timestamps with <c>.typhon-trace</c> absolute timestamps.
+    /// Zero if CPU sampling was not enabled.
+    /// </summary>
+    public long SamplingSessionStartQpc;
+
+    /// <summary>Reserved for future use — pads header to 64 bytes.</summary>
+    public unsafe fixed byte Reserved[21];
+
+    /// <summary>File magic constant: ASCII "TYTR".</summary>
+    public const uint MagicValue = 0x52_54_59_54; // 'T','Y','T','R' little-endian
+
+    /// <summary>Current format version.</summary>
+    public const ushort CurrentVersion = 1;
+}

--- a/src/Typhon.Profiler/TraceFileReader.cs
+++ b/src/Typhon.Profiler/TraceFileReader.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using K4os.Compression.LZ4;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Reads a <c>.typhon-trace</c> binary trace file. Provides sequential block-by-block access to trace events, restoring delta-encoded timestamps to absolute values.
+/// </summary>
+public sealed class TraceFileReader : IDisposable
+{
+    private readonly Stream _stream;
+    private readonly BinaryReader _binaryReader;
+    private byte[] _compressedBuffer;
+    private byte[] _rawBuffer;
+    private bool _disposed;
+
+    private static readonly int EventSize = Unsafe.SizeOf<TraceEvent>();
+
+    /// <summary>File header, available after <see cref="ReadHeader"/>.</summary>
+    public TraceFileHeader Header { get; private set; }
+
+    /// <summary>System definitions, available after <see cref="ReadSystemDefinitions"/>.</summary>
+    public IReadOnlyList<SystemDefinitionRecord> Systems => _systems;
+
+    private readonly List<SystemDefinitionRecord> _systems = [];
+
+    public TraceFileReader(Stream stream)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _binaryReader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+        _compressedBuffer = new byte[64 * 1024];
+        _rawBuffer = new byte[64 * 1024];
+    }
+
+    /// <summary>
+    /// Reads and validates the file header. Must be called first.
+    /// </summary>
+    /// <exception cref="InvalidDataException">If the magic or version is invalid.</exception>
+    public TraceFileHeader ReadHeader()
+    {
+        Span<byte> headerBytes = stackalloc byte[Unsafe.SizeOf<TraceFileHeader>()];
+        _stream.ReadExactly(headerBytes);
+
+        Header = MemoryMarshal.Read<TraceFileHeader>(headerBytes);
+
+        if (Header.Magic != TraceFileHeader.MagicValue)
+        {
+            throw new InvalidDataException(
+                $"Invalid trace file magic: 0x{Header.Magic:X8} (expected 0x{TraceFileHeader.MagicValue:X8})");
+        }
+
+        if (Header.Version > TraceFileHeader.CurrentVersion)
+        {
+            throw new InvalidDataException(
+                $"Unsupported trace file version: {Header.Version} (max supported: {TraceFileHeader.CurrentVersion})");
+        }
+
+        return Header;
+    }
+
+    /// <summary>
+    /// Reads the system definition table. Must be called after <see cref="ReadHeader"/>.
+    /// </summary>
+    public IReadOnlyList<SystemDefinitionRecord> ReadSystemDefinitions()
+    {
+        _systems.Clear();
+
+        var count = _binaryReader.ReadUInt16();
+
+        for (var i = 0; i < count; i++)
+        {
+            var index = _binaryReader.ReadUInt16();
+
+            var nameLen = _binaryReader.ReadByte();
+            var nameBytes = _binaryReader.ReadBytes(nameLen);
+            var name = Encoding.UTF8.GetString(nameBytes);
+
+            var type = _binaryReader.ReadByte();
+            var priority = _binaryReader.ReadByte();
+            var isParallel = _binaryReader.ReadBoolean();
+            var tierFilter = _binaryReader.ReadByte();
+
+            var predCount = _binaryReader.ReadByte();
+            var predecessors = new ushort[predCount];
+            for (var p = 0; p < predCount; p++)
+            {
+                predecessors[p] = _binaryReader.ReadUInt16();
+            }
+
+            var succCount = _binaryReader.ReadByte();
+            var successors = new ushort[succCount];
+            for (var s = 0; s < succCount; s++)
+            {
+                successors[s] = _binaryReader.ReadUInt16();
+            }
+
+            _systems.Add(new SystemDefinitionRecord
+            {
+                Index = index,
+                Name = name,
+                Type = type,
+                Priority = priority,
+                IsParallel = isParallel,
+                TierFilter = tierFilter,
+                Predecessors = predecessors,
+                Successors = successors
+            });
+        }
+
+        return _systems;
+    }
+
+    /// <summary>Span name intern table, available after <see cref="ReadSpanNames"/>.</summary>
+    public IReadOnlyDictionary<int, string> SpanNames => _spanNames;
+
+    private readonly Dictionary<int, string> _spanNames = new();
+
+    /// <summary>
+    /// Reads the span name intern table. Must be called after <see cref="ReadSystemDefinitions"/>.
+    /// </summary>
+    public IReadOnlyDictionary<int, string> ReadSpanNames()
+    {
+        var magic = _binaryReader.ReadUInt32();
+        if (magic != TraceFileWriter.SpanNameTableMagic)
+        {
+            // Not a span name table — seek back and return
+            _stream.Position -= 4;
+            return _spanNames;
+        }
+
+        var count = _binaryReader.ReadUInt16();
+        for (var i = 0; i < count; i++)
+        {
+            var id = _binaryReader.ReadUInt16();
+            var nameLen = _binaryReader.ReadByte();
+            var nameBytes = _binaryReader.ReadBytes(nameLen);
+            _spanNames[id] = Encoding.UTF8.GetString(nameBytes);
+        }
+
+        return _spanNames;
+    }
+
+    /// <summary>
+    /// Reads the next compressed block of events. Returns false if no more blocks.
+    /// Events are returned with absolute timestamps (delta decoding applied).
+    /// </summary>
+    /// <param name="events">Receives the decoded events. Empty if no more blocks.</param>
+    /// <returns>True if a block was read, false if end of stream.</returns>
+    public bool ReadNextBlock(out TraceEvent[] events)
+    {
+        events = [];
+
+        // Read block header: uncompressed (4B) + compressed (4B) + event count (4B)
+        Span<byte> blockHeader = stackalloc byte[12];
+        var bytesRead = _stream.Read(blockHeader);
+        if (bytesRead == 0)
+        {
+            return false;
+        }
+
+        if (bytesRead < 4)
+        {
+            return false; // Not enough data for any header
+        }
+
+        // Check if this is a span name table marker (appears before events and at end of file)
+        var firstWord = BinaryPrimitives.ReadUInt32LittleEndian(blockHeader);
+        if (firstWord == TraceFileWriter.SpanNameTableMagic)
+        {
+            // Seek back and read (skip) the span name table, then continue looking for event blocks
+            _stream.Position -= bytesRead;
+            ReadSpanNames();
+            return ReadNextBlock(out events); // recurse to try the next block
+        }
+
+        if (bytesRead < 12)
+        {
+            return false; // Truncated block — stop reading
+        }
+
+        var (uncompressedSize, compressedSize, eventCount) = TraceBlockEncoder.ReadBlockHeader(blockHeader);
+
+        // Grow buffers if needed
+        if (_compressedBuffer.Length < compressedSize)
+        {
+            _compressedBuffer = new byte[compressedSize];
+        }
+
+        if (_rawBuffer.Length < uncompressedSize)
+        {
+            _rawBuffer = new byte[uncompressedSize];
+        }
+
+        // Read compressed data
+        _stream.ReadExactly(_compressedBuffer.AsSpan(0, compressedSize));
+
+        // Decompress + undo delta encoding (via shared encoder)
+        events = new TraceEvent[eventCount];
+        TraceBlockEncoder.DecodeBlock(
+            _compressedBuffer.AsSpan(0, compressedSize),
+            uncompressedSize,
+            eventCount,
+            _rawBuffer,
+            events);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Reads all events from the file (after header + system defs + span names) into a single list.
+    /// Also reads trailing span name table written at shutdown.
+    /// </summary>
+    public List<TraceEvent> ReadAllEvents()
+    {
+        var all = new List<TraceEvent>();
+
+        while (ReadNextBlock(out var events))
+        {
+            all.AddRange(events);
+        }
+
+        // Try to read trailing span name table (written at shutdown with all interned names)
+        try
+        {
+            if (_stream.Position < _stream.Length)
+            {
+                ReadSpanNames();
+            }
+        }
+        catch
+        {
+            // No trailing span names — the initial table (or none) is used
+        }
+
+        return all;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _binaryReader.Dispose();
+        _stream.Dispose();
+    }
+}

--- a/src/Typhon.Profiler/TraceFileWriter.cs
+++ b/src/Typhon.Profiler/TraceFileWriter.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using K4os.Compression.LZ4;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Writes a <c>.typhon-trace</c> binary trace file. Thread-safe for concurrent event appending via <see cref="WriteEvents"/> (called from the background
+/// flush thread).
+/// </summary>
+/// <remarks>
+/// File layout:
+/// <code>
+/// [TraceFileHeader]          64 bytes, fixed
+/// [SystemDefinitionTable]    variable length, written once after header
+/// [CompressedBlock]*         repeating: BlockHeader + LZ4-compressed TraceEvent[]
+/// </code>
+/// Each compressed block contains events from one or more ticks, delta-encoded for better compression.
+/// </remarks>
+public sealed class TraceFileWriter : IDisposable
+{
+    private readonly BinaryWriter _writer;
+    private readonly Stream _stream;
+    private readonly byte[] _rawBuffer;
+    private readonly byte[] _compressedBuffer;
+    private bool _disposed;
+
+    /// <summary>Maximum events per compressed block before forcing a flush.</summary>
+    private const int MaxEventsPerBlock = 4096;
+
+    /// <summary>Size of a single TraceEvent in bytes.</summary>
+    private static readonly int EventSize = Unsafe.SizeOf<TraceEvent>();
+
+    public TraceFileWriter(Stream stream)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        // Pre-allocate buffers for compression
+        _rawBuffer = new byte[MaxEventsPerBlock * EventSize];
+        _compressedBuffer = new byte[LZ4Codec.MaximumOutputSize(_rawBuffer.Length)];
+    }
+
+    /// <summary>
+    /// Writes the file header. Must be called exactly once before any other writes.
+    /// </summary>
+    public void WriteHeader(in TraceFileHeader header)
+    {
+        var span = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(in header, 1));
+        _stream.Write(span);
+    }
+
+    /// <summary>
+    /// Writes the system definition table. Must be called exactly once after the header.
+    /// </summary>
+    public void WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord> systems)
+    {
+        _writer.Write((ushort)systems.Length);
+
+        foreach (var sys in systems)
+        {
+            _writer.Write(sys.Index);
+
+            var nameBytes = Encoding.UTF8.GetBytes(sys.Name);
+            _writer.Write((byte)Math.Min(nameBytes.Length, 255));
+            _writer.Write(nameBytes, 0, Math.Min(nameBytes.Length, 255));
+
+            _writer.Write(sys.Type);
+            _writer.Write(sys.Priority);
+            _writer.Write(sys.IsParallel);
+            _writer.Write(sys.TierFilter);
+
+            // Predecessors
+            _writer.Write((byte)sys.Predecessors.Length);
+            foreach (var pred in sys.Predecessors)
+            {
+                _writer.Write(pred);
+            }
+
+            // Successors
+            _writer.Write((byte)sys.Successors.Length);
+            foreach (var succ in sys.Successors)
+            {
+                _writer.Write(succ);
+            }
+        }
+
+        _writer.Flush();
+    }
+
+    /// <summary>Magic marker written before the trailing span name table to distinguish it from event blocks.</summary>
+    public const uint SpanNameTableMagic = 0x4E_41_50_53; // "SPAN" little-endian
+
+    /// <summary>
+    /// Writes the span name intern table. Called after system definitions (empty) and at shutdown (populated).
+    /// </summary>
+    public void WriteSpanNames(IReadOnlyDictionary<int, string> spanNames)
+    {
+        _writer.Write(SpanNameTableMagic);
+        _writer.Write((ushort)spanNames.Count);
+        foreach (var kv in spanNames)
+        {
+            _writer.Write((ushort)kv.Key);
+            var nameBytes = Encoding.UTF8.GetBytes(kv.Value);
+            _writer.Write((byte)Math.Min(nameBytes.Length, 255));
+            _writer.Write(nameBytes, 0, Math.Min(nameBytes.Length, 255));
+        }
+
+        _writer.Flush();
+    }
+
+    /// <summary>
+    /// Writes a batch of trace events as a compressed block. Events are delta-encoded (timestamps relative to the first event in the block) before LZ4 compression.
+    /// </summary>
+    /// <param name="events">Events to write. Must not exceed <see cref="MaxEventsPerBlock"/>.</param>
+    public void WriteEvents(ReadOnlySpan<TraceEvent> events)
+    {
+        if (events.IsEmpty)
+        {
+            return;
+        }
+
+        if (events.Length > MaxEventsPerBlock)
+        {
+            throw new ArgumentException($"Event count {events.Length} exceeds max {MaxEventsPerBlock}");
+        }
+
+        Span<byte> blockHeader = stackalloc byte[TraceBlockEncoder.BlockHeaderSize];
+        var compressedSize = TraceBlockEncoder.EncodeBlock(events, _rawBuffer, _compressedBuffer, blockHeader);
+
+        _stream.Write(blockHeader);
+        _stream.Write(_compressedBuffer.AsSpan(0, compressedSize));
+    }
+
+    public void Flush() => _stream.Flush();
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _writer.Dispose();
+        _stream.Dispose();
+    }
+}

--- a/src/Typhon.Profiler/Typhon.Profiler.csproj
+++ b/src/Typhon.Profiler/Typhon.Profiler.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>default</LangVersion>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
+    </ItemGroup>
+
+</Project>

--- a/test/Typhon.Engine.Tests/Observability/TraceBlockEncoderTests.cs
+++ b/test/Typhon.Engine.Tests/Observability/TraceBlockEncoderTests.cs
@@ -1,0 +1,229 @@
+using System;
+using System.IO;
+using K4os.Compression.LZ4;
+using NUnit.Framework;
+using Typhon.Profiler;
+using ProfilerTickPhase = Typhon.Profiler.TickPhase;
+
+namespace Typhon.Engine.Tests.Observability;
+
+/// <summary>
+/// Verifies that <see cref="TraceBlockEncoder"/> round-trips events correctly and that the on-disk
+/// format produced via <see cref="TraceFileWriter"/> + <see cref="TraceFileReader"/> matches the shared
+/// encoder output byte-for-byte. Both the file writer and the TCP live-stream inspector go through
+/// this same encoder, so this is a contract test for the protocol.
+/// </summary>
+[TestFixture]
+public class TraceBlockEncoderTests
+{
+    private static TraceEvent MakeEvent(long timestamp, int tickNumber, TraceEventType type, ushort systemIndex = 0,
+        ushort chunkIndex = 0, byte workerId = 0, int payload = 0, int entities = 0)
+    {
+        return new TraceEvent
+        {
+            TimestampTicks = timestamp,
+            TickNumber = tickNumber,
+            SystemIndex = systemIndex,
+            ChunkIndex = chunkIndex,
+            WorkerId = workerId,
+            EventType = type,
+            Phase = ProfilerTickPhase.SystemDispatch,
+            SkipReason = 0,
+            EntitiesProcessed = entities,
+            Payload = payload,
+            Reserved = 0
+        };
+    }
+
+    [Test]
+    public void RoundTrip_SingleEvent_PreservesAllFields()
+    {
+        var original = new[]
+        {
+            MakeEvent(1_000_000, 42, TraceEventType.ChunkStart, systemIndex: 7, chunkIndex: 3, workerId: 5, payload: 16, entities: 1234)
+        };
+
+        var decoded = EncodeDecode(original);
+
+        Assert.That(decoded.Length, Is.EqualTo(1));
+        Assert.That(decoded[0].TimestampTicks, Is.EqualTo(original[0].TimestampTicks));
+        Assert.That(decoded[0].TickNumber, Is.EqualTo(original[0].TickNumber));
+        Assert.That(decoded[0].SystemIndex, Is.EqualTo(original[0].SystemIndex));
+        Assert.That(decoded[0].ChunkIndex, Is.EqualTo(original[0].ChunkIndex));
+        Assert.That(decoded[0].WorkerId, Is.EqualTo(original[0].WorkerId));
+        Assert.That(decoded[0].EventType, Is.EqualTo(original[0].EventType));
+        Assert.That(decoded[0].Payload, Is.EqualTo(original[0].Payload));
+        Assert.That(decoded[0].EntitiesProcessed, Is.EqualTo(original[0].EntitiesProcessed));
+    }
+
+    [Test]
+    public void RoundTrip_MultipleEvents_PreservesAbsoluteTimestampsAfterDeltaEncoding()
+    {
+        // Non-monotonic-difference timestamps to exercise delta encoding
+        var original = new[]
+        {
+            MakeEvent(10_000, 1, TraceEventType.TickStart),
+            MakeEvent(10_100, 1, TraceEventType.PhaseStart),
+            MakeEvent(11_234, 1, TraceEventType.ChunkStart, systemIndex: 2),
+            MakeEvent(15_999, 1, TraceEventType.ChunkEnd, systemIndex: 2, entities: 42),
+            MakeEvent(20_000, 1, TraceEventType.PhaseEnd),
+            MakeEvent(20_050, 1, TraceEventType.TickEnd)
+        };
+
+        var decoded = EncodeDecode(original);
+
+        Assert.That(decoded.Length, Is.EqualTo(original.Length));
+        for (var i = 0; i < original.Length; i++)
+        {
+            Assert.That(decoded[i].TimestampTicks, Is.EqualTo(original[i].TimestampTicks), $"timestamp mismatch at index {i}");
+            Assert.That(decoded[i].EventType, Is.EqualTo(original[i].EventType), $"event type mismatch at index {i}");
+        }
+    }
+
+    [Test]
+    public void RoundTrip_MaxBlockSize_Works()
+    {
+        // 4096 events is the advertised max block size
+        var original = new TraceEvent[4096];
+        for (var i = 0; i < original.Length; i++)
+        {
+            original[i] = MakeEvent(1000 + i * 37, 1, TraceEventType.ChunkStart, systemIndex: (ushort)(i % 100));
+        }
+
+        var decoded = EncodeDecode(original);
+
+        Assert.That(decoded.Length, Is.EqualTo(original.Length));
+        for (var i = 0; i < original.Length; i++)
+        {
+            Assert.That(decoded[i].TimestampTicks, Is.EqualTo(original[i].TimestampTicks));
+            Assert.That(decoded[i].SystemIndex, Is.EqualTo(original[i].SystemIndex));
+        }
+    }
+
+    [Test]
+    public void BlockHeader_ExposesCorrectFields()
+    {
+        var original = new[]
+        {
+            MakeEvent(100, 1, TraceEventType.TickStart),
+            MakeEvent(200, 1, TraceEventType.TickEnd)
+        };
+
+        var rawBuffer = new byte[original.Length * TraceBlockEncoder.EventSize];
+        var compressedBuffer = new byte[LZ4Codec.MaximumOutputSize(rawBuffer.Length)];
+        var blockHeader = new byte[TraceBlockEncoder.BlockHeaderSize];
+
+        var compressedSize = TraceBlockEncoder.EncodeBlock(original, rawBuffer, compressedBuffer, blockHeader);
+
+        var (uncompressed, compressed, count) = TraceBlockEncoder.ReadBlockHeader(blockHeader);
+        Assert.That(uncompressed, Is.EqualTo(original.Length * TraceBlockEncoder.EventSize));
+        Assert.That(compressed, Is.EqualTo(compressedSize));
+        Assert.That(count, Is.EqualTo(original.Length));
+    }
+
+    [Test]
+    public void FileWriterAndReader_RoundTripViaSharedEncoder()
+    {
+        // Full pipeline: write through TraceFileWriter, read back through TraceFileReader.
+        // Both use TraceBlockEncoder under the hood, so this validates the shared contract.
+        var original = new[]
+        {
+            MakeEvent(1_000, 1, TraceEventType.TickStart),
+            MakeEvent(1_050, 1, TraceEventType.ChunkStart, systemIndex: 5, workerId: 2),
+            MakeEvent(1_200, 1, TraceEventType.ChunkEnd, systemIndex: 5, workerId: 2, entities: 100),
+            MakeEvent(1_300, 1, TraceEventType.TickEnd)
+        };
+
+        // Use two separate MemoryStreams: write into one, copy bytes, read from another.
+        // TraceFileWriter's Dispose closes the stream, so we can't reuse a single MemoryStream.
+        var writeStream = new MemoryStream();
+        var writer = new TraceFileWriter(writeStream);
+        var header = new TraceFileHeader
+        {
+            Magic = TraceFileHeader.MagicValue,
+            Version = TraceFileHeader.CurrentVersion,
+            Flags = 0,
+            TimestampFrequency = 10_000_000,
+            BaseTickRate = 60,
+            WorkerCount = 1,
+            SystemCount = 0,
+            CreatedUtcTicks = DateTime.UtcNow.Ticks,
+            SamplingSessionStartQpc = 0
+        };
+        writer.WriteHeader(in header);
+        writer.WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord>.Empty);
+        writer.WriteSpanNames(new System.Collections.Generic.Dictionary<int, string>());
+        writer.WriteEvents(original);
+        writer.Flush();
+
+        var bytes = writeStream.ToArray();
+        var readStream = new MemoryStream(bytes);
+
+        using (var reader = new TraceFileReader(readStream))
+        {
+            var readHeader = reader.ReadHeader();
+            Assert.That(readHeader.Magic, Is.EqualTo(TraceFileHeader.MagicValue));
+
+            reader.ReadSystemDefinitions();
+            reader.ReadSpanNames();
+
+            Assert.That(reader.ReadNextBlock(out var events), Is.True);
+            Assert.That(events.Length, Is.EqualTo(original.Length));
+
+            for (var i = 0; i < original.Length; i++)
+            {
+                Assert.That(events[i].TimestampTicks, Is.EqualTo(original[i].TimestampTicks));
+                Assert.That(events[i].EventType, Is.EqualTo(original[i].EventType));
+                Assert.That(events[i].SystemIndex, Is.EqualTo(original[i].SystemIndex));
+                Assert.That(events[i].WorkerId, Is.EqualTo(original[i].WorkerId));
+                Assert.That(events[i].EntitiesProcessed, Is.EqualTo(original[i].EntitiesProcessed));
+            }
+        }
+    }
+
+    [Test]
+    public void DoesNotMutateInput()
+    {
+        // The encoder must not mutate the caller's event span — delta encoding happens in the scratch buffer
+        var original = new[]
+        {
+            MakeEvent(1000, 1, TraceEventType.TickStart),
+            MakeEvent(2000, 1, TraceEventType.TickEnd)
+        };
+
+        var rawBuffer = new byte[original.Length * TraceBlockEncoder.EventSize];
+        var compressedBuffer = new byte[LZ4Codec.MaximumOutputSize(rawBuffer.Length)];
+        var blockHeader = new byte[TraceBlockEncoder.BlockHeaderSize];
+
+        TraceBlockEncoder.EncodeBlock(original, rawBuffer, compressedBuffer, blockHeader);
+
+        // Originals unchanged
+        Assert.That(original[0].TimestampTicks, Is.EqualTo(1000));
+        Assert.That(original[1].TimestampTicks, Is.EqualTo(2000));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════════════════════════
+
+    private static TraceEvent[] EncodeDecode(TraceEvent[] original)
+    {
+        var rawBuffer = new byte[original.Length * TraceBlockEncoder.EventSize];
+        var compressedBuffer = new byte[LZ4Codec.MaximumOutputSize(rawBuffer.Length)];
+        var blockHeader = new byte[TraceBlockEncoder.BlockHeaderSize];
+
+        var compressedSize = TraceBlockEncoder.EncodeBlock(original, rawBuffer, compressedBuffer, blockHeader);
+        var (uncompressed, _, count) = TraceBlockEncoder.ReadBlockHeader(blockHeader);
+
+        var decoded = new TraceEvent[count];
+        var decodeRawBuffer = new byte[uncompressed];
+        TraceBlockEncoder.DecodeBlock(
+            compressedBuffer.AsSpan(0, compressedSize),
+            uncompressed,
+            count,
+            decodeRawBuffer,
+            decoded);
+
+        return decoded;
+    }
+}

--- a/test/Typhon.Engine.Tests/Typhon.Engine.Tests.csproj
+++ b/test/Typhon.Engine.Tests/Typhon.Engine.Tests.csproj
@@ -36,6 +36,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Typhon.Engine\Typhon.Engine.csproj" />
+        <ProjectReference Include="..\..\src\Typhon.Profiler\Typhon.Profiler.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tools/Typhon.Profiler.Server/.gitignore
+++ b/tools/Typhon.Profiler.Server/.gitignore
@@ -1,0 +1,2 @@
+wwwroot/
+ClientApp/node_modules/

--- a/tools/Typhon.Profiler.Server/ClientApp/index.html
+++ b/tools/Typhon.Profiler.Server/ClientApp/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Typhon Profiler</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace; background: #1a1a2e; color: #e0e0e0; }
+    #app { width: 100vw; height: 100vh; display: flex; flex-direction: column; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/tools/Typhon.Profiler.Server/ClientApp/package-lock.json
+++ b/tools/Typhon.Profiler.Server/ClientApp/package-lock.json
@@ -1,0 +1,2070 @@
+{
+  "name": "typhon-profiler-client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typhon-profiler-client",
+      "version": "0.1.0",
+      "dependencies": {
+        "preact": "^10.25.0"
+      },
+      "devDependencies": {
+        "@preact/preset-vite": "^2.9.0",
+        "typescript": "^5.7.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+      "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-jsx": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+      "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@preact/preset-vite": {
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.10.5.tgz",
+      "integrity": "sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+        "@prefresh/vite": "^2.4.11",
+        "@rollup/pluginutils": "^5.0.0",
+        "babel-plugin-transform-hook-names": "^1.0.2",
+        "debug": "^4.4.3",
+        "magic-string": "^0.30.21",
+        "picocolors": "^1.1.1",
+        "vite-prerender-plugin": "^0.5.8",
+        "zimmerframe": "^1.1.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "7.x",
+        "vite": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x"
+      }
+    },
+    "node_modules/@prefresh/babel-plugin": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@prefresh/babel-plugin/-/babel-plugin-0.5.3.tgz",
+      "integrity": "sha512-57LX2SHs4BX2s1IwCjNzTE2OJeEepRCNf1VTEpbNcUyHfMO68eeOWGDIt4ob9aYlW6PEWZ1SuwNikuoIXANDtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@prefresh/core": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/@prefresh/core/-/core-1.5.9.tgz",
+      "integrity": "sha512-IKBKCPaz34OFVC+adiQ2qaTF5qdztO2/4ZPf4KsRTgjKosWqxVXmEbxCiUydYZRY8GVie+DQlKzQr9gt6HQ+EQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": "^10.0.0 || ^11.0.0-0"
+      }
+    },
+    "node_modules/@prefresh/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@prefresh/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@prefresh/vite": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.4.12.tgz",
+      "integrity": "sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.22.1",
+        "@prefresh/babel-plugin": "^0.5.2",
+        "@prefresh/core": "^1.5.0",
+        "@prefresh/utils": "^1.2.0",
+        "@rollup/pluginutils": "^4.2.1"
+      },
+      "peerDependencies": {
+        "preact": "^10.4.0 || ^11.0.0-0",
+        "vite": ">=2.0.0"
+      }
+    },
+    "node_modules/@prefresh/vite/node_modules/@rollup/pluginutils": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@prefresh/vite/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-transform-hook-names": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
+      "integrity": "sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@babel/core": "^7.12.10"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.334",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/simple-code-frame": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/simple-code-frame/-/simple-code-frame-1.3.0.tgz",
+      "integrity": "sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kolorist": "^1.6.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "1.0.0-pre2",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre2.tgz",
+      "integrity": "sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-prerender-plugin": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/vite-prerender-plugin/-/vite-prerender-plugin-0.5.13.tgz",
+      "integrity": "sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kolorist": "^1.8.0",
+        "magic-string": "0.x >= 0.26.0",
+        "node-html-parser": "^6.1.12",
+        "simple-code-frame": "^1.3.0",
+        "source-map": "^0.7.4",
+        "stack-trace": "^1.0.0-pre2"
+      },
+      "peerDependencies": {
+        "vite": "5.x || 6.x || 7.x || 8.x"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/package.json
+++ b/tools/Typhon.Profiler.Server/ClientApp/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "typhon-profiler-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "preact": "^10.25.0"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.9.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/App.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/App.tsx
@@ -1,0 +1,258 @@
+import { useState, useCallback, useRef, useEffect } from 'preact/hooks';
+import { uploadTrace, fetchEvents } from './api';
+import { processTrace, createEmptyTrace, processTickAndAppend, mergeSpanNames, type ProcessedTrace, type ChunkSpan } from './traceModel';
+import type { TimeRange } from './uiTypes';
+import type { TraceEvent } from './types';
+import { MenuBar } from './MenuBar';
+import { TickTimeline } from './TickTimeline';
+import { Workspace } from './Workspace';
+import { DIM_TEXT } from './canvasUtils';
+import { connectLive } from './liveSource';
+
+/** Buffered tick data waiting to be processed into the trace. */
+interface BufferedTick {
+  tickNumber: number;
+  events: TraceEvent[];
+  spanNames?: Record<number, string>;
+}
+
+export function App() {
+  const [trace, setTrace] = useState<ProcessedTrace | null>(null);
+  const [tracePath, setTracePath] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [viewRange, setViewRange] = useState<TimeRange>({ startUs: 0, endUs: 0 });
+  const [selectedChunk, setSelectedChunk] = useState<ChunkSpan | null>(null);
+
+  // Live mode state
+  const [isLive, setIsLive] = useState(false);
+  const liveRef = useRef<EventSource | null>(null);
+  const tickBufferRef = useRef<BufferedTick[]>([]);
+  const traceRef = useRef<ProcessedTrace | null>(null);
+  const flushIntervalRef = useRef<number>(0);
+  // Explicit follow-mode flag. True = auto-scroll viewRange to the latest tick on each flush.
+  // Set false as soon as the user interacts with the timeline/graph (pan, zoom, click).
+  // Lives in a ref so changing it doesn't re-render, and the flush callback always sees the latest value.
+  const followRef = useRef<boolean>(true);
+
+  // Keep traceRef in sync with state
+  useEffect(() => {
+    traceRef.current = trace;
+  }, [trace]);
+
+  // File loading handler (existing)
+  const handleFileSelected = useCallback(async (files: File[]) => {
+    // Disconnect live if active
+    if (liveRef.current) {
+      liveRef.current.close();
+      liveRef.current = null;
+      setIsLive(false);
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await uploadTrace(files);
+      const eventsData = await fetchEvents(result.path);
+      const processed = processTrace(result.metadata, eventsData.events, eventsData.spanNames ?? {});
+      setTrace(processed);
+      setTracePath(result.path);
+      const traceFile = files.find(f => f.name.endsWith('.typhon-trace'));
+      setFileName(traceFile?.name ?? files[0].name);
+      setSelectedChunk(null);
+      // Default view: first tick
+      if (processed.ticks.length > 0) {
+        const first = processed.ticks[0];
+        setViewRange({ startUs: first.startUs, endUs: first.endUs });
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load trace');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Live mode: flush buffered ticks into trace state (called at ~10Hz)
+  const flushTickBuffer = useCallback(() => {
+    const buffer = tickBufferRef.current;
+    if (buffer.length === 0) return;
+
+    // Grab all buffered ticks and clear the buffer
+    const ticks = buffer.splice(0, buffer.length);
+
+    let current = traceRef.current;
+    if (!current) return;
+
+    for (const { tickNumber, events, spanNames } of ticks) {
+      // Span names, if present, are merged into the trace ahead of processing the events that
+      // may reference them (processTickAndAppend does the merge internally).
+      if (events.length > 0) {
+        current = processTickAndAppend(current, tickNumber, events, spanNames);
+      } else if (spanNames) {
+        current = mergeSpanNames(current, spanNames);
+      }
+    }
+
+    setTrace(current);
+    traceRef.current = current;
+
+    // If the selected chunk's tick has been evicted from the ring buffer,
+    // clear it so the detail pane doesn't keep rendering stale data.
+    setSelectedChunk(prev => {
+      if (prev == null) return prev;
+      if (current && prev.startUs < current.globalStartUs) {
+        return null;
+      }
+      return prev;
+    });
+
+    // Auto-scroll to the latest tick when in follow mode. Manual interaction disables follow
+    // via handleViewRangeChange / onChunkSelect — this callback just reads the flag.
+    if (followRef.current && current.ticks.length > 0) {
+      const latest = current.ticks[current.ticks.length - 1];
+      const showCount = Math.min(3, current.ticks.length);
+      const firstShown = current.ticks[current.ticks.length - showCount];
+      setViewRange({ startUs: firstShown.startUs, endUs: latest.endUs });
+    }
+  }, []);
+
+  // Live connect handler
+  const handleLiveConnect = useCallback(() => {
+    setError(null);
+    setLoading(true);
+
+    followRef.current = true;
+
+    const es = connectLive({
+      onMetadata: (metadata, spanNames) => {
+        const empty = createEmptyTrace(metadata);
+        const withSpans = spanNames && Object.keys(spanNames).length > 0
+          ? mergeSpanNames(empty, spanNames)
+          : empty;
+        setTrace(withSpans);
+        traceRef.current = withSpans;
+        setTracePath(null);
+        setFileName(null);
+        setSelectedChunk(null);
+        setIsLive(true);
+        setLoading(false);
+        setViewRange({ startUs: 0, endUs: 0 });
+      },
+      onTick: (tickNumber, events, newSpanNames) => {
+        tickBufferRef.current.push({ tickNumber, events, spanNames: newSpanNames });
+      },
+      onDisconnect: () => {
+        setIsLive(false);
+        setLoading(false);
+        if (flushIntervalRef.current) {
+          clearInterval(flushIntervalRef.current);
+          flushIntervalRef.current = 0;
+        }
+        // Flush any remaining buffered ticks
+        flushTickBuffer();
+      },
+      onError: (msg) => {
+        setError(msg);
+      },
+    });
+
+    liveRef.current = es;
+
+    // Set up 100ms flush interval (10Hz state updates)
+    flushIntervalRef.current = window.setInterval(flushTickBuffer, 100);
+  }, [flushTickBuffer]);
+
+  // Live disconnect handler
+  const handleLiveDisconnect = useCallback(() => {
+    if (liveRef.current) {
+      liveRef.current.close();
+      liveRef.current = null;
+    }
+    if (flushIntervalRef.current) {
+      clearInterval(flushIntervalRef.current);
+      flushIntervalRef.current = 0;
+    }
+    setIsLive(false);
+    followRef.current = false;
+    // Flush remaining
+    flushTickBuffer();
+  }, [flushTickBuffer]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (liveRef.current) liveRef.current.close();
+      if (flushIntervalRef.current) clearInterval(flushIntervalRef.current);
+    };
+  }, []);
+
+  const handleViewRangeChange = useCallback((range: TimeRange) => {
+    // Any manual pan/zoom/click that moves the view range cancels follow mode.
+    // The user is exploring history — don't yank them back to the latest tick.
+    followRef.current = false;
+    setViewRange(range);
+    setSelectedChunk(null);
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <MenuBar
+        trace={trace}
+        fileName={fileName}
+        loading={loading}
+        isLive={isLive}
+        onFileSelected={handleFileSelected}
+        onLiveConnect={handleLiveConnect}
+        onLiveDisconnect={handleLiveDisconnect}
+      />
+
+      {error && (
+        <div style={{
+          padding: '6px 16px',
+          background: '#5c1a1a',
+          color: '#ff6b6b',
+          fontSize: '12px',
+          fontFamily: 'monospace',
+          flexShrink: 0,
+        }}>
+          {error}
+        </div>
+      )}
+
+      {trace ? (
+        <>
+          <TickTimeline
+            trace={trace}
+            viewRange={viewRange}
+            onViewRangeChange={handleViewRangeChange}
+            isLive={isLive}
+          />
+          <Workspace
+            trace={trace}
+            tracePath={tracePath}
+            viewRange={viewRange}
+            onViewRangeChange={handleViewRangeChange}
+            selectedChunk={selectedChunk}
+            onChunkSelect={setSelectedChunk}
+          />
+        </>
+      ) : (
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          gap: '12px',
+          color: DIM_TEXT,
+          fontFamily: 'monospace',
+        }}>
+          <div style={{ fontSize: '24px', color: '#e94560' }}>Typhon Profiler</div>
+          <div style={{ fontSize: '13px' }}>File &gt; Load to open a .typhon-trace file</div>
+          <div style={{ fontSize: '13px' }}>File &gt; Connect Live for real-time streaming</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/DetailPane.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/DetailPane.tsx
@@ -1,0 +1,154 @@
+import type { ChunkSpan } from './traceModel';
+import type { SystemDef } from './types';
+import { getSystemColor, HEADER_BG, BORDER_COLOR, TEXT_COLOR, DIM_TEXT, BG_COLOR } from './canvasUtils';
+
+interface DetailPaneProps {
+  chunk: ChunkSpan | null;
+  systems: SystemDef[];
+  onClose: () => void;
+}
+
+const SYSTEM_TYPE_NAMES: Record<number, string> = {
+  0: 'PipelineSystem',
+  1: 'QuerySystem',
+  2: 'CallbackSystem',
+};
+
+function formatTier(tier: number): string {
+  if (tier === 0x0F || tier === 15) return 'All';
+  const names: string[] = [];
+  if (tier & 1) names.push('Tier0');
+  if (tier & 2) names.push('Tier1');
+  if (tier & 4) names.push('Tier2');
+  if (tier & 8) names.push('Tier3');
+  return names.join(' | ') || 'None';
+}
+
+export function DetailPane({ chunk, systems, onClose }: DetailPaneProps) {
+  const fieldStyle = {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '3px 0',
+    borderBottom: `1px solid ${BG_COLOR}`,
+    fontSize: '11px',
+  };
+
+  const labelStyle = { color: DIM_TEXT };
+  const valueStyle = { color: TEXT_COLOR, textAlign: 'right' as const };
+
+  if (!chunk) {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        color: DIM_TEXT,
+        fontSize: '12px',
+        fontFamily: 'monospace',
+      }}>
+        Select a chunk to view details
+      </div>
+    );
+  }
+
+  const sys = systems[chunk.systemIndex];
+  const color = getSystemColor(chunk.systemIndex);
+  const typeName = sys ? (SYSTEM_TYPE_NAMES[sys.type] ?? `Type(${sys.type})`) : '?';
+  const fullTypeName = sys?.isParallel && sys.type === 1 ? 'QuerySystem.Parallel' : typeName;
+
+  return (
+    <div style={{
+      height: '100%',
+      overflow: 'auto',
+      fontFamily: 'monospace',
+      background: HEADER_BG,
+    }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '8px 12px',
+        borderBottom: `1px solid ${BORDER_COLOR}`,
+        background: BG_COLOR,
+      }}>
+        <span style={{ color, fontWeight: 'bold', fontSize: '13px' }}>
+          {chunk.isParallel ? `${chunk.systemName}[${chunk.chunkIndex}]` : chunk.systemName}
+        </span>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'transparent',
+            color: DIM_TEXT,
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: '14px',
+            fontFamily: 'monospace',
+            padding: '0 4px',
+          }}
+        >
+          x
+        </button>
+      </div>
+
+      {/* Fields */}
+      <div style={{ padding: '8px 12px' }}>
+        <div style={fieldStyle}>
+          <span style={labelStyle}>Type</span>
+          <span style={valueStyle}>{fullTypeName}</span>
+        </div>
+        <div style={fieldStyle}>
+          <span style={labelStyle}>Worker</span>
+          <span style={valueStyle}>{chunk.workerId}</span>
+        </div>
+        {chunk.isParallel && (
+          <div style={fieldStyle}>
+            <span style={labelStyle}>Chunk</span>
+            <span style={valueStyle}>{chunk.chunkIndex + 1} / {chunk.totalChunks || '?'}</span>
+          </div>
+        )}
+        <div style={fieldStyle}>
+          <span style={labelStyle}>Duration</span>
+          <span style={valueStyle}>{chunk.durationUs.toFixed(1)} us</span>
+        </div>
+        <div style={fieldStyle}>
+          <span style={labelStyle}>Entities</span>
+          <span style={valueStyle}>{chunk.entitiesProcessed.toLocaleString()}</span>
+        </div>
+        <div style={fieldStyle}>
+          <span style={labelStyle}>Tier</span>
+          <span style={valueStyle}>{sys ? formatTier(sys.tierFilter) : '?'}</span>
+        </div>
+
+        {/* DAG section */}
+        <div style={{
+          color: DIM_TEXT,
+          marginTop: '12px',
+          marginBottom: '4px',
+          textTransform: 'uppercase',
+          letterSpacing: '1px',
+          fontSize: '10px',
+        }}>
+          DAG
+        </div>
+        <div style={fieldStyle}>
+          <span style={labelStyle}>Predecessors</span>
+          <span style={valueStyle}>
+            {sys?.predecessors.length
+              ? sys.predecessors.map(i => systems[i]?.name ?? `[${i}]`).join(', ')
+              : '(none)'}
+          </span>
+        </div>
+        <div style={fieldStyle}>
+          <span style={labelStyle}>Successors</span>
+          <span style={valueStyle}>
+            {sys?.successors.length
+              ? sys.successors.map(i => systems[i]?.name ?? `[${i}]`).join(', ')
+              : '(none)'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/FlameGraph.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/FlameGraph.tsx
@@ -1,0 +1,248 @@
+import { useRef, useEffect, useCallback, useState } from 'preact/hooks';
+import { fetchFlameGraph, type FlameNode } from './api';
+import { setupCanvas, drawTooltip, BG_COLOR, HEADER_BG, BORDER_COLOR, TEXT_COLOR, DIM_TEXT } from './canvasUtils';
+import type { TimeRange } from './uiTypes';
+
+interface FlameGraphProps {
+  tracePath: string | null;
+  viewRange: TimeRange;
+}
+
+const FLAME_ROW_HEIGHT = 18;
+const FLAME_GAP = 1;
+const FLAME_TOTAL = FLAME_ROW_HEIGHT + FLAME_GAP;
+const MIN_WIDTH_FOR_LABEL = 35;
+const HEADER_HEIGHT = 24;
+
+/** Generate a stable color from a string (method name) */
+function nameToColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  const h = ((hash & 0xFFFF) % 360);
+  return `hsl(${h}, 55%, 45%)`;
+}
+
+interface LayoutRect {
+  x: number;
+  width: number;
+  y: number;
+  node: FlameNode;
+  depth: number;
+}
+
+function layoutFlame(root: FlameNode, totalWidth: number): LayoutRect[] {
+  const rects: LayoutRect[] = [];
+
+  function walk(node: FlameNode, x: number, width: number, depth: number) {
+    if (width < 0.5) return; // too narrow to render
+
+    rects.push({ x, width, y: depth * FLAME_TOTAL, node, depth });
+
+    let childX = x;
+    for (const child of node.children) {
+      const childWidth = (child.total / node.total) * width;
+      walk(child, childX, childWidth, depth + 1);
+      childX += childWidth;
+    }
+  }
+
+  if (root.total > 0) {
+    // Skip the root node, start from its children
+    let childX = 0;
+    for (const child of root.children) {
+      const childWidth = (child.total / root.total) * totalWidth;
+      walk(child, childX, childWidth, 0);
+      childX += childWidth;
+    }
+  }
+
+  return rects;
+}
+
+export function FlameGraph({ tracePath, viewRange }: FlameGraphProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [flameData, setFlameData] = useState<{ root: FlameNode; totalSamples: number } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hoverRef = useRef<{ x: number; y: number; lines: string[] } | null>(null);
+  const rafRef = useRef(0);
+
+  // Fetch flame graph data when viewRange changes
+  useEffect(() => {
+    if (!tracePath || viewRange.startUs >= viewRange.endUs) {
+      setFlameData(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchFlameGraph(tracePath, viewRange.startUs, viewRange.endUs)
+      .then(data => {
+        if (!cancelled) {
+          setFlameData({ root: data.root, totalSamples: data.totalSamples });
+          setLoading(false);
+        }
+      })
+      .catch(err => {
+        if (!cancelled) {
+          setError(err.message);
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [tracePath, viewRange.startUs, viewRange.endUs]);
+
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d')!;
+    const { width, height } = setupCanvas(canvas);
+
+    ctx.fillStyle = BG_COLOR;
+    ctx.fillRect(0, 0, width, height);
+
+    // Header
+    ctx.fillStyle = HEADER_BG;
+    ctx.fillRect(0, 0, width, HEADER_HEIGHT);
+    ctx.fillStyle = TEXT_COLOR;
+    ctx.font = '11px monospace';
+    ctx.textAlign = 'left';
+
+    if (loading) {
+      ctx.fillText('Loading flame graph...', 8, 16);
+      return;
+    }
+
+    if (error) {
+      ctx.fillStyle = '#ff6b6b';
+      ctx.fillText(`Error: ${error}`, 8, 16);
+      return;
+    }
+
+    if (!flameData || flameData.totalSamples === 0) {
+      ctx.fillStyle = DIM_TEXT;
+      ctx.fillText('No CPU samples in this range (enable sampling with enableCpuSampling: true)', 8, 16);
+      return;
+    }
+
+    ctx.fillText(`Flame Graph  |  ${flameData.totalSamples} samples`, 8, 16);
+
+    // Layout and render flames
+    const contentY = HEADER_HEIGHT + 4;
+    const rects = layoutFlame(flameData.root, width);
+
+    ctx.save();
+    ctx.translate(0, contentY);
+
+    for (const rect of rects) {
+      if (rect.x + rect.width < 0 || rect.x > width) continue;
+
+      const color = nameToColor(rect.node.name);
+      ctx.fillStyle = color;
+      ctx.fillRect(rect.x, rect.y, rect.width, FLAME_ROW_HEIGHT);
+
+      // Border
+      ctx.strokeStyle = 'rgba(0,0,0,0.2)';
+      ctx.lineWidth = 0.5;
+      ctx.strokeRect(rect.x, rect.y, rect.width, FLAME_ROW_HEIGHT);
+
+      // Label
+      if (rect.width > MIN_WIDTH_FOR_LABEL) {
+        ctx.fillStyle = '#fff';
+        ctx.font = '10px monospace';
+        ctx.textAlign = 'left';
+        // Shorten name: take last segment (method name)
+        const shortName = shortenName(rect.node.name);
+        ctx.fillText(shortName, rect.x + 2, rect.y + 13, rect.width - 4);
+      }
+    }
+
+    // Hover tooltip
+    const hover = hoverRef.current;
+    if (hover) {
+      drawTooltip(ctx, hover.x, hover.y - contentY, hover.lines, width, height - contentY);
+    }
+
+    ctx.restore();
+  }, [flameData, loading, error]);
+
+  const scheduleRender = useCallback(() => {
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => render());
+  }, [render]);
+
+  useEffect(() => {
+    scheduleRender();
+    const obs = new ResizeObserver(() => scheduleRender());
+    if (containerRef.current) obs.observe(containerRef.current);
+    return () => { obs.disconnect(); cancelAnimationFrame(rafRef.current); };
+  }, [scheduleRender]);
+
+  // Hover detection
+  const onMouseMove = useCallback((e: MouseEvent) => {
+    if (!flameData || flameData.totalSamples === 0) {
+      hoverRef.current = null;
+      scheduleRender();
+      return;
+    }
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top - HEADER_HEIGHT - 4;
+
+    const rects = layoutFlame(flameData.root, rect.width);
+
+    let found = false;
+    for (const r of rects) {
+      if (mx >= r.x && mx <= r.x + r.width && my >= r.y && my <= r.y + FLAME_ROW_HEIGHT) {
+        const pct = ((r.node.total / flameData.totalSamples) * 100).toFixed(1);
+        const selfPct = ((r.node.self / flameData.totalSamples) * 100).toFixed(1);
+        hoverRef.current = {
+          x: mx,
+          y: e.clientY - rect.top,
+          lines: [
+            r.node.name,
+            `Total: ${r.node.total} samples (${pct}%)`,
+            `Self: ${r.node.self} samples (${selfPct}%)`,
+          ]
+        };
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) hoverRef.current = null;
+    scheduleRender();
+  }, [flameData, scheduleRender]);
+
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <canvas
+        ref={canvasRef}
+        style={{ width: '100%', height: '100%', cursor: 'crosshair' }}
+        onMouseMove={onMouseMove}
+        onMouseLeave={() => { hoverRef.current = null; scheduleRender(); }}
+      />
+    </div>
+  );
+}
+
+/** Shorten a fully qualified .NET method name to something readable */
+function shortenName(name: string): string {
+  // "Namespace.Class.Method(args)" → "Class.Method"
+  const parenIdx = name.indexOf('(');
+  const base = parenIdx >= 0 ? name.substring(0, parenIdx) : name;
+  const parts = base.split('.');
+  if (parts.length >= 2) {
+    return parts.slice(-2).join('.');
+  }
+  return base;
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/GraphArea.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/GraphArea.tsx
@@ -1,0 +1,480 @@
+import { useRef, useEffect, useCallback, useState } from 'preact/hooks';
+import type { ProcessedTrace, ChunkSpan, TickData } from './traceModel';
+import { getTicksInRange } from './traceModel';
+import type { Viewport, TrackLayout, TimeRange } from './uiTypes';
+import {
+  setupCanvas, computeGridStep, drawTooltip, getSystemColor,
+  PHASE_COLOR, BG_COLOR, HEADER_BG, BORDER_COLOR, TEXT_COLOR, DIM_TEXT, GRID_COLOR
+} from './canvasUtils';
+
+interface GraphAreaProps {
+  trace: ProcessedTrace;
+  tracePath: string | null;
+  viewRange: TimeRange;
+  onViewRangeChange: (range: TimeRange) => void;
+  selectedChunk: ChunkSpan | null;
+  onChunkSelect: (chunk: ChunkSpan | null) => void;
+}
+
+const GUTTER_WIDTH = 100;
+const RULER_HEIGHT = 24;
+const TRACK_HEIGHT = 28;
+const TRACK_GAP = 2;
+const PHASE_TRACK_HEIGHT = 20;
+const COLLAPSED_HEIGHT = 4;
+const LABEL_ROW_HEIGHT = 18;
+const MIN_RECT_WIDTH = 1;
+const FLAME_ROW_HEIGHT = 14;
+const FLAME_TRACK_DEFAULT_HEIGHT = 120;
+
+const TICK_BOUNDARY_COLOR = 'rgba(100, 100, 200, 0.3)';
+
+function shortenName(name: string): string {
+  const parenIdx = name.indexOf('(');
+  const base = parenIdx >= 0 ? name.substring(0, parenIdx) : name;
+  const parts = base.split('.');
+  return parts.length >= 2 ? parts.slice(-2).join('.') : base;
+}
+
+function nameToColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  return `hsl(${(hash & 0xFFFF) % 360}, 50%, 42%)`;
+}
+
+export function GraphArea({ trace, tracePath, viewRange, onViewRangeChange, selectedChunk, onChunkSelect }: GraphAreaProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const vpRef = useRef<Viewport>({ offsetX: viewRange.startUs, scaleX: 0.5, scrollY: 0 });
+  const hoverRef = useRef<{ x: number; y: number; lines: string[] } | null>(null);
+  const isDraggingRef = useRef(false);
+  const dragStartRef = useRef({ x: 0, y: 0, offsetX: 0, scrollY: 0 });
+  const rafRef = useRef(0);
+  const [collapseState, setCollapseState] = useState<Record<string, boolean>>({});
+
+  const workerCount = trace.metadata.header.workerCount;
+
+  // Sync viewport on external viewRange change
+  useEffect(() => {
+    const vp = vpRef.current;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const contentWidth = rect.width - GUTTER_WIDTH;
+    const rangeUs = viewRange.endUs - viewRange.startUs;
+    if (rangeUs > 0 && contentWidth > 0) {
+      vp.offsetX = viewRange.startUs;
+      vp.scaleX = contentWidth / rangeUs;
+    }
+    scheduleRender();
+  }, [viewRange]);
+
+  const buildLayout = useCallback((): TrackLayout[] => {
+    const layout: TrackLayout[] = [];
+    let y = 0;
+
+    layout.push({ id: 'ruler', label: 'Time', y, height: RULER_HEIGHT, collapsedHeight: RULER_HEIGHT, collapsed: false, collapsible: false });
+    y += RULER_HEIGHT;
+
+    for (let w = 0; w < workerCount; w++) {
+      const id = `worker-${w}`;
+      const collapsed = collapseState[id] ?? false;
+      const h = collapsed ? COLLAPSED_HEIGHT + LABEL_ROW_HEIGHT : TRACK_HEIGHT + TRACK_GAP;
+      layout.push({ id, label: `Worker ${w}`, y, height: TRACK_HEIGHT, collapsedHeight: COLLAPSED_HEIGHT, collapsed, collapsible: true });
+      y += h;
+    }
+
+    // Phases track
+    const phasesCollapsed = collapseState['phases'] ?? false;
+    const ph = phasesCollapsed ? COLLAPSED_HEIGHT + LABEL_ROW_HEIGHT : PHASE_TRACK_HEIGHT + TRACK_GAP;
+    layout.push({ id: 'phases', label: 'Phases', y, height: PHASE_TRACK_HEIGHT, collapsedHeight: COLLAPSED_HEIGHT, collapsed: phasesCollapsed, collapsible: true });
+    y += ph;
+
+    // OTel Spans track
+    const spansCollapsed = collapseState['spans'] ?? false;
+    const spansHeight = spansCollapsed ? COLLAPSED_HEIGHT : 80;
+    const sh = spansCollapsed ? COLLAPSED_HEIGHT + LABEL_ROW_HEIGHT : spansHeight + TRACK_GAP;
+    layout.push({ id: 'spans', label: 'OTel Spans', y, height: spansHeight, collapsedHeight: COLLAPSED_HEIGHT, collapsed: spansCollapsed, collapsible: true });
+    y += sh;
+
+    return layout;
+  }, [workerCount, collapseState]);
+
+  const getVisibleTicks = useCallback((): TickData[] => {
+    const vp = vpRef.current;
+    const canvas = canvasRef.current;
+    if (!canvas) return [];
+    const rect = canvas.getBoundingClientRect();
+    const contentWidth = rect.width - GUTTER_WIDTH;
+    return getTicksInRange(trace, vp.offsetX, vp.offsetX + contentWidth / vp.scaleX);
+  }, [trace]);
+
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d')!;
+    const { width, height } = setupCanvas(canvas);
+    const vp = vpRef.current;
+    const layout = buildLayout();
+    const visibleTicks = getVisibleTicks();
+    const contentWidth = width - GUTTER_WIDTH;
+
+    ctx.fillStyle = BG_COLOR;
+    ctx.fillRect(0, 0, width, height);
+
+    if (visibleTicks.length === 0) {
+      ctx.fillStyle = DIM_TEXT;
+      ctx.font = '14px monospace';
+      ctx.textAlign = 'center';
+      ctx.fillText('No ticks in view', width / 2, height / 2);
+      return;
+    }
+
+    const pxOfUs = (us: number) => GUTTER_WIDTH + (us - vp.offsetX) * vp.scaleX;
+    const visStartUs = vp.offsetX;
+    const visEndUs = vp.offsetX + contentWidth / vp.scaleX;
+
+    // ── Left gutter ──
+    ctx.fillStyle = HEADER_BG;
+    ctx.fillRect(0, 0, GUTTER_WIDTH, height);
+    ctx.strokeStyle = BORDER_COLOR;
+    ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(GUTTER_WIDTH - 0.5, 0); ctx.lineTo(GUTTER_WIDTH - 0.5, height); ctx.stroke();
+
+    for (const track of layout) {
+      const ty = track.y - vp.scrollY;
+      ctx.fillStyle = DIM_TEXT;
+      ctx.font = '10px monospace';
+      ctx.textAlign = 'left';
+      if (track.collapsible) {
+        ctx.fillText(`${track.collapsed ? '\u25B6' : '\u25BC'} ${track.label}`, 6, ty + 12);
+      } else {
+        ctx.fillText(track.label, 6, ty + 12);
+      }
+      ctx.strokeStyle = BORDER_COLOR;
+      ctx.lineWidth = 0.5;
+      const sepY = track.y + (track.collapsed ? LABEL_ROW_HEIGHT + COLLAPSED_HEIGHT : track.height + TRACK_GAP) - vp.scrollY - 0.5;
+      ctx.beginPath(); ctx.moveTo(0, sepY); ctx.lineTo(width, sepY); ctx.stroke();
+    }
+
+    // ── Content area ──
+    ctx.save();
+    ctx.beginPath(); ctx.rect(GUTTER_WIDTH, 0, contentWidth, height); ctx.clip();
+
+    for (const track of layout) {
+      const ty = track.y - vp.scrollY;
+
+      if (track.id === 'ruler') {
+        const gridStep = computeGridStep(visEndUs - visStartUs);
+        const gridStart = Math.floor(visStartUs / gridStep) * gridStep;
+        for (let t = gridStart; t <= visEndUs; t += gridStep) {
+          const x = pxOfUs(t);
+          if (x < GUTTER_WIDTH) continue;
+          ctx.strokeStyle = GRID_COLOR; ctx.lineWidth = 0.5;
+          ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, height); ctx.stroke();
+          ctx.fillStyle = DIM_TEXT; ctx.font = '9px monospace'; ctx.textAlign = 'center';
+          ctx.fillText(`${(t - visibleTicks[0].startUs).toFixed(0)}us`, x, ty + 16);
+        }
+        ctx.setLineDash([3, 3]); ctx.strokeStyle = TICK_BOUNDARY_COLOR; ctx.lineWidth = 1;
+        for (const tick of visibleTicks) {
+          const x = pxOfUs(tick.startUs);
+          if (x >= GUTTER_WIDTH) { ctx.beginPath(); ctx.moveTo(x, RULER_HEIGHT); ctx.lineTo(x, height); ctx.stroke(); }
+        }
+        ctx.setLineDash([]);
+        ctx.fillStyle = '#666'; ctx.font = '8px monospace'; ctx.textAlign = 'left';
+        for (const tick of visibleTicks) {
+          const x = pxOfUs(tick.startUs);
+          if (x >= GUTTER_WIDTH) ctx.fillText(`T${tick.tickNumber}`, x + 2, ty + 8);
+        }
+        continue;
+      }
+
+      if (track.collapsed) {
+        ctx.fillStyle = '#222';
+        ctx.fillRect(GUTTER_WIDTH, ty + LABEL_ROW_HEIGHT, contentWidth, COLLAPSED_HEIGHT);
+        continue;
+      }
+
+      // ── Worker tracks ──
+      if (track.id.startsWith('worker-')) {
+        const workerId = parseInt(track.id.split('-')[1]);
+        for (const tick of visibleTicks) {
+          for (const chunk of tick.chunks) {
+            if (chunk.workerId !== workerId) continue;
+            const x1 = pxOfUs(chunk.startUs);
+            const x2 = pxOfUs(chunk.endUs);
+            if (x2 < GUTTER_WIDTH || x1 > width) continue;
+            const w = Math.max(x2 - x1, MIN_RECT_WIDTH);
+            ctx.fillStyle = getSystemColor(chunk.systemIndex);
+            ctx.fillRect(x1, ty + 1, w, TRACK_HEIGHT - 2);
+            if (selectedChunk && chunk.systemIndex === selectedChunk.systemIndex &&
+                chunk.chunkIndex === selectedChunk.chunkIndex && chunk.workerId === selectedChunk.workerId &&
+                Math.abs(chunk.startUs - selectedChunk.startUs) < 0.01) {
+              ctx.strokeStyle = '#fff'; ctx.lineWidth = 2;
+              ctx.strokeRect(x1, ty + 1, w, TRACK_HEIGHT - 2);
+            }
+            if (w > 40) {
+              ctx.fillStyle = '#000'; ctx.font = '10px monospace'; ctx.textAlign = 'left';
+              const label = chunk.isParallel ? `${chunk.systemName}[${chunk.chunkIndex}]` : chunk.systemName;
+              ctx.fillText(label, x1 + 3, ty + TRACK_HEIGHT / 2 + 3, w - 6);
+            }
+          }
+        }
+      }
+
+      // ── Phases track ──
+      if (track.id === 'phases') {
+        for (const tick of visibleTicks) {
+          for (const phase of tick.phases) {
+            const x1 = pxOfUs(phase.startUs);
+            const x2 = pxOfUs(phase.endUs);
+            if (x2 < GUTTER_WIDTH || x1 > width) continue;
+            const w = Math.max(x2 - x1, MIN_RECT_WIDTH);
+            ctx.fillStyle = PHASE_COLOR;
+            ctx.fillRect(x1, ty + 1, w, PHASE_TRACK_HEIGHT - 2);
+            if (w > 50) {
+              ctx.fillStyle = TEXT_COLOR; ctx.font = '9px monospace'; ctx.textAlign = 'left';
+              ctx.fillText(`${phase.phaseName} (${phase.durationUs.toFixed(0)}us)`, x1 + 3, ty + 12, w - 6);
+            }
+          }
+        }
+      }
+
+      // ── OTel Spans track ──
+      if (track.id === 'spans') {
+        let hasSpans = false;
+        const spanRowH = 14;
+        // Collect all spans from visible ticks and assign rows by name (stacked)
+        const spanNameRows = new Map<number, number>();
+        let nextRow = 0;
+
+        for (const tick of visibleTicks) {
+          for (const span of tick.spans) {
+            const x1 = pxOfUs(span.startUs);
+            const x2 = pxOfUs(span.endUs);
+            if (x2 < GUTTER_WIDTH || x1 > width) continue;
+
+            // Assign a row to each unique span name
+            if (!spanNameRows.has(span.nameId)) {
+              spanNameRows.set(span.nameId, nextRow++);
+            }
+            const row = spanNameRows.get(span.nameId)!;
+            const sy = ty + row * spanRowH;
+            if (sy > ty + track.height) continue; // clip to track height
+
+            const w = Math.max(x2 - x1, MIN_RECT_WIDTH);
+            ctx.fillStyle = nameToColor(span.name);
+            ctx.fillRect(x1, sy, w, spanRowH - 1);
+
+            if (w > 30) {
+              ctx.fillStyle = '#ddd'; ctx.font = '9px monospace'; ctx.textAlign = 'left';
+              ctx.fillText(`${span.name} (${span.durationUs.toFixed(0)}us)`, x1 + 2, sy + 10, w - 4);
+            }
+            hasSpans = true;
+          }
+        }
+
+        if (!hasSpans) {
+          ctx.fillStyle = '#333'; ctx.font = '10px monospace'; ctx.textAlign = 'center';
+          ctx.fillText('No OTel spans in view (enable telemetry in typhon.telemetry.json)',
+            GUTTER_WIDTH + contentWidth / 2, ty + track.height / 2 + 4);
+        }
+      }
+    }
+
+    const hover = hoverRef.current;
+    if (hover) drawTooltip(ctx, hover.x, hover.y, hover.lines, width, height);
+    ctx.restore();
+  }, [trace, viewRange, selectedChunk, collapseState, buildLayout, getVisibleTicks]);
+
+  const scheduleRender = useCallback(() => {
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => render());
+  }, [render]);
+
+  useEffect(() => {
+    scheduleRender();
+    const obs = new ResizeObserver(() => scheduleRender());
+    if (containerRef.current) obs.observe(containerRef.current);
+    return () => { obs.disconnect(); cancelAnimationFrame(rafRef.current); };
+  }, [scheduleRender]);
+
+  const onWheel = useCallback((e: WheelEvent) => {
+    e.preventDefault();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const vp = vpRef.current;
+    const contentWidth = rect.width - GUTTER_WIDTH;
+    const mouseX = e.clientX - rect.left - GUTTER_WIDTH;
+
+    if (e.ctrlKey || e.metaKey) {
+      vp.scrollY = Math.max(0, vp.scrollY + e.deltaY);
+    } else if (e.shiftKey || Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+      const delta = e.shiftKey ? e.deltaY : e.deltaX;
+      vp.offsetX += delta / vp.scaleX;
+      onViewRangeChange({ startUs: vp.offsetX, endUs: vp.offsetX + contentWidth / vp.scaleX });
+    } else {
+      const usAtMouse = vp.offsetX + mouseX / vp.scaleX;
+      const factor = e.deltaY > 0 ? 0.85 : 1.18;
+      vp.scaleX = Math.max(0.001, Math.min(100, vp.scaleX * factor));
+      vp.offsetX = usAtMouse - mouseX / vp.scaleX;
+      onViewRangeChange({ startUs: vp.offsetX, endUs: vp.offsetX + contentWidth / vp.scaleX });
+    }
+    scheduleRender();
+  }, [scheduleRender, onViewRangeChange]);
+
+  const onMouseDown = useCallback((e: MouseEvent) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+
+    if (mx < GUTTER_WIDTH) {
+      const layout = buildLayout();
+      for (const track of layout) {
+        if (!track.collapsible) continue;
+        const ty = track.y - vpRef.current.scrollY;
+        if (my >= ty && my <= ty + LABEL_ROW_HEIGHT) {
+          setCollapseState(prev => ({ ...prev, [track.id]: !track.collapsed }));
+          return;
+        }
+      }
+      return;
+    }
+
+    isDraggingRef.current = true;
+    dragStartRef.current = { x: e.clientX, y: e.clientY, offsetX: vpRef.current.offsetX, scrollY: vpRef.current.scrollY };
+  }, [buildLayout]);
+
+  const onMouseMove = useCallback((e: MouseEvent) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    if (isDraggingRef.current) {
+      const vp = vpRef.current;
+      const rect = canvas.getBoundingClientRect();
+      const contentWidth = rect.width - GUTTER_WIDTH;
+      vp.offsetX = dragStartRef.current.offsetX - (e.clientX - dragStartRef.current.x) / vp.scaleX;
+      vp.scrollY = Math.max(0, dragStartRef.current.scrollY - (e.clientY - dragStartRef.current.y));
+      onViewRangeChange({ startUs: vp.offsetX, endUs: vp.offsetX + contentWidth / vp.scaleX });
+      scheduleRender();
+      return;
+    }
+
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    if (mx < GUTTER_WIDTH) { hoverRef.current = null; scheduleRender(); return; }
+
+    const vp = vpRef.current;
+    const usAtMouse = vp.offsetX + (mx - GUTTER_WIDTH) / vp.scaleX;
+    const layout = buildLayout();
+    const visibleTicks = getVisibleTicks();
+
+    let found = false;
+    for (const track of layout) {
+      if (track.collapsed || track.id === 'ruler') continue;
+      const ty = track.y - vp.scrollY;
+      if (my < ty || my > ty + track.height) continue;
+
+      if (track.id.startsWith('worker-')) {
+        const workerId = parseInt(track.id.split('-')[1]);
+        for (const tick of visibleTicks) {
+          for (const chunk of tick.chunks) {
+            if (chunk.workerId === workerId && usAtMouse >= chunk.startUs && usAtMouse <= chunk.endUs) {
+              hoverRef.current = {
+                x: mx, y: my,
+                lines: [
+                  chunk.isParallel ? `${chunk.systemName}[${chunk.chunkIndex}]` : chunk.systemName,
+                  `Duration: ${chunk.durationUs.toFixed(1)} us`, `Worker: ${chunk.workerId}`,
+                  `Entities: ${chunk.entitiesProcessed.toLocaleString()}`, `Tick: ${tick.tickNumber}`,
+                ]
+              };
+              found = true; break;
+            }
+          }
+          if (found) break;
+        }
+      } else if (track.id === 'phases') {
+        for (const tick of visibleTicks) {
+          for (const phase of tick.phases) {
+            if (usAtMouse >= phase.startUs && usAtMouse <= phase.endUs) {
+              hoverRef.current = { x: mx, y: my, lines: [phase.phaseName, `Duration: ${phase.durationUs.toFixed(1)} us`, `Tick: ${tick.tickNumber}`] };
+              found = true; break;
+            }
+          }
+          if (found) break;
+        }
+      } else if (track.id === 'spans') {
+        for (const tick of visibleTicks) {
+          for (const span of tick.spans) {
+            if (usAtMouse >= span.startUs && usAtMouse <= span.endUs) {
+              hoverRef.current = {
+                x: mx, y: my,
+                lines: [span.name, `Duration: ${span.durationUs.toFixed(1)} us`, `Tick: ${tick.tickNumber}`]
+              };
+              found = true; break;
+            }
+          }
+          if (found) break;
+        }
+      }
+      break;
+    }
+    if (!found) hoverRef.current = null;
+    scheduleRender();
+  }, [trace, buildLayout, getVisibleTicks, scheduleRender, onViewRangeChange]);
+
+  const onMouseUp = useCallback((e: MouseEvent) => {
+    if (!isDraggingRef.current) return;
+    const dx = Math.abs(e.clientX - dragStartRef.current.x);
+    const dy = Math.abs(e.clientY - dragStartRef.current.y);
+    isDraggingRef.current = false;
+
+    if (dx < 3 && dy < 3) {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      if (mx < GUTTER_WIDTH) return;
+      const usAtMouse = vpRef.current.offsetX + (mx - GUTTER_WIDTH) / vpRef.current.scaleX;
+      const layout = buildLayout();
+      const visibleTicks = getVisibleTicks();
+
+      for (const track of layout) {
+        if (track.collapsed || !track.id.startsWith('worker-')) continue;
+        const ty = track.y - vpRef.current.scrollY;
+        if (my < ty || my > ty + track.height) continue;
+        const workerId = parseInt(track.id.split('-')[1]);
+        for (const tick of visibleTicks) {
+          for (const chunk of tick.chunks) {
+            if (chunk.workerId === workerId && usAtMouse >= chunk.startUs && usAtMouse <= chunk.endUs) {
+              onChunkSelect(chunk); return;
+            }
+          }
+        }
+        break;
+      }
+      onChunkSelect(null);
+    }
+  }, [buildLayout, getVisibleTicks, onChunkSelect]);
+
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <canvas
+        ref={canvasRef}
+        style={{ width: '100%', height: '100%', cursor: isDraggingRef.current ? 'grabbing' : 'crosshair' }}
+        onWheel={onWheel}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={() => { isDraggingRef.current = false; hoverRef.current = null; scheduleRender(); }}
+      />
+    </div>
+  );
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/MenuBar.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/MenuBar.tsx
@@ -1,0 +1,208 @@
+import { useState, useRef, useEffect } from 'preact/hooks';
+import type { ProcessedTrace } from './traceModel';
+import { HEADER_BG, BORDER_COLOR, SELECTED_COLOR, TEXT_COLOR, DIM_TEXT, BG_COLOR } from './canvasUtils';
+
+interface MenuBarProps {
+  trace: ProcessedTrace | null;
+  fileName: string | null;
+  loading: boolean;
+  isLive: boolean;
+  onFileSelected: (files: File[]) => void;
+  onLiveConnect: () => void;
+  onLiveDisconnect: () => void;
+}
+
+export function MenuBar({ trace, fileName, loading, isLive, onFileSelected, onLiveConnect, onLiveDisconnect }: MenuBarProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu on click outside
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [menuOpen]);
+
+  const handleLoad = () => {
+    setMenuOpen(false);
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: Event) => {
+    const input = e.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      onFileSelected(Array.from(input.files));
+      input.value = ''; // reset so same file can be reloaded
+    }
+  };
+
+  return (
+    <header style={{
+      height: '28px',
+      background: HEADER_BG,
+      borderBottom: `1px solid ${BORDER_COLOR}`,
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0 4px',
+      flexShrink: 0,
+      fontSize: '12px',
+      fontFamily: 'monospace',
+      userSelect: 'none',
+    }}>
+      {/* Menu items */}
+      <div ref={menuRef} style={{ position: 'relative' }}>
+        <button
+          onClick={() => setMenuOpen(!menuOpen)}
+          style={{
+            background: menuOpen ? BORDER_COLOR : 'transparent',
+            color: TEXT_COLOR,
+            border: 'none',
+            padding: '4px 10px',
+            cursor: 'pointer',
+            fontSize: '12px',
+            fontFamily: 'monospace',
+            borderRadius: '2px',
+          }}
+        >
+          File
+        </button>
+
+        {menuOpen && (
+          <div style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            background: HEADER_BG,
+            border: `1px solid ${BORDER_COLOR}`,
+            borderRadius: '2px',
+            minWidth: '140px',
+            zIndex: 1000,
+            boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
+          }}>
+            <button
+              onClick={handleLoad}
+              style={{
+                display: 'block',
+                width: '100%',
+                background: 'transparent',
+                color: TEXT_COLOR,
+                border: 'none',
+                padding: '6px 16px',
+                cursor: 'pointer',
+                fontSize: '12px',
+                fontFamily: 'monospace',
+                textAlign: 'left',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = BORDER_COLOR)}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            >
+              Load...
+            </button>
+            <div style={{ height: '1px', background: BORDER_COLOR, margin: '2px 8px' }} />
+            {!isLive ? (
+              <button
+                onClick={() => { setMenuOpen(false); onLiveConnect(); }}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  background: 'transparent',
+                  color: TEXT_COLOR,
+                  border: 'none',
+                  padding: '6px 16px',
+                  cursor: 'pointer',
+                  fontSize: '12px',
+                  fontFamily: 'monospace',
+                  textAlign: 'left',
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = BORDER_COLOR)}
+                onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+              >
+                Connect Live
+              </button>
+            ) : (
+              <button
+                onClick={() => { setMenuOpen(false); onLiveDisconnect(); }}
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  background: 'transparent',
+                  color: SELECTED_COLOR,
+                  border: 'none',
+                  padding: '6px 16px',
+                  cursor: 'pointer',
+                  fontSize: '12px',
+                  fontFamily: 'monospace',
+                  textAlign: 'left',
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = BORDER_COLOR)}
+                onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+              >
+                Disconnect
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Spacer */}
+      <div style={{ flex: 1 }} />
+
+      {/* Status info */}
+      {loading && (
+        <span style={{ color: SELECTED_COLOR, marginRight: '16px' }}>Loading...</span>
+      )}
+
+      {isLive && (
+        <span style={{
+          color: '#00ff88',
+          marginRight: '12px',
+          fontWeight: 'bold',
+          fontSize: '11px',
+          letterSpacing: '1px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+        }}>
+          <span style={{
+            width: '6px',
+            height: '6px',
+            borderRadius: '50%',
+            background: '#00ff88',
+            display: 'inline-block',
+            animation: 'pulse 1.5s ease-in-out infinite',
+          }} />
+          LIVE
+          <style>{`@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }`}</style>
+        </span>
+      )}
+
+      {trace && (
+        <div style={{ display: 'flex', gap: '16px', color: DIM_TEXT }}>
+          {fileName && (
+            <span style={{ color: TEXT_COLOR }}>{fileName}</span>
+          )}
+          <span>{trace.ticks.length} ticks</span>
+          <span>{trace.metadata.header.systemCount} systems</span>
+          <span>{trace.metadata.header.workerCount} workers</span>
+          <span>{trace.metadata.header.baseTickRate} Hz</span>
+        </div>
+      )}
+
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".typhon-trace,.nettrace"
+        multiple
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
+    </header>
+  );
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/TickTimeline.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/TickTimeline.tsx
@@ -1,0 +1,255 @@
+import { useRef, useEffect, useCallback } from 'preact/hooks';
+import type { ProcessedTrace } from './traceModel';
+import type { TimeRange } from './uiTypes';
+import { setupCanvas, drawTooltip, BG_COLOR, BORDER_COLOR, DIM_TEXT, SELECTED_COLOR } from './canvasUtils';
+
+interface TickTimelineProps {
+  trace: ProcessedTrace;
+  viewRange: TimeRange;
+  onViewRangeChange: (range: TimeRange) => void;
+  /** When true, auto-scroll to keep latest ticks visible. */
+  isLive?: boolean;
+}
+
+const TIMELINE_HEIGHT = 80;
+const BAR_COLOR = '#4ecdc4';
+const BAR_OVER_P95_COLOR = '#e94560';
+const OVERLAY_COLOR = 'rgba(255, 165, 0, 0.25)';
+const OVERLAY_BORDER = 'rgba(255, 165, 0, 0.7)';
+
+export function TickTimeline({ trace, viewRange, onViewRangeChange, isLive }: TickTimelineProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRangeRef = useRef({ startIdx: 0, endIdx: trace.ticks.length });
+  const hoverRef = useRef<{ tickIdx: number; x: number; y: number } | null>(null);
+  const rafRef = useRef(0);
+
+  useEffect(() => {
+    if (isLive) {
+      // In live mode, show a sliding window of the latest ticks
+      const maxVisible = 200;
+      const endIdx = trace.ticks.length;
+      const startIdx = Math.max(0, endIdx - maxVisible);
+      scrollRangeRef.current = { startIdx, endIdx };
+    } else {
+      scrollRangeRef.current = { startIdx: 0, endIdx: trace.ticks.length };
+    }
+  }, [trace, isLive]);
+
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const { width, height } = setupCanvas(canvas);
+    const ticks = trace.ticks;
+    const p95 = trace.p95TickDurationUs || 1;
+    const sr = scrollRangeRef.current;
+    const visibleCount = sr.endIdx - sr.startIdx;
+    if (visibleCount <= 0) return;
+
+    ctx.fillStyle = BG_COLOR;
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.strokeStyle = BORDER_COLOR;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, height - 0.5);
+    ctx.lineTo(width, height - 0.5);
+    ctx.stroke();
+
+    const barAreaHeight = height - 18;
+    const barAreaTop = 2;
+
+    // P95 reference line
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 0.5;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    ctx.moveTo(0, barAreaTop);
+    ctx.lineTo(width, barAreaTop);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    ctx.fillStyle = DIM_TEXT;
+    ctx.font = '8px monospace';
+    ctx.textAlign = 'left';
+    ctx.fillText(`P95: ${p95.toFixed(0)}us`, 4, barAreaTop + 8);
+
+    const barWidth = width / visibleCount;
+
+    // Draw bars
+    for (let i = sr.startIdx; i < sr.endIdx; i++) {
+      const tick = ticks[i];
+      const ratio = Math.min(tick.durationUs / p95, 1.0);
+      const barH = ratio * barAreaHeight;
+      const x = (i - sr.startIdx) * barWidth;
+      const y = barAreaTop + barAreaHeight - barH;
+
+      if (tick.durationUs > p95) {
+        ctx.fillStyle = BAR_OVER_P95_COLOR;
+      } else {
+        ctx.fillStyle = BAR_COLOR;
+      }
+
+      ctx.fillRect(x + 0.5, y, Math.max(barWidth - 1, 1), barH);
+    }
+
+    // Orange overlay — ticks that fall within viewRange
+    let overlayStartX = -1;
+    let overlayEndX = -1;
+    for (let i = sr.startIdx; i < sr.endIdx; i++) {
+      const tick = ticks[i];
+      if (tick.endUs >= viewRange.startUs && tick.startUs <= viewRange.endUs) {
+        const x = (i - sr.startIdx) * barWidth;
+        if (overlayStartX < 0) overlayStartX = x;
+        overlayEndX = x + barWidth;
+      }
+    }
+
+    if (overlayStartX >= 0) {
+      ctx.fillStyle = OVERLAY_COLOR;
+      ctx.fillRect(overlayStartX, barAreaTop, overlayEndX - overlayStartX, barAreaHeight);
+      ctx.strokeStyle = OVERLAY_BORDER;
+      ctx.lineWidth = 1.5;
+      ctx.strokeRect(overlayStartX, barAreaTop, overlayEndX - overlayStartX, barAreaHeight);
+    }
+
+    // Tick number labels
+    ctx.fillStyle = DIM_TEXT;
+    ctx.font = '8px monospace';
+    ctx.textAlign = 'center';
+    const labelEvery = Math.max(1, Math.floor(50 / barWidth));
+    for (let i = sr.startIdx; i < sr.endIdx; i += labelEvery) {
+      const x = (i - sr.startIdx) * barWidth + barWidth / 2;
+      ctx.fillText(`${ticks[i].tickNumber}`, x, height - 3);
+    }
+
+    // Hover
+    const hover = hoverRef.current;
+    if (hover && hover.tickIdx >= sr.startIdx && hover.tickIdx < sr.endIdx) {
+      const x = (hover.tickIdx - sr.startIdx) * barWidth;
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 1;
+      ctx.strokeRect(x, barAreaTop, barWidth, barAreaHeight);
+
+      const tick = ticks[hover.tickIdx];
+      drawTooltip(ctx, hover.x, hover.y, [
+        `Tick ${tick.tickNumber}`,
+        `Duration: ${tick.durationUs.toFixed(0)} us`,
+        `Chunks: ${tick.chunks.length}`,
+        `Skipped: ${tick.skips.length}`,
+      ], width, height);
+    }
+  }, [trace, viewRange]);
+
+  const scheduleRender = useCallback(() => {
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => render());
+  }, [render]);
+
+  useEffect(() => {
+    scheduleRender();
+    const obs = new ResizeObserver(() => scheduleRender());
+    if (containerRef.current) obs.observe(containerRef.current);
+    return () => { obs.disconnect(); cancelAnimationFrame(rafRef.current); };
+  }, [scheduleRender]);
+
+  const hitTestTickIdx = useCallback((e: MouseEvent): number => {
+    const canvas = canvasRef.current;
+    if (!canvas) return -1;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const sr = scrollRangeRef.current;
+    const visibleCount = sr.endIdx - sr.startIdx;
+    const barWidth = rect.width / visibleCount;
+    return sr.startIdx + Math.floor(mx / barWidth);
+  }, []);
+
+  // Click: set viewRange to that tick's [startUs, endUs]
+  const onClick = useCallback((e: MouseEvent) => {
+    const idx = hitTestTickIdx(e);
+    if (idx >= 0 && idx < trace.ticks.length) {
+      const tick = trace.ticks[idx];
+      onViewRangeChange({ startUs: tick.startUs, endUs: tick.endUs });
+    }
+  }, [trace, onViewRangeChange, hitTestTickIdx]);
+
+  // Shift+mousewheel: expand/contract the viewRange by whole ticks
+  const onWheel = useCallback((e: WheelEvent) => {
+    if (!e.shiftKey) return;
+    e.preventDefault();
+
+    const ticks = trace.ticks;
+    if (ticks.length === 0) return;
+
+    // Find current first and last tick indices in the viewRange
+    let firstIdx = ticks.findIndex(t => t.endUs >= viewRange.startUs && t.startUs <= viewRange.endUs);
+    let lastIdx = firstIdx;
+    for (let i = firstIdx + 1; i < ticks.length; i++) {
+      if (ticks[i].startUs <= viewRange.endUs) {
+        lastIdx = i;
+      } else {
+        break;
+      }
+    }
+
+    if (firstIdx < 0) {
+      firstIdx = 0;
+      lastIdx = 0;
+    }
+
+    if (e.deltaY < 0) {
+      // Scroll up: add one tick to end
+      lastIdx = Math.min(ticks.length - 1, lastIdx + 1);
+    } else {
+      // Scroll down: remove one tick from end (min 1)
+      if (lastIdx > firstIdx) {
+        lastIdx--;
+      }
+    }
+
+    onViewRangeChange({
+      startUs: ticks[firstIdx].startUs,
+      endUs: ticks[lastIdx].endUs
+    });
+  }, [trace, viewRange, onViewRangeChange]);
+
+  const onMouseMove = useCallback((e: MouseEvent) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const idx = hitTestTickIdx(e);
+
+    if (idx >= scrollRangeRef.current.startIdx && idx < scrollRangeRef.current.endIdx && idx < trace.ticks.length) {
+      hoverRef.current = { tickIdx: idx, x: mx, y: my };
+    } else {
+      hoverRef.current = null;
+    }
+    scheduleRender();
+  }, [trace, scheduleRender, hitTestTickIdx]);
+
+  const onMouseLeave = useCallback(() => {
+    hoverRef.current = null;
+    scheduleRender();
+  }, [scheduleRender]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: '100%', height: `${TIMELINE_HEIGHT}px`, flexShrink: 0, borderBottom: `1px solid ${BORDER_COLOR}` }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ width: '100%', height: '100%', cursor: 'pointer' }}
+        onWheel={onWheel}
+        onClick={onClick}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+      />
+    </div>
+  );
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/Workspace.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/Workspace.tsx
@@ -1,0 +1,117 @@
+import { useState, useRef, useCallback, useEffect } from 'preact/hooks';
+import type { ProcessedTrace, ChunkSpan } from './traceModel';
+import type { TimeRange } from './uiTypes';
+import { GraphArea } from './GraphArea';
+import { DetailPane } from './DetailPane';
+import { BORDER_COLOR, HEADER_BG, DIM_TEXT } from './canvasUtils';
+
+interface WorkspaceProps {
+  trace: ProcessedTrace;
+  tracePath: string | null;
+  viewRange: TimeRange;
+  onViewRangeChange: (range: TimeRange) => void;
+  selectedChunk: ChunkSpan | null;
+  onChunkSelect: (chunk: ChunkSpan | null) => void;
+}
+
+const MIN_DETAIL_WIDTH = 200;
+const MAX_DETAIL_WIDTH = 600;
+const DEFAULT_DETAIL_WIDTH = 280;
+
+export function Workspace({ trace, tracePath, viewRange, onViewRangeChange, selectedChunk, onChunkSelect }: WorkspaceProps) {
+  const [detailOpen, setDetailOpen] = useState(true);
+  const [detailWidth, setDetailWidth] = useState(DEFAULT_DETAIL_WIDTH);
+  const isDraggingRef = useRef(false);
+  const dragStartRef = useRef({ x: 0, width: 0 });
+
+  const onDividerMouseDown = useCallback((e: MouseEvent) => {
+    e.preventDefault();
+    isDraggingRef.current = true;
+    dragStartRef.current = { x: e.clientX, width: detailWidth };
+
+    const onMove = (me: MouseEvent) => {
+      const dx = dragStartRef.current.x - me.clientX;
+      setDetailWidth(Math.max(MIN_DETAIL_WIDTH, Math.min(MAX_DETAIL_WIDTH, dragStartRef.current.width + dx)));
+    };
+
+    const onUp = () => {
+      isDraggingRef.current = false;
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, [detailWidth]);
+
+  const handleClose = useCallback(() => {
+    setDetailOpen(false);
+    onChunkSelect(null);
+  }, [onChunkSelect]);
+
+  useEffect(() => {
+    if (selectedChunk && !detailOpen) {
+      setDetailOpen(true);
+    }
+  }, [selectedChunk, detailOpen]);
+
+  return (
+    <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+      <div style={{ flex: 1, minWidth: '200px', overflow: 'hidden' }}>
+        <GraphArea
+          trace={trace}
+          tracePath={tracePath}
+          viewRange={viewRange}
+          onViewRangeChange={onViewRangeChange}
+          selectedChunk={selectedChunk}
+          onChunkSelect={onChunkSelect}
+        />
+      </div>
+
+      {detailOpen ? (
+        <>
+          <div
+            onMouseDown={onDividerMouseDown}
+            style={{
+              width: '4px',
+              cursor: 'col-resize',
+              background: BORDER_COLOR,
+              flexShrink: 0,
+            }}
+          />
+          <div style={{ width: `${detailWidth}px`, flexShrink: 0, overflow: 'hidden' }}>
+            <DetailPane
+              chunk={selectedChunk}
+              systems={trace.metadata.systems}
+              onClose={handleClose}
+            />
+          </div>
+        </>
+      ) : (
+        <div
+          onClick={() => setDetailOpen(true)}
+          style={{
+            width: '20px',
+            cursor: 'pointer',
+            background: HEADER_BG,
+            borderLeft: `1px solid ${BORDER_COLOR}`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            fontSize: '12px',
+            color: DIM_TEXT,
+            writingMode: 'vertical-rl',
+          }}
+          title="Show detail pane"
+        >
+          Details
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/api.ts
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/api.ts
@@ -1,0 +1,107 @@
+import type { TraceMetadata, TraceEvent, TickSource } from './types';
+
+const BASE = '/api';
+
+/** Fetch trace file metadata (header + system definitions) */
+export async function fetchMetadata(path: string): Promise<TraceMetadata> {
+  const res = await fetch(`${BASE}/trace/metadata?path=${encodeURIComponent(path)}`);
+  if (!res.ok) throw new Error(`Failed to load metadata: ${res.statusText}`);
+  return res.json();
+}
+
+/** Events response from the server */
+export interface EventsResponse {
+  totalEvents: number;
+  spanNames: Record<number, string>;
+  events: TraceEvent[];
+}
+
+/** Fetch trace events, optionally filtered by tick range */
+export async function fetchEvents(
+  path: string,
+  fromTick?: number,
+  toTick?: number
+): Promise<EventsResponse> {
+  const params = new URLSearchParams({ path });
+  if (fromTick !== undefined) params.set('fromTick', String(fromTick));
+  if (toTick !== undefined) params.set('toTick', String(toTick));
+
+  const res = await fetch(`${BASE}/trace/events?${params}`);
+  if (!res.ok) throw new Error(`Failed to load events: ${res.statusText}`);
+  return res.json();
+}
+
+/** Upload result from POST /api/trace/upload */
+export interface UploadResult {
+  path: string;
+  metadata: TraceMetadata;
+}
+
+/** Upload trace files to the server (trace + optional nettrace companion) */
+export async function uploadTrace(files: File[]): Promise<UploadResult> {
+  const formData = new FormData();
+  for (const file of files) {
+    if (file.name.endsWith('.typhon-trace')) {
+      formData.append('trace', file);
+    } else if (file.name.endsWith('.nettrace')) {
+      formData.append('nettrace', file);
+    }
+  }
+
+  const res = await fetch(`${BASE}/trace/upload`, {
+    method: 'POST',
+    body: formData,
+  });
+  if (!res.ok) throw new Error(`Upload failed: ${res.statusText}`);
+  return res.json();
+}
+
+/** Flame graph node from the server */
+export interface FlameNode {
+  name: string;
+  total: number;
+  self: number;
+  children: FlameNode[];
+}
+
+/** Fetch aggregated flame graph for a time range */
+export async function fetchFlameGraph(
+  path: string,
+  fromUs: number,
+  toUs: number,
+  threadId?: number
+): Promise<{ totalSamples: number; hasSamples: boolean; root: FlameNode }> {
+  const params = new URLSearchParams({
+    path,
+    fromUs: String(fromUs),
+    toUs: String(toUs),
+  });
+  if (threadId !== undefined && threadId >= 0) {
+    params.set('threadId', String(threadId));
+  }
+
+  const res = await fetch(`${BASE}/trace/flamegraph?${params}`);
+  if (!res.ok) throw new Error(`Failed to load flame graph: ${res.statusText}`);
+  return res.json();
+}
+
+/** File-based tick source — loads from a .typhon-trace file via the REST API */
+export class FileTickSource implements TickSource {
+  readonly metadata: TraceMetadata;
+  private readonly _path: string;
+
+  constructor(path: string, metadata: TraceMetadata) {
+    this._path = path;
+    this.metadata = metadata;
+  }
+
+  async getEvents(fromTick: number, toTick: number): Promise<TraceEvent[]> {
+    const resp = await fetchEvents(this._path, fromTick, toTick);
+    return resp.events;
+  }
+
+  static async open(path: string): Promise<FileTickSource> {
+    const metadata = await fetchMetadata(path);
+    return new FileTickSource(path, metadata);
+  }
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/canvasUtils.ts
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/canvasUtils.ts
@@ -1,0 +1,76 @@
+import type { Viewport } from './uiTypes';
+
+/** Color palette for systems — visually distinct, dark-theme friendly */
+export const SYSTEM_COLORS = [
+  '#e94560', '#4ecdc4', '#ffe66d', '#95e1d3', '#f38181',
+  '#aa96da', '#a8d8ea', '#fcbad3', '#c3aed6', '#b8de6f',
+  '#ff9a76', '#679b9b', '#ffc4a3', '#e8a87c', '#41b3a3',
+  '#d63447', '#f57b51', '#f6efa6', '#5ee7df', '#b490ca',
+];
+
+export const PHASE_COLOR = '#2a5298';
+export const SELECTED_COLOR = '#e94560';
+export const BG_COLOR = '#1a1a2e';
+export const HEADER_BG = '#16213e';
+export const BORDER_COLOR = '#0f3460';
+export const TEXT_COLOR = '#e0e0e0';
+export const DIM_TEXT = '#888';
+export const GRID_COLOR = '#1a1a3e';
+
+/** Set up a canvas for HiDPI rendering. Returns logical width/height. */
+export function setupCanvas(canvas: HTMLCanvasElement): { width: number; height: number } {
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  const ctx = canvas.getContext('2d')!;
+  ctx.scale(dpr, dpr);
+  return { width: rect.width, height: rect.height };
+}
+
+/** Convert a timestamp in µs to a pixel X coordinate */
+export function toPixelX(us: number, baseUs: number, vp: Viewport, labelWidth: number): number {
+  return labelWidth + (us - baseUs - vp.offsetX) * vp.scaleX;
+}
+
+/** Compute adaptive grid step size for the time ruler */
+export function computeGridStep(timeRange: number): number {
+  const steps = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000];
+  for (const step of steps) {
+    if (timeRange / step < 20) return step;
+  }
+  return steps[steps.length - 1];
+}
+
+/** Draw a tooltip box with multiple lines of text */
+export function drawTooltip(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  lines: string[],
+  maxX: number,
+  maxY: number
+): void {
+  const tooltipW = 220;
+  const tooltipH = lines.length * 16 + 8;
+  const tx = Math.min(x + 12, maxX - tooltipW - 4);
+  const ty = Math.min(y + 12, maxY - tooltipH - 4);
+
+  ctx.fillStyle = 'rgba(22, 33, 62, 0.95)';
+  ctx.strokeStyle = BORDER_COLOR;
+  ctx.lineWidth = 1;
+  ctx.fillRect(tx, ty, tooltipW, tooltipH);
+  ctx.strokeRect(tx, ty, tooltipW, tooltipH);
+
+  ctx.fillStyle = TEXT_COLOR;
+  ctx.font = '11px monospace';
+  ctx.textAlign = 'left';
+  for (let i = 0; i < lines.length; i++) {
+    ctx.fillText(lines[i], tx + 6, ty + 14 + i * 16);
+  }
+}
+
+/** Generate system colors for N systems */
+export function getSystemColor(index: number): string {
+  return SYSTEM_COLORS[index % SYSTEM_COLORS.length];
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/liveSource.ts
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/liveSource.ts
@@ -1,0 +1,113 @@
+import type { TraceMetadata, TraceEvent, TickSource } from './types';
+
+/**
+ * Live streaming source. Implements the {@link TickSource} interface so both file-based and
+ * live data sources share the same shape for consumers that don't care which one is active.
+ *
+ * Unlike {@link FileTickSource}, the live source buffers ticks as they arrive and <code>getEvents</code>
+ * returns only the ticks currently in that in-memory buffer. Older ticks may have been evicted.
+ */
+export class LiveTickSource implements TickSource {
+  public metadata: TraceMetadata;
+  private readonly _buffer = new Map<number, TraceEvent[]>();
+
+  constructor(metadata: TraceMetadata) {
+    this.metadata = metadata;
+  }
+
+  /** Add a tick's events to the in-memory buffer. */
+  pushTick(tickNumber: number, events: TraceEvent[]): void {
+    this._buffer.set(tickNumber, events);
+  }
+
+  /** Evict ticks older than the given threshold (called by App.tsx after processing). */
+  evictBefore(tickNumber: number): void {
+    for (const key of this._buffer.keys()) {
+      if (key < tickNumber) {
+        this._buffer.delete(key);
+      }
+    }
+  }
+
+  async getEvents(fromTick: number, toTick: number): Promise<TraceEvent[]> {
+    const result: TraceEvent[] = [];
+    for (const [tick, events] of this._buffer) {
+      if (tick >= fromTick && tick <= toTick) {
+        result.push(...events);
+      }
+    }
+    return result;
+  }
+}
+
+/** Callbacks for live streaming events from the SSE connection. */
+export interface LiveCallbacks {
+  /** Called when the server sends session metadata (header + systems + span names). */
+  onMetadata: (metadata: TraceMetadata, spanNames: Record<number, string>) => void;
+  /** Called for each tick batch received. */
+  onTick: (tickNumber: number, events: TraceEvent[], newSpanNames?: Record<number, string>) => void;
+  /** Called when the SSE connection is lost. */
+  onDisconnect: () => void;
+  /** Called on connection errors. */
+  onError: (error: string) => void;
+}
+
+/** Tick batch received from the SSE stream. */
+interface LiveTickBatch {
+  tickNumber: number;
+  events: TraceEvent[];
+  newSpanNames?: Record<number, string>;
+}
+
+/** Metadata event from the SSE stream. */
+interface LiveMetadataEvent {
+  header: TraceMetadata['header'];
+  systems: TraceMetadata['systems'];
+  spanNames?: Record<number, string>;
+}
+
+/**
+ * Connect to the live SSE endpoint and receive real-time tick data.
+ * Returns the EventSource instance for lifecycle management (close to disconnect).
+ */
+export function connectLive(callbacks: LiveCallbacks): EventSource {
+  const es = new EventSource('/api/live/events');
+
+  es.addEventListener('metadata', (e: MessageEvent) => {
+    try {
+      const data = JSON.parse(e.data) as LiveMetadataEvent;
+      const metadata: TraceMetadata = {
+        header: data.header,
+        systems: data.systems,
+      };
+      callbacks.onMetadata(metadata, data.spanNames ?? {});
+    } catch (err) {
+      callbacks.onError(`Failed to parse metadata: ${err}`);
+    }
+  });
+
+  es.addEventListener('tick', (e: MessageEvent) => {
+    try {
+      const batch = JSON.parse(e.data) as LiveTickBatch;
+      // Span names (if any) are attached to the first batch of each engine flush, so they
+      // arrive with — or before — the events that reference them. No sentinel needed.
+      callbacks.onTick(batch.tickNumber, batch.events, batch.newSpanNames ?? undefined);
+    } catch (err) {
+      callbacks.onError(`Failed to parse tick data: ${err}`);
+    }
+  });
+
+  es.addEventListener('heartbeat', () => {
+    // Connection alive — no action needed
+  });
+
+  es.onerror = () => {
+    if (es.readyState === EventSource.CLOSED) {
+      callbacks.onDisconnect();
+    } else {
+      callbacks.onError('SSE connection error (will retry automatically)');
+    }
+  };
+
+  return es;
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/main.tsx
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/main.tsx
@@ -1,0 +1,4 @@
+import { render } from 'preact';
+import { App } from './App';
+
+render(<App />, document.getElementById('app')!);

--- a/tools/Typhon.Profiler.Server/ClientApp/src/traceModel.ts
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/traceModel.ts
@@ -1,0 +1,402 @@
+import { TraceEventType, type TraceEvent, type SystemDef, type TraceMetadata } from './types';
+
+/** A chunk span: one rectangle in the Gantt chart */
+export interface ChunkSpan {
+  systemIndex: number;
+  systemName: string;
+  chunkIndex: number;
+  workerId: number;
+  startUs: number;
+  endUs: number;
+  durationUs: number;
+  entitiesProcessed: number;
+  totalChunks: number;
+  isParallel: boolean;
+}
+
+/** A tick phase span */
+export interface PhaseSpan {
+  phase: number;
+  phaseName: string;
+  startUs: number;
+  endUs: number;
+  durationUs: number;
+}
+
+/** Skip event for a system */
+export interface SkipEvent {
+  systemIndex: number;
+  systemName: string;
+  reason: number;
+  reasonName: string;
+  timestampUs: number;
+}
+
+/** An OTel Activity span captured during tick execution */
+export interface SpanData {
+  nameId: number;
+  name: string;
+  workerId: number;
+  startUs: number;
+  endUs: number;
+  durationUs: number;
+}
+
+/** All data for a single tick */
+export interface TickData {
+  tickNumber: number;
+  startUs: number;
+  endUs: number;
+  durationUs: number;
+  chunks: ChunkSpan[];
+  phases: PhaseSpan[];
+  skips: SkipEvent[];
+  spans: SpanData[];
+  /** Per-system aggregate duration in µs (for heat map) */
+  systemDurations: Map<number, number>;
+}
+
+/** Processed trace ready for rendering */
+export interface ProcessedTrace {
+  metadata: TraceMetadata;
+  ticks: TickData[];
+  /** Interned span name lookup (ID → name) */
+  spanNames: Record<number, string>;
+  /** All tick numbers, sorted */
+  tickNumbers: number[];
+  /** Min/max timestamps across all ticks */
+  globalStartUs: number;
+  globalEndUs: number;
+  /** Max per-system duration across all ticks (for heat map color scaling) */
+  maxSystemDurationUs: number;
+  /** Max tick duration */
+  maxTickDurationUs: number;
+  /** P95 tick duration for timeline bar height scaling */
+  p95TickDurationUs: number;
+  /** System color palette */
+  systemColors: string[];
+}
+
+const PHASE_NAMES: Record<number, string> = {
+  0: 'System Dispatch',
+  1: 'UoW Flush',
+  2: 'Write Tick Fence',
+  3: 'Output Phase',
+  4: 'Tier Index Rebuild',
+  5: 'Dormancy Sweep'
+};
+
+const SKIP_REASON_NAMES: Record<number, string> = {
+  0: 'Not Skipped',
+  1: 'RunIf False',
+  2: 'Empty Input',
+  3: 'Empty Events',
+  4: 'Throttled',
+  5: 'Shed',
+  6: 'Exception',
+  7: 'Dependency Failed'
+};
+
+/** Color palette for systems — visually distinct, dark-theme friendly */
+const SYSTEM_PALETTE = [
+  '#e94560', '#4ecdc4', '#ffe66d', '#95e1d3', '#f38181',
+  '#aa96da', '#a8d8ea', '#fcbad3', '#c3aed6', '#b8de6f',
+  '#ff9a76', '#679b9b', '#ffc4a3', '#e8a87c', '#41b3a3',
+  '#d63447', '#f57b51', '#f6efa6', '#5ee7df', '#b490ca',
+];
+
+/** Generate system color based on index */
+function generateSystemColors(count: number): string[] {
+  const colors: string[] = [];
+  for (let i = 0; i < count; i++) {
+    colors.push(SYSTEM_PALETTE[i % SYSTEM_PALETTE.length]);
+  }
+  return colors;
+}
+
+/** Process raw events into renderable tick structures */
+export function processTrace(metadata: TraceMetadata, events: TraceEvent[], spanNames: Record<number, string> = {}): ProcessedTrace {
+  const systems = metadata.systems;
+  const systemColors = generateSystemColors(systems.length);
+
+  // Group events by tick
+  const tickMap = new Map<number, TraceEvent[]>();
+  for (const evt of events) {
+    let list = tickMap.get(evt.tickNumber);
+    if (!list) {
+      list = [];
+      tickMap.set(evt.tickNumber, list);
+    }
+    list.push(evt);
+  }
+
+  const ticks: TickData[] = [];
+  let maxSystemDurationUs = 0;
+  let maxTickDurationUs = 0;
+
+  for (const [tickNumber, tickEvents] of tickMap) {
+    const tickData = processTickEvents(tickNumber, tickEvents, systems, spanNames);
+    if (tickData.durationUs > maxTickDurationUs) {
+      maxTickDurationUs = tickData.durationUs;
+    }
+
+    for (const dur of tickData.systemDurations.values()) {
+      if (dur > maxSystemDurationUs) {
+        maxSystemDurationUs = dur;
+      }
+    }
+
+    ticks.push(tickData);
+  }
+
+  // Sort ticks by tick number
+  ticks.sort((a, b) => a.tickNumber - b.tickNumber);
+  const tickNumbers = ticks.map(t => t.tickNumber);
+
+  const globalStartUs = ticks.length > 0 ? ticks[0].startUs : 0;
+  const globalEndUs = ticks.length > 0 ? ticks[ticks.length - 1].endUs : 0;
+
+  // Compute P95 tick duration for timeline bar height scaling
+  const sortedDurations = ticks.map(t => t.durationUs).sort((a, b) => a - b);
+  const p95Idx = Math.floor(sortedDurations.length * 0.95);
+  const p95TickDurationUs = sortedDurations.length > 0 ? sortedDurations[Math.min(p95Idx, sortedDurations.length - 1)] : 0;
+
+  return {
+    metadata,
+    ticks,
+    spanNames,
+    tickNumbers,
+    globalStartUs,
+    globalEndUs,
+    maxSystemDurationUs,
+    maxTickDurationUs,
+    p95TickDurationUs,
+    systemColors
+  };
+}
+
+/** Find all ticks that overlap with the given absolute time range */
+export function getTicksInRange(trace: ProcessedTrace, startUs: number, endUs: number): TickData[] {
+  return trace.ticks.filter(t => t.endUs >= startUs && t.startUs <= endUs);
+}
+
+/** Find the tick index (in trace.ticks array) for a given tick number */
+export function findTickIndex(trace: ProcessedTrace, tickNumber: number): number {
+  return trace.ticks.findIndex(t => t.tickNumber === tickNumber);
+}
+
+export function processTickEvents(tickNumber: number, events: TraceEvent[], systems: SystemDef[], spanNames: Record<number, string>): TickData {
+  let startUs = Infinity;
+  let endUs = -Infinity;
+
+  const chunks: ChunkSpan[] = [];
+  const phases: PhaseSpan[] = [];
+  const skips: SkipEvent[] = [];
+  const spans: SpanData[] = [];
+  const systemDurations = new Map<number, number>();
+
+  // Track open chunk/phase/span events
+  const openChunks = new Map<string, TraceEvent>(); // key: sysIdx-chunkIdx-workerId
+  const openPhases = new Map<number, TraceEvent>();  // key: phase enum
+  const openSpans = new Map<string, TraceEvent>();   // key: nameId-workerId
+
+  for (const evt of events) {
+    switch (evt.eventType) {
+      case TraceEventType.TickStart:
+        startUs = evt.timestampUs;
+        break;
+
+      case TraceEventType.TickEnd:
+        endUs = evt.timestampUs;
+        break;
+
+      case TraceEventType.PhaseStart:
+        openPhases.set(evt.phase, evt);
+        break;
+
+      case TraceEventType.PhaseEnd: {
+        const open = openPhases.get(evt.phase);
+        if (open) {
+          const dur = evt.timestampUs - open.timestampUs;
+          phases.push({
+            phase: evt.phase,
+            phaseName: PHASE_NAMES[evt.phase] ?? `Phase ${evt.phase}`,
+            startUs: open.timestampUs,
+            endUs: evt.timestampUs,
+            durationUs: dur
+          });
+          openPhases.delete(evt.phase);
+        }
+        break;
+      }
+
+      case TraceEventType.ChunkStart: {
+        const key = `${evt.systemIndex}-${evt.chunkIndex}-${evt.workerId}`;
+        openChunks.set(key, evt);
+        break;
+      }
+
+      case TraceEventType.ChunkEnd: {
+        const key = `${evt.systemIndex}-${evt.chunkIndex}-${evt.workerId}`;
+        const open = openChunks.get(key);
+        if (open) {
+          const dur = evt.timestampUs - open.timestampUs;
+          const sys = systems[evt.systemIndex];
+          chunks.push({
+            systemIndex: evt.systemIndex,
+            systemName: sys?.name ?? `System[${evt.systemIndex}]`,
+            chunkIndex: evt.chunkIndex,
+            workerId: evt.workerId,
+            startUs: open.timestampUs,
+            endUs: evt.timestampUs,
+            durationUs: dur,
+            entitiesProcessed: evt.entitiesProcessed,
+            totalChunks: open.payload,
+            isParallel: sys?.isParallel ?? false
+          });
+
+          // Accumulate per-system duration (max across workers for parallel systems)
+          const existing = systemDurations.get(evt.systemIndex) ?? 0;
+          systemDurations.set(evt.systemIndex, existing + dur);
+
+          openChunks.delete(key);
+        }
+        break;
+      }
+
+      case TraceEventType.SystemSkipped:
+        skips.push({
+          systemIndex: evt.systemIndex,
+          systemName: systems[evt.systemIndex]?.name ?? `System[${evt.systemIndex}]`,
+          reason: evt.skipReason,
+          reasonName: SKIP_REASON_NAMES[evt.skipReason] ?? `Unknown(${evt.skipReason})`,
+          timestampUs: evt.timestampUs
+        });
+        break;
+
+      case TraceEventType.SpanStart: {
+        const spanKey = `${evt.payload}-${evt.workerId}`;
+        openSpans.set(spanKey, evt);
+        break;
+      }
+
+      case TraceEventType.SpanEnd: {
+        const spanKey = `${evt.payload}-${evt.workerId}`;
+        const open = openSpans.get(spanKey);
+        if (open) {
+          const dur = evt.timestampUs - open.timestampUs;
+          spans.push({
+            nameId: evt.payload,
+            name: spanNames[evt.payload] ?? `Span[${evt.payload}]`,
+            workerId: evt.workerId,
+            startUs: open.timestampUs,
+            endUs: evt.timestampUs,
+            durationUs: dur
+          });
+          openSpans.delete(spanKey);
+        }
+        break;
+      }
+    }
+  }
+
+  if (startUs === Infinity) startUs = 0;
+  if (endUs === -Infinity) endUs = startUs;
+
+  return {
+    tickNumber,
+    startUs,
+    endUs,
+    durationUs: endUs - startUs,
+    chunks,
+    phases,
+    skips,
+    spans,
+    systemDurations
+  };
+}
+
+/** Maximum ticks to keep in memory during live streaming (~50s at 60Hz). */
+const MAX_LIVE_TICKS = 3000;
+
+/** Create an empty ProcessedTrace for live session initialization. */
+export function createEmptyTrace(metadata: TraceMetadata): ProcessedTrace {
+  return {
+    metadata,
+    ticks: [],
+    spanNames: {},
+    tickNumbers: [],
+    globalStartUs: 0,
+    globalEndUs: 0,
+    maxSystemDurationUs: 0,
+    maxTickDurationUs: 0,
+    p95TickDurationUs: 0,
+    systemColors: generateSystemColors(metadata.systems.length)
+  };
+}
+
+/**
+ * Incrementally process a single tick and append it to an existing ProcessedTrace.
+ * Used in live streaming mode to avoid reprocessing the entire trace on every tick.
+ */
+export function processTickAndAppend(
+  trace: ProcessedTrace,
+  tickNumber: number,
+  events: TraceEvent[],
+  newSpanNames?: Record<number, string>
+): ProcessedTrace {
+  const spanNames = newSpanNames
+    ? { ...trace.spanNames, ...newSpanNames }
+    : trace.spanNames;
+
+  const tickData = processTickEvents(tickNumber, events, trace.metadata.systems, spanNames);
+
+  const ticks = [...trace.ticks, tickData];
+  const tickNumbers = [...trace.tickNumbers, tickNumber];
+
+  // Evict oldest ticks beyond the cap
+  if (ticks.length > MAX_LIVE_TICKS) {
+    const excess = ticks.length - MAX_LIVE_TICKS;
+    ticks.splice(0, excess);
+    tickNumbers.splice(0, excess);
+  }
+
+  // Update aggregate stats incrementally
+  let maxSystemDurationUs = trace.maxSystemDurationUs;
+  for (const dur of tickData.systemDurations.values()) {
+    if (dur > maxSystemDurationUs) {
+      maxSystemDurationUs = dur;
+    }
+  }
+
+  // Recompute P95 every 100 ticks (cheap: sort durations array)
+  let p95TickDurationUs = trace.p95TickDurationUs;
+  if (ticks.length % 100 === 0 && ticks.length > 0) {
+    const sorted = ticks.map(t => t.durationUs).sort((a, b) => a - b);
+    const idx = Math.floor(sorted.length * 0.95);
+    p95TickDurationUs = sorted[Math.min(idx, sorted.length - 1)];
+  }
+
+  return {
+    ...trace,
+    ticks,
+    tickNumbers,
+    spanNames,
+    globalStartUs: ticks[0]?.startUs ?? 0,
+    globalEndUs: tickData.endUs,
+    maxTickDurationUs: Math.max(trace.maxTickDurationUs, tickData.durationUs),
+    maxSystemDurationUs,
+    p95TickDurationUs,
+  };
+}
+
+/** Merge span names into an existing trace without adding ticks. */
+export function mergeSpanNames(
+  trace: ProcessedTrace,
+  newSpanNames: Record<number, string>
+): ProcessedTrace {
+  return {
+    ...trace,
+    spanNames: { ...trace.spanNames, ...newSpanNames }
+  };
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/types.ts
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/types.ts
@@ -1,0 +1,86 @@
+/** Matches TraceEventType enum from Typhon.Profiler */
+export const enum TraceEventType {
+  TickStart = 0,
+  TickEnd = 1,
+  PhaseStart = 2,
+  PhaseEnd = 3,
+  SystemReady = 4,
+  ChunkStart = 5,
+  ChunkEnd = 6,
+  SystemSkipped = 7,
+  SpanStart = 8,
+  SpanEnd = 9
+}
+
+/** Matches TickPhase enum */
+export const enum TickPhase {
+  SystemDispatch = 0,
+  UowFlush = 1,
+  WriteTickFence = 2,
+  OutputPhase = 3,
+  TierIndexRebuild = 4,
+  DormancySweep = 5
+}
+
+export const TickPhaseNames: Record<number, string> = {
+  0: 'System Dispatch',
+  1: 'UoW Flush',
+  2: 'Write Tick Fence',
+  3: 'Output Phase',
+  4: 'Tier Index Rebuild',
+  5: 'Dormancy Sweep'
+};
+
+export const SkipReasonNames: Record<number, string> = {
+  0: 'Not Skipped',
+  1: 'RunIf False',
+  2: 'Empty Input',
+  3: 'Empty Events',
+  4: 'Throttled',
+  5: 'Shed',
+  6: 'Exception',
+  7: 'Dependency Failed'
+};
+
+export interface TraceMetadata {
+  header: {
+    version: number;
+    timestampFrequency: number;
+    baseTickRate: number;
+    workerCount: number;
+    systemCount: number;
+    createdUtc: string;
+    samplingSessionStartQpc: number;
+  };
+  systems: SystemDef[];
+}
+
+export interface SystemDef {
+  index: number;
+  name: string;
+  type: number;
+  priority: number;
+  isParallel: boolean;
+  tierFilter: number;
+  predecessors: number[];
+  successors: number[];
+}
+
+export interface TraceEvent {
+  timestampUs: number;
+  tickNumber: number;
+  systemIndex: number;
+  chunkIndex: number;
+  workerId: number;
+  eventType: TraceEventType;
+  phase: TickPhase;
+  skipReason: number;
+  entitiesProcessed: number;
+  payload: number;
+}
+
+/** A tick source abstracts over file-based and live-streamed data */
+export interface TickSource {
+  readonly metadata: TraceMetadata;
+  getEvents(fromTick: number, toTick: number): Promise<TraceEvent[]>;
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/src/uiTypes.ts
+++ b/tools/Typhon.Profiler.Server/ClientApp/src/uiTypes.ts
@@ -1,0 +1,23 @@
+/** Viewport state shared across all tracks in the GraphArea */
+export interface Viewport {
+  offsetX: number;   // µs offset (left edge of visible area, absolute)
+  scaleX: number;    // pixels per µs
+  scrollY: number;   // vertical scroll in pixels
+}
+
+/** Time range displayed in the graph area (absolute µs timestamps) */
+export interface TimeRange {
+  startUs: number;
+  endUs: number;
+}
+
+/** Track layout descriptor — precomputed for rendering */
+export interface TrackLayout {
+  id: string;           // "ruler", "worker-0", "phases"
+  label: string;        // "Worker 0", "Phases"
+  y: number;            // top Y position in content coordinates
+  height: number;       // height in pixels (expanded)
+  collapsedHeight: number; // height when collapsed (4px strip)
+  collapsed: boolean;
+  collapsible: boolean; // ruler is not collapsible
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/tsconfig.json
+++ b/tools/Typhon.Profiler.Server/ClientApp/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/tools/Typhon.Profiler.Server/ClientApp/vite.config.ts
+++ b/tools/Typhon.Profiler.Server/ClientApp/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import preact from '@preact/preset-vite';
+
+export default defineConfig({
+  plugins: [preact()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
+  },
+  build: {
+    outDir: '../wwwroot',
+    emptyOutDir: true
+  }
+});

--- a/tools/Typhon.Profiler.Server/FlameGraphService.cs
+++ b/tools/Typhon.Profiler.Server/FlameGraphService.cs
@@ -1,0 +1,161 @@
+using Microsoft.Diagnostics.Tracing.Etlx;
+
+namespace Typhon.Profiler.Server;
+
+/// <summary>
+/// Parses a <c>.nettrace</c> file and builds flame graph data by correlating
+/// CPU sample timestamps with trace event time ranges.
+/// </summary>
+public static class FlameGraphService
+{
+    public class FlameNode
+    {
+        public string Name { get; set; } = "";
+        public int TotalSamples { get; set; }
+        public int SelfSamples { get; set; }
+        public Dictionary<string, FlameNode> Children { get; set; } = new();
+    }
+
+    /// <summary>
+    /// Builds a flame graph from CPU samples in a <c>.nettrace</c> file.
+    /// </summary>
+    /// <param name="nettracePath">Path to the <c>.nettrace</c> file.</param>
+    /// <param name="samplingSessionStartQpc">QPC timestamp when EventPipe session started (from trace file header).</param>
+    /// <param name="timestampFrequency">Stopwatch.Frequency from trace file header.</param>
+    /// <param name="fromUs">Start of time range in absolute µs (same time base as .typhon-trace).</param>
+    /// <param name="toUs">End of time range in absolute µs.</param>
+    /// <param name="threadId">Optional: filter to a specific OS thread ID. -1 = all threads.</param>
+    public static (FlameNode root, int totalSamples) Build(
+        string nettracePath,
+        long samplingSessionStartQpc,
+        long timestampFrequency,
+        double fromUs,
+        double toUs,
+        int threadId = -1)
+    {
+        var root = new FlameNode { Name = "(root)" };
+        int totalSamples = 0;
+
+        if (!File.Exists(nettracePath))
+        {
+            return (root, 0);
+        }
+
+        // Convert .nettrace → TraceLog (.etlx) to get resolved call stacks
+        var etlxPath = Path.ChangeExtension(nettracePath, ".etlx");
+        try { File.Delete(etlxPath); } catch { }
+
+        var options = new TraceLogOptions { ContinueOnError = true };
+        try
+        {
+            TraceLog.CreateFromEventPipeDataFile(nettracePath, etlxPath, options);
+        }
+        catch
+        {
+            // Truncated .nettrace — partial conversion may still be usable
+        }
+
+        if (!File.Exists(etlxPath))
+        {
+            return (root, 0);
+        }
+
+        using var traceLog = new TraceLog(etlxPath);
+
+        // Convert EventPipe relative ms → absolute µs (same time base as .typhon-trace)
+        // eventAbsoluteUs = sessionStartUs + eventRelativeMs * 1000
+        double sessionStartUs = samplingSessionStartQpc > 0 && timestampFrequency > 0
+            ? (double)samplingSessionStartQpc / timestampFrequency * 1_000_000.0
+            : 0;
+
+        bool hasTimeFilter = samplingSessionStartQpc > 0 && fromUs > 0;
+
+        foreach (var evt in traceLog.Events)
+        {
+            // Filter by thread if specified
+            if (threadId >= 0 && evt.ThreadID != threadId)
+            {
+                continue;
+            }
+
+            // Convert to absolute µs and filter by time range
+            if (hasTimeFilter)
+            {
+                double eventAbsoluteUs = sessionStartUs + evt.TimeStampRelativeMSec * 1000.0;
+                if (eventAbsoluteUs < fromUs || eventAbsoluteUs > toUs)
+                {
+                    continue;
+                }
+            }
+
+            // Get call stack
+            var callStack = evt.CallStack();
+            if (callStack == null)
+            {
+                continue;
+            }
+
+            // Walk the stack from leaf to root
+            var frames = new List<string>();
+            for (var frame = callStack; frame != null; frame = frame.Caller)
+            {
+                var name = frame.CodeAddress?.FullMethodName;
+                if (string.IsNullOrEmpty(name))
+                {
+                    name = $"0x{frame.CodeAddress?.Address:x}";
+                }
+
+                frames.Add(name);
+            }
+
+            frames.Reverse();
+
+            if (frames.Count == 0)
+            {
+                continue;
+            }
+
+            totalSamples++;
+            root.TotalSamples++;
+
+            var current = root;
+            foreach (var frame in frames)
+            {
+                if (!current.Children.TryGetValue(frame, out var child))
+                {
+                    child = new FlameNode { Name = frame };
+                    current.Children[frame] = child;
+                }
+
+                child.TotalSamples++;
+                current = child;
+            }
+
+            current.SelfSamples++;
+        }
+
+        try { File.Delete(etlxPath); } catch { }
+
+        return (root, totalSamples);
+    }
+
+    public static object ToSerializable(FlameNode node, int minSamples = 0)
+    {
+        var children = new List<object>();
+        foreach (var child in node.Children.Values.OrderByDescending(c => c.TotalSamples))
+        {
+            if (child.TotalSamples >= minSamples)
+            {
+                children.Add(ToSerializable(child, minSamples));
+            }
+        }
+
+        return new
+        {
+            name = node.Name,
+            total = node.TotalSamples,
+            self = node.SelfSamples,
+            children
+        };
+    }
+}

--- a/tools/Typhon.Profiler.Server/LiveSessionService.Logging.cs
+++ b/tools/Typhon.Profiler.Server/LiveSessionService.Logging.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Logging;
+
+namespace Typhon.Profiler.Server;
+
+/// <summary>Source-generated log messages for <see cref="LiveSessionService"/>.</summary>
+public sealed partial class LiveSessionService
+{
+    [LoggerMessage(Level = LogLevel.Information, Message = "LiveSessionService starting — will connect to {Host}:{Port}")]
+    private partial void LogStarting(string host, int port);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Connected to engine at {Host}:{Port}")]
+    private partial void LogConnected(string host, int port);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Connection to engine lost, reconnecting...")]
+    private partial void LogConnectionLost();
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Unexpected error in live session")]
+    private partial void LogUnexpectedError(System.Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Engine sent SHUTDOWN frame")]
+    private partial void LogShutdownReceived();
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Unknown frame type: 0x{Type:X2}")]
+    private partial void LogUnknownFrame(byte type);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Malformed {FrameType} frame ({Reason}) — dropping")]
+    private partial void LogMalformedFrame(string frameType, string reason);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "INIT received: {SystemCount} systems, {WorkerCount} workers, {Rate:F0} Hz")]
+    private partial void LogInitReceived(int systemCount, int workerCount, float rate);
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "LZ4 decompression mismatch: expected {Expected}, got {Got}")]
+    private partial void LogDecompressionMismatch(int expected, int got);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Received {Count} new span names")]
+    private partial void LogSpanNamesReceived(int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "SSE subscriber {Id} connected (total: {Count})")]
+    private partial void LogSubscriberConnected(int id, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "SSE subscriber {Id} disconnected (total: {Count})")]
+    private partial void LogSubscriberDisconnected(int id, int count);
+}

--- a/tools/Typhon.Profiler.Server/LiveSessionService.cs
+++ b/tools/Typhon.Profiler.Server/LiveSessionService.cs
@@ -1,0 +1,516 @@
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Channels;
+using K4os.Compression.LZ4;
+
+namespace Typhon.Profiler.Server;
+
+/// <summary>
+/// Current state of a live session, built from the INIT frame.
+/// </summary>
+public sealed class LiveSessionState
+{
+    public TraceFileHeader Header { get; init; }
+    public SystemDefinitionRecord[] Systems { get; init; }
+    public Dictionary<int, string> SpanNames { get; } = new();
+    public double TicksPerUs => Header.TimestampFrequency / 1_000_000.0;
+}
+
+/// <summary>
+/// A single tick's worth of events, ready for SSE serialization.
+/// </summary>
+public sealed class LiveTickBatch
+{
+    public int TickNumber { get; init; }
+    public LiveTraceEvent[] Events { get; init; }
+    public Dictionary<int, string> NewSpanNames { get; init; }
+}
+
+/// <summary>
+/// JSON-serializable trace event matching the client's TraceEvent interface.
+/// </summary>
+public sealed class LiveTraceEvent
+{
+    public double TimestampUs { get; init; }
+    public int TickNumber { get; init; }
+    public int SystemIndex { get; init; }
+    public int ChunkIndex { get; init; }
+    public int WorkerId { get; init; }
+    public int EventType { get; init; }
+    public int Phase { get; init; }
+    public int SkipReason { get; init; }
+    public int EntitiesProcessed { get; init; }
+    public int Payload { get; init; }
+}
+
+/// <summary>
+/// Background service that connects to a Typhon engine's TCP live stream port,
+/// reads framed binary trace data, and fans out to SSE subscribers via bounded channels.
+/// </summary>
+public sealed partial class LiveSessionService : BackgroundService
+{
+    private readonly ILogger<LiveSessionService> _logger;
+    private readonly string _engineHost;
+    private readonly int _enginePort;
+
+    private volatile LiveSessionState _state;
+    private readonly ConcurrentDictionary<int, Channel<LiveTickBatch>> _subscribers = new();
+    private int _nextSubscriberId;
+    private long _tickCount;
+
+    private static readonly int EventSize = Unsafe.SizeOf<TraceEvent>();
+
+    public LiveSessionService(IConfiguration config, ILogger<LiveSessionService> logger)
+    {
+        _logger = logger;
+        _engineHost = config.GetValue<string>("LiveStream:Host") ?? "127.0.0.1";
+        _enginePort = config.GetValue<int>("LiveStream:Port", LiveStreamProtocol.DefaultPort);
+    }
+
+    /// <summary>Current session state, or null if not connected.</summary>
+    public LiveSessionState GetState() => _state;
+
+    /// <summary>Total ticks received in the current session.</summary>
+    public long TickCount => Interlocked.Read(ref _tickCount);
+
+    /// <summary>Whether a live session is currently connected.</summary>
+    public bool IsConnected => _state != null;
+
+    /// <summary>Subscribe to receive tick batches. Returns a subscriber ID and channel reader.</summary>
+    public (int Id, ChannelReader<LiveTickBatch> Reader) Subscribe()
+    {
+        var channel = Channel.CreateBounded<LiveTickBatch>(
+            new BoundedChannelOptions(64) { FullMode = BoundedChannelFullMode.DropOldest });
+        var id = Interlocked.Increment(ref _nextSubscriberId);
+        _subscribers[id] = channel;
+        LogSubscriberConnected(id, _subscribers.Count);
+        return (id, channel.Reader);
+    }
+
+    /// <summary>Remove a subscriber.</summary>
+    public void Unsubscribe(int id)
+    {
+        if (_subscribers.TryRemove(id, out var ch))
+        {
+            ch.Writer.TryComplete();
+            LogSubscriberDisconnected(id, _subscribers.Count);
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        LogStarting(_engineHost, _enginePort);
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                using var tcp = new TcpClient();
+                await tcp.ConnectAsync(_engineHost, _enginePort, ct);
+                tcp.NoDelay = true;
+                LogConnected(_engineHost, _enginePort);
+
+                await ProcessStreamAsync(tcp.GetStream(), ct);
+            }
+            catch (SocketException) when (!ct.IsCancellationRequested)
+            {
+                // Engine not running or connection refused — retry
+            }
+            catch (IOException) when (!ct.IsCancellationRequested)
+            {
+                LogConnectionLost();
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                LogUnexpectedError(ex);
+            }
+
+            _state = null;
+            _pendingSpanNames = null;
+            Interlocked.Exchange(ref _tickCount, 0);
+
+            if (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(2000, ct);
+            }
+        }
+    }
+
+    private async Task ProcessStreamAsync(NetworkStream stream, CancellationToken ct)
+    {
+        var headerBuf = new byte[LiveStreamProtocol.FrameHeaderSize];
+
+        while (!ct.IsCancellationRequested)
+        {
+            await stream.ReadExactlyAsync(headerBuf, ct);
+            var (type, length) = LiveStreamProtocol.ReadFrameHeader(headerBuf);
+
+            // Defensive: reject implausible frame sizes (8 MB ceiling — a tick with every worker maxed out is < 1 MB compressed)
+            if (length < 0 || length > 8 * 1024 * 1024)
+            {
+                LogMalformedFrame(type.ToString(), $"invalid length {length}");
+                return; // disconnect and let the reconnect loop restart
+            }
+
+            var payload = new byte[length];
+            if (length > 0)
+            {
+                await stream.ReadExactlyAsync(payload, ct);
+            }
+
+            // Each handler is wrapped so a malformed frame logs and is dropped rather than poisoning the reconnect loop
+            try
+            {
+                switch (type)
+                {
+                    case LiveFrameType.Init:
+                        HandleInit(payload);
+                        break;
+
+                    case LiveFrameType.TickEvents:
+                        HandleTickEvents(payload);
+                        break;
+
+                    case LiveFrameType.SpanNames:
+                        HandleSpanNames(payload);
+                        break;
+
+                    case LiveFrameType.Shutdown:
+                        LogShutdownReceived();
+                        _state = null;
+                        return;
+
+                    default:
+                        LogUnknownFrame((byte)type);
+                        break;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogMalformedFrame(type.ToString(), ex.Message);
+                // Continue reading — next frame may be valid
+            }
+        }
+    }
+
+    private void HandleInit(byte[] payload)
+    {
+        var headerSize = Unsafe.SizeOf<TraceFileHeader>();
+        if (payload.Length < headerSize)
+        {
+            LogMalformedFrame("Init", $"payload length {payload.Length} < header size {headerSize}");
+            return;
+        }
+
+        var span = payload.AsSpan();
+
+        // Read header (64 bytes). The wire format is little-endian on x86/x64/ARM64.
+        // Running on big-endian hardware is unsupported and will produce garbage here.
+        var header = MemoryMarshal.Read<TraceFileHeader>(span[..headerSize]);
+        var pos = headerSize;
+
+        // Read system definitions (same binary format as file)
+        var systems = ReadSystemDefinitions(span, ref pos);
+
+        var state = new LiveSessionState
+        {
+            Header = header,
+            Systems = systems
+        };
+
+        ReadSpanNames(span, ref pos, state.SpanNames);
+
+        _state = state;
+        Interlocked.Exchange(ref _tickCount, 0);
+        LogInitReceived(header.SystemCount, header.WorkerCount, header.BaseTickRate);
+    }
+
+    // Reusable scratch for DTO conversion to avoid per-tick allocation.
+    // Sized on first use; grows on demand. Accessed only from the single reader thread.
+    private LiveTraceEvent[] _dtoScratch;
+
+    // Span names received via SPAN_NAMES frame since the last TICK_EVENTS broadcast. Attached to
+    // the first batch of the next TICK_EVENTS so the client has the name dictionary before it
+    // renders any chunk/span that might reference it.
+    private Dictionary<int, string> _pendingSpanNames;
+
+    private void HandleTickEvents(byte[] payload)
+    {
+        var state = _state;
+        if (state == null)
+        {
+            return;
+        }
+
+        if (payload.Length < 12)
+        {
+            LogMalformedFrame("TickEvents", "payload shorter than 12-byte block header");
+            return;
+        }
+
+        var span = payload.AsSpan();
+
+        // Read block header: uncompressed (4B) + compressed (4B) + event count (4B)
+        var uncompressedSize = BinaryPrimitives.ReadInt32LittleEndian(span);
+        var compressedSize = BinaryPrimitives.ReadInt32LittleEndian(span[4..]);
+        var eventCount = BinaryPrimitives.ReadInt32LittleEndian(span[8..]);
+
+        if (uncompressedSize < 0 || compressedSize < 0 || eventCount < 0
+            || payload.Length < 12 + compressedSize
+            || uncompressedSize != eventCount * Unsafe.SizeOf<TraceEvent>())
+        {
+            LogMalformedFrame("TickEvents", $"inconsistent block header (u={uncompressedSize}, c={compressedSize}, n={eventCount})");
+            return;
+        }
+
+        var rawBuffer = new byte[uncompressedSize];
+        var decoded = LZ4Codec.Decode(
+            span.Slice(12, compressedSize),
+            rawBuffer.AsSpan(0, uncompressedSize));
+
+        if (decoded != uncompressedSize)
+        {
+            LogDecompressionMismatch(uncompressedSize, decoded);
+            return;
+        }
+
+        // Cast to TraceEvent[] and restore absolute timestamps (undo delta encoding)
+        var rawEvents = MemoryMarshal.Cast<byte, TraceEvent>(rawBuffer.AsSpan(0, uncompressedSize));
+        var events = new TraceEvent[eventCount];
+        rawEvents[..eventCount].CopyTo(events);
+
+        for (var i = 1; i < events.Length; i++)
+        {
+            events[i].TimestampTicks += events[i - 1].TimestampTicks;
+        }
+
+        if (events.Length == 0)
+        {
+            return;
+        }
+
+        // Events are sorted by timestamp, which means ticks form contiguous runs (once a tick's
+        // events are done, we never see that tick again). Walk the array once and emit one batch
+        // per run — no Dictionary, no per-tick List, one DTO allocation per event.
+        if (_dtoScratch == null || _dtoScratch.Length < events.Length)
+        {
+            _dtoScratch = new LiveTraceEvent[Math.Max(events.Length, 1024)];
+        }
+
+        var ticksPerUs = state.TicksPerUs;
+        var runStart = 0;
+        var runTick = events[0].TickNumber;
+
+        for (var i = 0; i < events.Length; i++)
+        {
+            ref var evt = ref events[i];
+
+            if (evt.TickNumber != runTick)
+            {
+                EmitTickBatch(runTick, runStart, i, events, ticksPerUs);
+                runStart = i;
+                runTick = evt.TickNumber;
+            }
+
+            _dtoScratch[i] = new LiveTraceEvent
+            {
+                TimestampUs = evt.TimestampTicks / ticksPerUs,
+                TickNumber = evt.TickNumber,
+                SystemIndex = evt.SystemIndex,
+                ChunkIndex = evt.ChunkIndex,
+                WorkerId = evt.WorkerId,
+                EventType = (int)evt.EventType,
+                Phase = (int)evt.Phase,
+                SkipReason = evt.SkipReason,
+                EntitiesProcessed = evt.EntitiesProcessed,
+                Payload = evt.Payload
+            };
+        }
+
+        EmitTickBatch(runTick, runStart, events.Length, events, ticksPerUs);
+    }
+
+    /// <summary>Emit a batch for the given run of events. Copies out of <c>_dtoScratch</c> into an array sized exactly to the run.</summary>
+    private void EmitTickBatch(int tickNumber, int startInclusive, int endExclusive, TraceEvent[] _, double ticksPerUs)
+    {
+        var count = endExclusive - startInclusive;
+        if (count == 0)
+        {
+            return;
+        }
+
+        var batchEvents = new LiveTraceEvent[count];
+        Array.Copy(_dtoScratch, startInclusive, batchEvents, 0, count);
+
+        // Attach pending span names to the FIRST batch of this frame so the client has them before
+        // rendering events that reference them. Subsequent batches from the same frame carry null.
+        var attachedSpanNames = _pendingSpanNames;
+        _pendingSpanNames = null;
+
+        var batch = new LiveTickBatch
+        {
+            TickNumber = tickNumber,
+            Events = batchEvents,
+            NewSpanNames = attachedSpanNames
+        };
+
+        Interlocked.Increment(ref _tickCount);
+        BroadcastBatch(batch);
+    }
+
+    private void HandleSpanNames(byte[] payload)
+    {
+        var state = _state;
+        if (state == null)
+        {
+            return;
+        }
+
+        if (payload.Length < 2)
+        {
+            LogMalformedFrame("SpanNames", "payload shorter than 2-byte count");
+            return;
+        }
+
+        var span = payload.AsSpan();
+        var pos = 0;
+        var count = BinaryPrimitives.ReadUInt16LittleEndian(span);
+        pos += 2;
+
+        for (var i = 0; i < count; i++)
+        {
+            if (pos + 3 > span.Length)
+            {
+                LogMalformedFrame("SpanNames", $"truncated at entry {i}");
+                return;
+            }
+
+            var id = BinaryPrimitives.ReadUInt16LittleEndian(span[pos..]);
+            pos += 2;
+
+            var nameLen = span[pos++];
+            if (pos + nameLen > span.Length)
+            {
+                LogMalformedFrame("SpanNames", $"truncated name at entry {i}");
+                return;
+            }
+
+            var name = Encoding.UTF8.GetString(span.Slice(pos, nameLen));
+            pos += nameLen;
+
+            // Update both the authoritative state (so new SSE clients see it in their initial metadata)
+            // and the pending buffer (so the next tick batch carries it).
+            state.SpanNames[id] = name;
+            (_pendingSpanNames ??= new Dictionary<int, string>())[id] = name;
+        }
+
+        if (count > 0)
+        {
+            LogSpanNamesReceived(count);
+        }
+    }
+
+    private void BroadcastBatch(LiveTickBatch batch)
+    {
+        foreach (var (_, channel) in _subscribers)
+        {
+            channel.Writer.TryWrite(batch); // Drop if subscriber is slow (bounded channel)
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Binary parsing helpers (same format as TraceFileReader)
+    // ══════════════��═════════════════════════════════════���══════════
+
+    private static SystemDefinitionRecord[] ReadSystemDefinitions(ReadOnlySpan<byte> data, ref int pos)
+    {
+        var count = BinaryPrimitives.ReadUInt16LittleEndian(data[pos..]);
+        pos += 2;
+
+        var systems = new SystemDefinitionRecord[count];
+
+        for (var i = 0; i < count; i++)
+        {
+            var index = BinaryPrimitives.ReadUInt16LittleEndian(data[pos..]);
+            pos += 2;
+
+            var nameLen = data[pos++];
+            var name = Encoding.UTF8.GetString(data.Slice(pos, nameLen));
+            pos += nameLen;
+
+            var type = data[pos++];
+            var priority = data[pos++];
+            var isParallel = data[pos++] != 0;
+            var tierFilter = data[pos++];
+
+            var predCount = data[pos++];
+            var predecessors = new ushort[predCount];
+            for (var p = 0; p < predCount; p++)
+            {
+                predecessors[p] = BinaryPrimitives.ReadUInt16LittleEndian(data[pos..]);
+                pos += 2;
+            }
+
+            var succCount = data[pos++];
+            var successors = new ushort[succCount];
+            for (var s = 0; s < succCount; s++)
+            {
+                successors[s] = BinaryPrimitives.ReadUInt16LittleEndian(data[pos..]);
+                pos += 2;
+            }
+
+            systems[i] = new SystemDefinitionRecord
+            {
+                Index = index,
+                Name = name,
+                Type = type,
+                Priority = priority,
+                IsParallel = isParallel,
+                TierFilter = tierFilter,
+                Predecessors = predecessors,
+                Successors = successors
+            };
+        }
+
+        return systems;
+    }
+
+    private static void ReadSpanNames(ReadOnlySpan<byte> data, ref int pos, Dictionary<int, string> spanNames)
+    {
+        if (pos + 4 > data.Length)
+        {
+            return;
+        }
+
+        var magic = BinaryPrimitives.ReadUInt32LittleEndian(data[pos..]);
+        if (magic != TraceFileWriter.SpanNameTableMagic)
+        {
+            return;
+        }
+
+        pos += 4;
+
+        var count = BinaryPrimitives.ReadUInt16LittleEndian(data[pos..]);
+        pos += 2;
+
+        for (var i = 0; i < count; i++)
+        {
+            var id = BinaryPrimitives.ReadUInt16LittleEndian(data[pos..]);
+            pos += 2;
+
+            var nameLen = data[pos++];
+            var name = Encoding.UTF8.GetString(data.Slice(pos, nameLen));
+            pos += nameLen;
+
+            spanNames[id] = name;
+        }
+    }
+}

--- a/tools/Typhon.Profiler.Server/Program.cs
+++ b/tools/Typhon.Profiler.Server/Program.cs
@@ -1,0 +1,360 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Typhon.Profiler;
+using Typhon.Profiler.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// CORS for local dev (Vite dev server runs on a different port)
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy => policy
+        .AllowAnyOrigin()
+        .AllowAnyMethod()
+        .AllowAnyHeader());
+});
+
+// Live streaming service — connects to engine TCP port, fans out via SSE
+builder.Services.AddSingleton<LiveSessionService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<LiveSessionService>());
+
+var app = builder.Build();
+
+var jsonOpts = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+};
+app.UseCors();
+
+// Serve static files from the client build output (production)
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
+// ══════════════════════════════════════════════════════════════
+// REST API — Trace file operations
+// ══════════════════════════════════════════════════════════════
+
+app.MapGet("/api/health", () => Results.Ok(new { status = "ok", version = "0.1.0" }));
+
+/// <summary>Upload trace files (multipart form: 'trace' = .typhon-trace, optional 'nettrace' = .nettrace).</summary>
+app.MapPost("/api/trace/upload", async (HttpRequest request) =>
+{
+    var form = await request.ReadFormAsync();
+
+    var traceFile = form.Files.GetFile("trace");
+    if (traceFile == null)
+    {
+        return Results.BadRequest(new { error = "No .typhon-trace file in upload" });
+    }
+
+    var tempDir = Path.Combine(Path.GetTempPath(), "typhon-profiler");
+    Directory.CreateDirectory(tempDir);
+    var sessionId = Guid.NewGuid().ToString();
+    var tempTracePath = Path.Combine(tempDir, $"{sessionId}.typhon-trace");
+
+    // Save .typhon-trace
+    await using (var fs = File.Create(tempTracePath))
+    {
+        await traceFile.CopyToAsync(fs);
+    }
+
+    // Save companion .nettrace if provided
+    var nettraceFile = form.Files.GetFile("nettrace");
+    if (nettraceFile != null)
+    {
+        var tempNettracePath = Path.Combine(tempDir, $"{sessionId}.nettrace");
+        await using var fs = File.Create(tempNettracePath);
+        await nettraceFile.CopyToAsync(fs);
+    }
+
+    using var reader = new TraceFileReader(File.OpenRead(tempTracePath));
+    var header = reader.ReadHeader();
+    var systems = reader.ReadSystemDefinitions();
+    reader.ReadSpanNames();
+
+    return Results.Ok(new
+    {
+        path = tempTracePath,
+        metadata = new
+        {
+            header = new
+            {
+                version = header.Version,
+                timestampFrequency = header.TimestampFrequency,
+                baseTickRate = header.BaseTickRate,
+                workerCount = header.WorkerCount,
+                systemCount = header.SystemCount,
+                createdUtc = new DateTime(header.CreatedUtcTicks, DateTimeKind.Utc),
+                samplingSessionStartQpc = header.SamplingSessionStartQpc
+            },
+            systems = systems.Select(s => new
+            {
+                index = s.Index,
+                name = s.Name,
+                type = s.Type,
+                priority = s.Priority,
+                isParallel = s.IsParallel,
+                tierFilter = s.TierFilter,
+                predecessors = s.Predecessors,
+                successors = s.Successors
+            })
+        }
+    });
+});
+
+/// <summary>Load a trace file and return metadata (header + system definitions).</summary>
+app.MapGet("/api/trace/metadata", (string path) =>
+{
+    if (string.IsNullOrEmpty(path) || !File.Exists(path))
+    {
+        return Results.NotFound(new { error = "Trace file not found", path });
+    }
+
+    using var reader = new TraceFileReader(File.OpenRead(path));
+    var header = reader.ReadHeader();
+    var systems = reader.ReadSystemDefinitions();
+
+    return Results.Ok(new
+    {
+        header = new
+        {
+            version = header.Version,
+            timestampFrequency = header.TimestampFrequency,
+            baseTickRate = header.BaseTickRate,
+            workerCount = header.WorkerCount,
+            systemCount = header.SystemCount,
+            createdUtc = new DateTime(header.CreatedUtcTicks, DateTimeKind.Utc)
+        },
+        systems = systems.Select(s => new
+        {
+            index = s.Index,
+            name = s.Name,
+            type = s.Type,
+            priority = s.Priority,
+            isParallel = s.IsParallel,
+            tierFilter = s.TierFilter,
+            predecessors = s.Predecessors,
+            successors = s.Successors
+        })
+    });
+});
+
+/// <summary>Load all events from a trace file, optionally filtered by tick range.</summary>
+app.MapGet("/api/trace/events", (string path, int? fromTick, int? toTick) =>
+{
+    if (string.IsNullOrEmpty(path) || !File.Exists(path))
+    {
+        return Results.NotFound(new { error = "Trace file not found", path });
+    }
+
+    using var reader = new TraceFileReader(File.OpenRead(path));
+    reader.ReadHeader();
+    reader.ReadSystemDefinitions();
+    reader.ReadSpanNames();
+    var events = reader.ReadAllEvents();
+
+    // Filter by tick range if specified
+    if (fromTick.HasValue || toTick.HasValue)
+    {
+        var from = fromTick ?? 0;
+        var to = toTick ?? int.MaxValue;
+        events = events.Where(e => e.TickNumber >= from && e.TickNumber <= to).ToList();
+    }
+
+    var ticksPerUs = reader.Header.TimestampFrequency / 1_000_000.0;
+
+    return Results.Ok(new
+    {
+        totalEvents = events.Count,
+        spanNames = reader.SpanNames,
+        events = events.Select(e => new
+        {
+            timestampUs = e.TimestampTicks / ticksPerUs,
+            tickNumber = e.TickNumber,
+            systemIndex = e.SystemIndex,
+            chunkIndex = e.ChunkIndex,
+            workerId = e.WorkerId,
+            eventType = (int)e.EventType,
+            phase = (int)e.Phase,
+            skipReason = e.SkipReason,
+            entitiesProcessed = e.EntitiesProcessed,
+            payload = e.Payload
+        })
+    });
+});
+
+/// <summary>Export trace to Chrome Trace JSON format.</summary>
+app.MapGet("/api/trace/export/chrome", (string path) =>
+{
+    if (string.IsNullOrEmpty(path) || !File.Exists(path))
+    {
+        return Results.NotFound(new { error = "Trace file not found", path });
+    }
+
+    var memStream = new MemoryStream();
+    ChromeTraceExporter.Export(path, memStream);
+    memStream.Position = 0;
+
+    return Results.File(memStream, "application/json", "trace.json");
+});
+
+// ══════════════════════════════════════════════════════════════
+// Flame Graph API — parses companion .nettrace file
+// ══════════════════════════════════════════════════════════════
+
+/// <summary>Build a flame graph from CPU samples in the companion .nettrace file.</summary>
+app.MapGet("/api/trace/flamegraph", (string path, double? fromUs, double? toUs, int? threadId) =>
+{
+    var nettracePath = Path.ChangeExtension(path, ".nettrace");
+    if (!File.Exists(nettracePath))
+    {
+        return Results.NotFound(new { error = "No .nettrace file found (CPU sampling was not enabled)", nettracePath });
+    }
+
+    try
+    {
+        // Read the trace header for timestamp correlation
+        using var traceReader = new TraceFileReader(File.OpenRead(path));
+        var header = traceReader.ReadHeader();
+
+        var from = fromUs ?? 0;
+        var to = toUs ?? double.MaxValue;
+        var tid = threadId ?? -1;
+
+        var (root, totalSamples) = Typhon.Profiler.Server.FlameGraphService.Build(
+            nettracePath, header.SamplingSessionStartQpc, header.TimestampFrequency, from, to, tid);
+
+        return Results.Ok(new
+        {
+            totalSamples,
+            hasSamples = totalSamples > 0,
+            root = Typhon.Profiler.Server.FlameGraphService.ToSerializable(root)
+        });
+    }
+    catch (Exception ex)
+    {
+        return Results.Problem(detail: ex.ToString(), statusCode: 500);
+    }
+});
+
+// ══════════════════════════════════════════════════════════════
+// Live streaming API — SSE events from engine via TCP
+// ══════════════════════════════════════════════════════════════
+
+app.MapGet("/api/live/status", (LiveSessionService live) =>
+{
+    return Results.Ok(new
+    {
+        connected = live.IsConnected,
+        tickCount = live.TickCount
+    });
+});
+
+// Shared metadata DTO builder — used by both /api/live/metadata and the first /api/live/events payload.
+// Note for future maintainers: do NOT enable response compression (UseResponseCompression) on these
+// endpoints. SSE streams need immediate bytes on the wire — compression buffers them and breaks real-time
+// delivery. CORS/static-files middleware above is already configured to leave this path untouched.
+static object BuildLiveMetadataDto(LiveSessionState state) => new
+{
+    header = new
+    {
+        version = state.Header.Version,
+        timestampFrequency = state.Header.TimestampFrequency,
+        baseTickRate = state.Header.BaseTickRate,
+        workerCount = state.Header.WorkerCount,
+        systemCount = state.Header.SystemCount,
+        createdUtc = new DateTime(state.Header.CreatedUtcTicks, DateTimeKind.Utc),
+        samplingSessionStartQpc = state.Header.SamplingSessionStartQpc
+    },
+    systems = state.Systems.Select(s => new
+    {
+        index = s.Index,
+        name = s.Name,
+        type = s.Type,
+        priority = s.Priority,
+        isParallel = s.IsParallel,
+        tierFilter = s.TierFilter,
+        predecessors = s.Predecessors,
+        successors = s.Successors
+    }),
+    spanNames = state.SpanNames
+};
+
+app.MapGet("/api/live/metadata", (LiveSessionService live) =>
+{
+    var state = live.GetState();
+    if (state == null)
+    {
+        return Results.NotFound(new { error = "No live session" });
+    }
+
+    return Results.Ok(BuildLiveMetadataDto(state));
+});
+
+app.MapGet("/api/live/events", async (HttpContext context, LiveSessionService live) =>
+{
+    context.Response.ContentType = "text/event-stream";
+    context.Response.Headers.CacheControl = "no-cache";
+    context.Response.Headers.Connection = "keep-alive";
+
+    // Send metadata as first event if session is active
+    var state = live.GetState();
+    if (state != null)
+    {
+        var meta = JsonSerializer.Serialize(BuildLiveMetadataDto(state), jsonOpts);
+
+        await context.Response.WriteAsync($"event: metadata\ndata: {meta}\n\n");
+        await context.Response.Body.FlushAsync();
+    }
+
+    var (subId, reader) = live.Subscribe();
+    try
+    {
+        var ct = context.RequestAborted;
+
+        while (!ct.IsCancellationRequested)
+        {
+            // Wait for data with a 5-second timeout for heartbeat
+            LiveTickBatch batch;
+            try
+            {
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                timeoutCts.CancelAfter(5000);
+
+                if (await reader.WaitToReadAsync(timeoutCts.Token))
+                {
+                    if (!reader.TryRead(out batch))
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    break; // Channel completed
+                }
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // Timeout — send heartbeat
+                await context.Response.WriteAsync($"event: heartbeat\ndata: {{\"status\":\"connected\"}}\n\n");
+                await context.Response.Body.FlushAsync();
+                continue;
+            }
+
+            var json = JsonSerializer.Serialize(batch, jsonOpts);
+            await context.Response.WriteAsync($"event: tick\ndata: {json}\n\n");
+            await context.Response.Body.FlushAsync();
+        }
+    }
+    catch (OperationCanceledException)
+    {
+        // Client disconnected
+    }
+    finally
+    {
+        live.Unsubscribe(subId);
+    }
+});
+
+app.Run();

--- a/tools/Typhon.Profiler.Server/Typhon.Profiler.Server.csproj
+++ b/tools/Typhon.Profiler.Server/Typhon.Profiler.Server.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <LangVersion>default</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Typhon.Profiler\Typhon.Profiler.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.2" />
+    </ItemGroup>
+
+    <!-- Exclude client build artifacts and node_modules from the C# project -->
+    <ItemGroup>
+        <Content Remove="ClientApp\**" />
+        <None Remove="ClientApp\**" />
+    </ItemGroup>
+
+    <!-- Build the client app when wwwroot/index.html is missing (first build or after clean) -->
+    <Target Name="BuildClientApp" BeforeTargets="Build" Condition="!Exists('wwwroot\index.html')">
+        <Message Importance="high" Text="Building Typhon Profiler client..." />
+        <Exec Command="npm install --no-audit --no-fund" WorkingDirectory="ClientApp" />
+        <Exec Command="npm run build" WorkingDirectory="ClientApp" />
+    </Target>
+
+    <!-- Always rebuild client on publish -->
+    <Target Name="PublishClientApp" BeforeTargets="Publish">
+        <Message Importance="high" Text="Building Typhon Profiler client for publish..." />
+        <Exec Command="npm install --no-audit --no-fund" WorkingDirectory="ClientApp" />
+        <Exec Command="npm run build" WorkingDirectory="ClientApp" />
+    </Target>
+
+    <!-- Clean: remove wwwroot build output -->
+    <Target Name="CleanClientApp" AfterTargets="Clean">
+        <RemoveDir Directories="wwwroot" />
+    </Target>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds a complete runtime profiling system for the Typhon engine: trace format, capture inspectors (file + live TCP stream), profiler server, and a browser-based viewer UI.

### Engine-side capture
- `TraceEventCaptureBase` — abstract per-thread SPSC ring buffer pipeline (~20-30 ns/event hot path, zero contention between worker threads)
- `TraceFileInspector` — writes to `.typhon-trace` binary files with LZ4 block compression and delta-encoded timestamps
- `TcpStreamInspector` — streams the same block format over TCP with **non-blocking** sends (`Socket.Blocking = false` + `SocketError.WouldBlock` handling), so the timer thread never blocks on I/O. Drops frames under backpressure rather than stalling the engine
- `DagScheduler` instrumented at 23 points guarded by a JIT-eliminated `TelemetryConfig.SchedulerDeepTrace` static readonly flag
- OTel `ActivityListener` integration captures spans from the `Typhon.Engine` `ActivitySource` with interned name IDs

### Wire format
- Binary `.typhon-trace` files: header + system definition table + span name table + LZ4-compressed event blocks
- Live streaming uses a framed TCP protocol (INIT / TICK_EVENTS / SPAN_NAMES / SHUTDOWN) where the TICK_EVENTS payload is **byte-identical** to the file's block format — `TraceBlockEncoder` is the shared encode/decode path, so file writer and TCP inspector can never drift
- Span name table offset is tracked at build time (not scanned for magic bytes) so a system named ``SpawnManager`` won't collide with the ``SPAN`` marker

### Profiler server (ASP.NET Core)
- `LiveSessionService` — `BackgroundService` that connects to the engine's TCP port, decompresses frames, and fans out to SSE subscribers via bounded `Channel<T>` (`DropOldest` backpressure)
- REST endpoints for uploading/inspecting `.typhon-trace` files and building flame graphs from companion `.nettrace` files
- SSE endpoint `/api/live/events` streams tick batches with 5s heartbeats
- Malformed frames log and are dropped rather than poisoning the reconnect loop

### Viewer (Preact + TypeScript + Vite)
- Single-project layout: client source in `ClientApp/`, built output in `wwwroot/`, MSBuild targets run npm install + vite build on ``dotnet build``
- Canvas-based track layout (Perfetto-style): time ruler, per-worker chunks, phases, OTel spans
- Tick timeline bar chart with P95 scaling and live follow-mode sliding window
- Incremental `processTickAndAppend` for live mode with 100ms state-update batching (~10 Hz React rerender at 60 Hz engine tick rate)
- Detail pane for selected chunks; dropped/evicted chunks auto-clear

### Tests
- New `TraceBlockEncoderTests` round-trip contract test: writes events through `TraceFileWriter`, reads back through `TraceFileReader`, verifies all fields preserved (6 tests)
- Full suite: **3,216 tests passing** (no regressions from pre-profiler baseline)

## Test plan

- [ ] ``dotnet build Typhon.slnx`` — clean build
- [ ] ``dotnet test test/Typhon.Engine.Tests`` — all 3,216 tests pass
- [ ] ``npx tsc --noEmit`` in ``tools/Typhon.Profiler.Server/ClientApp`` — zero TypeScript errors
- [ ] ``npm run build`` in ``ClientApp`` — vite production build succeeds
- [ ] Manually wire ``TcpStreamInspector`` into a test harness (e.g. AntHill) and verify end-to-end live streaming in the browser (**follow-up — demo harness changes not in this PR**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)