### PR TITLE
RFC 07 — System Access Declarations + Auto-DAG (Units 1-5)

### DIFF
--- a/Typhon.sln.DotSettings
+++ b/Typhon.sln.DotSettings
@@ -1,6 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AABB/@EntryIndexedValue">AABB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AB/@EntryIndexedValue">AB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ACW/@EntryIndexedValue">ACW</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BA/@EntryIndexedValue">BA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CRUD/@EntryIndexedValue">CRUD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CT/@EntryIndexedValue">CT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>

--- a/src/Typhon.Engine/Data/ECS/EntityRef.cs
+++ b/src/Typhon.Engine/Data/ECS/EntityRef.cs
@@ -132,6 +132,7 @@ public unsafe ref struct EntityRef
     public ref T Write<T>(Comp<T> comp) where T : unmanaged
     {
         Debug.Assert(_writable, "EntityRef opened as read-only — use OpenMut for writes");
+        SystemAccessValidator.AssertWrite<T>();
         byte slot = _archetype.GetSlot(comp._componentTypeId);
         Debug.Assert(slot < _archetype.ComponentCount);
         Debug.Assert((_enabledBits & (1 << slot)) != 0, $"Component at slot {slot} is disabled");
@@ -236,6 +237,7 @@ public unsafe ref struct EntityRef
     public ref T Write<T>() where T : unmanaged
     {
         Debug.Assert(_writable, "EntityRef opened as read-only — use OpenMut for writes");
+        SystemAccessValidator.AssertWrite<T>();
         int typeId = ArchetypeRegistry.GetComponentTypeId<T>();
         Debug.Assert(typeId >= 0, $"Component type {typeof(T).Name} not registered");
         byte slot = _archetype.GetSlot(typeId);

--- a/src/Typhon.Engine/Errors/InvalidAccessException.cs
+++ b/src/Typhon.Engine/Errors/InvalidAccessException.cs
@@ -1,0 +1,28 @@
+using JetBrains.Annotations;
+using System;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Thrown when a system attempts to mutate a component or resource that it did not declare in its access set (RFC 07 — Unit 4). DEBUG builds only;
+/// <see cref="SystemAccessValidator"/> compiles out in RELEASE.
+/// </summary>
+/// <remarks>
+/// Indicates declaration drift: the system body's actual writes diverged from what was registered
+/// via <see cref="SystemBuilder.Writes{T}"/> / <see cref="SystemBuilder.SideWrites{T}"/>. Fix by adding the missing declaration.
+/// </remarks>
+[PublicAPI]
+public sealed class InvalidAccessException : TyphonException
+{
+    public InvalidAccessException(string systemName, Type undeclaredType, string declaredSummary) : base(TyphonErrorCode.InvalidSystemAccess,
+            $"System '{systemName}' wrote component '{undeclaredType.Name}' but did not declare it. Add `b.Writes<{undeclaredType.Name}>()`" +
+            $" (or `b.SideWrites<{undeclaredType.Name}>()` for side-transactions) in Configure. Currently declared: {declaredSummary}.")
+    {
+        SystemName = systemName;
+        UndeclaredType = undeclaredType;
+    }
+
+    public string SystemName { get; }
+
+    public Type UndeclaredType { get; }
+}

--- a/src/Typhon.Engine/Errors/TyphonErrorCode.cs
+++ b/src/Typhon.Engine/Errors/TyphonErrorCode.cs
@@ -38,4 +38,7 @@ public enum TyphonErrorCode
     WalClaimTooLarge                = 7002,
     WalWriteFailure                 = 7003,
     WalSegmentError                 = 7004,
+
+    // 8xxx — Runtime / Scheduler
+    InvalidSystemAccess             = 8001,
 }

--- a/src/Typhon.Engine/Runtime/AccessDagDeriver.cs
+++ b/src/Typhon.Engine/Runtime/AccessDagDeriver.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Derives DAG edges from declared system access (RFC 07 — Unit 3). Validates that conflicts within a phase are either explicitly resolved
+/// (via <c>.After()</c>/<c>.Before()</c>) or expressed declaratively (<see cref="SystemBuilder.ReadsFresh{T}"/> / <see cref="SystemBuilder.ReadsSnapshot{T}"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Inputs: per-system info (name, resolved phase index, access descriptor) + the explicit edges already declared via <c>.After()</c>, <c>.Before()</c>, and
+/// <c>.AfterAll()</c>. Output: a list of derived edges to add to the DAG.
+/// </para>
+/// <para>
+/// Conflict detection (hard errors at <c>Build()</c>):
+/// <list type="bullet">
+///   <item>W×W same phase, no explicit ordering between the writers.</item>
+///   <item>R×W plain (<c>b.Reads&lt;T&gt;()</c>) with a same-phase writer of T — must upgrade to <c>ReadsFresh</c> or <c>ReadsSnapshot</c>.</item>
+///   <item>Resource W×W same phase, no explicit ordering.</item>
+///   <item><c>ExclusivePhase()</c> declared on a system that shares its phase with another system.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Edge derivation:
+/// <list type="bullet">
+///   <item>R×W fresh: writer → reader (reader sees this-tick value).</item>
+///   <item>R×W snapshot: reader → writer (reader sees previous-tick value, parallelism enabled).</item>
+///   <item>Event producer → consumer in same phase.</item>
+///   <item>Resource R×W: writer → reader if both fresh-style is implicit (reader after writer). Resource snapshot semantics not yet expressed.</item>
+///   <item>Cross-phase: every system in phase N depends on every system in phase N-1 (transitivity covers non-adjacent pairs).</item>
+/// </list>
+/// </para>
+/// <para>
+/// Systems with <c>PhaseIndex == -1</c> (no phase declared) and no access declarations are ignored — they participate in the DAG only via explicit edges.
+/// This preserves backwards compatibility during the migration window.
+/// </para>
+/// </remarks>
+internal static class AccessDagDeriver
+{
+    /// <summary>Lightweight view of a system passed to the deriver. Avoids leaking <c>SystemRegistration</c> outside <see cref="RuntimeSchedule"/>.</summary>
+    public readonly struct SystemInfo
+    {
+        public readonly string Name;
+        public readonly int PhaseIndex;
+        public readonly SystemAccessDescriptor Access;
+
+        public SystemInfo(string name, int phaseIndex, SystemAccessDescriptor access)
+        {
+            Name = name;
+            PhaseIndex = phaseIndex;
+            Access = access;
+        }
+    }
+
+    /// <summary>
+    /// Validates declared access and derives DAG edges. Returns the list of edges to add to the DAG.
+    /// Throws <see cref="InvalidOperationException"/> on conflict with a copy-paste-ready suggestion.
+    /// </summary>
+    public static List<(string From, string To)> DeriveAndValidate(IReadOnlyList<SystemInfo> systems, IReadOnlyList<(string From, string To)> explicitEdges)
+    {
+        var derived = new List<(string From, string To)>();
+
+        // Build lookup: explicit direct edges (used to check W×W resolution).
+        // We use direct adjacency only — transitive reachability is not checked. If transitive ordering is needed, the user should add an explicit edge.
+        var explicitAdjacency = new HashSet<(string, string)>();
+        foreach (var (from, to) in explicitEdges)
+        {
+            explicitAdjacency.Add((from, to));
+        }
+
+        // Group systems by phase. PhaseIndex == -1 is the "no phase" sentinel — should be unreachable post-Unit-5 (RuntimeSchedule.Build
+        // assigns RuntimeOptions.DefaultPhase to undeclared registrations) but kept as a defensive skip for systems built outside the
+        // RuntimeSchedule path.
+        var byPhase = new Dictionary<int, List<SystemInfo>>();
+        foreach (var sys in systems)
+        {
+            if (sys.PhaseIndex < 0)
+            {
+                continue;
+            }
+
+            if (!byPhase.TryGetValue(sys.PhaseIndex, out var list))
+            {
+                list = [];
+                byPhase[sys.PhaseIndex] = list;
+            }
+
+            list.Add(sys);
+        }
+
+        // ── Per-phase conflict detection + intra-phase edge derivation ─────
+        foreach (var (phaseIdx, phaseSystems) in byPhase)
+        {
+            DerivePhase(phaseIdx, phaseSystems, explicitAdjacency, derived);
+        }
+
+        // ── Cross-phase edges: chain consecutive populated phases ──
+        // Empty phases between two populated ones don't break the chain — we link them directly. Transitivity handles further pairs.
+        var populatedPhaseIndices = new List<int>(byPhase.Keys);
+        populatedPhaseIndices.Sort();
+        for (var p = 0; p < populatedPhaseIndices.Count - 1; p++)
+        {
+            var fromList = byPhase[populatedPhaseIndices[p]];
+            var toList = byPhase[populatedPhaseIndices[p + 1]];
+
+            foreach (var fromSys in fromList)
+            {
+                foreach (var toSys in toList)
+                {
+                    derived.Add((fromSys.Name, toSys.Name));
+                }
+            }
+        }
+
+        return derived;
+    }
+
+    private static void DerivePhase(int phaseIdx, List<SystemInfo> phaseSystems, HashSet<(string, string)> explicitAdjacency, List<(string From, string To)> derived)
+    {
+        // ── ExclusivePhase enforcement ──
+        SystemInfo? exclusive = null;
+        foreach (var sys in phaseSystems)
+        {
+            if (sys.Access != null && sys.Access.ExclusivePhase)
+            {
+                if (exclusive.HasValue)
+                {
+                    throw new InvalidOperationException(
+                        $"Multiple systems declare ExclusivePhase() in the same phase (index {phaseIdx}): " +
+                        $"'{exclusive.Value.Name}' and '{sys.Name}'. Only one system may claim exclusivity per phase.");
+                }
+
+                if (phaseSystems.Count > 1)
+                {
+                    throw new InvalidOperationException(
+                        $"System '{sys.Name}' declared ExclusivePhase() but other systems share its phase (index {phaseIdx}). " +
+                        "Either move the other systems to a different phase, or remove ExclusivePhase() from this system.");
+                }
+
+                exclusive = sys;
+            }
+        }
+
+        // ── Group access by component / event / resource ──
+        var writers = new Dictionary<Type, List<SystemInfo>>();
+        var readsPlain = new Dictionary<Type, List<SystemInfo>>();
+        var readsFresh = new Dictionary<Type, List<SystemInfo>>();
+        var readsSnapshot = new Dictionary<Type, List<SystemInfo>>();
+        var eventProducers = new Dictionary<EventQueueBase, List<SystemInfo>>();
+        var eventConsumers = new Dictionary<EventQueueBase, List<SystemInfo>>();
+        var resourceWriters = new Dictionary<string, List<SystemInfo>>(StringComparer.Ordinal);
+        var resourceReaders = new Dictionary<string, List<SystemInfo>>(StringComparer.Ordinal);
+
+        foreach (var sys in phaseSystems)
+        {
+            var access = sys.Access;
+            if (access == null)
+            {
+                continue;
+            }
+
+            foreach (var t in access.Writes)
+            {
+                Bucket(writers, t, sys);
+            }
+
+            foreach (var t in access.Reads)
+            {
+                Bucket(readsPlain, t, sys);
+            }
+
+            foreach (var t in access.ReadsFresh)
+            {
+                Bucket(readsFresh, t, sys);
+            }
+
+            foreach (var t in access.ReadsSnapshot)
+            {
+                Bucket(readsSnapshot, t, sys);
+            }
+
+            foreach (var q in access.WritesEvents)
+            {
+                Bucket(eventProducers, q, sys);
+            }
+
+            foreach (var q in access.ReadsEvents)
+            {
+                Bucket(eventConsumers, q, sys);
+            }
+
+            foreach (var r in access.WritesResources)
+            {
+                Bucket(resourceWriters, r, sys);
+            }
+
+            foreach (var r in access.ReadsResources)
+            {
+                Bucket(resourceReaders, r, sys);
+            }
+        }
+
+        // ── W×W: hard error unless EXACTLY one explicit direction is declared ──
+        // We require XOR not OR: declaring both `(a→b)` and `(b→a)` produces a cycle, and the user's intent is genuinely
+        // ambiguous (the cycle detector would later complain anyway with a less-specific message).
+        // Limitation: only direct adjacency is consulted — transitive reachability is not. With 3+ writers of the same component,
+        // each pair must be directly ordered. A linear chain `A.Before(B).Before(C)` does not implicitly resolve `(A,C)`.
+        foreach (var (compType, writerList) in writers)
+        {
+            if (writerList.Count <= 1)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < writerList.Count; i++)
+            {
+                for (var j = i + 1; j < writerList.Count; j++)
+                {
+                    var a = writerList[i];
+                    var b = writerList[j];
+
+                    var hasAB = explicitAdjacency.Contains((a.Name, b.Name));
+                    var hasBA = explicitAdjacency.Contains((b.Name, a.Name));
+
+                    if (hasAB && hasBA)
+                    {
+                        throw new InvalidOperationException(
+                            $"Systems '{a.Name}' and '{b.Name}' both declare Writes<{compType.Name}> in phase index {phaseIdx} AND have explicit edges in both directions " +
+                            "(would form a cycle). Pick one direction: either `.After(...)` or `.Before(...)`, not both.");
+                    }
+
+                    if (!hasAB && !hasBA)
+                    {
+                        throw new InvalidOperationException(
+                            $"Systems '{a.Name}' and '{b.Name}' both declare Writes<{compType.Name}> in phase index {phaseIdx}. " +
+                            $"Resolution: add `.After(\"{a.Name}\")` on `{b.Name}`, or `.Before(\"{b.Name}\")` on `{a.Name}`, or move one system to a different phase.");
+                    }
+                }
+            }
+        }
+
+        // ── R×W plain: hard error if same-phase writer exists ──
+        foreach (var (compType, readers) in readsPlain)
+        {
+            if (!writers.TryGetValue(compType, out var writerList) || writerList.Count == 0)
+            {
+                continue;
+            }
+
+            var writerName = writerList[0].Name;
+            var reader = readers[0];
+
+            throw new InvalidOperationException(
+                $"System '{reader.Name}' declares Reads<{compType.Name}> in phase index {phaseIdx}, but system '{writerName}' writes the same component in this phase. " +
+                $"Upgrade the read to `ReadsFresh<{compType.Name}>()` (run after writers, see this-tick value) or `ReadsSnapshot<{compType.Name}>()` (run before writers, see previous-tick value).");
+        }
+
+        // ── R×W fresh: derive writer → reader edge ──
+        foreach (var (compType, freshReaders) in readsFresh)
+        {
+            if (!writers.TryGetValue(compType, out var writerList))
+            {
+                continue;
+            }
+
+            foreach (var writer in writerList)
+            {
+                foreach (var reader in freshReaders)
+                {
+                    if (writer.Name == reader.Name)
+                    {
+                        continue;
+                    }
+
+                    derived.Add((writer.Name, reader.Name));
+                }
+            }
+        }
+
+        // ── R×W snapshot: derive reader → writer edge ──
+        foreach (var (compType, snapshotReaders) in readsSnapshot)
+        {
+            if (!writers.TryGetValue(compType, out var writerList))
+            {
+                continue;
+            }
+
+            foreach (var reader in snapshotReaders)
+            {
+                foreach (var writer in writerList)
+                {
+                    if (writer.Name == reader.Name)
+                    {
+                        continue;
+                    }
+
+                    derived.Add((reader.Name, writer.Name));
+                }
+            }
+        }
+
+        // ── Event producer → consumer edges (same phase only — cross-phase handled by phase ordering) ──
+        foreach (var (queue, producers) in eventProducers)
+        {
+            if (!eventConsumers.TryGetValue(queue, out var consumers))
+            {
+                continue;
+            }
+
+            foreach (var producer in producers)
+            {
+                foreach (var consumer in consumers)
+                {
+                    if (producer.Name == consumer.Name)
+                    {
+                        continue;
+                    }
+
+                    derived.Add((producer.Name, consumer.Name));
+                }
+            }
+        }
+
+        // ── Resource W×W: hard error unless EXACTLY one explicit direction is declared (same XOR rule as component W×W) ──
+        foreach (var (resourceName, writerList) in resourceWriters)
+        {
+            if (writerList.Count <= 1)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < writerList.Count; i++)
+            {
+                for (var j = i + 1; j < writerList.Count; j++)
+                {
+                    var a = writerList[i];
+                    var b = writerList[j];
+
+                    var hasAB = explicitAdjacency.Contains((a.Name, b.Name));
+                    var hasBA = explicitAdjacency.Contains((b.Name, a.Name));
+
+                    if (hasAB && hasBA)
+                    {
+                        throw new InvalidOperationException(
+                            $"Systems '{a.Name}' and '{b.Name}' both declare WritesResource(\"{resourceName}\") in phase index {phaseIdx} AND have explicit edges in both directions " +
+                            "(would form a cycle). Pick one direction: either `.After(...)` or `.Before(...)`, not both.");
+                    }
+
+                    if (!hasAB && !hasBA)
+                    {
+                        throw new InvalidOperationException(
+                            $"Systems '{a.Name}' and '{b.Name}' both declare WritesResource(\"{resourceName}\") in phase index {phaseIdx}. " +
+                            $"Resolution: add `.After(\"{a.Name}\")` on `{b.Name}`, or `.Before(\"{b.Name}\")` on `{a.Name}`, or move one system to a different phase.");
+                    }
+                }
+            }
+        }
+
+        // ── Resource R×W: derive writer → reader edge (no Fresh/Snapshot distinction for resources in v1) ──
+        foreach (var (resourceName, readers) in resourceReaders)
+        {
+            if (!resourceWriters.TryGetValue(resourceName, out var writerList))
+            {
+                continue;
+            }
+
+            foreach (var writer in writerList)
+            {
+                foreach (var reader in readers)
+                {
+                    if (writer.Name == reader.Name)
+                    {
+                        continue;
+                    }
+
+                    derived.Add((writer.Name, reader.Name));
+                }
+            }
+        }
+    }
+
+    private static void Bucket<TKey>(Dictionary<TKey, List<SystemInfo>> map, TKey key, SystemInfo sys)
+    {
+        if (!map.TryGetValue(key, out var list))
+        {
+            list = [];
+            map[key] = list;
+        }
+
+        list.Add(sys);
+    }
+}

--- a/src/Typhon.Engine/Runtime/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.cs
@@ -581,6 +581,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                     var chunkFailed = false;
                     for (var chunk = 0; chunk < totalChunks; chunk++)
                     {
+                        SystemAccessValidator.EnterSystem(sys.Access, sys.Name);
                         try
                         {
                             ParallelQueryChunkCallback?.Invoke(sysIdx, chunk, totalChunks, 0);
@@ -596,6 +597,10 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                                 _systemFailed[succ] = true;
                             }
                         }
+                        finally
+                        {
+                            SystemAccessValidator.LeaveSystem();
+                        }
                     }
 
                     morePhases = ParallelQueryCleanupCallback?.Invoke(sysIdx) ?? false;
@@ -609,6 +614,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             {
                 for (var chunk = 0; chunk < sys.TotalChunks; chunk++)
                 {
+                    SystemAccessValidator.EnterSystem(sys.Access, sys.Name);
                     try
                     {
                         sys.PipelineChunkAction(chunk, sys.TotalChunks);
@@ -623,12 +629,17 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                             _systemFailed[succ] = true;
                         }
                     }
+                    finally
+                    {
+                        SystemAccessValidator.LeaveSystem();
+                    }
                 }
             }
             else // CallbackSystem or non-parallel QuerySystem — single invocation
             {
                 var ctx = SystemStartCallback?.Invoke(sysIdx) ?? new TickContext { TickNumber = _currentTickNumber, DeltaTime = 0f };
                 var success = true;
+                SystemAccessValidator.EnterSystem(sys.Access, sys.Name);
                 try
                 {
                     sys.CallbackAction(ctx);
@@ -644,6 +655,10 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                     {
                         _systemFailed[succ] = true;
                     }
+                }
+                finally
+                {
+                    SystemAccessValidator.LeaveSystem();
                 }
 
                 SystemEndCallback?.Invoke(sysIdx, success);
@@ -830,6 +845,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         InspectorChunkStart(sysIdx, 0, workStart, 1);
 
         var success = true;
+        SystemAccessValidator.EnterSystem(Systems[sysIdx].Access, Systems[sysIdx].Name);
         try
         {
             Systems[sysIdx].CallbackAction(ctx);
@@ -843,6 +859,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         }
         finally
         {
+            SystemAccessValidator.LeaveSystem();
             // System lifecycle hook: commit/dispose per-system Transaction
             SystemEndCallback?.Invoke(sysIdx, success);
 
@@ -886,6 +903,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
             var workStart = Stopwatch.GetTimestamp();
             InspectorChunkStart(sysIdx, chunk, workStart, sys.TotalChunks);
+            SystemAccessValidator.EnterSystem(sys.Access, sys.Name);
             try
             {
                 sys.PipelineChunkAction(chunk, sys.TotalChunks);
@@ -895,6 +913,10 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                 _systemFailed[sysIdx] = true;
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                 LogSystemException(sysIdx, sys.Name, ex);
+            }
+            finally
+            {
+                SystemAccessValidator.LeaveSystem();
             }
 
             var workEnd = Stopwatch.GetTimestamp();
@@ -948,6 +970,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
             var workStart = Stopwatch.GetTimestamp();
             InspectorChunkStart(sysIdx, chunk, workStart, sys.TotalChunks);
+            SystemAccessValidator.EnterSystem(sys.Access, sys.Name);
             try
             {
                 ParallelQueryChunkCallback?.Invoke(sysIdx, chunk, sys.TotalChunks, workerId);
@@ -957,6 +980,10 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                 _systemFailed[sysIdx] = true;
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                 LogSystemException(sysIdx, sys.Name, ex);
+            }
+            finally
+            {
+                SystemAccessValidator.LeaveSystem();
             }
 
             var workEnd = Stopwatch.GetTimestamp();
@@ -1102,6 +1129,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         InspectorChunkStart(sysIdx, 0, workStart, 1);
 
         var success = true;
+        SystemAccessValidator.EnterSystem(Systems[sysIdx].Access, Systems[sysIdx].Name);
         try
         {
             Systems[sysIdx].CallbackAction(ctx);
@@ -1115,6 +1143,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         }
         finally
         {
+            SystemAccessValidator.LeaveSystem();
             SystemEndCallback?.Invoke(sysIdx, success);
 
             var workEnd = Stopwatch.GetTimestamp();

--- a/src/Typhon.Engine/Runtime/Phase.cs
+++ b/src/Typhon.Engine/Runtime/Phase.cs
@@ -1,0 +1,54 @@
+using JetBrains.Annotations;
+using System;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// A phase token in the system scheduler. Phases form a user-defined total order (see RFC 07 / Q3) — every system
+/// belongs to a phase, and all systems in phase N complete before any system in phase N+1 starts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Typhon ships four default phases via static fields: <see cref="Input"/>, <see cref="Simulation"/>, <see cref="Output"/>, <see cref="Cleanup"/>.
+/// User code extends the set by declaring additional phases as static fields in its own class and listing them
+/// (in order) in <see cref="RuntimeOptions.Phases"/>.
+/// </para>
+/// <para>
+/// The token wraps a <see cref="string"/> for diagnostic clarity and minimal memory footprint — phases are resolved to integer indices
+/// once at <see cref="RuntimeSchedule.Build"/> time, after which the runtime uses the int form everywhere.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public readonly struct Phase : IEquatable<Phase>
+{
+    /// <summary>The phase name — used for equality, hashing, and diagnostic output.</summary>
+    public readonly string Name;
+
+    /// <summary>Constructs a phase token. Prefer the static fields (<see cref="Input"/>, etc.) or define your own statics.</summary>
+    public Phase(string name) => Name = name;
+
+    // ─── Typhon-shipped default phases ──────────────────────────────
+    /// <summary>The Input phase — runs first by default. Reserved for systems that ingest external commands or inputs.</summary>
+    public static readonly Phase Input = new("Input");
+
+    /// <summary>The Simulation phase — runs after Input by default. Reserved for the bulk of game-logic / simulation systems.</summary>
+    public static readonly Phase Simulation = new("Simulation");
+
+    /// <summary>The Output phase — runs after Simulation by default. Reserved for systems that emit data downstream (rendering, network, persistence).</summary>
+    public static readonly Phase Output = new("Output");
+
+    /// <summary>The Cleanup phase — runs last by default. Reserved for systems that finalise tick state (archetype cleanup, index updates, etc.).</summary>
+    public static readonly Phase Cleanup = new("Cleanup");
+
+    public bool Equals(Phase other) => string.Equals(Name, other.Name, StringComparison.Ordinal);
+
+    public override bool Equals(object obj) => obj is Phase p && Equals(p);
+
+    public override int GetHashCode() => Name?.GetHashCode(StringComparison.Ordinal) ?? 0;
+
+    public static bool operator ==(Phase a, Phase b) => a.Equals(b);
+
+    public static bool operator !=(Phase a, Phase b) => !a.Equals(b);
+
+    public override string ToString() => Name ?? "<unset>";
+}

--- a/src/Typhon.Engine/Runtime/RuntimeOptions.cs
+++ b/src/Typhon.Engine/Runtime/RuntimeOptions.cs
@@ -48,6 +48,36 @@ public class RuntimeOptions
     public int ParallelQueryMinChunkSize { get; set; } = 64;
 
     /// <summary>
+    /// Returns a fresh array of Typhon-shipped default phases. Each call returns a new array so callers may mutate without
+    /// affecting other <see cref="RuntimeOptions"/> instances. Order: <see cref="Phase.Input"/> → <see cref="Phase.Simulation"/>
+    /// → <see cref="Phase.Output"/> → <see cref="Phase.Cleanup"/>.
+    /// </summary>
+    public static Phase[] DefaultPhases =>
+    [
+        Phase.Input,
+        Phase.Simulation,
+        Phase.Output,
+        Phase.Cleanup,
+    ];
+
+    /// <summary>
+    /// Ordered list of phases for the system scheduler. Forms a total order — all systems in phase N complete before any system
+    /// in phase N+1 starts. User code extends this by declaring its own <see cref="Phase"/> statics and inserting them in the
+    /// desired position. Default: a fresh array equivalent to <see cref="DefaultPhases"/>. See RFC 07 / Q3.
+    /// </summary>
+    public Phase[] Phases { get; set; } = DefaultPhases;
+
+    /// <summary>
+    /// The phase that systems registered without an explicit <c>b.Phase(...)</c> call are assigned to (RFC 07 — Unit 5).
+    /// Must be present in <see cref="Phases"/>. Default: <see cref="Phase.Simulation"/>.
+    /// </summary>
+    /// <remarks>
+    /// New systems should declare their phase explicitly — the default exists so pre-RFC test fixtures and quick-and-dirty
+    /// callbacks land in a sensible bucket without forcing every call site to be touched.
+    /// </remarks>
+    public Phase DefaultPhase { get; set; } = Phase.Simulation;
+
+    /// <summary>
     /// Resolves the effective worker count, applying the auto-detect formula if <see cref="WorkerCount"/> is -1.
     /// </summary>
     internal int ResolveWorkerCount() => WorkerCount == -1 ? Math.Max(1, Environment.ProcessorCount - 4) : WorkerCount;

--- a/src/Typhon.Engine/Runtime/RuntimeSchedule.cs
+++ b/src/Typhon.Engine/Runtime/RuntimeSchedule.cs
@@ -45,6 +45,11 @@ public sealed class RuntimeSchedule
     /// <summary>
     /// Registers a CallbackSystem — lightweight single-invocation, no entity input.
     /// </summary>
+    /// <remarks>
+    /// This lambda-style overload does NOT support RFC 07 access declarations (<c>Reads&lt;T&gt;</c>, <c>Writes&lt;T&gt;</c>, <c>Phase</c>, etc.).
+    /// Systems registered here land in <see cref="RuntimeOptions.DefaultPhase"/> with an empty access descriptor — fine for systems
+    /// that don't need conflict detection or auto-DAG. For declared access, use a class-based system and <see cref="Add(CallbackSystem)"/>.
+    /// </remarks>
     public RuntimeSchedule CallbackSystem(string name, Action<TickContext> action, string after = null, string[] afterAll = null,
         SystemPriority priority = SystemPriority.Normal, Func<bool> runIf = null, int tickDivisor = 1, int throttledTickDivisor = 1, bool canShed = false)
     {
@@ -71,6 +76,11 @@ public sealed class RuntimeSchedule
     /// <summary>
     /// Registers a QuerySystem — single-worker entity iteration.
     /// </summary>
+    /// <remarks>
+    /// This lambda-style overload does NOT support RFC 07 access declarations.
+    /// See <see cref="CallbackSystem(string,Action{TickContext},string,string[],SystemPriority,Func{bool},int,int,bool)"/> for the same caveat —
+    /// use <see cref="Add(QuerySystem)"/> with a class-based system for declared access.
+    /// </remarks>
     public RuntimeSchedule QuerySystem(string name, Action<TickContext> action, string after = null, string[] afterAll = null,
         SystemPriority priority = SystemPriority.Normal, Func<bool> runIf = null, Func<ViewBase> input = null, Type[] changeFilter = null,
         int tickDivisor = 1, int throttledTickDivisor = 1, bool canShed = false, bool parallel = false, bool writesVersioned = false,
@@ -106,6 +116,10 @@ public sealed class RuntimeSchedule
     /// <summary>
     /// Registers a PipelineSystem — multi-worker chunk-parallel execution.
     /// </summary>
+    /// <remarks>
+    /// This lambda-style overload does NOT support RFC 07 access declarations. See the CallbackSystem lambda overload for the same caveat — declared access
+    /// requires the class-based API.
+    /// </remarks>
     public RuntimeSchedule PipelineSystem(string name, Action<int, int> chunkAction, int totalChunks, string after = null, string[] afterAll = null,
         SystemPriority priority = SystemPriority.Normal, Func<bool> runIf = null, Func<ViewBase> input = null, Type[] changeFilter = null,
         int tickDivisor = 1, int throttledTickDivisor = 1, bool canShed = false)
@@ -162,7 +176,11 @@ public sealed class RuntimeSchedule
             InputFactory = builder._inputFactory,
             ChangeFilter = builder._changeFilter,
             Parallel = builder._parallel,
-            WritesVersioned = builder._writesVersioned
+            WritesVersioned = builder._writesVersioned,
+            Phase = builder._phase,
+            PhaseSet = builder._phaseSet,
+            Before = builder._before,
+            Access = builder._access
         });
         return this;
     }
@@ -195,7 +213,11 @@ public sealed class RuntimeSchedule
             WritesVersioned = builder._writesVersioned,
             TierFilter = builder._tierFilter,
             CellAmortize = builder._cellAmortize,
-            Checkerboard = builder._checkerboard
+            Checkerboard = builder._checkerboard,
+            Phase = builder._phase,
+            PhaseSet = builder._phaseSet,
+            Before = builder._before,
+            Access = builder._access
         });
         return this;
     }
@@ -313,6 +335,16 @@ public sealed class RuntimeSchedule
     {
         ThrowIfBuilt();
 
+        // ── Resolve phase index map (RFC 07 / Q3) ──
+        var phaseIndexMap = BuildPhaseIndexMap(_options.Phases);
+
+        if (!phaseIndexMap.TryGetValue(_options.DefaultPhase.Name, out var defaultPhaseIndex))
+        {
+            throw new InvalidOperationException(
+                $"RuntimeOptions.DefaultPhase '{_options.DefaultPhase.Name}' must be present in RuntimeOptions.Phases. " +
+                "Either add it to Phases or set DefaultPhase to one of the listed phases.");
+        }
+
         // ── Build-time validation ──
         var seenNames = new HashSet<string>(StringComparer.Ordinal);
         foreach (var reg in _registrations)
@@ -422,21 +454,69 @@ public sealed class RuntimeSchedule
             }
         }
 
-        // Phase 2: Add dependency edges
+        // Phase 1b: Resolve each registration's phase index up-front (RFC 07 / Q3 — needed by access-edge derivation).
+        // Systems that didn't call b.Phase(...) get RuntimeOptions.DefaultPhase so every system lands in some phase
+        // (RFC 07 / Unit 5 — closes the PhaseIndex==-1 escape hatch from Unit 1).
+        var regPhaseIndex = new Dictionary<string, int>(_registrations.Count, StringComparer.Ordinal);
+        foreach (var reg in _registrations)
+        {
+            if (!reg.PhaseSet)
+            {
+                regPhaseIndex[reg.Name] = defaultPhaseIndex;
+                continue;
+            }
+
+            if (!phaseIndexMap.TryGetValue(reg.Phase.Name, out var phaseIdx))
+            {
+                throw new InvalidOperationException(
+                    $"System '{reg.Name}' declares phase '{reg.Phase.Name}' which is not in RuntimeOptions.Phases. " +
+                    "Add it to options.Phases or use a phase already listed there.");
+            }
+
+            regPhaseIndex[reg.Name] = phaseIdx;
+        }
+
+        // Phase 2: Collect dependency edges (explicit, declared via .After/.AfterAll/.Before)
+        var explicitEdges = new List<(string From, string To)>();
         foreach (var reg in _registrations)
         {
             if (reg.After != null)
             {
-                dagBuilder.AddEdge(reg.After, reg.Name);
+                explicitEdges.Add((reg.After, reg.Name));
             }
 
             if (reg.AfterAll != null)
             {
                 foreach (var dep in reg.AfterAll)
                 {
-                    dagBuilder.AddEdge(dep, reg.Name);
+                    explicitEdges.Add((dep, reg.Name));
                 }
             }
+
+            if (reg.Before != null)
+            {
+                explicitEdges.Add((reg.Name, reg.Before));
+            }
+        }
+
+        // Phase 2b: Derive access-based edges + validate conflicts (RFC 07 — Unit 3)
+        var systemInfos = new List<AccessDagDeriver.SystemInfo>(_registrations.Count);
+        foreach (var reg in _registrations)
+        {
+            systemInfos.Add(new AccessDagDeriver.SystemInfo(reg.Name, regPhaseIndex[reg.Name], reg.Access));
+        }
+
+        var derivedEdges = AccessDagDeriver.DeriveAndValidate(systemInfos, explicitEdges);
+
+        // Phase 2c: Apply all edges (explicit + derived) to the DAG builder
+        foreach (var (from, to) in explicitEdges)
+        {
+            dagBuilder.AddEdge(from, to);
+        }
+
+        foreach (var (from, to) in derivedEdges)
+        {
+            dagBuilder.AddEdge(from, to);
         }
 
         // Phase 3: Build DAG (validates acyclicity, computes predecessors/successors)
@@ -521,10 +601,51 @@ public sealed class RuntimeSchedule
             systems[sysIdx].TierFilter = reg.TierFilter;
             systems[sysIdx].CellAmortize = reg.CellAmortize;
             systems[sysIdx].IsCheckerboard = reg.Checkerboard;
+
+            if (reg.Access != null)
+            {
+                systems[sysIdx].Access = reg.Access;
+            }
+        }
+
+        // Phase 5b: Stamp resolved phase + index onto each SystemDefinition (RFC 07 / Q3-Q5 — index already resolved in Phase 1b).
+        // Undeclared systems get RuntimeOptions.DefaultPhase via the same path.
+        foreach (var reg in _registrations)
+        {
+            if (!nameToIndex.TryGetValue(reg.Name, out var sysIdx))
+            {
+                continue;
+            }
+
+            systems[sysIdx].Phase = reg.PhaseSet ? reg.Phase : _options.DefaultPhase;
+            systems[sysIdx].PhaseIndex = regPhaseIndex[reg.Name];
         }
 
         // Phase 6: Create scheduler
         return new DagScheduler(systems, topologicalOrder, _options, parent, [.. _eventQueues], logger);
+    }
+
+    /// <summary>
+    /// Builds the phase-token → index map from <see cref="RuntimeOptions.Phases"/>. Validates that the list is non-empty and contains no duplicates.
+    /// </summary>
+    private static Dictionary<string, int> BuildPhaseIndexMap(Phase[] phases)
+    {
+        if (phases is null || phases.Length == 0)
+        {
+            throw new InvalidOperationException("RuntimeOptions.Phases must contain at least one phase. Default is RuntimeOptions.DefaultPhases.");
+        }
+
+        var map = new Dictionary<string, int>(phases.Length, StringComparer.Ordinal);
+        for (var i = 0; i < phases.Length; i++)
+        {
+            var name = phases[i].Name;
+            if (!map.TryAdd(name, i))
+            {
+                throw new InvalidOperationException($"Duplicate phase '{name}' in RuntimeOptions.Phases at index {i}. Each phase must appear at most once.");
+            }
+        }
+
+        return map;
     }
 
     private void ThrowIfBuilt()
@@ -560,5 +681,9 @@ public sealed class RuntimeSchedule
         public SimTier TierFilter = SimTier.All;
         public int CellAmortize;
         public bool Checkerboard;
+        public Phase Phase;
+        public bool PhaseSet;
+        public string Before;
+        public SystemAccessDescriptor Access;
     }
 }

--- a/src/Typhon.Engine/Runtime/SystemAccessDescriptor.cs
+++ b/src/Typhon.Engine/Runtime/SystemAccessDescriptor.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Accumulator for a system's declared read/write access (RFC 07 — System Access Declarations + Auto-DAG). Populated by <see cref="SystemBuilder"/> declaration
+/// methods, copied into <see cref="SystemRegistration"/>, then onto <see cref="SystemDefinition.Access"/> at <see cref="RuntimeSchedule.Build"/> time.
+/// </summary>
+/// <remarks>
+/// Unit 2 of the auto-DAG migration: storage only. Conflict detection (W×W errors, R×W-plain errors, derived edges) lands in Unit 3. All sets default to
+/// empty; entries are deduped automatically by the underlying <see cref="HashSet{T}"/>.
+/// </remarks>
+internal sealed class SystemAccessDescriptor
+{
+    /// <summary>Component types declared with <c>b.Reads&lt;T&gt;()</c>. Ambiguous about same-tick freshness — Unit 3 errors if a same-phase writer of T exists.</summary>
+    public readonly HashSet<Type> Reads = [];
+
+    /// <summary>Component types declared with <c>b.ReadsFresh&lt;T&gt;()</c>. Reader is ordered AFTER any same-phase writer of T (Unit 3).</summary>
+    public readonly HashSet<Type> ReadsFresh = [];
+
+    /// <summary>Component types declared with <c>b.ReadsSnapshot&lt;T&gt;()</c>. Reader is ordered BEFORE any same-phase writer of T (Unit 3) — sees previous-tick value.</summary>
+    public readonly HashSet<Type> ReadsSnapshot = [];
+
+    /// <summary>Component types read beyond the system's primary View input (cross-entity reads).</summary>
+    public readonly HashSet<Type> AdditionalReads = [];
+
+    /// <summary>Component types this system mutates via <c>EntityRef.Write&lt;T&gt;()</c>.</summary>
+    public readonly HashSet<Type> Writes = [];
+
+    /// <summary>Component types written via <see cref="DurabilityMode.Immediate"/> side-transactions. Surfaced in tooling but does NOT affect scheduler ordering.</summary>
+    public readonly HashSet<Type> SideWrites = [];
+
+    /// <summary>Event queues this system publishes to. Producer→consumer edges are derived in Unit 3.</summary>
+    public readonly HashSet<EventQueueBase> WritesEvents = [];
+
+    /// <summary>Event queues this system consumes from.</summary>
+    public readonly HashSet<EventQueueBase> ReadsEvents = [];
+
+    /// <summary>Named resources this system mutates (e.g., a shared physics-world handle).</summary>
+    public readonly HashSet<string> WritesResources = new(StringComparer.Ordinal);
+
+    /// <summary>Named resources this system reads.</summary>
+    public readonly HashSet<string> ReadsResources = new(StringComparer.Ordinal);
+
+    /// <summary>When true, this system runs alone in its phase — no other system in the same phase may execute concurrently with it (Unit 3 enforces).</summary>
+    public bool ExclusivePhase;
+
+    /// <summary>Returns true if any access has been declared. Used by Unit 3 to skip conflict detection on undeclared systems during the migration window.</summary>
+    public bool HasAnyDeclaration => Reads.Count > 0 || ReadsFresh.Count > 0 || ReadsSnapshot.Count > 0 || AdditionalReads.Count > 0 || Writes.Count > 0 || 
+                                     SideWrites.Count > 0 || WritesEvents.Count > 0 || ReadsEvents.Count > 0 || WritesResources.Count > 0 || 
+                                     ReadsResources.Count > 0 || ExclusivePhase;
+}

--- a/src/Typhon.Engine/Runtime/SystemAccessValidator.cs
+++ b/src/Typhon.Engine/Runtime/SystemAccessValidator.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Debug-only runtime safety net for declared system access (RFC 07 — Unit 4). The scheduler tags each worker thread with the currently-executing
+/// system's <see cref="SystemAccessDescriptor"/> via <see cref="EnterSystem"/>; <see cref="EntityRef.Write{T}"/> calls
+/// <see cref="AssertWrite{T}"/> to verify the type was declared. All three public methods are <see cref="ConditionalAttribute"/>-stripped from
+/// RELEASE builds — call sites disappear at compile time, so the dispatch path takes zero overhead in production.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Storage is per-thread (<see cref="ThreadStaticAttribute"/>). Each worker maintains its own descriptor — multi-worker dispatch is
+/// safe by construction. Push/pop semantics let inline successor execution restore the previous system's descriptor when a worker
+/// runs multiple systems back-to-back.
+/// </para>
+/// <para>
+/// Migration policy: a system whose access descriptor has <see cref="SystemAccessDescriptor.HasAnyDeclaration"/> = false is treated as
+/// "undeclared" and the assertion silently passes — preserves backwards compatibility for systems that haven't migrated to declared access.
+/// Once a developer adds any declaration, the validator activates fully (a <c>Writes&lt;T&gt;</c> not in the declared set throws).
+/// </para>
+/// </remarks>
+internal static class SystemAccessValidator
+{
+    [ThreadStatic]
+    private static SystemAccessDescriptor Current;
+
+    [ThreadStatic]
+    private static string CurrentSystemName;
+
+    [ThreadStatic]
+    private static Stack<(SystemAccessDescriptor Prev, string PrevName)> Frames;
+
+    /// <summary>
+    /// Push the given descriptor as the current thread's active system context.
+    /// Compiled out in RELEASE — call sites strip entirely (zero dispatch-path overhead in production).
+    /// Each call must be paired with a matching <see cref="LeaveSystem"/> in a finally block.
+    /// </summary>
+    [Conditional("DEBUG")]
+    public static void EnterSystem(SystemAccessDescriptor descriptor, string systemName)
+    {
+        var stack = Frames ??= new Stack<(SystemAccessDescriptor, string)>(8);
+        stack.Push((Current, CurrentSystemName));
+        Current = descriptor;
+        CurrentSystemName = systemName;
+    }
+
+    /// <summary>Restore the previous descriptor + name. Compiled out in RELEASE.</summary>
+    [Conditional("DEBUG")]
+    public static void LeaveSystem()
+    {
+        var (prev, prevName) = Frames.Pop();
+        Current = prev;
+        CurrentSystemName = prevName;
+    }
+
+    /// <summary>
+    /// Assert that the currently-executing system declared <c>Writes&lt;T&gt;</c> or <c>SideWrites&lt;T&gt;</c>.
+    /// Compiled out in RELEASE. Skips the check when no system context is active (e.g., direct test code outside scheduler dispatch),
+    /// or when the active descriptor has no declarations (transitional — system hasn't migrated yet).
+    /// </summary>
+    [Conditional("DEBUG")]
+    public static void AssertWrite<T>() where T : unmanaged
+    {
+        var current = Current;
+        if (current == null)
+        {
+            return;
+        }
+
+        if (!current.HasAnyDeclaration)
+        {
+            return;
+        }
+
+        var t = typeof(T);
+        if (current.Writes.Contains(t))
+        {
+            return;
+        }
+
+        if (current.SideWrites.Contains(t))
+        {
+            return;
+        }
+
+        throw new InvalidAccessException(CurrentSystemName ?? "<unknown>", t, SummarizeDeclared(current));
+    }
+
+    private static string SummarizeDeclared(SystemAccessDescriptor d)
+    {
+        if (d.Writes.Count == 0 && d.SideWrites.Count == 0)
+        {
+            return "(none)";
+        }
+
+        var parts = new List<string>(d.Writes.Count + d.SideWrites.Count);
+        foreach (var w in d.Writes)
+        {
+            parts.Add($"Writes<{w.Name}>");
+        }
+
+        foreach (var w in d.SideWrites)
+        {
+            parts.Add($"SideWrites<{w.Name}>");
+        }
+
+        return string.Join(", ", parts);
+    }
+}

--- a/src/Typhon.Engine/Runtime/SystemBuilder.cs
+++ b/src/Typhon.Engine/Runtime/SystemBuilder.cs
@@ -7,12 +7,16 @@ namespace Typhon.Engine;
 /// Configuration builder for class-based system definitions.
 /// Used by <see cref="CallbackSystem"/>, <see cref="QuerySystem"/>, and <see cref="PipelineSystem"/> in their Configure method.
 /// </summary>
+/// <remarks>
+/// All methods return the builder so calls can chain: <c>b.Name("X").After("Y").Reads&lt;Position&gt;().Writes&lt;Velocity&gt;()</c>.
+/// </remarks>
 [PublicAPI]
 public sealed class SystemBuilder
 {
     internal string _name;
     internal string _after;
     internal string[] _afterAll;
+    internal string _before;
     internal SystemPriority _priority = SystemPriority.Normal;
     internal Func<bool> _runIf;
     internal Func<ViewBase> _inputFactory;
@@ -25,57 +29,287 @@ public sealed class SystemBuilder
     internal SimTier _tierFilter = SimTier.All;
     internal int _cellAmortize;
     internal bool _checkerboard;
+    internal Phase _phase;
+    internal bool _phaseSet;
+    internal readonly SystemAccessDescriptor _access = new();
+
+    // ═══════════════════════════════════════════════════════════════
+    // Identity, ordering, and overload parameters
+    // ═══════════════════════════════════════════════════════════════
 
     /// <summary>Set the system's unique name in the DAG.</summary>
-    public void Name(string name) => _name = name;
+    public SystemBuilder Name(string name)
+    {
+        _name = name;
+        return this;
+    }
 
     /// <summary>Declare a dependency on another system (this system runs after it).</summary>
-    public void After(string dependency) => _after = dependency;
+    public SystemBuilder After(string dependency)
+    {
+        _after = dependency;
+        return this;
+    }
 
     /// <summary>Declare dependencies on multiple systems (this system runs after all of them).</summary>
-    public void AfterAll(params string[] dependencies) => _afterAll = dependencies;
+    public SystemBuilder AfterAll(params string[] dependencies)
+    {
+        _afterAll = dependencies;
+        return this;
+    }
+
+    /// <summary>Declare that this system must run before another (mirror of <see cref="After"/>). Useful for the W×W disambiguation case (RFC 07 / Q5).</summary>
+    public SystemBuilder Before(string dependent)
+    {
+        _before = dependent;
+        return this;
+    }
 
     /// <summary>Set the system's overload priority.</summary>
-    public void Priority(SystemPriority priority) => _priority = priority;
+    public SystemBuilder Priority(SystemPriority priority)
+    {
+        _priority = priority;
+        return this;
+    }
 
     /// <summary>Set a predicate that must return true for the system to execute. Evaluated before any input processing.</summary>
-    public void RunIf(Func<bool> predicate) => _runIf = predicate;
+    public SystemBuilder RunIf(Func<bool> predicate)
+    {
+        _runIf = predicate;
+        return this;
+    }
 
     /// <summary>Set the View factory providing the system's entity input.</summary>
-    public void Input(Func<ViewBase> viewFactory) => _inputFactory = viewFactory;
+    public SystemBuilder Input(Func<ViewBase> viewFactory)
+    {
+        _inputFactory = viewFactory;
+        return this;
+    }
 
     /// <summary>Set the component types for change-filtered reactive input. OR logic: entity included if any filtered component was written.</summary>
-    public void ChangeFilter(params Type[] componentTypes) => _changeFilter = componentTypes;
+    public SystemBuilder ChangeFilter(params Type[] componentTypes)
+    {
+        _changeFilter = componentTypes;
+        return this;
+    }
 
     /// <summary>Set the tick divisor (system runs every Nth tick at normal load).</summary>
-    public void TickDivisor(int divisor) => _tickDivisor = divisor;
+    public SystemBuilder TickDivisor(int divisor)
+    {
+        _tickDivisor = divisor;
+        return this;
+    }
 
     /// <summary>Set the throttled tick divisor (system runs every Nth tick under overload).</summary>
-    public void ThrottledTickDivisor(int divisor) => _throttledTickDivisor = divisor;
+    public SystemBuilder ThrottledTickDivisor(int divisor)
+    {
+        _throttledTickDivisor = divisor;
+        return this;
+    }
 
     /// <summary>Set whether this system can be shed entirely under severe overload.</summary>
-    public void CanShed(bool value) => _canShed = value;
+    public SystemBuilder CanShed(bool value)
+    {
+        _canShed = value;
+        return this;
+    }
 
     /// <summary>Enable automatic chunk-parallel execution across workers. QuerySystem only.</summary>
-    public void Parallel() => _parallel = true;
+    public SystemBuilder Parallel()
+    {
+        _parallel = true;
+        return this;
+    }
 
     /// <summary>Declare that this parallel QuerySystem writes Versioned components. Forces per-chunk Transaction fallback instead of the optimized PointInTimeAccessor path.</summary>
-    public void WritesVersioned() => _writesVersioned = true;
+    public SystemBuilder WritesVersioned()
+    {
+        _writesVersioned = true;
+        return this;
+    }
 
     /// <summary>
     /// Set the simulation-tier dispatch filter (issue #231). Default <see cref="SimTier.All"/> matches pre-#231 behaviour (all clusters dispatched).
     /// Single-tier (e.g. <see cref="SimTier.Tier0"/>) or multi-tier flag combinations (<see cref="SimTier.Near"/>, <see cref="SimTier.Active"/>) are both
     /// supported.
     /// </summary>
-    public void Tier(SimTier tier) => _tierFilter = tier;
+    public SystemBuilder Tier(SimTier tier)
+    {
+        _tierFilter = tier;
+        return this;
+    }
 
     /// <summary>
     /// Set the cell-level amortization denominator (issue #231). When greater than 0, the system processes <c>1/N</c> of the tier's clusters per tick,
     /// and <see cref="TickContext.AmortizedDeltaTime"/> becomes <c>DeltaTime × N</c>. Requires a non-<see cref="SimTier.All"/> <see cref="Tier"/>.
     /// </summary>
-    public void CellAmortize(int denominator) => _cellAmortize = denominator;
+    public SystemBuilder CellAmortize(int denominator)
+    {
+        _cellAmortize = denominator;
+        return this;
+    }
 
     /// <summary>Enable two-phase checkerboard dispatch (issue #234). Requires <see cref="Parallel"/>. Clusters are split into Red/Black sets
     /// based on cell coordinates — no two adjacent cells are processed simultaneously.</summary>
-    public void Checkerboard() => _checkerboard = true;
+    public SystemBuilder Checkerboard()
+    {
+        _checkerboard = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Assign this system to a phase (RFC 07 / Q3). Phases form a total order in <see cref="RuntimeOptions.Phases"/> — all systems in
+    /// phase N complete before any system in phase N+1 starts. If not called, the system is unaffected by phase ordering (transitional;
+    /// Unit 5 of the auto-DAG migration will tighten this to require a phase per system).
+    /// </summary>
+    public SystemBuilder Phase(Phase phase)
+    {
+        _phase = phase;
+        _phaseSet = true;
+        return this;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Access declarations (RFC 07 — Unit 2)
+    // Storage only; conflict detection + DAG-edge derivation lands in Unit 3.
+    // Generic constraint matches EntityRef.Write&lt;T&gt;: where T : unmanaged.
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>Declare that this system reads component T. Unit 3 errors at <c>Build()</c> if a same-phase writer of T exists — upgrade to <see cref="ReadsFresh{T}"/> or <see cref="ReadsSnapshot{T}"/>.</summary>
+    public SystemBuilder Reads<T>() where T : unmanaged
+    {
+        _access.Reads.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>Declare that this system reads component T and must be ordered AFTER any same-phase writer of T (sees this-tick value).</summary>
+    public SystemBuilder ReadsFresh<T>() where T : unmanaged
+    {
+        _access.ReadsFresh.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>Declare that this system reads component T and must be ordered BEFORE any same-phase writer of T (sees previous-tick value, enables parallelism with the writer).</summary>
+    public SystemBuilder ReadsSnapshot<T>() where T : unmanaged
+    {
+        _access.ReadsSnapshot.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>Declare a read of T beyond the system's primary View input (cross-entity read).</summary>
+    public SystemBuilder AdditionalReads<T>() where T : unmanaged
+    {
+        _access.AdditionalReads.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>Declare that this system mutates component T via <c>EntityRef.Write&lt;T&gt;()</c>. Unit 3 errors at <c>Build()</c> if another system in the same phase also declares <c>Writes&lt;T&gt;</c> without an explicit <see cref="After"/>/<see cref="Before"/>.</summary>
+    public SystemBuilder Writes<T>() where T : unmanaged
+    {
+        _access.Writes.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>Declare that this system writes T via a side-transaction (<see cref="DurabilityMode.Immediate"/>). Surfaced in tooling but does NOT affect scheduler ordering.</summary>
+    public SystemBuilder SideWrites<T>() where T : unmanaged
+    {
+        _access.SideWrites.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>Declare that this system publishes to the given event queue. Unit 3 derives a producer→consumer edge from this against any matching <see cref="ReadsEvents"/> in the same phase.</summary>
+    public SystemBuilder WritesEvents(EventQueueBase queue)
+    {
+        ArgumentNullException.ThrowIfNull(queue);
+        _access.WritesEvents.Add(queue);
+        return this;
+    }
+
+    /// <summary>Declare that this system consumes from the given event queue.</summary>
+    public SystemBuilder ReadsEvents(EventQueueBase queue)
+    {
+        ArgumentNullException.ThrowIfNull(queue);
+        _access.ReadsEvents.Add(queue);
+        return this;
+    }
+
+    /// <summary>Declare that this system mutates a named resource (e.g., a shared physics-world handle that isn't a component).</summary>
+    public SystemBuilder WritesResource(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        _access.WritesResources.Add(name);
+        return this;
+    }
+
+    /// <summary>Declare that this system reads a named resource.</summary>
+    public SystemBuilder ReadsResource(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        _access.ReadsResources.Add(name);
+        return this;
+    }
+
+    /// <summary>Mark this system as having exclusive control of its phase — no other system in the same phase may run concurrently. Use sparingly for systems that own the tick boundary (e.g. archetype cleanup, spatial-index update).</summary>
+    public SystemBuilder ExclusivePhase()
+    {
+        _access.ExclusivePhase = true;
+        return this;
+    }
+
+    // ─── Batch overloads (RFC 07 / Q1 — verbosity relief) ───
+    // Identical to calling the single-T variant N times. Generated for arities 2..6.
+
+    public SystemBuilder Reads<T1, T2>() where T1 : unmanaged where T2 : unmanaged => Reads<T1>().Reads<T2>();
+
+    public SystemBuilder Reads<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged => Reads<T1>().Reads<T2>().Reads<T3>();
+
+    public SystemBuilder Reads<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged 
+        => Reads<T1>().Reads<T2>().Reads<T3>().Reads<T4>();
+
+    public SystemBuilder Reads<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
+        => Reads<T1>().Reads<T2>().Reads<T3>().Reads<T4>().Reads<T5>();
+
+    public SystemBuilder Reads<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
+        where T6 : unmanaged => Reads<T1>().Reads<T2>().Reads<T3>().Reads<T4>().Reads<T5>().Reads<T6>();
+
+    public SystemBuilder Writes<T1, T2>() where T1 : unmanaged where T2 : unmanaged => Writes<T1>().Writes<T2>();
+
+    public SystemBuilder Writes<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged => Writes<T1>().Writes<T2>().Writes<T3>();
+
+    public SystemBuilder Writes<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged 
+        => Writes<T1>().Writes<T2>().Writes<T3>().Writes<T4>();
+
+    public SystemBuilder Writes<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged where T5 : unmanaged
+        => Writes<T1>().Writes<T2>().Writes<T3>().Writes<T4>().Writes<T5>();
+
+    public SystemBuilder Writes<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
+        where T5 : unmanaged where T6 : unmanaged => Writes<T1>().Writes<T2>().Writes<T3>().Writes<T4>().Writes<T5>().Writes<T6>();
+
+    public SystemBuilder ReadsFresh<T1, T2>() where T1 : unmanaged where T2 : unmanaged => ReadsFresh<T1>().ReadsFresh<T2>();
+
+    public SystemBuilder ReadsFresh<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
+        => ReadsFresh<T1>().ReadsFresh<T2>().ReadsFresh<T3>();
+
+    public SystemBuilder ReadsFresh<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
+        => ReadsFresh<T1>().ReadsFresh<T2>().ReadsFresh<T3>().ReadsFresh<T4>();
+
+    public SystemBuilder ReadsFresh<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
+        where T5 : unmanaged => ReadsFresh<T1>().ReadsFresh<T2>().ReadsFresh<T3>().ReadsFresh<T4>().ReadsFresh<T5>();
+
+    public SystemBuilder ReadsFresh<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
+        where T5 : unmanaged where T6 : unmanaged => ReadsFresh<T1>().ReadsFresh<T2>().ReadsFresh<T3>().ReadsFresh<T4>().ReadsFresh<T5>().ReadsFresh<T6>();
+
+    public SystemBuilder ReadsSnapshot<T1, T2>() where T1 : unmanaged where T2 : unmanaged => ReadsSnapshot<T1>().ReadsSnapshot<T2>();
+
+    public SystemBuilder ReadsSnapshot<T1, T2, T3>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged
+        => ReadsSnapshot<T1>().ReadsSnapshot<T2>().ReadsSnapshot<T3>();
+
+    public SystemBuilder ReadsSnapshot<T1, T2, T3, T4>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
+        => ReadsSnapshot<T1>().ReadsSnapshot<T2>().ReadsSnapshot<T3>().ReadsSnapshot<T4>();
+
+    public SystemBuilder ReadsSnapshot<T1, T2, T3, T4, T5>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
+        where T5 : unmanaged => ReadsSnapshot<T1>().ReadsSnapshot<T2>().ReadsSnapshot<T3>().ReadsSnapshot<T4>().ReadsSnapshot<T5>();
+
+    public SystemBuilder ReadsSnapshot<T1, T2, T3, T4, T5, T6>() where T1 : unmanaged where T2 : unmanaged where T3 : unmanaged where T4 : unmanaged
+        where T5 : unmanaged where T6 : unmanaged => ReadsSnapshot<T1>().ReadsSnapshot<T2>().ReadsSnapshot<T3>().ReadsSnapshot<T4>().ReadsSnapshot<T5>().ReadsSnapshot<T6>();
 }

--- a/src/Typhon.Engine/Runtime/SystemDefinition.cs
+++ b/src/Typhon.Engine/Runtime/SystemDefinition.cs
@@ -22,6 +22,24 @@ public sealed class SystemDefinition
     /// <summary>Priority for overload management. Defined but not enforced until #201.</summary>
     public SystemPriority Priority { get; init; } = SystemPriority.Normal;
 
+    /// <summary>
+    /// The phase this system belongs to (RFC 07 / Q3). Set by <see cref="RuntimeSchedule.Build"/> from <see cref="SystemBuilder.Phase"/>.
+    /// Default-valued (zero <see cref="Phase"/>) when no phase was declared — pair with <see cref="PhaseIndex"/> = -1 to detect.
+    /// </summary>
+    public Phase Phase { get; internal set; }
+
+    /// <summary>
+    /// Index into <see cref="RuntimeOptions.Phases"/> for the resolved phase. -1 when no phase was declared (transitional; Unit 5 of the
+    /// auto-DAG migration will require a phase per system).
+    /// </summary>
+    public int PhaseIndex { get; internal set; } = -1;
+
+    /// <summary>
+    /// Declared read/write access for this system (RFC 07 — Unit 2). Populated from <see cref="SystemBuilder"/> declaration methods.
+    /// Storage only at the Unit 2 stage — Unit 3 will consume this for conflict detection and DAG-edge derivation.
+    /// </summary>
+    internal SystemAccessDescriptor Access { get; set; } = new();
+
     // ═══════════════════════════════════════════════════════════════
     // Execution delegates
     // ═══════════════════════════════════════════════════════════════

--- a/test/Typhon.Engine.Tests/Runtime/AccessDagDerivationTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/AccessDagDerivationTests.cs
@@ -1,0 +1,368 @@
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Typhon.Engine.Tests.Runtime;
+
+[TestFixture]
+public class AccessDagDerivationTests
+{
+    private ResourceRegistry _registry;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _registry = new ResourceRegistry(new ResourceRegistryOptions { Name = "AccessDerivTest" });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _registry?.Dispose();
+    }
+
+    // ── Component fixtures ──
+
+    private struct CompA { public int V; }
+    private struct CompB { public int V; }
+    private struct CompC { public int V; }
+
+    private class Sys : CallbackSystem
+    {
+        public Action<SystemBuilder> ConfigureAction;
+        protected override void Configure(SystemBuilder b) => ConfigureAction?.Invoke(b);
+        protected override void Execute(TickContext ctx) { }
+    }
+
+    private static RuntimeOptions Options() => new() { BaseTickRate = 1000, WorkerCount = 1 };
+
+    // ── W×W detection ──────────────────────────────────────────────────
+
+    [Test]
+    public void WW_SamePhase_NoOrdering_Throws()
+    {
+        var schedule = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Simulation).Writes<CompA>() });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("'A'"));
+        Assert.That(ex.Message, Does.Contain("'B'"));
+        Assert.That(ex.Message, Does.Contain("Writes<CompA>"));
+        Assert.That(ex.Message, Does.Contain(".After("));
+    }
+
+    [Test]
+    public void WW_SamePhase_ResolvedByAfter_Builds()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Simulation).Writes<CompA>().After("A") })
+            .Build(_registry.Runtime);
+
+        var aDef = scheduler.Systems.First(s => s.Name == "A");
+        var bDef = scheduler.Systems.First(s => s.Name == "B");
+        Assert.That(aDef.Successors, Does.Contain(bDef.Index));
+    }
+
+    [Test]
+    public void WW_SamePhase_ResolvedByBefore_Builds()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).Writes<CompA>().Before("B") })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Simulation).Writes<CompA>() })
+            .Build(_registry.Runtime);
+
+        var aDef = scheduler.Systems.First(s => s.Name == "A");
+        var bDef = scheduler.Systems.First(s => s.Name == "B");
+        Assert.That(aDef.Successors, Does.Contain(bDef.Index));
+    }
+
+    [Test]
+    public void WW_DifferentPhases_NoConflict()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Output).Writes<CompA>() })
+            .Build(_registry.Runtime);
+
+        var aDef = scheduler.Systems.First(s => s.Name == "A");
+        var bDef = scheduler.Systems.First(s => s.Name == "B");
+        // Cross-phase edge: A → B (Simulation index 1 → Output index 2)
+        Assert.That(aDef.Successors, Does.Contain(bDef.Index));
+    }
+
+    // ── R×W plain detection ───────────────────────────────────────────
+
+    [Test]
+    public void RW_PlainReadWithSamePhaseWriter_Throws()
+    {
+        var schedule = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Writer").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Reader").Phase(Phase.Simulation).Reads<CompA>() });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("'Reader'"));
+        Assert.That(ex.Message, Does.Contain("Reads<CompA>"));
+        Assert.That(ex.Message, Does.Contain("ReadsFresh"));
+        Assert.That(ex.Message, Does.Contain("ReadsSnapshot"));
+    }
+
+    [Test]
+    public void RW_PlainReadInDifferentPhase_OK()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Writer").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Reader").Phase(Phase.Output).Reads<CompA>() })
+            .Build(_registry.Runtime);
+
+        Assert.That(scheduler.Systems, Has.Length.EqualTo(2));
+    }
+
+    // ── R×W fresh / snapshot derivation ───────────────────────────────
+
+    [Test]
+    public void ReadsFresh_DerivesWriterToReaderEdge()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Writer").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Reader").Phase(Phase.Simulation).ReadsFresh<CompA>() })
+            .Build(_registry.Runtime);
+
+        var writerDef = scheduler.Systems.First(s => s.Name == "Writer");
+        var readerDef = scheduler.Systems.First(s => s.Name == "Reader");
+        Assert.That(writerDef.Successors, Does.Contain(readerDef.Index));
+    }
+
+    [Test]
+    public void ReadsSnapshot_DerivesReaderToWriterEdge()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Writer").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Reader").Phase(Phase.Simulation).ReadsSnapshot<CompA>() })
+            .Build(_registry.Runtime);
+
+        var writerDef = scheduler.Systems.First(s => s.Name == "Writer");
+        var readerDef = scheduler.Systems.First(s => s.Name == "Reader");
+        Assert.That(readerDef.Successors, Does.Contain(writerDef.Index));
+    }
+
+    // ── Cross-phase edges ─────────────────────────────────────────────
+
+    [Test]
+    public void CrossPhase_AdjacentPhases_DerivesEdges()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("InputSys").Phase(Phase.Input) })
+            .Add(new Sys { ConfigureAction = b => b.Name("SimSys").Phase(Phase.Simulation) })
+            .Build(_registry.Runtime);
+
+        var inputDef = scheduler.Systems.First(s => s.Name == "InputSys");
+        var simDef = scheduler.Systems.First(s => s.Name == "SimSys");
+        Assert.That(inputDef.Successors, Does.Contain(simDef.Index));
+    }
+
+    [Test]
+    public void CrossPhase_NonAdjacent_OrderedByTransitivity()
+    {
+        // Input → Simulation → Output → Cleanup. Input and Cleanup are not adjacent.
+        // We assert Input is reachable from Cleanup's predecessor count > 0 indirectly via topological order.
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("In").Phase(Phase.Input) })
+            .Add(new Sys { ConfigureAction = b => b.Name("Sim").Phase(Phase.Simulation) })
+            .Add(new Sys { ConfigureAction = b => b.Name("Out").Phase(Phase.Output) })
+            .Add(new Sys { ConfigureAction = b => b.Name("Clean").Phase(Phase.Cleanup) })
+            .Build(_registry.Runtime);
+
+        var inIdx = scheduler.Systems.First(s => s.Name == "In").Index;
+        var cleanIdx = scheduler.Systems.First(s => s.Name == "Clean").Index;
+        // Topological order: In must appear before Clean
+        var topOrder = new System.Collections.Generic.List<int>();
+        for (var i = 0; i < scheduler.Systems.Length; i++)
+        {
+            topOrder.Add(scheduler.Systems[i].Index);
+        }
+        // Use the topo info on each definition; simplest check: cleanup has nonzero predecessor count
+        var cleanDef = scheduler.Systems.First(s => s.Name == "Clean");
+        Assert.That(cleanDef.PredecessorCount, Is.GreaterThan(0));
+    }
+
+    // ── Event queue derivation ────────────────────────────────────────
+
+    [Test]
+    public void Events_ProducerToConsumer_DerivesEdge()
+    {
+        var schedule = RuntimeSchedule.Create(Options());
+        var queue = schedule.CreateEventQueue<int>("Q", 16);
+
+        using var scheduler = schedule
+            .Add(new Sys { ConfigureAction = b => b.Name("Producer").Phase(Phase.Simulation).WritesEvents(queue) })
+            .Add(new Sys { ConfigureAction = b => b.Name("Consumer").Phase(Phase.Simulation).ReadsEvents(queue) })
+            .Build(_registry.Runtime);
+
+        var producerDef = scheduler.Systems.First(s => s.Name == "Producer");
+        var consumerDef = scheduler.Systems.First(s => s.Name == "Consumer");
+        Assert.That(producerDef.Successors, Does.Contain(consumerDef.Index));
+    }
+
+    // ── Resource derivation ───────────────────────────────────────────
+
+    [Test]
+    public void Resource_WW_SamePhase_NoOrdering_Throws()
+    {
+        var schedule = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).WritesResource("X") })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Simulation).WritesResource("X") });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("WritesResource"));
+        Assert.That(ex.Message, Does.Contain("\"X\""));
+    }
+
+    [Test]
+    public void Resource_RW_DerivesWriterToReaderEdge()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Writer").Phase(Phase.Simulation).WritesResource("Physics") })
+            .Add(new Sys { ConfigureAction = b => b.Name("Reader").Phase(Phase.Simulation).ReadsResource("Physics") })
+            .Build(_registry.Runtime);
+
+        var writerDef = scheduler.Systems.First(s => s.Name == "Writer");
+        var readerDef = scheduler.Systems.First(s => s.Name == "Reader");
+        Assert.That(writerDef.Successors, Does.Contain(readerDef.Index));
+    }
+
+    // ── ExclusivePhase enforcement ────────────────────────────────────
+
+    [Test]
+    public void ExclusivePhase_WithOtherSystemInPhase_Throws()
+    {
+        var schedule = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Excl").Phase(Phase.Cleanup).ExclusivePhase() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Other").Phase(Phase.Cleanup) });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("ExclusivePhase"));
+        Assert.That(ex.Message, Does.Contain("'Excl'"));
+    }
+
+    [Test]
+    public void ExclusivePhase_AloneInPhase_OK()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Excl").Phase(Phase.Cleanup).ExclusivePhase() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Other").Phase(Phase.Simulation) })
+            .Build(_registry.Runtime);
+
+        Assert.That(scheduler.Systems, Has.Length.EqualTo(2));
+    }
+
+    // ── Undeclared systems land in DefaultPhase and ARE conflict-detected (Unit 5) ──
+
+    [Test]
+    public void NoPhaseDeclared_LandsInDefaultPhase_AndConflictsDetected()
+    {
+        // Two systems both Writes<CompA>, neither calls b.Phase(). Both default to Phase.Simulation → W×W triggers.
+        var schedule = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Writes<CompA>() });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("'A'"));
+        Assert.That(ex.Message, Does.Contain("'B'"));
+        Assert.That(ex.Message, Does.Contain("Writes<CompA>"));
+    }
+
+    [Test]
+    public void NoPhaseDeclared_NoDeclarations_StillBuilds()
+    {
+        // Two systems with no phase AND no declarations land in Phase.Simulation but conflict detection no-ops (HasAnyDeclaration == false).
+        // Cross-phase edges: none (both in same default phase).
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A") })
+            .Add(new Sys { ConfigureAction = b => b.Name("B") })
+            .Build(_registry.Runtime);
+
+        var aDef = scheduler.Systems.First(s => s.Name == "A");
+        var bDef = scheduler.Systems.First(s => s.Name == "B");
+        Assert.That(aDef.PhaseIndex, Is.EqualTo(1)); // Phase.Simulation
+        Assert.That(bDef.PhaseIndex, Is.EqualTo(1));
+        // Same phase, no declarations → no derived edges
+        Assert.That(aDef.Successors, Does.Not.Contain(bDef.Index));
+        Assert.That(bDef.Successors, Does.Not.Contain(aDef.Index));
+    }
+
+    // ── Multiple components, mixed access ─────────────────────────────
+
+    // ── XOR resolution: both .After AND .Before between same pair → cycle, hard error ──
+
+    [Test]
+    public void WW_BothBeforeAndAfterBetweenSamePair_ThrowsCycleError()
+    {
+        // A.Before("B").After("B") — both edges declared between A and B forms a cycle.
+        // The W×W check should detect this as ambiguous (XOR rule) before the cycle detector kicks in.
+        var schedule = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).Writes<CompA>().After("B").Before("B") })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Simulation).Writes<CompA>() });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("both directions").Or.Contain("cycle"));
+    }
+
+    // ── Empty system list builds cleanly ──────────────────────────────
+
+    [Test]
+    public void EmptySchedule_BuildsCleanly()
+    {
+        using var scheduler = RuntimeSchedule.Create(Options()).Build(_registry.Runtime);
+        Assert.That(scheduler.Systems, Is.Empty);
+    }
+
+    // ── Direct-adjacency limitation: 3+ writers force pairwise edges ──
+
+    [Test]
+    public void WW_ThreeWriters_LinearChain_ForcesPairwiseEdges()
+    {
+        // C2 limitation: A.Before(B).Before(C) does NOT implicitly resolve (A,C) — user must add `.After(A)` to C.
+        // This test documents the limitation rather than asserting better behavior.
+        var schedule = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).Writes<CompA>().Before("B") })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Simulation).Writes<CompA>().Before("C") })
+            .Add(new Sys { ConfigureAction = b => b.Name("C").Phase(Phase.Simulation).Writes<CompA>() });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        // Error should name A and C (the unordered pair); the chain through B is not transitively traced
+        Assert.That(ex.Message, Does.Contain("'A'").And.Contain("'C'"));
+    }
+
+    [Test]
+    public void WW_ThreeWriters_AllPairwiseEdgesDeclared_Builds()
+    {
+        // With explicit edges for every pair, the deriver accepts the configuration.
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("A").Phase(Phase.Simulation).Writes<CompA>().Before("B") })
+            .Add(new Sys { ConfigureAction = b => b.Name("B").Phase(Phase.Simulation).Writes<CompA>().Before("C") })
+            .Add(new Sys { ConfigureAction = b => b.Name("C").Phase(Phase.Simulation).Writes<CompA>().After("A") })
+            .Build(_registry.Runtime);
+
+        Assert.That(scheduler.Systems, Has.Length.EqualTo(3));
+    }
+
+    [Test]
+    public void MixedAccess_DerivesAllEdges()
+    {
+        // Movement writes Position. Render reads Position fresh (after Movement). Replay reads Position snapshot (before Movement).
+        using var scheduler = RuntimeSchedule.Create(Options())
+            .Add(new Sys { ConfigureAction = b => b.Name("Movement").Phase(Phase.Simulation).Writes<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Render").Phase(Phase.Simulation).ReadsFresh<CompA>() })
+            .Add(new Sys { ConfigureAction = b => b.Name("Replay").Phase(Phase.Simulation).ReadsSnapshot<CompA>() })
+            .Build(_registry.Runtime);
+
+        var movement = scheduler.Systems.First(s => s.Name == "Movement");
+        var render = scheduler.Systems.First(s => s.Name == "Render");
+        var replay = scheduler.Systems.First(s => s.Name == "Replay");
+
+        Assert.That(movement.Successors, Does.Contain(render.Index));
+        Assert.That(replay.Successors, Does.Contain(movement.Index));
+    }
+}

--- a/test/Typhon.Engine.Tests/Runtime/PhaseTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/PhaseTests.cs
@@ -1,0 +1,279 @@
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Typhon.Engine.Tests.Runtime;
+
+[TestFixture]
+public class PhaseTests
+{
+    private ResourceRegistry _registry;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _registry = new ResourceRegistry(new ResourceRegistryOptions { Name = "PhaseTest" });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _registry?.Dispose();
+    }
+
+    // ── Test system fixtures ──────────────────────────────────────────
+
+    private class PhasedSystem : CallbackSystem
+    {
+        private readonly string _name;
+        private readonly Phase? _phase;
+
+        public PhasedSystem(string name, Phase? phase)
+        {
+            _name = name;
+            _phase = phase;
+        }
+
+        protected override void Configure(SystemBuilder b)
+        {
+            b.Name(_name);
+            if (_phase.HasValue)
+            {
+                b.Phase(_phase.Value);
+            }
+        }
+
+        protected override void Execute(TickContext ctx)
+        {
+        }
+    }
+
+    // ── 1. Phase struct equality ──────────────────────────────────────
+
+    [Test]
+    public void Phase_Equality_SameNameEqual()
+    {
+        var a = new Phase("Simulation");
+        var b = new Phase("Simulation");
+
+        Assert.That(a == b, Is.True);
+        Assert.That(a.Equals(b), Is.True);
+        Assert.That(Phase.Simulation == new Phase("Simulation"), Is.True);
+    }
+
+    [Test]
+    public void Phase_Equality_DifferentNamesNotEqual()
+    {
+        Assert.That(Phase.Input == Phase.Simulation, Is.False);
+        Assert.That(Phase.Input != Phase.Simulation, Is.True);
+        Assert.That(Phase.Input.Equals(Phase.Simulation), Is.False);
+    }
+
+    // ── 2. Phase struct hash ──────────────────────────────────────────
+
+    [Test]
+    public void Phase_HashCode_EqualPhasesShareHash()
+    {
+        var a = new Phase("Cleanup");
+        var b = Phase.Cleanup;
+
+        Assert.That(a.GetHashCode(), Is.EqualTo(b.GetHashCode()));
+    }
+
+    // ── 3. Phase.ToString ─────────────────────────────────────────────
+
+    [Test]
+    public void Phase_ToString_ReturnsName()
+    {
+        Assert.That(Phase.Input.ToString(), Is.EqualTo("Input"));
+        Assert.That(Phase.Simulation.ToString(), Is.EqualTo("Simulation"));
+        Assert.That(new Phase("Custom").ToString(), Is.EqualTo("Custom"));
+    }
+
+    // ── 4. RuntimeOptions.DefaultPhases ───────────────────────────────
+
+    [Test]
+    public void DefaultPhases_HasFourEntriesInOrder()
+    {
+        var phases = RuntimeOptions.DefaultPhases;
+
+        Assert.That(phases, Has.Length.EqualTo(4));
+        Assert.That(phases[0], Is.EqualTo(Phase.Input));
+        Assert.That(phases[1], Is.EqualTo(Phase.Simulation));
+        Assert.That(phases[2], Is.EqualTo(Phase.Output));
+        Assert.That(phases[3], Is.EqualTo(Phase.Cleanup));
+    }
+
+    // ── 5. Custom phase insertion ─────────────────────────────────────
+
+    [Test]
+    public void CustomPhase_RegisteredAndResolved()
+    {
+        var ai = new Phase("AI");
+        var physics = new Phase("Physics");
+
+        var options = new RuntimeOptions
+        {
+            BaseTickRate = 1000,
+            WorkerCount = 1,
+            Phases = [Phase.Input, ai, physics, Phase.Simulation, Phase.Output, Phase.Cleanup],
+            DefaultPhase = Phase.Simulation,
+        };
+
+        using var scheduler = RuntimeSchedule.Create(options)
+            .Add(new PhasedSystem("AISystem", ai))
+            .Add(new PhasedSystem("PhysicsSystem", physics))
+            .Build(_registry.Runtime);
+
+        var aiSys = scheduler.Systems.First(s => s.Name == "AISystem");
+        var physicsSys = scheduler.Systems.First(s => s.Name == "PhysicsSystem");
+
+        Assert.That(aiSys.PhaseIndex, Is.EqualTo(1));
+        Assert.That(aiSys.Phase, Is.EqualTo(ai));
+        Assert.That(physicsSys.PhaseIndex, Is.EqualTo(2));
+        Assert.That(physicsSys.Phase, Is.EqualTo(physics));
+    }
+
+    // ── 6. Duplicate phase rejection ──────────────────────────────────
+
+    [Test]
+    public void DuplicatePhase_InOptions_ThrowsAtBuild()
+    {
+        var options = new RuntimeOptions
+        {
+            Phases = [Phase.Input, Phase.Simulation, Phase.Input],
+        };
+
+        var schedule = RuntimeSchedule.Create(options)
+            .Add(new PhasedSystem("Sys", Phase.Simulation));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("Duplicate phase"));
+        Assert.That(ex.Message, Does.Contain("Input"));
+    }
+
+    // ── 7. Empty phases rejection ─────────────────────────────────────
+
+    [Test]
+    public void EmptyPhases_InOptions_ThrowsAtBuild()
+    {
+        var options = new RuntimeOptions
+        {
+            Phases = [],
+        };
+
+        var schedule = RuntimeSchedule.Create(options)
+            .Add(new PhasedSystem("Sys", null));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("at least one phase"));
+    }
+
+    // ── 8. Unknown phase rejection ────────────────────────────────────
+
+    [Test]
+    public void UnknownPhase_DeclaredBySystem_ThrowsAtBuild()
+    {
+        var options = new RuntimeOptions
+        {
+            Phases = RuntimeOptions.DefaultPhases,
+        };
+
+        var schedule = RuntimeSchedule.Create(options)
+            .Add(new PhasedSystem("BogusSystem", new Phase("NotInList")));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("BogusSystem"));
+        Assert.That(ex.Message, Does.Contain("NotInList"));
+    }
+
+    // ── 9. Undeclared phase resolves to the default (RFC 07 / Unit 5) ─
+
+    [Test]
+    public void NoPhaseDeclared_GetsDefaultPhase()
+    {
+        // Default RuntimeOptions: DefaultPhase = Phase.Simulation (index 1 in DefaultPhases)
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(new PhasedSystem("NoPhaseSys", null))
+            .Build(_registry.Runtime);
+
+        var sys = scheduler.Systems.First(s => s.Name == "NoPhaseSys");
+        Assert.That(sys.PhaseIndex, Is.EqualTo(1));
+        Assert.That(sys.Phase, Is.EqualTo(Phase.Simulation));
+    }
+
+    // ── 10. Default phases round-trip (Cleanup → index 3) ─────────────
+
+    [Test]
+    public void DefaultPhases_DeclaredCleanup_ResolvesToIndex3()
+    {
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(new PhasedSystem("CleanupSys", Phase.Cleanup))
+            .Build(_registry.Runtime);
+
+        var sys = scheduler.Systems.First(s => s.Name == "CleanupSys");
+        Assert.That(sys.PhaseIndex, Is.EqualTo(3));
+        Assert.That(sys.Phase, Is.EqualTo(Phase.Cleanup));
+    }
+
+    // ── 11. Custom default phase applies to undeclared systems ────────
+
+    [Test]
+    public void CustomDefaultPhase_AppliesToUndeclaredSystems()
+    {
+        var options = new RuntimeOptions
+        {
+            BaseTickRate = 1000,
+            WorkerCount = 1,
+            DefaultPhase = Phase.Output,
+        };
+
+        using var scheduler = RuntimeSchedule.Create(options)
+            .Add(new PhasedSystem("UndeclaredSys", null))
+            .Build(_registry.Runtime);
+
+        var sys = scheduler.Systems.First(s => s.Name == "UndeclaredSys");
+        Assert.That(sys.Phase, Is.EqualTo(Phase.Output));
+        Assert.That(sys.PhaseIndex, Is.EqualTo(2));
+    }
+
+    // ── 12. Default phase missing from Phases throws at Build ─────────
+
+    [Test]
+    public void DefaultPhase_NotInPhasesList_ThrowsAtBuild()
+    {
+        var custom = new Phase("NotShipped");
+        var options = new RuntimeOptions
+        {
+            BaseTickRate = 1000,
+            WorkerCount = 1,
+            DefaultPhase = custom, // not in DefaultPhases
+        };
+
+        var schedule = RuntimeSchedule.Create(options)
+            .Add(new PhasedSystem("Sys", null));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("DefaultPhase"));
+        Assert.That(ex.Message, Does.Contain("NotShipped"));
+    }
+
+    // ── 13. Mixed declared + undeclared cohabit cleanly ──────────────
+
+    [Test]
+    public void MixedDeclared_And_Undeclared_BothLandSomewhere()
+    {
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(new PhasedSystem("Declared", Phase.Cleanup))
+            .Add(new PhasedSystem("Undeclared", null))
+            .Build(_registry.Runtime);
+
+        var declared = scheduler.Systems.First(s => s.Name == "Declared");
+        var undeclared = scheduler.Systems.First(s => s.Name == "Undeclared");
+
+        Assert.That(declared.PhaseIndex, Is.EqualTo(3));   // Cleanup
+        Assert.That(undeclared.PhaseIndex, Is.EqualTo(1)); // Default = Simulation
+        // Cross-phase edge: undeclared (Sim) → declared (Cleanup)
+        Assert.That(undeclared.Successors, Does.Contain(declared.Index));
+    }
+}

--- a/test/Typhon.Engine.Tests/Runtime/SystemAccessValidatorTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/SystemAccessValidatorTests.cs
@@ -1,0 +1,300 @@
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Typhon.Engine.Tests.Runtime;
+
+[TestFixture]
+public class SystemAccessValidatorTests
+{
+    private ResourceRegistry _registry;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _registry = new ResourceRegistry(new ResourceRegistryOptions { Name = "AccessValidatorTest" });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _registry?.Dispose();
+    }
+
+    private struct CompA { public int V; }
+    private struct CompB { public int V; }
+
+    // ─── Direct unit tests on the validator ───────────────────────────
+
+    [Test]
+    public void AssertWrite_NoContext_PassesSilently()
+    {
+        // No EnterSystem call has been made on this thread → _current is null → assertion no-ops.
+        Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompA>());
+    }
+
+    [Test]
+    public void AssertWrite_ContextWithNoDeclarations_PassesSilently()
+    {
+        // Descriptor exists but is empty (system hasn't migrated to declared access yet).
+        var d = new SystemAccessDescriptor();
+        SystemAccessValidator.EnterSystem(d, "MigratingSys");
+        try
+        {
+            Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompA>());
+        }
+        finally
+        {
+            SystemAccessValidator.LeaveSystem();
+        }
+    }
+
+    [Test]
+    public void AssertWrite_DeclaredWrites_Passes()
+    {
+        var d = new SystemAccessDescriptor();
+        d.Writes.Add(typeof(CompA));
+        SystemAccessValidator.EnterSystem(d, "WriterSys");
+        try
+        {
+            Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompA>());
+        }
+        finally
+        {
+            SystemAccessValidator.LeaveSystem();
+        }
+    }
+
+    [Test]
+    public void AssertWrite_DeclaredSideWrites_Passes()
+    {
+        var d = new SystemAccessDescriptor();
+        d.SideWrites.Add(typeof(CompA));
+        SystemAccessValidator.EnterSystem(d, "SideWriterSys");
+        try
+        {
+            Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompA>());
+        }
+        finally
+        {
+            SystemAccessValidator.LeaveSystem();
+        }
+    }
+
+#if DEBUG
+    [Test]
+    public void AssertWrite_Undeclared_ThrowsInDebug()
+    {
+        var d = new SystemAccessDescriptor();
+        d.Writes.Add(typeof(CompA)); // CompA declared, CompB NOT declared
+        SystemAccessValidator.EnterSystem(d, "DriftySystem");
+        try
+        {
+            var ex = Assert.Throws<InvalidAccessException>(() => SystemAccessValidator.AssertWrite<CompB>());
+            Assert.That(ex.SystemName, Is.EqualTo("DriftySystem"));
+            Assert.That(ex.UndeclaredType, Is.EqualTo(typeof(CompB)));
+            Assert.That(ex.Message, Does.Contain("DriftySystem"));
+            Assert.That(ex.Message, Does.Contain("CompB"));
+            Assert.That(ex.Message, Does.Contain("Writes<CompB>"));
+            Assert.That(ex.ErrorCode, Is.EqualTo(TyphonErrorCode.InvalidSystemAccess));
+        }
+        finally
+        {
+            SystemAccessValidator.LeaveSystem();
+        }
+    }
+#endif
+
+    // ─── Push/pop semantics ───────────────────────────────────────────
+
+    [Test]
+    public void EnterLeave_NestedScopes_RestorePreviousDescriptor()
+    {
+        var outerD = new SystemAccessDescriptor();
+        outerD.Writes.Add(typeof(CompA));
+
+        var innerD = new SystemAccessDescriptor();
+        innerD.Writes.Add(typeof(CompB));
+
+        SystemAccessValidator.EnterSystem(outerD, "Outer");
+        try
+        {
+            // In outer scope: CompA OK, CompB would throw (in DEBUG)
+            Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompA>());
+
+            SystemAccessValidator.EnterSystem(innerD, "Inner");
+            try
+            {
+                // In inner scope: CompB OK
+                Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompB>());
+            }
+            finally
+            {
+                SystemAccessValidator.LeaveSystem();
+            }
+
+            // Back in outer scope: CompA OK again
+            Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompA>());
+        }
+        finally
+        {
+            SystemAccessValidator.LeaveSystem();
+        }
+
+        // Outside any scope: anything passes (no context)
+        Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompB>());
+    }
+
+    [Test]
+    public async Task EnterLeave_PerThread_IsolatedBetweenThreads()
+    {
+        // Two threads each set their own descriptor; neither sees the other.
+        var dA = new SystemAccessDescriptor();
+        dA.Writes.Add(typeof(CompA));
+
+        var dB = new SystemAccessDescriptor();
+        dB.Writes.Add(typeof(CompB));
+
+        var threadAReady = new ManualResetEventSlim(false);
+        var threadBReady = new ManualResetEventSlim(false);
+        var bothChecked = new ManualResetEventSlim(false);
+        var aSawCompA = false;
+        var bSawCompB = false;
+
+        var taskA = Task.Run(() =>
+        {
+            SystemAccessValidator.EnterSystem(dA, "TA");
+            threadAReady.Set();
+            threadBReady.Wait();
+            try
+            {
+                aSawCompA = true;
+                SystemAccessValidator.AssertWrite<CompA>();
+                bothChecked.Wait();
+            }
+            finally
+            {
+                SystemAccessValidator.LeaveSystem();
+            }
+        });
+
+        var taskB = Task.Run(() =>
+        {
+            SystemAccessValidator.EnterSystem(dB, "TB");
+            threadBReady.Set();
+            threadAReady.Wait();
+            try
+            {
+                bSawCompB = true;
+                SystemAccessValidator.AssertWrite<CompB>();
+                bothChecked.Set();
+            }
+            finally
+            {
+                SystemAccessValidator.LeaveSystem();
+            }
+        });
+
+        await Task.WhenAll(taskA, taskB);
+        Assert.That(aSawCompA, Is.True);
+        Assert.That(bSawCompB, Is.True);
+    }
+
+    // ─── Integration: dispatch sets the context ───────────────────────
+
+    private class CapturingSystem : CallbackSystem
+    {
+        public Action<SystemBuilder> ConfigureAction;
+        public Action OnExecute;
+
+        protected override void Configure(SystemBuilder b) => ConfigureAction?.Invoke(b);
+
+        protected override void Execute(TickContext ctx) => OnExecute?.Invoke();
+    }
+
+    [Test]
+    public void DispatchedSystem_AssertWriteForDeclaredType_Passes()
+    {
+        var observed = false;
+        var sys = new CapturingSystem
+        {
+            ConfigureAction = b => b.Name("ASys").Phase(Phase.Simulation).Writes<CompA>(),
+            OnExecute = () =>
+            {
+                SystemAccessValidator.AssertWrite<CompA>();
+                observed = true;
+            },
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sys)
+            .Build(_registry.Runtime);
+
+        scheduler.Start();
+        SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 1, TimeSpan.FromSeconds(5));
+        scheduler.Shutdown();
+
+        Assert.That(observed, Is.True);
+    }
+
+#if DEBUG
+    [Test]
+    public void DispatchedSystem_AssertWriteForUndeclaredType_ThrowsInDebug()
+    {
+        Exception captured = null;
+        var sys = new CapturingSystem
+        {
+            ConfigureAction = b => b.Name("BSys").Phase(Phase.Simulation).Writes<CompA>(),
+            OnExecute = () =>
+            {
+                try
+                {
+                    SystemAccessValidator.AssertWrite<CompB>();
+                }
+                catch (Exception e)
+                {
+                    captured = e;
+                }
+            },
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sys)
+            .Build(_registry.Runtime);
+
+        scheduler.Start();
+        SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 1, TimeSpan.FromSeconds(5));
+        scheduler.Shutdown();
+
+        Assert.That(captured, Is.InstanceOf<InvalidAccessException>());
+        var iae = (InvalidAccessException)captured;
+        Assert.That(iae.SystemName, Is.EqualTo("BSys"));
+        Assert.That(iae.UndeclaredType, Is.EqualTo(typeof(CompB)));
+    }
+#endif
+
+    [Test]
+    public void DispatchedSystem_AfterExecution_ContextIsCleared()
+    {
+        // Dispatcher must restore the previous (null) descriptor after the system finishes.
+        var sys = new CapturingSystem
+        {
+            ConfigureAction = b => b.Name("CleanupCheck").Phase(Phase.Simulation).Writes<CompA>(),
+            OnExecute = () => { /* no-op */ },
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sys)
+            .Build(_registry.Runtime);
+
+        scheduler.Start();
+        SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 1, TimeSpan.FromSeconds(5));
+        scheduler.Shutdown();
+
+        // Back on the test thread, no descriptor should be set — assertion silent for any type.
+        Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompA>());
+        Assert.DoesNotThrow(() => SystemAccessValidator.AssertWrite<CompB>());
+    }
+}

--- a/test/Typhon.Engine.Tests/Runtime/SystemBuilderFluentTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/SystemBuilderFluentTests.cs
@@ -1,0 +1,287 @@
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Typhon.Engine.Tests.Runtime;
+
+[TestFixture]
+public class SystemBuilderFluentTests
+{
+    private ResourceRegistry _registry;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _registry = new ResourceRegistry(new ResourceRegistryOptions { Name = "FluentBuilderTest" });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _registry?.Dispose();
+    }
+
+    // ── Component types used for declaration tests ──
+
+    private struct CompA { public int V; }
+    private struct CompB { public int V; }
+    private struct CompC { public int V; }
+    private struct CompD { public int V; }
+
+    // ── Test system that exposes its builder for assertion ──
+
+    private class DeclarativeSystem : CallbackSystem
+    {
+        public Action<SystemBuilder> ConfigureAction;
+
+        protected override void Configure(SystemBuilder b) => ConfigureAction?.Invoke(b);
+
+        protected override void Execute(TickContext ctx)
+        {
+        }
+    }
+
+    // ─── Layer A: fluent return ────────────────────────────────────────
+
+    [Test]
+    public void AllExistingMethods_ReturnSameBuilder()
+    {
+        var b = new SystemBuilder();
+
+        Assert.That(b.Name("X"), Is.SameAs(b));
+        Assert.That(b.After("Y"), Is.SameAs(b));
+        Assert.That(b.AfterAll("A", "B"), Is.SameAs(b));
+        Assert.That(b.Before("Z"), Is.SameAs(b));
+        Assert.That(b.Priority(SystemPriority.High), Is.SameAs(b));
+        Assert.That(b.RunIf(() => true), Is.SameAs(b));
+        Assert.That(b.TickDivisor(2), Is.SameAs(b));
+        Assert.That(b.ThrottledTickDivisor(3), Is.SameAs(b));
+        Assert.That(b.CanShed(true), Is.SameAs(b));
+        Assert.That(b.Phase(Phase.Simulation), Is.SameAs(b));
+    }
+
+    [Test]
+    public void DeclarationMethods_ReturnSameBuilder()
+    {
+        var b = new SystemBuilder();
+
+        Assert.That(b.Reads<CompA>(), Is.SameAs(b));
+        Assert.That(b.ReadsFresh<CompA>(), Is.SameAs(b));
+        Assert.That(b.ReadsSnapshot<CompA>(), Is.SameAs(b));
+        Assert.That(b.AdditionalReads<CompA>(), Is.SameAs(b));
+        Assert.That(b.Writes<CompB>(), Is.SameAs(b));
+        Assert.That(b.SideWrites<CompB>(), Is.SameAs(b));
+        Assert.That(b.WritesResource("res"), Is.SameAs(b));
+        Assert.That(b.ReadsResource("res"), Is.SameAs(b));
+        Assert.That(b.ExclusivePhase(), Is.SameAs(b));
+    }
+
+    [Test]
+    public void ChainedConfiguration_AccumulatesAllSettings()
+    {
+        var sys = new DeclarativeSystem
+        {
+            ConfigureAction = b => b
+                .Name("Chained")
+                .Priority(SystemPriority.High)
+                .Phase(Phase.Simulation)
+                .Reads<CompA>()
+                .Writes<CompB>()
+                .ReadsSnapshot<CompC>(),
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sys)
+            .Build(_registry.Runtime);
+
+        var def = scheduler.Systems.First(s => s.Name == "Chained");
+        Assert.That(def.Priority, Is.EqualTo(SystemPriority.High));
+        Assert.That(def.PhaseIndex, Is.EqualTo(1)); // Simulation in default phase order
+        Assert.That(def.Access.Reads, Does.Contain(typeof(CompA)));
+        Assert.That(def.Access.Writes, Does.Contain(typeof(CompB)));
+        Assert.That(def.Access.ReadsSnapshot, Does.Contain(typeof(CompC)));
+    }
+
+    // ─── Layer B: Before edge ─────────────────────────────────────────
+
+    [Test]
+    public void Before_AddsEdgeFromCurrentToTarget()
+    {
+        var sysA = new DeclarativeSystem { ConfigureAction = b => b.Name("A").Before("B") };
+        var sysB = new DeclarativeSystem { ConfigureAction = b => b.Name("B") };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sysA)
+            .Add(sysB)
+            .Build(_registry.Runtime);
+
+        var aDef = scheduler.Systems.First(s => s.Name == "A");
+        var bDef = scheduler.Systems.First(s => s.Name == "B");
+
+        // A.Before(B) means: edge A → B, so B's predecessor count increases
+        Assert.That(bDef.PredecessorCount, Is.EqualTo(1));
+        Assert.That(aDef.Successors, Does.Contain(bDef.Index));
+    }
+
+    [Test]
+    public void BeforeAndAfter_OnSameSystem_DetectedAsCycle()
+    {
+        // X.After(Y) creates edge Y -> X
+        // X.Before(Y) creates edge X -> Y
+        // Together: cycle Y -> X -> Y
+        var sysX = new DeclarativeSystem { ConfigureAction = b => b.Name("X").After("Y").Before("Y") };
+        var sysY = new DeclarativeSystem { ConfigureAction = b => b.Name("Y") };
+
+        var schedule = RuntimeSchedule.Create()
+            .Add(sysX)
+            .Add(sysY);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("cycle").IgnoreCase);
+    }
+
+    // ─── Layer C: declaration accumulation ────────────────────────────
+
+    [Test]
+    public void Reads_SingleCall_AddsToReadsSet()
+    {
+        var sys = new DeclarativeSystem { ConfigureAction = b => b.Name("R").Reads<CompA>() };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sys)
+            .Build(_registry.Runtime);
+
+        var def = scheduler.Systems.First(s => s.Name == "R");
+        Assert.That(def.Access.Reads, Does.Contain(typeof(CompA)));
+        Assert.That(def.Access.Reads.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Reads_BatchOverload_EquivalentToIndividualCalls()
+    {
+        var batch = new DeclarativeSystem
+        {
+            ConfigureAction = b => b.Name("Batch").Reads<CompA, CompB, CompC, CompD>(),
+        };
+        var individual = new DeclarativeSystem
+        {
+            ConfigureAction = b => b.Name("Individual").Reads<CompA>().Reads<CompB>().Reads<CompC>().Reads<CompD>(),
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(batch)
+            .Add(individual)
+            .Build(_registry.Runtime);
+
+        var batchDef = scheduler.Systems.First(s => s.Name == "Batch");
+        var individualDef = scheduler.Systems.First(s => s.Name == "Individual");
+
+        Assert.That(batchDef.Access.Reads, Is.EquivalentTo(individualDef.Access.Reads));
+        Assert.That(batchDef.Access.Reads.Count, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void Writes_BatchOverload_EquivalentToIndividualCalls()
+    {
+        var batch = new DeclarativeSystem
+        {
+            ConfigureAction = b => b.Name("WBatch").Writes<CompA, CompB, CompC>(),
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(batch)
+            .Build(_registry.Runtime);
+
+        var def = scheduler.Systems.First(s => s.Name == "WBatch");
+        Assert.That(def.Access.Writes, Is.EquivalentTo(new[] { typeof(CompA), typeof(CompB), typeof(CompC) }));
+    }
+
+    [Test]
+    public void ReadsFresh_And_ReadsSnapshot_AreDistinctSets()
+    {
+        var sys = new DeclarativeSystem
+        {
+            ConfigureAction = b => b.Name("Mix").ReadsFresh<CompA>().ReadsSnapshot<CompB>(),
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sys)
+            .Build(_registry.Runtime);
+
+        var def = scheduler.Systems.First(s => s.Name == "Mix");
+        Assert.That(def.Access.ReadsFresh, Does.Contain(typeof(CompA)));
+        Assert.That(def.Access.ReadsFresh, Does.Not.Contain(typeof(CompB)));
+        Assert.That(def.Access.ReadsSnapshot, Does.Contain(typeof(CompB)));
+        Assert.That(def.Access.ReadsSnapshot, Does.Not.Contain(typeof(CompA)));
+    }
+
+    [Test]
+    public void DuplicateDeclaration_IsDeduped()
+    {
+        var sys = new DeclarativeSystem
+        {
+            ConfigureAction = b => b.Name("Dup").Reads<CompA>().Reads<CompA>().Reads<CompA>(),
+        };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(sys)
+            .Build(_registry.Runtime);
+
+        var def = scheduler.Systems.First(s => s.Name == "Dup");
+        Assert.That(def.Access.Reads.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void EventQueueAndResource_DeclarationsAccumulate()
+    {
+        var schedule = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 });
+        var queue = schedule.CreateEventQueue<int>("Q", 16);
+
+        var sys = new DeclarativeSystem
+        {
+            ConfigureAction = b => b
+                .Name("Eventy")
+                .WritesEvents(queue)
+                .ReadsResource("PhysicsWorld")
+                .WritesResource("SpatialIndex")
+                .ExclusivePhase(),
+        };
+
+        using var scheduler = schedule.Add(sys).Build(_registry.Runtime);
+
+        var def = scheduler.Systems.First(s => s.Name == "Eventy");
+        Assert.That(def.Access.WritesEvents, Does.Contain(queue));
+        Assert.That(def.Access.ReadsResources, Does.Contain("PhysicsWorld"));
+        Assert.That(def.Access.WritesResources, Does.Contain("SpatialIndex"));
+        Assert.That(def.Access.ExclusivePhase, Is.True);
+    }
+
+    [Test]
+    public void HasAnyDeclaration_FalseForUndeclared_TrueWhenAccessSet()
+    {
+        var undeclared = new DeclarativeSystem { ConfigureAction = b => b.Name("Plain") };
+        var declared = new DeclarativeSystem { ConfigureAction = b => b.Name("Declared").Reads<CompA>() };
+
+        using var scheduler = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 1000, WorkerCount = 1 })
+            .Add(undeclared)
+            .Add(declared)
+            .Build(_registry.Runtime);
+
+        var plainDef = scheduler.Systems.First(s => s.Name == "Plain");
+        var declaredDef = scheduler.Systems.First(s => s.Name == "Declared");
+
+        Assert.That(plainDef.Access.HasAnyDeclaration, Is.False);
+        Assert.That(declaredDef.Access.HasAnyDeclaration, Is.True);
+    }
+
+    [Test]
+    public void NullArguments_ToDeclarationMethods_Throw()
+    {
+        var b = new SystemBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => b.WritesEvents(null));
+        Assert.Throws<ArgumentNullException>(() => b.ReadsEvents(null));
+        Assert.Throws<ArgumentNullException>(() => b.WritesResource(null));
+        Assert.Throws<ArgumentNullException>(() => b.ReadsResource(null));
+    }
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SchemaInspector/SchemaRelationshipsPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SchemaInspector/SchemaRelationshipsPanel.tsx
@@ -38,9 +38,9 @@ export default function SchemaRelationshipsPanel(_props: IDockviewPanelProps) {
         <StatusBadge
           tone="warn"
           className="ml-auto"
-          title="Write access is not tracked — see design doc §4.3"
+          title="System access details (RFC 07) become available once Workbench hosts a live TyphonRuntime — see issue #275"
         >
-          writes not tracked
+          access details pending runtime hosting
         </StatusBadge>
       </div>
 

--- a/tools/Typhon.Workbench/Dtos/Schema/SystemRelationshipDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Schema/SystemRelationshipDto.cs
@@ -1,8 +1,11 @@
 namespace Typhon.Workbench.Dtos.Schema;
 
 /// <summary>
-/// One system that reads or reacts to the focused component. Writes are NOT tracked — by design (see
-/// <c>claude/design/typhon-workbench/modules/03-schema-inspector.md</c> §4.3).
+/// One system that reads or reacts to the focused component. This DTO is reads-only for legacy compatibility — full system
+/// access (writes, fresh/snapshot reads, side-writes, events, named resources) is now tracked via
+/// <c>SystemAccessDescriptor</c> (RFC 07 — Unit 2 in the engine layer). Surfacing it through Workbench requires
+/// <c>OpenSession</c> to host a live <c>TyphonRuntime</c>, tracked in issue #275 (Unit 6). Once that lands, extend this record
+/// or create a sibling <c>SystemAccessDto</c> exposing the full access shape.
 /// </summary>
 /// <param name="Access">
 /// <c>"read"</c> — component is in the system's input view schema (implicit read set via query filter).


### PR DESCRIPTION
## Summary

Implements RFC 07 — System Access Declarations + Auto-DAG (Units 1-5). This is the engine-side delivery; Workbench surfacing (Unit 6 / #275) is deferred pending runtime hosting in Workbench's `OpenSession`.

Closes #270, #271, #272, #273, #274.

## What this delivers

- **Unit 1 — `Phase` primitive + registration** (#270): readonly struct wrapping `string`, Typhon-shipped statics (Input/Simulation/Output/Cleanup), `RuntimeOptions.Phases` ordered list + `RuntimeOptions.DefaultPhase`, phase-token → integer index map resolved at `Build()`.
- **Unit 2 — `SystemBuilder` declaration methods** (#271): converted all 14 existing methods to fluent (`return this`); added `.Before(string)`; 11 new declaration methods (`Reads`/`ReadsFresh`/`ReadsSnapshot`/`AdditionalReads`/`Writes`/`SideWrites`/`WritesEvents`/`ReadsEvents`/`WritesResource`/`ReadsResource`/`ExclusivePhase`); batch overloads (arities 2–6) for `Reads`/`Writes`/`ReadsFresh`/`ReadsSnapshot`.
- **Unit 3 — `Build()` validator + auto-DAG derivation** (#272): per-phase conflict detection (W×W with XOR rule, R×W-plain hard error, R×W-fresh/snapshot edge derivation), event producer→consumer + named resource edges, ExclusivePhase enforcement, cross-phase chain over consecutive populated phases, merge with explicit `.After()`/`.Before()` edges, downstream Kahn cycle detection.
- **Unit 4 — Debug-runtime write assertion** (#273): `[ThreadStatic]` `SystemAccessValidator` with push/pop frame stack; `[Conditional("DEBUG")]` on `EnterSystem`/`LeaveSystem`/`AssertWrite` so all 7 dispatch-site call sites in `DagScheduler` strip entirely in RELEASE; `InvalidAccessException` thrown on undeclared writes in DEBUG with system name + undeclared type + declared summary.
- **Unit 5 — Phase enforcement + R3 retirement** (#274): `RuntimeOptions.DefaultPhase` ensures every system lands in some phase post-`Build()`; pragmatic divergence from "strict required Phase" documented in RFC body; `02-system-scheduling.md` superseded by RFC 07; new `claude/rules/runtime-scheduling.md` codifies the auto-DAG invariants.

## Test plan

- [x] `dotnet build Typhon.slnx -c Debug` clean (no new warnings)
- [x] `dotnet test --filter "FullyQualifiedName~PhaseTests|SystemBuilderFluentTests|AccessDagDerivationTests|SystemAccessValidatorTests"` — 61 RFC 07 tests green
- [x] Full `dotnet test` regression — 3387+ tests pass, no failures (one flaky concurrent BTree test passes on rerun)
- [x] Verify `[Conditional("DEBUG")]` stripping by inspecting Release IL for `EntityRef.Write<T>` (no validator calls present)

## Documentation

- RFC 07 amended with "Compatibility notes" + "Implementation note: default-phase divergence" sections
- `02-system-scheduling.md` header note → RFC 07 supersedes R3/R-Q6
- `claude/rules/runtime-scheduling.md` — NEW rules file with 5 modules (Phase Resolution, Access Conflict Detection, Edge Derivation, Debug-Runtime Write Validation, API Contract Stability)
- Workbench placeholder updates: `SchemaRelationshipsPanel.tsx` badge text + `SystemRelationshipDto.cs` doc-comment now point at #275 for runtime-hosting prerequisite

## Known limitations / follow-ups

1. **Test fixture conversion deferred** — DefaultPhase mechanism makes mass conversion of pre-RFC fixtures unnecessary; opportunistic cleanup as files are touched.
2. **W×W resolution = direct adjacency only** — three writers of the same component need pairwise edges; transitive chain ordering is a future enhancement.
3. **Structured `AccessConflictError` envelope not built** — current implementation uses formatted `InvalidOperationException`; substantive UX is met.
4. **Perf benchmarks not run** — Goal #5 < 20% overhead is structurally guaranteed by `[Conditional("DEBUG")]` IL stripping; BenchmarkDotNet measurement nice-to-have.
5. **`claude/overview/13-runtime.md` prose update pending** — RFC body + rules file capture the design; overview prose is a follow-up.
6. **Unit 6 (#275) blocked** on `OpenSession` hosting a live `TyphonRuntime` in Workbench.

## Companion PR

`claude/` documentation changes: see the typhon-claude repo PR (link to follow once created).
