### PR TITLE
Profiler Source Attribution v2 — file:line for every span (#302)

### DIFF
--- a/.claude/skills/wb-dev/SKILL.md
+++ b/.claude/skills/wb-dev/SKILL.md
@@ -6,188 +6,60 @@ argument-hint: start | stop | status | restart
 
 # wb-dev — Workbench Dev Server Controller
 
-Launches and manages the two Workbench dev servers with a persistent PID file at `.claude/state/wb-dev.json`, so a new Claude Code session (or a later slash-command invocation) can still stop servers it didn't start itself.
+Thin wrapper over `wb-dev.ps1` at the repo root. The PowerShell script does all the
+work in one shot — pre-flight, launch, port-bind wait, state-file write, report.
+The previous skill needed 7-9 Bash round-trips per action; this one does 1.
 
 ## Input
 
-`$ARGUMENTS` first token determines the action:
+`$ARGUMENTS` first token determines the action; default is `start`. Pass `--help`,
+`-h`, or `help` to display the script's help block.
 
-- `start` (default when no args) — launches both servers, waits for binding, writes PID file, tails startup output
-- `stop` — reads the PID file, kills each process tree, deletes the file
-- `status` — reads the PID file, checks each PID for liveness, reports
-- `restart` — `stop` then `start`
-- `--help` / `-h` — show the help block below and stop
+Recognized actions: `start`, `stop`, `status`, `restart`, `help`.
 
-```
-/wb-dev [start | stop | status | restart]
+## Behavior
 
-  Manage the Typhon Workbench dev servers with file-based PID tracking.
+Run the PowerShell script with the resolved action via Bash, then display its
+stdout verbatim:
 
-Actions:
-  start       Launch Kestrel (:5200) + Vite (:5173) in background, save PIDs
-  stop        Kill the process trees recorded in the PID file, clear the file
-  status      Report each process as alive | dead | no-state
-  restart     Stop then start
-  --help, -h  Show this help
-
-State file:
-  .claude/state/wb-dev.json — { kestrelRootPid, kestrelListenerPid,
-                                vitePid, viteListenerPid, startedAt }
-
-Examples:
-  /wb-dev             (shorthand for /wb-dev start)
-  /wb-dev start
-  /wb-dev stop
-  /wb-dev status
-  /wb-dev restart
+```bash
+pwsh -NoProfile -Command './wb-dev.ps1 <action>'
 ```
 
-## State file shape
+(Fall back to `powershell -NoProfile -Command` if `pwsh` isn't on PATH.) Use
+`-Command` (not `-File`) so the relative `./wb-dev.ps1` resolves against Bash's
+working directory — `-File` on Windows pwsh requires an absolute path. The script
+handles state-file reads/writes, port checks, PID tracking, log tailing on
+failure, and stale-state warnings on its own. **Do not** run extra `netstat`,
+`taskkill`, or state-file manipulation from Bash — the script covers everything
+in a single PowerShell session, which is the whole point of consolidating the
+workflow into one file.
 
-`/c/Dev/github/Typhon/.claude/state/wb-dev.json`:
+## State / logs
+
+- State JSON: `.claude/state/wb-dev.json` (gitignored)
+- Logs: `.claude/state/wb-dev.kestrel{,err}.log`, `.claude/state/wb-dev.vite{,err}.log`
+
+Shape of the state file (kept simple — no listener-PID tracking; `taskkill /T`
+inside the script cascades from the recorded root PID to its descendants):
 
 ```json
 {
-  "kestrelRootPid": 111,
-  "kestrelListenerPid": 222,
-  "vitePid": 333,
-  "viteListenerPid": 444,
-  "startedAt": "2026-04-23T10:42:15+02:00"
+  "kestrelPid": 1234,
+  "vitePid":    5678,
+  "startedAt":  "2026-05-05T...",
+  "kestrelLog": "...",
+  "viteLog":    "..."
 }
 ```
 
-**Root vs listener**: `dotnet watch` spawns `Typhon.Workbench.exe` as a child (the listener on :5200). Killing only the listener would cause watch to respawn it — so we also track the `dotnet watch` process itself (`kestrelRootPid`) and `taskkill /T` it at stop time. `npm run dev` similarly spawns vite.
+## Endpoints (after start)
 
-The `.claude/state/` directory is gitignored.
-
-## Discovery strategy
-
-Identifying PIDs by capturing `$!` in a backgrounded bash shell is racy (the bash shell's own PID vs. the command's PID, shell exiting before the echo lands) and fragile across OS / shell variants. Instead:
-
-1. Launch the two servers in the background with `run_in_background: true` — fire-and-forget, no PID capture.
-2. Poll `netstat -ano` until both :5200 and :5173 are `LISTENING` (timeout 30 s).
-3. For each listener PID, use **PowerShell `Get-CimInstance Win32_Process`** filtered by command-line to find the root `dotnet watch` / `npm run dev` process. This is more robust than parent-walking because the relevant processes are uniquely identifiable by their command line:
-   - Kestrel root: `dotnet.exe` whose command-line contains `watch` and `Typhon.Workbench`
-   - Vite root: `node.exe` whose command-line contains `vite` (spawned by `npm run dev`)
-4. Write JSON with both root PIDs and listener PIDs.
-
-## Workflows
-
-### `start`
-
-**Pre-flight.** Check the state file.
-- If present and all recorded PIDs alive → print "already running" + endpoints + **stop** (don't relaunch).
-- If present but any recorded PID is dead → print "stale state", delete the file, continue.
-- If absent → continue.
-
-**Port pre-flight.**
-```bash
-netstat -ano | grep -E ':(5200|5173)\s' | grep LISTENING || true
-```
-If either port is LISTENING → warn the user, list the owning PIDs, **stop** (ask them to `/wb-dev stop` or kill manually first).
-
-**Launch.** Two separate `run_in_background: true` Bash calls. Neither captures `$!`; both just run the server command in the foreground of their background shell:
-
-Shell 1 (Kestrel):
-```bash
-cd /c/Dev/github/Typhon
-mkdir -p .claude/state
-dotnet watch --project tools/Typhon.Workbench > .claude/state/wb-dev.kestrel.log 2>&1
-```
-
-Shell 2 (Vite):
-```bash
-cd /c/Dev/github/Typhon/tools/Typhon.Workbench/ClientApp
-npm run dev > /c/Dev/github/Typhon/.claude/state/wb-dev.vite.log 2>&1
-```
-
-**Wait for binding.** Poll every 2 s up to 30 s total:
-```bash
-K=""; V=""
-for i in $(seq 1 15); do
-  K=$(netstat -ano | grep -E ':5200\s' | grep LISTENING | awk '{print $NF}' | head -1)
-  V=$(netstat -ano | grep -E ':5173\s' | grep LISTENING | awk '{print $NF}' | head -1)
-  if [ -n "$K" ] && [ -n "$V" ]; then break; fi
-  sleep 2
-done
-echo "KESTREL_LISTENER=$K VITE_LISTENER=$V"
-```
-If the loop exits without both PIDs → tail the two log files (`.claude/state/wb-dev.*.log`), report "failed to bind within 30 s", stop.
-
-**Resolve root PIDs via PowerShell.**
-```powershell
-$k = Get-CimInstance Win32_Process -Filter "Name='dotnet.exe'" |
-     Where-Object { $_.CommandLine -match 'watch' -and $_.CommandLine -match 'Typhon\.Workbench' } |
-     Select-Object -First 1 -ExpandProperty ProcessId
-$v = Get-CimInstance Win32_Process -Filter "Name='node.exe'" |
-     Where-Object { $_.CommandLine -match 'npm.*run.*dev' -or $_.CommandLine -match 'vite' } |
-     Select-Object -First 1 -ExpandProperty ProcessId
-"$k $v"
-```
-On POSIX, fall back to `pgrep -f 'dotnet watch.*Typhon.Workbench'` and `pgrep -f 'vite'`.
-
-**Write the JSON.**
-```bash
-python3 -c "
-import json, datetime
-s = {
-    'kestrelRootPid':     $K_ROOT,
-    'kestrelListenerPid': $K_LISTENER,
-    'vitePid':            $V_ROOT,
-    'viteListenerPid':    $V_LISTENER,
-    'startedAt':          datetime.datetime.now().astimezone().isoformat(),
-}
-open('.claude/state/wb-dev.json', 'w').write(json.dumps(s, indent=2) + '\n')
-print(json.dumps(s))
-"
-```
-
-**Tail ~15 lines of each log** so the user sees the binding message / any compile errors.
-
-**Report:**
-- Backend: http://localhost:5200/health
+- Backend:  http://localhost:5200/health
 - Frontend: http://localhost:5173
-- API docs: http://localhost:5200/openapi.json
-- Logs: `.claude/state/wb-dev.kestrel.log`, `.claude/state/wb-dev.vite.log`
-- PIDs: from the JSON (root + listener)
+- OpenAPI:  http://localhost:5200/openapi.json
 
-### `stop`
+## When to use
 
-1. Read `.claude/state/wb-dev.json`. If missing → "no wb-dev state file; nothing to stop". Also run `netstat` to note anything actually bound to :5200 / :5173 that a prior session may have orphaned.
-
-2. Tree-kill each **root** PID — `/T` cascades to children (the listener is always a child):
-   ```bash
-   taskkill //F //T //PID <kestrelRootPid> 2>/dev/null || kill -TERM <kestrelRootPid> 2>/dev/null || true
-   taskkill //F //T //PID <vitePid>        2>/dev/null || kill -TERM <vitePid>        2>/dev/null || true
-   ```
-
-3. Delete `.claude/state/wb-dev.json`. Leave `.log` files for post-mortem.
-
-4. Verify with `netstat` — if either port is still bound, report the surviving PID and suggest a manual `taskkill //F //PID <pid>`. In that case *do not* recreate the state file — the user will want to triage first.
-
-5. Report: "stopped Kestrel (root pid N, listener M) + Vite (root pid X, listener Y)".
-
-### `status`
-
-1. Read `.claude/state/wb-dev.json`. If missing → "no state file; servers not tracked".
-2. For each PID (root + listener) use `tasklist //FI "PID eq <pid>" 2>NUL | grep -q "<pid>"` to test liveness. On POSIX fall back to `kill -0 <pid>`.
-3. Report a table:
-   ```
-   Kestrel  root      (pid 111)  alive   since 2026-04-23T10:42:15+02:00
-   Kestrel  listener  (pid 222)  alive   bound :5200
-   Vite     root      (pid 333)  alive
-   Vite     listener  (pid 444)  alive   bound :5173
-   ```
-4. Cross-check with `netstat` — if :5200 or :5173 is bound to a **different** PID than the recorded listener, flag state-file staleness (probably a reboot or manual kill).
-
-### `restart`
-
-`stop` → `sleep 1` (let ports release) → `start`.
-
-## Notes
-
-- `dotnet watch` hot-reloads C# changes; Vite HMR handles TypeScript/CSS changes.
-- Vite proxies `/api`, `/openapi.json`, `/swagger`, `/health` to `:5200` — only open `:5173` in the browser.
-- JSON state survives Claude Code session switches.
-- **Stale-PID trap after reboot**: PIDs can be reused. `status` cross-checks the listener PID against netstat; `stop` will blindly kill the recorded PIDs, so run `status` first after a reboot, or delete the state file if suspicious.
-- `.claude/state/` is in `.gitignore`.
+- **Before running Playwright specs / hitting `/api/*` by hand / testing the dev UI** — run `/wb-dev status` first; if nothing is running, `/wb-dev start`. Don't launch `dotnet watch` or `npm run dev` directly; it leaves untracked processes that clash with future `/wb-dev` invocations.
+- **When done** — `/wb-dev stop`. Leaving the servers running between sessions is fine (they hot-reload), but a stale Kestrel will lock `Typhon.Workbench.dll` and break any subsequent `dotnet build tools/Typhon.Workbench`.

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -703,6 +703,20 @@ This means you can jump between issues mid-day without losing your place — eac
 
 ---
 
+### Workbench Dev Server (`wb-dev.ps1`)
+
+A repo-root PowerShell script (`wb-dev.ps1`) starts and stops the Workbench dev stack — Kestrel on `:5200` and Vite on `:5173` — in a single shot. Tracks PIDs in `.claude/state/wb-dev.json` so a follow-up session can stop them even if it didn't start them.
+
+```powershell
+pwsh -NoProfile -Command './wb-dev.ps1 start'    # boot both servers, wait for ports
+pwsh -NoProfile -Command './wb-dev.ps1 status'   # report whether each is listening
+pwsh -NoProfile -Command './wb-dev.ps1 stop'     # tear them down
+```
+
+Equivalent to running `dotnet watch` + `npm run dev` by hand, but tracks the processes properly so a stale Kestrel doesn't lock `Typhon.Workbench.dll` and break the next build. Inside Claude Code, use the `/wb-dev` skill — same script, no manual invocation.
+
+---
+
 ## Developer's Daily Guide
 
 ### Morning Routine

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,32 @@
+<Project>
+
+  <!--
+    Repo-relative source paths in IL via PathMap (per design doc
+    claude/design/observability/10-profiler-source-attribution.md §4.4).
+
+    Effects:
+    - Profiler source-attribution generator captures repo-relative paths
+      ("/_/src/...") instead of absolute build-machine paths.
+    - Stripped paths are smaller in trace files and portable across
+      machines (no leaked developer home-directory paths).
+
+    The /_/ sentinel is the .NET convention. The Workbench client strips
+    it before joining with the user's workspace root.
+  -->
+  <PropertyGroup>
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+    <PathMap>$(MSBuildThisFileDirectory)=/_/</PathMap>
+    <!--
+      Repo root, exposed to source generators via CompilerVisibleProperty below.
+      SourceLocationGenerator uses this to manually rewrite SyntaxTree.FilePath into the
+      repo-relative "/_/..." form (PathMap is applied to PDB / [CallerFilePath] but not to
+      the strings a generator reads from SyntaxTree.FilePath).
+    -->
+    <TyphonRepoRoot>$(MSBuildThisFileDirectory)</TyphonRepoRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="TyphonRepoRoot" />
+  </ItemGroup>
+
+</Project>

--- a/src/Typhon.Engine/Profiler/Events/EcsQueryEvents.cs
+++ b/src/Typhon.Engine/Profiler/Events/EcsQueryEvents.cs
@@ -69,10 +69,11 @@ public ref partial struct EcsQueryAnyEvent
     private EcsQueryScanMode _scanMode;
 
     public readonly int ComputeSize()
-        => EcsQueryEventCodec.ComputeSize(Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask);
+        => EcsQueryEventCodec.ComputeSize(Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => EcsQueryEventCodec.Encode(destination, endTimestamp, TraceEventKind.EcsQueryAny, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, ArchetypeTypeId, _optMask, 0, _scanMode, _found, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, ArchetypeTypeId, _optMask, 0, _scanMode,
+            _found, out bytesWritten, sourceLocationId: Header.SourceLocationId);
 }
 

--- a/src/Typhon.Engine/Profiler/Events/PageCacheEvents.cs
+++ b/src/Typhon.Engine/Profiler/Events/PageCacheEvents.cs
@@ -21,11 +21,12 @@ public ref partial struct PageCacheFetchEvent
     public int FilePageIndex;
 
     public readonly int ComputeSize()
-        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheFetch, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0);
+        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheFetch, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => PageCacheEventCodec.Encode(destination, endTimestamp, TraceEventKind.PageCacheFetch, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, pageCount: 0, optMask: 0, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, pageCount: 0, optMask: 0, out bytesWritten,
+            sourceLocationId: Header.SourceLocationId);
 }
 
 /// <summary>
@@ -39,11 +40,12 @@ public ref partial struct PageCacheDiskReadEvent
     public int FilePageIndex;
 
     public readonly int ComputeSize()
-        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheDiskRead, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0);
+        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheDiskRead, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => PageCacheEventCodec.Encode(destination, endTimestamp, TraceEventKind.PageCacheDiskRead, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, pageCount: 0, optMask: 0, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, pageCount: 0, optMask: 0, out bytesWritten,
+            sourceLocationId: Header.SourceLocationId);
 }
 
 [TraceEvent(TraceEventKind.PageCacheDiskWrite, Codec = typeof(PageCacheEventCodec))]
@@ -56,11 +58,12 @@ public ref partial struct PageCacheDiskWriteEvent
     private int _pageCount;
 
     public readonly int ComputeSize()
-        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheDiskWrite, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask);
+        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheDiskWrite, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => PageCacheEventCodec.Encode(destination, endTimestamp, TraceEventKind.PageCacheDiskWrite, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, _pageCount, _optMask, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, _pageCount, _optMask, out bytesWritten,
+            sourceLocationId: Header.SourceLocationId);
 }
 
 [TraceEvent(TraceEventKind.PageCacheAllocatePage)]
@@ -70,11 +73,12 @@ public ref partial struct PageCacheAllocatePageEvent
     public int FilePageIndex;
 
     public readonly int ComputeSize()
-        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheAllocatePage, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0);
+        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheAllocatePage, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => PageCacheEventCodec.Encode(destination, endTimestamp, TraceEventKind.PageCacheAllocatePage, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, pageCount: 0, optMask: 0, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, FilePageIndex, pageCount: 0, optMask: 0, out bytesWritten,
+            sourceLocationId: Header.SourceLocationId);
 }
 
 /// <summary>
@@ -103,12 +107,13 @@ public ref partial struct PageCacheFlushEvent
     public int PageCount;
 
     public readonly int ComputeSize()
-        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheFlush, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0);
+        => PageCacheEventCodec.ComputeSize(TraceEventKind.PageCacheFlush, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, 0, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         // PageCount intentionally goes into the codec's `filePageIndex` slot — see the <remarks> on this struct.
         => PageCacheEventCodec.Encode(destination, endTimestamp, TraceEventKind.PageCacheFlush, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, filePageIndex: PageCount, pageCount: 0, optMask: 0, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, filePageIndex: PageCount, pageCount: 0, optMask: 0, out bytesWritten,
+            sourceLocationId: Header.SourceLocationId);
 }
 
 /// <summary>

--- a/src/Typhon.Engine/Profiler/Events/TraceSpanHeader.cs
+++ b/src/Typhon.Engine/Profiler/Events/TraceSpanHeader.cs
@@ -17,9 +17,10 @@ namespace Typhon.Engine.Profiler;
 /// not eliminate. There is no behavior to encapsulate here — this is data carried between Begin and Dispose.
 /// </para>
 /// <para>
-/// <b>Field order.</b> Fields are declared 8-byte first, 1-byte last so the default sequential layout packs into 49 bytes (six u64/i64 + one
-/// byte) instead of the 56 bytes the natural-reading order would produce (the byte at offset 0 forces 7 bytes of alignment padding). Saves 7
-/// bytes per ref-struct instance on the stack. Wire format is unaffected — the codec methods take individual fields, never the struct as a blob.
+/// <b>Field order.</b> Fields are declared 8-byte first, 2-byte next, 1-byte last so the default sequential layout stays compact. With the
+/// 8-byte fields up front, the trailing <c>SourceLocationId</c> (u16) and <c>ThreadSlot</c> (u8) pack into the tail with 5 bytes of padding to
+/// the next 8-byte alignment — total ~56 bytes vs. the 64 bytes the natural-reading order would produce. Wire format is unaffected — the codec
+/// methods take individual fields, never the struct as a blob.
 /// </para>
 /// </remarks>
 public struct TraceSpanHeader
@@ -41,6 +42,13 @@ public struct TraceSpanHeader
 
     /// <summary>Low 64 bits of the W3C trace context. Zero when no trace context attached.</summary>
     public ulong TraceIdLo;
+
+    /// <summary>
+    /// Compile-time call-site identifier assigned by <c>SourceLocationGenerator</c> via the C# 14 interceptor wrapper. Zero when the call site
+    /// is outside the generator's scope (i.e. anywhere outside <c>Typhon.Engine</c>) or when source attribution is disabled — codecs treat the
+    /// zero value as "no source attribution" and omit the optional 2-byte wire payload. See <c>claude/design/observability/10-profiler-source-attribution.md</c>.
+    /// </summary>
+    public ushort SourceLocationId;
 
     /// <summary>Producer thread slot — index into <c>ThreadSlotRegistry</c>. Set by the <c>BeginX</c> factory.</summary>
     public byte ThreadSlot;

--- a/src/Typhon.Engine/Profiler/Events/TransactionEvents.cs
+++ b/src/Typhon.Engine/Profiler/Events/TransactionEvents.cs
@@ -22,11 +22,12 @@ public ref partial struct TransactionCommitEvent
     [Optional]
     private bool _conflictDetected;
     public readonly int ComputeSize()
-        => TransactionEventCodec.ComputeSize(TraceEventKind.TransactionCommit, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask);
+        => TransactionEventCodec.ComputeSize(TraceEventKind.TransactionCommit, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => TransactionEventCodec.Encode(destination, endTimestamp, TraceEventKind.TransactionCommit, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, 0, _optMask, _componentCount, _conflictDetected, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, 0, _optMask, _componentCount, _conflictDetected, out bytesWritten,
+            sourceLocationId: Header.SourceLocationId);
 }
 
 [TraceEvent(TraceEventKind.TransactionRollback, Codec = typeof(TransactionEventCodec))]
@@ -43,11 +44,12 @@ public ref partial struct TransactionRollbackEvent
     private TransactionRollbackReason _reason;
 
     public readonly int ComputeSize()
-        => TransactionEventCodec.ComputeSize(TraceEventKind.TransactionRollback, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask);
+        => TransactionEventCodec.ComputeSize(TraceEventKind.TransactionRollback, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => TransactionEventCodec.Encode(destination, endTimestamp, TraceEventKind.TransactionRollback, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, 0, _optMask, _componentCount, false, out bytesWritten, _reason);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, 0, _optMask, _componentCount, false, out bytesWritten, _reason,
+            sourceLocationId: Header.SourceLocationId);
 }
 
 [TraceEvent(TraceEventKind.TransactionCommitComponent, Codec = typeof(TransactionEventCodec))]
@@ -63,12 +65,12 @@ public ref partial struct TransactionCommitComponentEvent
     private int _rowCount;
 
     public readonly int ComputeSize()
-        => TransactionEventCodec.ComputeSize(TraceEventKind.TransactionCommitComponent, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask);
+        => TransactionEventCodec.ComputeSize(TraceEventKind.TransactionCommitComponent, Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => TransactionEventCodec.Encode(destination, endTimestamp, TraceEventKind.TransactionCommitComponent, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, ComponentTypeId, _optMask, componentCount: 0, conflictDetected: false, 
-            out bytesWritten, rowCount: _rowCount);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, ComponentTypeId, _optMask, componentCount: 0, conflictDetected: false,
+            out bytesWritten, rowCount: _rowCount, sourceLocationId: Header.SourceLocationId);
 }
 
 /// <summary>
@@ -85,10 +87,11 @@ public ref partial struct TransactionPersistEvent
     [Optional]
     private long _walLsn;
     public readonly int ComputeSize()
-        => TransactionEventCodec.ComputePersistSize(Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask);
+        => TransactionEventCodec.ComputePersistSize(Header.TraceIdHi != 0 || Header.TraceIdLo != 0, _optMask, Header.SourceLocationId);
 
     public readonly void EncodeTo(Span<byte> destination, long endTimestamp, out int bytesWritten)
         => TransactionEventCodec.EncodePersist(destination, endTimestamp, Header.ThreadSlot, Header.StartTimestamp,
-            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, _optMask, _walLsn, out bytesWritten);
+            Header.SpanId, Header.ParentSpanId, Header.TraceIdHi, Header.TraceIdLo, Tsn, _optMask, _walLsn, out bytesWritten,
+            sourceLocationId: Header.SourceLocationId);
 }
 

--- a/src/Typhon.Engine/Profiler/Exporters/FileExporter.cs
+++ b/src/Typhon.Engine/Profiler/Exporters/FileExporter.cs
@@ -25,6 +25,7 @@ public sealed class FileExporter : ResourceNode, IProfilerExporter
     private readonly string _filePath;
     private FileStream _stream;
     private TraceFileWriter _writer;
+    private TraceFileHeader _header;  // stashed at Initialize so Dispose can patch the trailer offsets in
     private bool _disposed;
     private long _batchesProcessed;
     private long _recordsProcessed;
@@ -52,10 +53,13 @@ public sealed class FileExporter : ResourceNode, IProfilerExporter
             throw new ArgumentNullException(nameof(metadata));
         }
 
-        _stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.Read, 64 * 1024);
+        // Open with FileAccess.ReadWrite so Dispose can rewind and patch the header with the trailer
+        // (FileTable + SourceLocationManifest) offsets — see WriteSourceLocationManifestAtClose. ReadAccess
+        // is needed for the seek-back; without it the rewrite throws "Stream does not support reading".
+        _stream = new FileStream(_filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, 64 * 1024);
         _writer = new TraceFileWriter(_stream);
 
-        var header = new TraceFileHeader
+        _header = new TraceFileHeader
         {
             Magic = TraceFileHeader.MagicValue,
             Version = TraceFileHeader.CurrentVersion,
@@ -68,11 +72,38 @@ public sealed class FileExporter : ResourceNode, IProfilerExporter
             ComponentTypeCount = (ushort)metadata.ComponentTypes.Length,
             CreatedUtcTicks = metadata.StartedUtc.Ticks,
             SamplingSessionStartQpc = metadata.SamplingSessionStartQpc,
+            // FileTableOffset + SourceLocationManifestOffset are 0 — patched in WriteSourceLocationManifestAtClose.
         };
-        _writer.WriteHeader(in header);
+        _writer.WriteHeader(in _header);
         _writer.WriteSystemDefinitions(metadata.Systems);
         _writer.WriteArchetypes(metadata.Archetypes);
         _writer.WriteComponentTypes(metadata.ComponentTypes);
+    }
+
+    /// <summary>
+    /// Append the source-location manifest as a trailer section and patch the header offsets in.
+    /// Called from <see cref="Dispose(bool)"/> before the writer is closed. No-op if the generated <c>SourceLocations</c> table is empty (zero attributed
+    /// sites). See claude/design/observability/10-profiler-source-attribution.md §4.6.
+    /// </summary>
+    private void WriteSourceLocationManifestAtClose()
+    {
+        if (_writer == null)
+        {
+            return;
+        }
+        // Merged: compile-time call sites + runtime-resolved system entries (DagScheduler populates
+        // the runtime side at construction). Empty manifests skip the trailer write entirely.
+        var (files, manifest) = RuntimeSourceLocationManifest.BuildMerged();
+        if (files.Length == 0 || manifest.Length == 0)
+        {
+            return;
+        }
+
+        var (fileTableOffset, manifestOffset) = _writer.WriteSourceLocationManifest(files, manifest);
+        _header.FileTableOffset = fileTableOffset;
+        _header.SourceLocationManifestOffset = manifestOffset;
+        _writer.RewriteHeader(in _header);
+        _writer.Flush();
     }
 
     /// <inheritdoc />
@@ -106,6 +137,14 @@ public sealed class FileExporter : ResourceNode, IProfilerExporter
 
         if (disposing)
         {
+            // Append the source-location manifest BEFORE disposing the writer (which closes the stream).
+            // Failures here are non-fatal — the trace stays valid without source attribution.
+            try { WriteSourceLocationManifestAtClose(); }
+            catch
+            {
+                // ignored — trace remains usable, just without source attribution.
+            }
+
             try { _writer?.Dispose(); }
             catch
             {

--- a/src/Typhon.Engine/Profiler/Exporters/TcpExporter.cs
+++ b/src/Typhon.Engine/Profiler/Exporters/TcpExporter.cs
@@ -346,6 +346,19 @@ public sealed class TcpExporter : ResourceNode, IProfilerExporter
                 socket.SendTimeout = 5000;
                 socket.Send(frameBuffer);
 
+                // #302 Phase 4: send the FileTable + SourceLocationManifest frames once during the init handshake.
+                // No-op when the generated SourceLocations table is empty (zero attributed sites).
+                // Sent BEFORE the catch-up block so the client has the manifest by the time spans start arriving.
+                var (fileTableFrame, slManifestFrame) = BuildSourceLocationFrames();
+                if (fileTableFrame != null)
+                {
+                    socket.Send(fileTableFrame);
+                }
+                if (slManifestFrame != null)
+                {
+                    socket.Send(slManifestFrame);
+                }
+
                 // Before switching to non-blocking (and before exposing _client to ProcessBatch), send a catch-up Block frame
                 // carrying a synthetic ThreadInfo record for every currently-claimed slot. Without this, mid-session live
                 // connections never see the one-shot ThreadInfo records emitted when each worker claimed its slot — those
@@ -376,6 +389,70 @@ public sealed class TcpExporter : ResourceNode, IProfilerExporter
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// #302 Phase 4: build the optional FileTable + SourceLocationManifest frames sent during the init handshake.
+    /// Returns (null, null) when the generated <c>SourceLocations</c> table is empty (zero attributed sites).
+    /// Each frame's payload mirrors the corresponding <c>.typhon-trace</c> trailer section MINUS the magic constants (the LiveFrameType byte already identifies
+    /// the section). See claude/design/observability/10-profiler-source-attribution.md §4.7.
+    /// </summary>
+    private static (byte[] FileTableFrame, byte[] ManifestFrame) BuildSourceLocationFrames()
+    {
+        // Merged manifest: compile-time call sites + runtime-resolved system entries from
+        // RuntimeSourceLocationManifest (populated by DagScheduler's constructor).
+        var (files, entries) = RuntimeSourceLocationManifest.BuildMerged();
+        if (files.Length == 0 || entries.Length == 0)
+        {
+            return (null, null);
+        }
+
+        // FileTable frame payload: [u32 entryCount][per entry: u16 fileId, u16 pathLen, UTF-8 bytes]
+        byte[] fileTableFrame;
+        using (var ms = new MemoryStream())
+        using (var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: false))
+        {
+            bw.Write((uint)files.Length);
+            for (ushort i = 0; i < files.Length; i++)
+            {
+                bw.Write(i);
+                var bytes = Encoding.UTF8.GetBytes(files[i] ?? string.Empty);
+                var len = (ushort)Math.Min(bytes.Length, ushort.MaxValue);
+                bw.Write(len);
+                bw.Write(bytes, 0, len);
+            }
+            bw.Flush();
+            var payload = ms.ToArray();
+            fileTableFrame = new byte[LiveStreamProtocol.FrameHeaderSize + payload.Length];
+            LiveStreamProtocol.WriteFrameHeader(fileTableFrame.AsSpan(), LiveFrameType.FileTable, payload.Length);
+            payload.CopyTo(fileTableFrame.AsSpan(LiveStreamProtocol.FrameHeaderSize));
+        }
+
+        // SourceLocationManifest frame payload: [u32 entryCount][per entry: u16 id, u16 fileId, u32 line, u8 kind, u8 methodLen, UTF-8 method bytes]
+        byte[] manifestFrame;
+        using (var ms = new MemoryStream())
+        using (var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: false))
+        {
+            bw.Write((uint)entries.Length);
+            foreach (var e in entries)
+            {
+                bw.Write(e.Id);
+                bw.Write(e.FileId);
+                bw.Write(e.Line);
+                bw.Write(e.Kind);
+                var bytes = Encoding.UTF8.GetBytes(e.Method ?? string.Empty);
+                var len = (byte)Math.Min(bytes.Length, 255);
+                bw.Write(len);
+                bw.Write(bytes, 0, len);
+            }
+            bw.Flush();
+            var payload = ms.ToArray();
+            manifestFrame = new byte[LiveStreamProtocol.FrameHeaderSize + payload.Length];
+            LiveStreamProtocol.WriteFrameHeader(manifestFrame.AsSpan(), LiveFrameType.SourceLocationManifest, payload.Length);
+            payload.CopyTo(manifestFrame.AsSpan(LiveStreamProtocol.FrameHeaderSize));
+        }
+
+        return (fileTableFrame, manifestFrame);
     }
 
     /// <summary>

--- a/src/Typhon.Engine/Profiler/RuntimeSourceLocationManifest.cs
+++ b/src/Typhon.Engine/Profiler/RuntimeSourceLocationManifest.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Typhon.Profiler;
+
+namespace Typhon.Engine.Profiler;
+
+/// <summary>
+/// Combines the compile-time source-location table emitted by <c>SourceLocationGenerator</c> (call-site attribution for <c>Begin*</c> factories) with
+/// runtime-resolved entries for the scheduler's registered systems (PDB-derived in <see cref="SystemSourceResolver"/>). Exporters — both <c>FileExporter</c>
+/// and <c>TcpExporter</c> — ship the merged manifest so the Workbench can resolve a span <em>and</em> a chunk's system to file:line through one
+/// <c>SourceLocationManifestEntry</c> table.
+/// </summary>
+/// <remarks>
+/// <para>
+/// System entries use synthesized ids in the high half of the <c>ushort</c> space:
+/// <c>id = SystemSourceIdMask | systemIndex</c>. Compile-time ids start at 1 and grow sequentially — they will not reach 0x8000 until ~32K distinct call sites
+/// exist (we have ~hundreds today). This avoids a wire-format extension (a third trailer pointer) and lets the existing <c>useSourceLocationStore</c> on the
+/// client resolve both span and chunk source through one lookup table.
+/// </para>
+/// <para>
+/// File ids: when a system's PDB-resolved file path matches a compile-time entry, the system reuses that file id.
+/// New paths are appended after the compile-time entries.
+/// </para>
+/// <para>
+/// <b>Thread safety:</b> all public methods take <c>_lock</c>. <see cref="SetSystems"/> is called from a single <see cref="DagScheduler"/> construction;
+/// concurrent scheduler builds are theoretical (no production path does this) but the lock makes the rebuild atomic. Readers (<see cref="BuildMerged"/>)
+/// snapshot the merged arrays under the lock and return references — callers must not mutate the returned arrays. The result is memoized;
+/// <see cref="SetSystems"/> invalidates the cache so the next <see cref="BuildMerged"/> rebuilds.
+/// </para>
+/// </remarks>
+public static class RuntimeSourceLocationManifest
+{
+    /// <summary>High bit reserved on <c>SourceLocationManifestEntry.Id</c> to flag a system entry.</summary>
+    private const ushort SystemSourceIdMask = 0x8000;
+
+    /// <summary>Compute the synthetic source-location id for a system's chunk-span source.</summary>
+    private static ushort SystemSourceId(int systemIndex) => (ushort)(SystemSourceIdMask | (systemIndex & 0x7FFF));
+
+    private static readonly Lock Lock = new();
+    private static readonly List<string> RuntimeFiles = [];
+    private static readonly Dictionary<string, ushort> RuntimeFileIds = new(StringComparer.Ordinal);
+    private static readonly List<SourceLocationManifestEntry> SystemEntries = [];
+
+    /// <summary>Memoized merged-manifest snapshot. Invalidated by <see cref="SetSystems"/> / <see cref="Clear"/>.</summary>
+    private static (string[] Files, SourceLocationManifestEntry[] Entries)? CachedMerged;
+
+    /// <summary>
+    /// Replaces the runtime system table with entries derived from the given system definitions.
+    /// Called once per <c>DagScheduler</c> construction. Clears the previous registration so repeat
+    /// scheduler builds (in tests, multi-session hosts) do not accumulate stale entries.
+    /// </summary>
+    public static void SetSystems(IReadOnlyList<SystemDefinition> systems)
+    {
+        if (systems == null) return;
+        lock (Lock)
+        {
+            RuntimeFiles.Clear();
+            RuntimeFileIds.Clear();
+            SystemEntries.Clear();
+            CachedMerged = null;
+
+            foreach (var sys in systems)
+            {
+                if (string.IsNullOrEmpty(sys?.SourceFilePath) || sys.SourceLine <= 0)
+                {
+                    continue;
+                }
+                var fileId = InternFile(sys.SourceFilePath);
+                SystemEntries.Add(new SourceLocationManifestEntry(SystemSourceId(sys.Index), fileId, (uint)sys.SourceLine, 0, sys.SourceMethod ?? sys.Name ?? string.Empty));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resets the runtime table. Intended for tests — production paths use <see cref="SetSystems"/>
+    /// which already clears before re-registering.
+    /// </summary>
+    public static void Clear()
+    {
+        lock (Lock)
+        {
+            RuntimeFiles.Clear();
+            RuntimeFileIds.Clear();
+            SystemEntries.Clear();
+            CachedMerged = null;
+        }
+    }
+
+    /// <summary>
+    /// Builds the merged file table + manifest entries for export. Compile-time entries come first
+    /// to preserve the file-id contract used by <c>SourceLocations.All</c> (its <c>FileId</c> values
+    /// are indices into the compile-time files array).
+    /// </summary>
+    public static (string[] Files, SourceLocationManifestEntry[] Entries) BuildMerged()
+    {
+        lock (Lock)
+        {
+            if (CachedMerged.HasValue) return CachedMerged.Value;
+
+            var compileFiles = Generated.SourceLocations.Files ?? [];
+            var compileEntries = Generated.SourceLocations.All ?? [];
+
+            var files = new string[compileFiles.Length + RuntimeFiles.Count];
+            Array.Copy(compileFiles, files, compileFiles.Length);
+            for (var i = 0; i < RuntimeFiles.Count; i++)
+            {
+                files[compileFiles.Length + i] = RuntimeFiles[i];
+            }
+
+            var entries = new SourceLocationManifestEntry[compileEntries.Length + SystemEntries.Count];
+            for (var i = 0; i < compileEntries.Length; i++)
+            {
+                var e = compileEntries[i];
+                entries[i] = new SourceLocationManifestEntry(e.Id, e.FileId, (uint)e.Line, e.KindByte, e.Method ?? string.Empty);
+            }
+            for (var i = 0; i < SystemEntries.Count; i++)
+            {
+                entries[compileEntries.Length + i] = SystemEntries[i];
+            }
+            CachedMerged = (files, entries);
+            return CachedMerged.Value;
+        }
+    }
+
+    private static ushort InternFile(string path)
+    {
+        var compileFiles = Generated.SourceLocations.Files ?? [];
+        for (ushort i = 0; i < compileFiles.Length; i++)
+        {
+            if (string.Equals(compileFiles[i], path, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+        if (RuntimeFileIds.TryGetValue(path, out var existing))
+        {
+            return existing;
+        }
+        var fileId = (ushort)(compileFiles.Length + RuntimeFiles.Count);
+        RuntimeFiles.Add(path);
+        RuntimeFileIds[path] = fileId;
+        return fileId;
+    }
+}

--- a/src/Typhon.Engine/Profiler/SystemSourceResolver.cs
+++ b/src/Typhon.Engine/Profiler/SystemSourceResolver.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace Typhon.Engine.Profiler;
+
+/// <summary>
+/// Maps a registered system <see cref="Delegate"/> to its source location by reading sequence points from the assembly's portable PDB (#302 system-side
+/// attribution). The resolver is best-effort: when the delegate's assembly is missing a PDB, has only Windows-PDB symbols, or is dynamically generated
+/// the resolver returns <c>null</c> and the system silently has no Source row in the Workbench (same fallback as a span with siteId = 0).
+/// </summary>
+/// <remarks>
+/// We attribute the delegate's <see cref="MethodInfo"/> directly. Method-group references resolve to the user's named method
+/// (e.g. <c>TyphonBridge.MoveAllAnts</c>); lambdas resolve to the compiler-synthesized lambda method, whose first sequence point is the lambda body line —
+/// which is exactly what the user wrote inline at the registration site. Both shapes give a useful "click → see code" target.
+/// </remarks>
+internal static class SystemSourceResolver
+{
+    /// <summary>
+    /// Per-module cache of opened PDB providers. Entries are kept for the process lifetime — module identity is process-stable, system-registration assemblies
+    /// are few (typically 1–2 user assemblies + Typhon.Engine), and the underlying file streams must outlive the cache
+    /// (see <see cref="TryOpenPdbForAssemblyFile"/>'s "do not dispose" note). Only successful opens are cached; failures land in <see cref="_pdbMissing"/>
+    /// instead of being represented as null entries here.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Module, MetadataReaderProvider> _pdbCache = new();
+
+    /// <summary>Modules whose PDB lookup has already failed; checked first to avoid retrying.</summary>
+    private static readonly ConcurrentDictionary<Module, bool> _pdbMissing = new();
+
+    /// <summary>
+    /// Resolves the given delegate to <c>(filePath, line, methodName)</c>, or null when the PDB is unavailable or the method has no sequence points (purely
+    /// synthesized methods, native, etc.).
+    /// </summary>
+    public static (string FilePath, int Line, string MethodName)? Resolve(Delegate del)
+    {
+        if (del?.Method == null)
+        {
+            return null;
+        }
+
+        var method = del.Method;
+        var module = method.Module;
+
+        if (_pdbMissing.ContainsKey(module))
+        {
+            return null;
+        }
+
+        if (!_pdbCache.TryGetValue(module, out var provider))
+        {
+            // Open lazily on first miss; only cache successes.
+            // Failures populate _pdbMissing so we never thrash on the slow PDB-search path for the same module twice.
+            provider = OpenPdb(module);
+            if (provider == null)
+            {
+                _pdbMissing[module] = true;
+                return null;
+            }
+            _pdbCache[module] = provider;
+        }
+
+        try
+        {
+            var reader = provider.GetMetadataReader();
+            var handle = MetadataTokens.MethodDefinitionHandle(method.MetadataToken);
+            var debugInfo = reader.GetMethodDebugInformation(handle);
+            if (debugInfo.Document.IsNil && debugInfo.SequencePointsBlob.IsNil)
+            {
+                return null;
+            }
+
+            // First non-hidden sequence point — that's the method body's first executable line, which is what the user wants to navigate to
+            // (matches what F12-Go-To-Definition does in IDEs).
+            foreach (var sp in debugInfo.GetSequencePoints())
+            {
+                if (sp.IsHidden)
+                {
+                    continue;
+                }
+                var doc = reader.GetDocument(sp.Document);
+                var path = reader.GetString(doc.Name);
+                return (path, sp.StartLine, method.Name);
+            }
+        }
+        catch
+        {
+            // PDB read failures are non-fatal: a system without source attribution falls back to the
+            // existing "no Source row" UX rather than crashing the engine.
+        }
+        return null;
+    }
+
+    private static MetadataReaderProvider OpenPdb(Module module)
+    {
+        // Fast path: standard dotnet hosts publish a real path via Assembly.Location or Module.FullyQualifiedName. Try those first.
+        var asmPath = module.Assembly?.Location;
+        if (string.IsNullOrEmpty(asmPath) || !File.Exists(asmPath))
+        {
+            asmPath = module.FullyQualifiedName;
+        }
+        if (!string.IsNullOrEmpty(asmPath) && File.Exists(asmPath))
+        {
+            var fast = TryOpenPdbForAssemblyFile(asmPath);
+            if (fast != null)
+            {
+                return fast;
+            }
+        }
+
+        // Slow path: Godot mono (and a few other hosts) report "<Unknown>" for both paths. Search the filesystem for an assembly whose AssemblyDefinition
+        // matches the loaded module's name and version. The first match yields the PE file whose associated PDB we want.
+        return SearchPdbByAssemblyName(module);
+    }
+
+    private static MetadataReaderProvider TryOpenPdbForAssemblyFile(string asmPath)
+    {
+        try
+        {
+            var stream = File.Open(asmPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var peReader = new PEReader(stream);
+            if (peReader.TryOpenAssociatedPortablePdb(asmPath, OpenPdbStream, out var pdbProvider, out _))
+            {
+                // peReader is intentionally not disposed — disposing tears down the underlying stream that pdbProvider is mapped over. One PEReader per
+                // assembly for process lifetime; cache misses are rare (one per system delegate's assembly).
+                return pdbProvider;
+            }
+            peReader.Dispose();
+            stream.Dispose();
+        }
+        catch
+        {
+            // Fall through to "no PDB" — assembly is unreadable or PDB is malformed.
+        }
+        return null;
+    }
+
+    private static MetadataReaderProvider SearchPdbByAssemblyName(Module module)
+    {
+        var asmName = module.Assembly?.GetName();
+        if (string.IsNullOrEmpty(asmName.Name))
+        {
+            return null;
+        }
+        var targetName = asmName.Name;
+        var targetVersion = asmName.Version;
+
+        var seen = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var root in GetSearchRoots())
+        {
+            if (string.IsNullOrEmpty(root) || !seen.Add(root) || !Directory.Exists(root))
+            {
+                continue;
+            }
+
+            System.Collections.Generic.IEnumerable<string> candidates;
+            try
+            {
+                candidates = Directory.EnumerateFiles(root, $"{targetName}.dll", SearchOption.AllDirectories);
+            }
+            catch
+            {
+                continue;
+            }
+            var checkedCount = 0;
+            foreach (var dllPath in candidates)
+            {
+                if (++checkedCount > 50)
+                {
+                    break; // sanity cap; typical projects have <5 candidates.
+                }
+
+                if (!IsAssemblyMatch(dllPath, targetName, targetVersion))
+                {
+                    continue;
+                }
+
+                var found = TryOpenPdbForAssemblyFile(dllPath);
+                if (found != null)
+                {
+                    return found;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static bool IsAssemblyMatch(string dllPath, string expectedName, Version expectedVersion)
+    {
+        try
+        {
+            using var stream = File.Open(dllPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var pe = new PEReader(stream);
+            if (!pe.HasMetadata)
+            {
+                return false;
+            }
+
+            var mr = pe.GetMetadataReader();
+            var def = mr.GetAssemblyDefinition();
+            var defName = mr.GetString(def.Name);
+            if (!string.Equals(defName, expectedName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return expectedVersion == null || def.Version == expectedVersion;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> GetSearchRoots()
+    {
+        var custom = Environment.GetEnvironmentVariable("TYPHON_PDB_SEARCH_PATHS");
+        if (!string.IsNullOrEmpty(custom))
+        {
+            foreach (var p in custom.Split(';', StringSplitOptions.RemoveEmptyEntries))
+            {
+                yield return p;
+            }
+        }
+        yield return Environment.CurrentDirectory;
+        yield return AppDomain.CurrentDomain.BaseDirectory;
+    }
+
+    private static Stream OpenPdbStream(string pdbPath)
+    {
+        try
+        {
+            return File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Typhon.Engine/Profiler/TyphonEvent.cs
+++ b/src/Typhon.Engine/Profiler/TyphonEvent.cs
@@ -306,7 +306,7 @@ public static partial class TyphonEvent
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static TraceSpanHeader MakeHeader(int slotIdx, long startTs, ulong spanId, ulong parentSpanId, ulong previousSpanId,
-        ulong traceIdHi, ulong traceIdLo)
+        ulong traceIdHi, ulong traceIdLo, ushort siteId)
         => new()
         {
             ThreadSlot = (byte)slotIdx,
@@ -316,6 +316,7 @@ public static partial class TyphonEvent
             PreviousSpanId = previousSpanId,
             TraceIdHi = traceIdHi,
             TraceIdLo = traceIdLo,
+            SourceLocationId = siteId,
         };
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/Typhon.Engine/Runtime/DagBuilder.cs
+++ b/src/Typhon.Engine/Runtime/DagBuilder.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
+using Typhon.Engine.Profiler;
 
 namespace Typhon.Engine;
 
@@ -37,6 +38,7 @@ public sealed class DagBuilder
 
         var idx = _systems.Count;
         _nameToIndex[name] = idx;
+        var src = SystemSourceResolver.Resolve(action);
         _systems.Add(new SystemDefinition
         {
             Name = name,
@@ -45,7 +47,10 @@ public sealed class DagBuilder
             Priority = priority,
             CallbackAction = action,
             RunIf = runIf,
-            TotalChunks = 1
+            TotalChunks = 1,
+            SourceFilePath = src?.FilePath,
+            SourceLine = src?.Line ?? 0,
+            SourceMethod = src?.MethodName
         });
         return this;
     }
@@ -69,6 +74,7 @@ public sealed class DagBuilder
 
         var idx = _systems.Count;
         _nameToIndex[name] = idx;
+        var src = SystemSourceResolver.Resolve(action);
         _systems.Add(new SystemDefinition
         {
             Name = name,
@@ -77,7 +83,10 @@ public sealed class DagBuilder
             Priority = priority,
             CallbackAction = action,
             RunIf = runIf,
-            TotalChunks = 1
+            TotalChunks = 1,
+            SourceFilePath = src?.FilePath,
+            SourceLine = src?.Line ?? 0,
+            SourceMethod = src?.MethodName
         });
         return this;
     }
@@ -107,6 +116,7 @@ public sealed class DagBuilder
 
         var idx = _systems.Count;
         _nameToIndex[name] = idx;
+        var src = SystemSourceResolver.Resolve(chunkAction);
         _systems.Add(new SystemDefinition
         {
             Name = name,
@@ -115,7 +125,10 @@ public sealed class DagBuilder
             Priority = priority,
             PipelineChunkAction = chunkAction,
             RunIf = runIf,
-            TotalChunks = totalChunks
+            TotalChunks = totalChunks,
+            SourceFilePath = src?.FilePath,
+            SourceLine = src?.Line ?? 0,
+            SourceMethod = src?.MethodName
         });
         return this;
     }
@@ -149,7 +162,7 @@ public sealed class DagBuilder
     /// <exception cref="InvalidOperationException">The graph contains a cycle.</exception>
     public (SystemDefinition[] Systems, int[] TopologicalOrder) Build()
     {
-        var graphSpan = Profiler.TyphonEvent.BeginSchedulerGraphBuild();
+        var graphSpan = TyphonEvent.BeginSchedulerGraphBuild();
         try
         {
             return BuildCore(ref graphSpan);
@@ -160,7 +173,7 @@ public sealed class DagBuilder
         }
     }
 
-    private (SystemDefinition[] Systems, int[] TopologicalOrder) BuildCore(ref Profiler.SchedulerGraphBuildEvent graphSpan)
+    private (SystemDefinition[] Systems, int[] TopologicalOrder) BuildCore(ref SchedulerGraphBuildEvent graphSpan)
     {
         var count = _systems.Count;
         if (count == 0)

--- a/src/Typhon.Engine/Runtime/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.cs
@@ -259,6 +259,10 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         ArgumentNullException.ThrowIfNull(options);
 
         Systems = systems;
+        // #302: register PDB-resolved system source locations into the runtime manifest so the
+        // exporters (FileExporter / TcpExporter) ship them alongside the compile-time call-site
+        // attribution. Synthetic ids = 0x8000 | systemIndex distinguish system entries from spans.
+        RuntimeSourceLocationManifest.SetSystems(systems);
         _topologicalOrder = topologicalOrder;
         _systemCount = systems.Length;
         _options = options;

--- a/src/Typhon.Engine/Runtime/SystemDefinition.cs
+++ b/src/Typhon.Engine/Runtime/SystemDefinition.cs
@@ -58,6 +58,23 @@ public sealed class SystemDefinition
     public Action<int, int> PipelineChunkAction { get; init; }
 
     // ═══════════════════════════════════════════════════════════════
+    // Source attribution (#302 — system-side via PDB sequence points)
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Repo-relative or absolute path to the source file declaring this system's entry method.
+    /// Resolved from the delegate's PDB at <see cref="DagBuilder"/> registration. Empty/null when
+    /// no PDB was available — the Workbench falls back to "no Source row" for the chunk.
+    /// </summary>
+    public string SourceFilePath { get; init; }
+
+    /// <summary>1-based line number of the entry method's first sequence point. 0 when not resolved.</summary>
+    public int SourceLine { get; init; }
+
+    /// <summary>Containing-method short name (e.g. <c>MoveAllAnts</c>) for display in the Source row.</summary>
+    public string SourceMethod { get; init; }
+
+    // ═══════════════════════════════════════════════════════════════
     // DAG structure (set by DagBuilder.Build)
     // ═══════════════════════════════════════════════════════════════
 

--- a/src/Typhon.Engine/Typhon.Engine.csproj
+++ b/src/Typhon.Engine/Typhon.Engine.csproj
@@ -5,6 +5,14 @@
         <Configurations>Debug;Release</Configurations>
         <Platforms>AnyCPU</Platforms>
         <LangVersion>default</LangVersion>
+        <!--
+            #302 — opt in the Typhon.Generators.Generated namespace for C# 14 [InterceptsLocation] attributes.
+            SourceLocationGenerator emits per-call-site interceptor wrappers that redirect TyphonEvent.Begin*
+            calls to the matching Begin*_WithSiteId overload, baking the literal ushort siteId into the IL.
+            Engine-only scope by design (the generator gates on AssemblyName == "Typhon.Engine"); other
+            consumers fall through to siteId = 0 ("unknown source"). See claude/design/observability/10-profiler-source-attribution.md §4.4.
+        -->
+        <InterceptorsNamespaces>$(InterceptorsNamespaces);Typhon.Generators.Generated</InterceptorsNamespaces>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Typhon.Generators/SourceLocationGenerator.cs
+++ b/src/Typhon.Generators/SourceLocationGenerator.cs
@@ -1,0 +1,592 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Typhon.Generators;
+
+/// <summary>
+/// Source generator that attributes every <c>TyphonEvent.BeginXxx(...)</c> call site to a deterministic <c>ushort</c> id and emits per-call-site
+/// <c>[InterceptsLocation]</c> wrappers that forward to the matching <c>BeginXxxWithSiteId</c> overload, baking the literal id into the IL.
+///
+/// Design: see `claude/design/observability/10-profiler-source-attribution.md`.
+///
+/// Output:
+///   - One generated source unit holding all interceptor methods (file-local class).
+///   - One generated source unit holding the static <c>SourceLocations</c> table (id → file/line/method/kind).
+///
+/// Determinism: discovered call sites are sorted by <c>(filePath, line, column)</c> before id assignment, so every build of the same source produces a
+/// byte-identical generated table.
+///
+/// Scope: factories that have a corresponding <c>BeginXxxWithSiteId</c> overload on <c>TyphonEvent</c> are intercepted. Factories without that overload are
+/// left alone (they fall through to the default zero siteId pass-through path); a build info diagnostic is emitted with attributed/skipped counts so a
+/// regression in coverage is loud.
+/// </summary>
+[Generator(LanguageNames.CSharp)]
+public class SourceLocationGenerator : IIncrementalGenerator
+{
+    private const string TyphonEventFqn = "Typhon.Engine.Profiler.TyphonEvent";
+    private const string GeneratedNamespace = "Typhon.Generators.Generated";
+    private const string TraceEventAttributeFqn = "Typhon.Engine.Profiler.TraceEventAttribute";
+    private const string BeginParamAttributeFqn = "Typhon.Engine.Profiler.BeginParamAttribute";
+    
+    /// <summary>
+    /// Per design Q3 (claude/design/observability/10-profiler-source-attribution.md §4.1): the generator's interceptor scope is Typhon.Engine *only*.
+    /// Other consumers (tests, tools) pay through siteId=0 ("unknown source"). The SourceLocations table is also engine-only; tests can read it via the
+    /// engine's assembly.
+    /// </summary>
+    private const string TargetAssemblyName = "Typhon.Engine";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Repo root from MSBuild — used to rewrite absolute paths to "/_/..." form (matches the design's
+        // PathMap convention; the C# compiler's PathMap doesn't affect SyntaxTree.FilePath, so we do it here).
+        var repoRoot = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) => 
+            provider.GlobalOptions.TryGetValue("build_property.TyphonRepoRoot", out var v) ? v : "");
+
+        // v2 (#302) — factory metadata pipeline.
+        //
+        // Roslyn's parallel generator pipeline doesn't expose other generators' emitted methods to a generator's SemanticModel. So when SourceLocationGenerator
+        // runs against TyphonEvent.BeginXxx call sites, the GetSymbolInfo on the invocation returns null (TraceEventGenerator's BeginXxx + BeginXxx_WithSiteId
+        // factories aren't visible yet). To recover the factory signatures (return type + parameter types) we duplicate TraceEventGenerator's discovery:
+        // enumerate every [TraceEvent]-attributed partial struct, extract the kindName/factoryName + the [BeginParam] field types, and build a map keyed by
+        // factory name. The map gives the interceptor emission step the exact signature it needs.
+        //
+        // Hand-written factories (with visible symbols on TyphonEvent) are picked up too — the symbol-based path stays as a fallback for those.
+        var factoryMap = context.SyntaxProvider.ForAttributeWithMetadataName(
+            TraceEventAttributeFqn, static (node, _) => node is StructDeclarationSyntax, ExtractFactoryMetadata
+        ).Where(static f => f != null).Collect();
+
+        // Discover candidate invocations: any TyphonEvent.BeginXxx(...) call. Returns the call-site syntax info
+        // without inferring parameter types (those come from the factory map, joined later).
+        var candidates = context.SyntaxProvider.CreateSyntaxProvider(
+            static (node, _) => IsCandidateInvocation(node), TryExtractCallSiteRaw
+        ).Where(static c => c != null).Collect();
+
+        var assemblyName = context.CompilationProvider.Select(static (compilation, _) => compilation.AssemblyName ?? "");
+
+        var combined = candidates.Combine(factoryMap).Combine(assemblyName).Combine(repoRoot);
+
+        context.RegisterSourceOutput(combined, static (spc, input) =>
+        {
+            var (((sites, factories), asmName), repoRootValue) = input;
+            if (asmName != TargetAssemblyName)
+            {
+                return;
+            }
+            EmitOutputs(spc, sites, factories, repoRootValue);
+        });
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Factory metadata: enumerate [TraceEvent] partial structs and capture
+    // factory name + parameter list (from the struct's [BeginParam] fields).
+    // ───────────────────────────────────────────────────────────────────────
+
+    private sealed class FactoryInfo
+    {
+        public string FactoryName { get; }
+        public string ReturnTypeFqn { get; }
+        public ImmutableArray<ParamInfo> Parameters { get; }
+        public FactoryInfo(string factoryName, string returnTypeFqn, ImmutableArray<ParamInfo> parameters)
+        {
+            FactoryName = factoryName;
+            ReturnTypeFqn = returnTypeFqn;
+            Parameters = parameters;
+        }
+    }
+
+    private static FactoryInfo ExtractFactoryMetadata(GeneratorAttributeSyntaxContext ctx, CancellationToken ct)
+    {
+        if (ctx.TargetSymbol is not INamedTypeSymbol structSymbol)
+        {
+            return null;
+        }
+        var attr = ctx.Attributes.FirstOrDefault();
+        if (attr == null || attr.ConstructorArguments.Length < 1)
+        {
+            return null;
+        }
+
+        // Resolve kind name from the enum constant — used to derive the default factory name (Begin + kindName).
+        var kindArg = attr.ConstructorArguments[0];
+        string kindName = null;
+        if (kindArg.Type is INamedTypeSymbol enumType && enumType.TypeKind == TypeKind.Enum && kindArg.Value != null)
+        {
+            long ordinal = System.Convert.ToInt64(kindArg.Value);
+            foreach (var m in enumType.GetMembers())
+            {
+                if (m is IFieldSymbol fs && fs.IsConst && fs.HasConstantValue && fs.ConstantValue != null
+                    && System.Convert.ToInt64(fs.ConstantValue) == ordinal)
+                {
+                    kindName = fs.Name;
+                    break;
+                }
+            }
+        }
+        if (kindName == null)
+        {
+            return null;
+        }
+
+        // Named args: FactoryName override, GenerateFactory off-switch.
+        string factoryName = "Begin" + kindName;
+        bool generateFactory = true;
+        foreach (var named in attr.NamedArguments)
+        {
+            if (named.Key == "FactoryName" && named.Value.Value is string fn && !string.IsNullOrEmpty(fn))
+            {
+                factoryName = fn;
+            }
+            else if (named.Key == "GenerateFactory" && named.Value.Value is bool gf)
+            {
+                generateFactory = gf;
+            }
+        }
+        if (!generateFactory)
+        {
+            return null;
+        }
+
+        // Walk fields to find [BeginParam]-attributed ones — these are the factory's parameter list.
+        var paramsBuilder = ImmutableArray.CreateBuilder<ParamInfo>();
+        foreach (var member in structSymbol.GetMembers())
+        {
+            if (member is not IFieldSymbol field)
+            {
+                continue;
+            }
+            AttributeData beginParamAttr = null;
+            foreach (var a in field.GetAttributes())
+            {
+                if (a.AttributeClass?.ToDisplayString() == BeginParamAttributeFqn)
+                {
+                    beginParamAttr = a;
+                    break;
+                }
+            }
+            if (beginParamAttr == null)
+            {
+                continue;
+            }
+            // Per [BeginParam(ParamType = ...)] override or default to field's declared type.
+            string paramTypeFqn = field.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            foreach (var na in beginParamAttr.NamedArguments)
+            {
+                if (na.Key == "ParamType" && na.Value.Value is string ptOverride && !string.IsNullOrEmpty(ptOverride))
+                {
+                    // Resolve unqualified override names to a fully-qualified form via the compilation —
+                    // the interceptor file is `file static class` and doesn't have user usings, so unqualified
+                    // type names won't compile. Try the user-provided name first; if not found, leave as-is.
+                    var resolved = ctx.SemanticModel.Compilation.GetTypeByMetadataName(ptOverride);
+                    if (resolved == null && !ptOverride.Contains('.'))
+                    {
+                        // Common case: short name in Typhon.Profiler. Try that namespace before giving up.
+                        resolved = ctx.SemanticModel.Compilation.GetTypeByMetadataName("Typhon.Profiler." + ptOverride);
+                    }
+                    paramTypeFqn = resolved?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? ptOverride;
+                }
+            }
+            // Match TraceEventGenerator's parameter-name derivation: lowercase first char.
+            string paramName = field.Name.Length > 0 ? char.ToLowerInvariant(field.Name[0]) + field.Name.Substring(1) : field.Name;
+            paramsBuilder.Add(new ParamInfo(paramTypeFqn, paramName));
+        }
+
+        var returnTypeFqn = "global::" + structSymbol.ContainingNamespace.ToDisplayString() + "." + structSymbol.Name;
+        return new FactoryInfo(factoryName, returnTypeFqn, paramsBuilder.ToImmutable());
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Discovery
+    // ───────────────────────────────────────────────────────────────────────
+
+    private static bool IsCandidateInvocation(SyntaxNode node)
+    {
+        if (node is not InvocationExpressionSyntax invocation)
+        {
+            return false;
+        }
+        // Cheap textual prefilter — `TyphonEvent.Begin*(...)` appears as MemberAccess `<expr>.BeginXxx`.
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+        return memberAccess.Name.Identifier.Text.StartsWith("Begin", StringComparison.Ordinal);
+    }
+
+    private sealed class CallSite
+    {
+        public InterceptableLocation Location { get; }
+        public string BaseName { get; }
+        public string ReturnTypeFqn { get; }
+        public ImmutableArray<ParamInfo> Parameters { get; }
+        public string FilePath { get; }
+        public int Line { get; }
+        public int Column { get; }
+        public string MethodName { get; }
+
+        public CallSite(
+            InterceptableLocation location,
+            string baseName,
+            string returnTypeFqn,
+            ImmutableArray<ParamInfo> parameters,
+            string filePath,
+            int line,
+            int column,
+            string methodName)
+        {
+            Location = location;
+            BaseName = baseName;
+            ReturnTypeFqn = returnTypeFqn;
+            Parameters = parameters;
+            FilePath = filePath;
+            Line = line;
+            Column = column;
+            MethodName = methodName;
+        }
+    }
+
+    private readonly struct ParamInfo
+    {
+        public string TypeFqn { get; }
+        public string Name { get; }
+        public ParamInfo(string typeFqn, string name)
+        {
+            TypeFqn = typeFqn;
+            Name = name;
+        }
+    }
+
+    /// <summary>
+    /// v2 (#302): syntax-only call-site extraction. The factory's actual signature (return type + parameter
+    /// types) is supplied by the factory map joined later — see the Initialize pipeline. Don't depend on
+    /// GetSymbolInfo here because TraceEventGenerator's emitted methods may not be visible yet (parallel-
+    /// generator design).
+    /// </summary>
+    private static CallSite TryExtractCallSiteRaw(GeneratorSyntaxContext ctx, CancellationToken ct)
+    {
+        var invocation = (InvocationExpressionSyntax)ctx.Node;
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return null;
+        }
+
+        // Receiver check — accept "TyphonEvent" or fully-qualified forms.
+        var receiverText = memberAccess.Expression.ToString();
+        if (receiverText != "TyphonEvent"
+            && receiverText != "Typhon.Engine.Profiler.TyphonEvent"
+            && receiverText != "global::Typhon.Engine.Profiler.TyphonEvent")
+        {
+            return null;
+        }
+
+        var methodNameText = memberAccess.Name.Identifier.Text;
+        if (!methodNameText.StartsWith("Begin", StringComparison.Ordinal))
+        {
+            return null;
+        }
+        if (methodNameText.EndsWith("_WithSiteId", StringComparison.Ordinal))
+        {
+            return null;
+        }
+        // Hand-written internal emitters (private TLS-stash pattern, not user-callable factories) — they
+        // pay siteId = 0 by design. Detected by syntactic naming convention.
+        if (methodNameText.EndsWith("Tls", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var location = ctx.SemanticModel.GetInterceptableLocation(invocation, ct);
+        if (location == null)
+        {
+            return null;
+        }
+
+        var enclosingMethod = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        var methodName = enclosingMethod?.Identifier.Text ?? "<unknown>";
+
+        var span = invocation.GetLocation().GetLineSpan();
+
+        return new CallSite(
+            location,
+            methodNameText,
+            "", // filled in by EmitOutputs from the factory map
+            ImmutableArray<ParamInfo>.Empty, // ditto
+            span.Path ?? "<unknown>",
+            span.StartLinePosition.Line + 1,
+            span.StartLinePosition.Character + 1,
+            methodName);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Emit
+    // ───────────────────────────────────────────────────────────────────────
+
+    private static void EmitOutputs(SourceProductionContext spc, ImmutableArray<CallSite> sites, ImmutableArray<FactoryInfo> factories, string repoRoot)
+    {
+        if (sites.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        // Build a lookup: factory name → FactoryInfo. The factory metadata comes from enumerating
+        // [TraceEvent] partial structs (a separate pipeline step) — its content is independent of generator
+        // ordering, so we always have correct signatures even when TraceEventGenerator hasn't run yet.
+        var factoryByName = new Dictionary<string, FactoryInfo>(StringComparer.Ordinal);
+        if (!factories.IsDefaultOrEmpty)
+        {
+            foreach (var f in factories)
+            {
+                if (f != null)
+                {
+                    factoryByName[f.FactoryName] = f;
+                }
+            }
+        }
+
+        var attributable = new List<CallSite>(sites.Length);
+        var skippedCount = 0;
+        foreach (var site in sites)
+        {
+            if (site == null)
+            {
+                continue;
+            }
+            // Look up the factory metadata; skip if not found (likely a hand-written factory we don't know about).
+            // Skipping is safe — the call site falls through to siteId = 0.
+            if (!factoryByName.TryGetValue(site.BaseName, out var factory))
+            {
+                skippedCount++;
+                continue;
+            }
+            // Replace the empty signature with the factory's actual signature.
+            var enriched = new CallSite(site.Location, site.BaseName, factory.ReturnTypeFqn, factory.Parameters, site.FilePath, site.Line, site.Column, site.MethodName);
+            attributable.Add(NormalizeFilePath(enriched, repoRoot));
+        }
+
+        // Deterministic order: sort by (filePath, line, column).
+        attributable.Sort((a, b) =>
+        {
+            var c = string.CompareOrdinal(a.FilePath, b.FilePath);
+            if (c != 0) return c;
+            c = a.Line.CompareTo(b.Line);
+            if (c != 0) return c;
+            return a.Column.CompareTo(b.Column);
+        });
+
+        // Cap enforcement: ushort max is 65535, id 0 is reserved for "unknown source".
+        if (attributable.Count > 65535)
+        {
+            spc.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    "TPH9002",
+                    "Too many TyphonEvent emission sites",
+                    $"SourceLocationGenerator: {attributable.Count} sites exceed the 65535 ushort cap; id width must be widened.",
+                    "Typhon.Profiler",
+                    DiagnosticSeverity.Error,
+                    true),
+                Location.None));
+            return;
+        }
+
+        // Emit interceptor file.
+        var interceptorSource = BuildInterceptorSource(attributable);
+        spc.AddSource("SourceLocations.Interceptors.g.cs", interceptorSource);
+
+        // Emit static SourceLocations table.
+        var tableSource = BuildSourceLocationsTable(attributable);
+        spc.AddSource("SourceLocations.g.cs", tableSource);
+
+        // Build-time summary diagnostic — loud if a regression cuts attribution coverage.
+        spc.ReportDiagnostic(Diagnostic.Create(
+            new DiagnosticDescriptor(
+                "TPH9000",
+                "SourceLocationGenerator summary",
+                $"SourceLocationGenerator: {attributable.Count} sites attributed, {skippedCount} skipped (no WithSiteId factory).",
+                "Typhon.Profiler",
+                DiagnosticSeverity.Info,
+                true),
+            Location.None));
+    }
+
+    private static string BuildInterceptorSource(List<CallSite> sites)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/> SourceLocationGenerator — interceptor wrappers.");
+        sb.AppendLine("// Each method redirects a `TyphonEvent.Begin*` call site to the matching `BeginXxxWithSiteId`,");
+        sb.AppendLine("// passing a literal ushort siteId baked into the IL by the C# 14 interceptors feature.");
+        sb.AppendLine("#nullable disable");
+        sb.AppendLine();
+        sb.AppendLine("namespace System.Runtime.CompilerServices");
+        sb.AppendLine("{");
+        sb.AppendLine("    [global::System.AttributeUsage(global::System.AttributeTargets.Method, AllowMultiple = true)]");
+        sb.AppendLine("    file sealed class InterceptsLocationAttribute : global::System.Attribute");
+        sb.AppendLine("    {");
+        sb.AppendLine("        public InterceptsLocationAttribute(int version, string data) { _ = version; _ = data; }");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine($"namespace {GeneratedNamespace}");
+        sb.AppendLine("{");
+        sb.AppendLine("    file static class TyphonEventInterceptors");
+        sb.AppendLine("    {");
+
+        for (int i = 0; i < sites.Count; i++)
+        {
+            var site = sites[i];
+            var siteId = (ushort)(i + 1); // ids start at 1; 0 = unknown.
+
+            // Build the parameter list for the interceptor (must exactly match the original factory's signature).
+            var paramSb = new StringBuilder();
+            for (int p = 0; p < site.Parameters.Length; p++)
+            {
+                if (p > 0) paramSb.Append(", ");
+                paramSb.Append(site.Parameters[p].TypeFqn).Append(' ').Append(site.Parameters[p].Name);
+            }
+            // Build the forwarded argument list for the WithSiteId call: literal siteId, then the param names.
+            var forwardSb = new StringBuilder();
+            forwardSb.Append("0x").Append(siteId.ToString("X4"));
+            foreach (var p in site.Parameters)
+            {
+                forwardSb.Append(", ").Append(p.Name);
+            }
+
+            sb.Append("        ");
+            sb.AppendLine(site.Location.GetInterceptsLocationAttributeSyntax());
+            sb.Append("        [global::System.Runtime.CompilerServices.MethodImpl(")
+              .Append("global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]")
+              .AppendLine();
+            sb.Append("        public static ")
+              .Append(site.ReturnTypeFqn)
+              .Append(" Intercepted_")
+              .Append(site.BaseName)
+              .Append("_0x")
+              .Append(siteId.ToString("X4"))
+              .Append('(')
+              .Append(paramSb)
+              .AppendLine(")");
+            sb.AppendLine("        {");
+            sb.Append("            return global::Typhon.Engine.Profiler.TyphonEvent.")
+              .Append(site.BaseName)
+              .Append("_WithSiteId(")
+              .Append(forwardSb)
+              .AppendLine(");");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string BuildSourceLocationsTable(List<CallSite> sites)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/> SourceLocationGenerator — id → (file, line, method, kind) table.");
+        sb.AppendLine("// Wire-format manifest emitters dump these arrays straight to the trace stream / file / cache.");
+        sb.AppendLine("#nullable disable");
+        sb.AppendLine();
+        sb.AppendLine("namespace Typhon.Engine.Profiler.Generated");
+        sb.AppendLine("{");
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine("    /// Compile-time source-location table built by SourceLocationGenerator.");
+        sb.AppendLine("    /// Indexed by the ushort siteId carried in span records (when SpanFlags bit 1 is set).");
+        sb.AppendLine("    /// Public so wire-format manifest emitters in Typhon.Profiler and tests in Typhon.Engine.Tests can read it.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine("    public static class SourceLocations");
+        sb.AppendLine("    {");
+
+        // File table (string[] indexed by FileId starting at 0).
+        var files = sites.Select(s => s.FilePath).Distinct(StringComparer.Ordinal).OrderBy(s => s, StringComparer.Ordinal).ToList();
+        var fileIdMap = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (int i = 0; i < files.Count; i++)
+        {
+            fileIdMap[files[i]] = i;
+        }
+
+        sb.AppendLine("        public static readonly string[] Files = new string[]");
+        sb.AppendLine("        {");
+        foreach (var f in files)
+        {
+            sb.Append("            ");
+            sb.Append(EncodeStringLiteral(f));
+            sb.AppendLine(",");
+        }
+        sb.AppendLine("        };");
+        sb.AppendLine();
+
+        // Entries: id → (fileId, line, method, kind-byte derived from base name).
+        sb.AppendLine("        public readonly record struct Entry(ushort Id, ushort FileId, int Line, string Method, byte KindByte);");
+        sb.AppendLine();
+        sb.AppendLine("        public static readonly Entry[] All = new Entry[]");
+        sb.AppendLine("        {");
+        for (int i = 0; i < sites.Count; i++)
+        {
+            var site = sites[i];
+            var siteId = (ushort)(i + 1);
+            var fileId = (ushort)fileIdMap[site.FilePath];
+            // KindByte is derived from BaseName: BeginBTreeInsert → "BTreeInsert" → matches enum member name.
+            // We don't reference the enum at gen time (would couple Typhon.Generators to Typhon.Profiler);
+            // we emit the bare name and let a runtime helper resolve to the byte if needed. For v1 we leave
+            // this 0 and rely on the wire's existing kind byte for decoding; the table just carries the name.
+            sb.Append("            new Entry(0x")
+              .Append(siteId.ToString("X4"))
+              .Append(", ")
+              .Append(fileId)
+              .Append(", ")
+              .Append(site.Line)
+              .Append(", ")
+              .Append(EncodeStringLiteral(site.MethodName))
+              .Append(", 0)")
+              .AppendLine(",");
+        }
+        sb.AppendLine("        };");
+
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string EncodeStringLiteral(string value)
+    {
+        if (value == null)
+        {
+            return "null";
+        }
+        // SymbolDisplay covers escaping for both regular and verbatim strings.
+        return SymbolDisplay.FormatLiteral(value, true);
+    }
+
+    /// <summary>
+    /// Rewrite absolute file paths from <c>SyntaxTree.FilePath</c> into the design's repo-relative
+    /// "/_/..." form, using the <c>TyphonRepoRoot</c> MSBuild property as the prefix to strip.
+    /// Backslashes are normalized to forward slashes so the manifest is platform-agnostic.
+    /// If the repo root isn't configured or the path doesn't sit under it, the path is left unchanged.
+    /// </summary>
+    private static CallSite NormalizeFilePath(CallSite site, string repoRoot)
+    {
+        if (string.IsNullOrEmpty(repoRoot))
+        {
+            return site;
+        }
+        var path = site.FilePath;
+        // Tolerate trailing-slash variations and case differences on Windows filesystems.
+        if (path.StartsWith(repoRoot, StringComparison.OrdinalIgnoreCase))
+        {
+            var rel = path.Substring(repoRoot.Length).Replace('\\', '/').TrimStart('/');
+            path = "/_/" + rel;
+        }
+        else
+        {
+            // Already mapped (e.g., compiler PathMap kicked in) or external — only normalize separators.
+            path = path.Replace('\\', '/');
+        }
+        return new CallSite(site.Location, site.BaseName, site.ReturnTypeFqn, site.Parameters, path, site.Line, site.Column, site.MethodName);
+    }
+}

--- a/src/Typhon.Generators/TraceEventGenerator.cs
+++ b/src/Typhon.Generators/TraceEventGenerator.cs
@@ -460,7 +460,8 @@ namespace Typhon.Engine.Profiler
         sb.Append(indent).AppendLine("    public readonly int ComputeSize()");
         sb.Append(indent).AppendLine("    {");
         sb.Append(indent).AppendLine($"        var hasTraceContext = Header.TraceIdHi != 0 || Header.TraceIdLo != 0;");
-        sb.Append(indent).Append("        var size = ").Append(TR).AppendLine(".SpanHeaderSize(hasTraceContext);");
+        sb.Append(indent).AppendLine($"        var hasSourceLocation = Header.SourceLocationId != 0;");
+        sb.Append(indent).Append("        var size = ").Append(TR).AppendLine(".SpanHeaderSize(hasTraceContext, hasSourceLocation);");
         if (requiredPayloadSize > 0)
         {
             sb.Append(indent).Append("        size += ").Append(requiredPayloadSize).AppendLine(";");
@@ -482,21 +483,28 @@ namespace Typhon.Engine.Profiler
         sb.Append(indent).AppendLine("    public readonly void EncodeTo(global::System.Span<byte> destination, long endTimestamp, out int bytesWritten)");
         sb.Append(indent).AppendLine("    {");
         sb.Append(indent).AppendLine("        var hasTraceContext = Header.TraceIdHi != 0 || Header.TraceIdLo != 0;");
+        sb.Append(indent).AppendLine("        var hasSourceLocation = Header.SourceLocationId != 0;");
         sb.Append(indent).AppendLine("        var size = ComputeSize();");
         sb.Append(indent).Append("        ").Append(TR).Append(".WriteCommonHeader(destination, (ushort)size, TraceEventKind.")
             .Append(model.KindName).AppendLine(", Header.ThreadSlot, Header.StartTimestamp);");
-        sb.Append(indent).Append("        var spanFlags = hasTraceContext ? ").Append(TR).AppendLine(".SpanFlagsHasTraceContext : (byte)0;");
+        sb.Append(indent).Append("        var spanFlags = (byte)0;").AppendLine();
+        sb.Append(indent).Append("        if (hasTraceContext) spanFlags |= ").Append(TR).AppendLine(".SpanFlagsHasTraceContext;");
+        sb.Append(indent).Append("        if (hasSourceLocation) spanFlags |= ").Append(TR).AppendLine(".SpanFlagsHasSourceLocation;");
         sb.Append(indent).Append("        ").Append(TR).Append(".WriteSpanHeaderExtension(destination[").Append(TR).AppendLine(".CommonHeaderSize..],");
         sb.Append(indent).AppendLine("            endTimestamp - Header.StartTimestamp, Header.SpanId, Header.ParentSpanId, spanFlags);");
         sb.Append(indent).AppendLine("        if (hasTraceContext)");
         sb.Append(indent).AppendLine("        {");
         sb.Append(indent).Append("            ").Append(TR).Append(".WriteTraceContext(destination[").Append(TR).AppendLine(".MinSpanHeaderSize..], Header.TraceIdHi, Header.TraceIdLo);");
         sb.Append(indent).AppendLine("        }");
+        sb.Append(indent).AppendLine("        if (hasSourceLocation)");
+        sb.Append(indent).AppendLine("        {");
+        sb.Append(indent).Append("            ").Append(TR).Append(".WriteSourceLocationId(destination[").Append(TR).AppendLine(".SourceLocationIdOffset(hasTraceContext)..], Header.SourceLocationId);");
+        sb.Append(indent).AppendLine("        }");
 
-        // Payload writes (after header).
+        // Payload writes (after header — including the optional source-location id when present).
         if (requiredPayloadSize > 0 || hasOptionals)
         {
-            sb.Append(indent).Append("        var headerSize = ").Append(TR).AppendLine(".SpanHeaderSize(hasTraceContext);");
+            sb.Append(indent).Append("        var headerSize = ").Append(TR).AppendLine(".SpanHeaderSize(hasTraceContext, hasSourceLocation);");
             sb.Append(indent).AppendLine("        var payload = destination[headerSize..];");
             int cursor = 0;
             foreach (var p in model.PayloadFields)
@@ -608,17 +616,40 @@ namespace Typhon.Engine.Profiler
         sb.Append(indent).AppendLine("}");
 
         // Begin factory emitted as a partial half of TyphonEvent (which itself is in this same namespace).
+        // Two factories are emitted side by side per event kind:
+        //   1. The user-facing BeginXxx(args) — a thin pass-through delegating to BeginXxx_WithSiteId(0, args).
+        //   2. BeginXxx_WithSiteId(ushort siteId, args) — does the actual work; receives the literal siteId from
+        //      the SourceLocationGenerator interceptor (or 0 from the pass-through, meaning "unknown source").
+        // The user-facing name is the interception target — never edit user code; the generator owns the pair.
+        // See claude/design/observability/10-profiler-source-attribution.md §4.3.
         if (model.GenerateFactory)
         {
             sb.AppendLine();
             sb.Append(indent).AppendLine("public static partial class TyphonEvent");
             sb.Append(indent).AppendLine("{");
+
+            // ── Factory 1: BeginXxx(args) — pass-through with siteId = 0 ──
             sb.Append(indent).AppendLine("    [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
             sb.Append(indent).Append("    public static ").Append(model.StructName).Append(' ').Append(model.FactoryName).Append('(');
             for (int i = 0; i < model.BeginParams.Length; i++)
             {
                 if (i > 0) sb.Append(", ");
                 sb.Append(model.BeginParams[i].ParamTypeFqn).Append(' ').Append(model.BeginParams[i].ParamName);
+            }
+            sb.Append(") => ").Append(model.FactoryName).Append("_WithSiteId(0");
+            foreach (var p in model.BeginParams)
+            {
+                sb.Append(", ").Append(p.ParamName);
+            }
+            sb.AppendLine(");");
+            sb.AppendLine();
+
+            // ── Factory 2: BeginXxx_WithSiteId(siteId, args) — does the work, threads literal siteId into Header ──
+            sb.Append(indent).AppendLine("    [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+            sb.Append(indent).Append("    public static ").Append(model.StructName).Append(' ').Append(model.FactoryName).Append("_WithSiteId(ushort siteId");
+            foreach (var p in model.BeginParams)
+            {
+                sb.Append(", ").Append(p.ParamTypeFqn).Append(' ').Append(p.ParamName);
             }
             sb.AppendLine(")");
             sb.Append(indent).AppendLine("    {");
@@ -629,7 +660,7 @@ namespace Typhon.Engine.Profiler
             sb.Append(indent).AppendLine("        }");
             sb.Append(indent).Append("        return new ").Append(model.StructName).AppendLine();
             sb.Append(indent).AppendLine("        {");
-            sb.Append(indent).AppendLine("            Header = MakeHeader(slotIdx, startTs, spanId, parentSpanId, previousSpanId, traceIdHi, traceIdLo),");
+            sb.Append(indent).AppendLine("            Header = MakeHeader(slotIdx, startTs, spanId, parentSpanId, previousSpanId, traceIdHi, traceIdLo, siteId),");
             foreach (var p in model.BeginParams)
             {
                 sb.Append(indent).Append("            ").Append(p.FieldName).Append(" = ");

--- a/src/Typhon.Profiler/BTreeEventCodec.cs
+++ b/src/Typhon.Profiler/BTreeEventCodec.cs
@@ -18,8 +18,11 @@ public readonly struct BTreeEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>Source-location id assigned by <c>SourceLocationGenerator</c> (#302). Zero when the wire record didn't carry source attribution.</summary>
+    public ushort SourceLocationId { get; }
+
     public BTreeEventData(TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId = 0)
     {
         Kind = kind;
         ThreadSlot = threadSlot;
@@ -29,10 +32,14 @@ public readonly struct BTreeEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
     }
 
     /// <summary><c>true</c> when <see cref="TraceIdHi"/> and <see cref="TraceIdLo"/> are non-zero (the record carried distributed-trace context).</summary>
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
+
+    /// <summary><c>true</c> when <see cref="SourceLocationId"/> is non-zero (the record carried source attribution from <c>SourceLocationGenerator</c>).</summary>
+    public bool HasSourceLocation => SourceLocationId != 0;
 }
 
 /// <summary>
@@ -53,13 +60,21 @@ public static class BTreeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        return new BTreeEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo);
+        return new BTreeEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId);
     }
 }
 

--- a/src/Typhon.Profiler/CheckpointEventCodec.cs
+++ b/src/Typhon.Profiler/CheckpointEventCodec.cs
@@ -19,6 +19,9 @@ public readonly struct CheckpointEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace's manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>Required for <see cref="TraceEventKind.CheckpointCycle"/> — target WAL LSN the checkpoint is advancing to.</summary>
     public long TargetLsn { get; }
 
@@ -47,7 +50,7 @@ public readonly struct CheckpointEventData
 
     public CheckpointEventData(
         TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks,
-        ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo,
+        ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId,
         long targetLsn, CheckpointReason reason, byte optionalFieldMask,
         int dirtyPageCount, int writtenCount, int transitionedCount, int recycledCount)
     {
@@ -59,6 +62,7 @@ public readonly struct CheckpointEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         TargetLsn = targetLsn;
         Reason = reason;
         OptionalFieldMask = optionalFieldMask;
@@ -157,13 +161,20 @@ public static class CheckpointEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
 
         long targetLsn = 0;
         var reason = CheckpointReason.Periodic;
@@ -237,7 +248,7 @@ public static class CheckpointEventCodec
             // CheckpointCollect, CheckpointFsync — no payload
         }
 
-        return new CheckpointEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new CheckpointEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             targetLsn, reason, optMask, dirtyPageCount, writtenCount, transitionedCount, recycledCount);
     }
 }

--- a/src/Typhon.Profiler/ClusterMigrationEventCodec.cs
+++ b/src/Typhon.Profiler/ClusterMigrationEventCodec.cs
@@ -15,6 +15,9 @@ public readonly struct ClusterMigrationEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>Required — archetype ID whose entities are being migrated between spatial cells.</summary>
     public ushort ArchetypeId { get; }
 
@@ -31,7 +34,7 @@ public readonly struct ClusterMigrationEventData
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public ClusterMigrationEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, ushort archetypeId, int migrationCount, int componentCount)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, ushort archetypeId, int migrationCount, int componentCount)
     {
         ThreadSlot = threadSlot;
         StartTimestamp = startTimestamp;
@@ -40,6 +43,7 @@ public readonly struct ClusterMigrationEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         ArchetypeId = archetypeId;
         MigrationCount = migrationCount;
         ComponentCount = componentCount;
@@ -68,13 +72,20 @@ public static class ClusterMigrationEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var archetypeId = BinaryPrimitives.ReadUInt16LittleEndian(payload);
         var migrationCount = BinaryPrimitives.ReadInt32LittleEndian(payload[ArchetypeIdSize..]);
@@ -83,7 +94,7 @@ public static class ClusterMigrationEventCodec
             ? BinaryPrimitives.ReadInt32LittleEndian(payload[(ArchetypeIdSize + MigrationCountSize)..])
             : 0;
 
-        return new ClusterMigrationEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new ClusterMigrationEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             archetypeId, migrationCount, componentCount);
     }
 }

--- a/src/Typhon.Profiler/DataIndexBTreeEventCodec.cs
+++ b/src/Typhon.Profiler/DataIndexBTreeEventCodec.cs
@@ -28,13 +28,15 @@ public readonly struct DataIndexBTreeRangeScanData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public int ResultCount { get; }
     public byte RestartCount { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public DataIndexBTreeRangeScanData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, int resultCount, byte restartCount)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, int resultCount, byte restartCount)
     { ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks; SpanId = spanId; ParentSpanId = parentSpanId;
-      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; ResultCount = resultCount; RestartCount = restartCount; }
+      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; SourceLocationId = sourceLocationId; ResultCount = resultCount; RestartCount = restartCount; }
 }
 
 /// <summary>Decoded Data:Index:BTree:RangeScan:Revalidate instant. Payload: <c>restartCount u8</c> (1 B).</summary>
@@ -70,13 +72,15 @@ public readonly struct DataIndexBTreeBulkInsertData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public int BufferId { get; }
     public int EntryCount { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public DataIndexBTreeBulkInsertData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, int bufferId, int entryCount)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, int bufferId, int entryCount)
     { ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks; SpanId = spanId; ParentSpanId = parentSpanId;
-      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; BufferId = bufferId; EntryCount = entryCount; }
+      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; SourceLocationId = sourceLocationId; BufferId = bufferId; EntryCount = entryCount; }
 }
 
 /// <summary>Decoded Data:Index:BTree:Root instant (op variant). Payload: <c>op u8, rootChunkId i32, height u8</c> (6 B).</summary>
@@ -223,12 +227,18 @@ public static class DataIndexBTreeEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
-        return new DataIndexBTreeRangeScanData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        ushort sourceLocationId = 0;
+        if (hasSL)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTC)..]);
+        }
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
+        return new DataIndexBTreeRangeScanData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt32LittleEndian(p), p[4]);
     }
 
@@ -239,12 +249,18 @@ public static class DataIndexBTreeEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
-        return new DataIndexBTreeBulkInsertData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        ushort sourceLocationId = 0;
+        if (hasSL)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTC)..]);
+        }
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
+        return new DataIndexBTreeBulkInsertData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt32LittleEndian(p),
             BinaryPrimitives.ReadInt32LittleEndian(p[4..]));
     }

--- a/src/Typhon.Profiler/DataMvccEventCodec.cs
+++ b/src/Typhon.Profiler/DataMvccEventCodec.cs
@@ -29,13 +29,15 @@ public readonly struct DataMvccVersionCleanupData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public long Pk { get; }
     public ushort EntriesFreed { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public DataMvccVersionCleanupData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, long pk, ushort entriesFreed)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, long pk, ushort entriesFreed)
     { ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks; SpanId = spanId; ParentSpanId = parentSpanId;
-      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; Pk = pk; EntriesFreed = entriesFreed; }
+      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; SourceLocationId = sourceLocationId; Pk = pk; EntriesFreed = entriesFreed; }
 }
 
 /// <summary>Wire codec for Data:MVCC events (kinds 178-179).</summary>
@@ -71,12 +73,18 @@ public static class DataMvccEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
-        return new DataMvccVersionCleanupData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        ushort sourceLocationId = 0;
+        if (hasSL)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTC)..]);
+        }
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
+        return new DataMvccVersionCleanupData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[8..]));
     }

--- a/src/Typhon.Profiler/DataTransactionEventCodec.cs
+++ b/src/Typhon.Profiler/DataTransactionEventCodec.cs
@@ -16,13 +16,15 @@ public readonly struct DataTransactionInitData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public long Tsn { get; }
     public ushort UowId { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public DataTransactionInitData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, long tsn, ushort uowId)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, long tsn, ushort uowId)
     { ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks; SpanId = spanId; ParentSpanId = parentSpanId;
-      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; Tsn = tsn; UowId = uowId; }
+      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; SourceLocationId = sourceLocationId; Tsn = tsn; UowId = uowId; }
 }
 
 /// <summary>Decoded Data:Transaction:Prepare span. Payload: <c>tsn i64</c> (8 B).</summary>
@@ -36,12 +38,14 @@ public readonly struct DataTransactionPrepareData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public long Tsn { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public DataTransactionPrepareData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, long tsn)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, long tsn)
     { ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks; SpanId = spanId; ParentSpanId = parentSpanId;
-      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; Tsn = tsn; }
+      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; SourceLocationId = sourceLocationId; Tsn = tsn; }
 }
 
 /// <summary>Decoded Data:Transaction:Validate span. Payload: <c>tsn i64, entryCount i32</c> (12 B).</summary>
@@ -55,13 +59,15 @@ public readonly struct DataTransactionValidateData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public long Tsn { get; }
     public int EntryCount { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public DataTransactionValidateData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, long tsn, int entryCount)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, long tsn, int entryCount)
     { ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks; SpanId = spanId; ParentSpanId = parentSpanId;
-      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; Tsn = tsn; EntryCount = entryCount; }
+      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; SourceLocationId = sourceLocationId; Tsn = tsn; EntryCount = entryCount; }
 }
 
 /// <summary>Decoded Data:Transaction:Conflict instant. Payload: <c>tsn i64, pk i64, componentTypeId i32, conflictType u8</c> (21 B).</summary>
@@ -89,13 +95,15 @@ public readonly struct DataTransactionCleanupData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public long Tsn { get; }
     public int EntityCount { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public DataTransactionCleanupData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, long tsn, int entityCount)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, long tsn, int entityCount)
     { ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks; SpanId = spanId; ParentSpanId = parentSpanId;
-      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; Tsn = tsn; EntityCount = entityCount; }
+      TraceIdHi = traceIdHi; TraceIdLo = traceIdLo; SourceLocationId = sourceLocationId; Tsn = tsn; EntityCount = entityCount; }
 }
 
 /// <summary>Wire codec for Data:Transaction events (kinds 173-177).</summary>
@@ -127,6 +135,18 @@ public static class DataTransactionEventCodec
         }
     }
 
+    /// <summary>
+    /// Read the optional <c>SourceLocationId</c> from the span header. Returns 0 when the
+    /// <c>SpanFlagsHasSourceLocation</c> bit is unset. Centralized so the four <c>Decode*</c>
+    /// methods don't repeat the read-and-conditional-skip dance.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ushort ReadSourceLocationIdIfPresent(ReadOnlySpan<byte> source, byte spanFlags, bool hasTC)
+    {
+        if ((spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) == 0) return 0;
+        return TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTC)..]);
+    }
+
     public static DataTransactionInitData DecodeInit(ReadOnlySpan<byte> source)
     {
         TraceRecordHeader.ReadCommonHeader(source, out _, out _, out var threadSlot, out var startTimestamp);
@@ -134,12 +154,14 @@ public static class DataTransactionEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
-        return new DataTransactionInitData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        var sourceLocationId = ReadSourceLocationIdIfPresent(source, spanFlags, hasTC);
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
+        return new DataTransactionInitData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[8..]));
     }
@@ -151,12 +173,14 @@ public static class DataTransactionEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
-        return new DataTransactionPrepareData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        var sourceLocationId = ReadSourceLocationIdIfPresent(source, spanFlags, hasTC);
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
+        return new DataTransactionPrepareData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt64LittleEndian(p));
     }
 
@@ -167,12 +191,14 @@ public static class DataTransactionEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
-        return new DataTransactionValidateData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        var sourceLocationId = ReadSourceLocationIdIfPresent(source, spanFlags, hasTC);
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
+        return new DataTransactionValidateData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             BinaryPrimitives.ReadInt32LittleEndian(p[8..]));
     }
@@ -206,12 +232,14 @@ public static class DataTransactionEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
-        return new DataTransactionCleanupData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        var sourceLocationId = ReadSourceLocationIdIfPresent(source, spanFlags, hasTC);
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
+        return new DataTransactionCleanupData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             BinaryPrimitives.ReadInt32LittleEndian(p[8..]));
     }

--- a/src/Typhon.Profiler/DurabilityCheckpointEventCodec.cs
+++ b/src/Typhon.Profiler/DurabilityCheckpointEventCodec.cs
@@ -93,11 +93,15 @@ public static class DurabilityCheckpointEventCodec
             out dur, out spanId, out parentSpanId, out var spanFlags);
         traceIdHi = 0; traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        return source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        // Source-location bytes (#302) are skipped here — they're not surfaced in this codec's EventData yet.
+        // Phase 4 will extend the codec when Workbench consumes siteId. The hasSL adjustment to SpanHeaderSize
+        // ensures the payload offset is correct when records carry the optional 2-byte siteId.
+        return source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
     }
 
     public static DurabilityCheckpointWriteBatchData DecodeWriteBatch(ReadOnlySpan<byte> source)

--- a/src/Typhon.Profiler/DurabilityRecoveryEventCodec.cs
+++ b/src/Typhon.Profiler/DurabilityRecoveryEventCodec.cs
@@ -184,11 +184,13 @@ public static class DurabilityRecoveryEventCodec
             out dur, out spanId, out parentSpanId, out var spanFlags);
         traceIdHi = 0; traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        return source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        // Source-location bytes (#302) are skipped here — Phase 4 will surface siteId in this codec.
+        return source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
     }
 
     // ── Start (instant) ──

--- a/src/Typhon.Profiler/DurabilityWalEventCodec.cs
+++ b/src/Typhon.Profiler/DurabilityWalEventCodec.cs
@@ -173,11 +173,13 @@ public static class DurabilityWalEventCodec
             out dur, out spanId, out parentSpanId, out var spanFlags);
         traceIdHi = 0; traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        return source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        // Source-location bytes (#302) are skipped here — Phase 4 will surface siteId in this codec.
+        return source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
     }
 
     // ── QueueDrain ──

--- a/src/Typhon.Profiler/EcsQueryDepthEventCodec.cs
+++ b/src/Typhon.Profiler/EcsQueryDepthEventCodec.cs
@@ -114,11 +114,13 @@ public static class EcsQueryDepthEventCodec
             out dur, out spanId, out parentSpanId, out var spanFlags);
         traceIdHi = 0; traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        return source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        // Source-location bytes (#302) are skipped here — Phase 4 will surface siteId in this codec.
+        return source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
     }
 
     // ── Construct (span) ──

--- a/src/Typhon.Profiler/EcsQueryEventCodec.cs
+++ b/src/Typhon.Profiler/EcsQueryEventCodec.cs
@@ -51,18 +51,23 @@ public readonly struct EcsQueryEventData
     /// <summary>Phase 7 (D2): variant byte for consolidated kind 32 producers. Valid iff <see cref="HasVariant"/> is <c>true</c>.</summary>
     public EcsQueryVariant Variant { get; }
 
+    /// <summary>Source-location id assigned by <c>SourceLocationGenerator</c> (#302). Zero when the wire record didn't carry source attribution.</summary>
+    public ushort SourceLocationId { get; }
+
     public bool HasResultCount => (OptionalFieldMask & EcsQueryEventCodec.OptResultCount) != 0;
     public bool HasScanMode => (OptionalFieldMask & EcsQueryEventCodec.OptScanMode) != 0;
     public bool HasFound => (OptionalFieldMask & EcsQueryEventCodec.OptFound) != 0;
     public bool HasVariant => (OptionalFieldMask & EcsQueryEventCodec.OptVariant) != 0;
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
+    public bool HasSourceLocation => SourceLocationId != 0;
 
     public EcsQueryEventData(
         TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks,
         ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo,
         ushort archetypeTypeId, byte optionalFieldMask,
         int resultCount, EcsQueryScanMode scanMode, bool found,
-        EcsQueryVariant variant = EcsQueryVariant.Execute)
+        EcsQueryVariant variant = EcsQueryVariant.Execute,
+        ushort sourceLocationId = 0)
     {
         Kind = kind;
         ThreadSlot = threadSlot;
@@ -78,6 +83,7 @@ public readonly struct EcsQueryEventData
         ScanMode = scanMode;
         Found = found;
         Variant = variant;
+        SourceLocationId = sourceLocationId;
     }
 }
 
@@ -124,9 +130,10 @@ public static class EcsQueryEventCodec
     private const int RequiredPayloadSize = 3;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int ComputeSize(bool hasTraceContext, byte optMask)
+    public static int ComputeSize(bool hasTraceContext, byte optMask, ushort sourceLocationId = 0)
     {
-        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext) + RequiredPayloadSize;
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation) + RequiredPayloadSize;
         // ResultCount and Found share the same 4 B slot — only one of them is ever set for a given kind.
         if ((optMask & (OptResultCount | OptFound)) != 0)
         {
@@ -145,7 +152,8 @@ public static class EcsQueryEventCodec
 
     /// <summary>
     /// Internal encoder shared by the three ECS query event kinds. Writes the span header, required payload, and any optional fields whose mask
-    /// bit is set.
+    /// bit is set. When <paramref name="sourceLocationId"/> is non-zero, sets <see cref="TraceRecordHeader.SpanFlagsHasSourceLocation"/> and
+    /// writes 2 extra bytes after the optional trace context (#302).
     /// </summary>
     internal static void Encode(
         Span<byte> destination,
@@ -163,26 +171,34 @@ public static class EcsQueryEventCodec
         EcsQueryScanMode scanMode,
         bool found,
         out int bytesWritten,
-        EcsQueryVariant variant = EcsQueryVariant.Execute)
+        EcsQueryVariant variant = EcsQueryVariant.Execute,
+        ushort sourceLocationId = 0)
     {
         var hasTraceContext = traceIdHi != 0 || traceIdLo != 0;
-        var size = ComputeSize(hasTraceContext, optMask);
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = ComputeSize(hasTraceContext, optMask, sourceLocationId);
 
         // ── Common header + span extension ──
         TraceRecordHeader.WriteCommonHeader(destination, (ushort)size, kind, threadSlot, startTimestamp);
-        var spanFlags = hasTraceContext ? TraceRecordHeader.SpanFlagsHasTraceContext : (byte)0;
+        var spanFlags = (byte)0;
+        if (hasTraceContext) spanFlags |= TraceRecordHeader.SpanFlagsHasTraceContext;
+        if (hasSourceLocation) spanFlags |= TraceRecordHeader.SpanFlagsHasSourceLocation;
         TraceRecordHeader.WriteSpanHeaderExtension(destination[TraceRecordHeader.CommonHeaderSize..],
             durationTicks: endTimestamp - startTimestamp,
             spanId: spanId,
             parentSpanId: parentSpanId,
             spanFlags: spanFlags);
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext);
         if (hasTraceContext)
         {
             TraceRecordHeader.WriteTraceContext(destination[TraceRecordHeader.MinSpanHeaderSize..], traceIdHi, traceIdLo);
         }
+        if (hasSourceLocation)
+        {
+            TraceRecordHeader.WriteSourceLocationId(destination[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..], sourceLocationId);
+        }
 
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         // ── Required payload ──
         var payload = destination[headerSize..];
         BinaryPrimitives.WriteUInt16LittleEndian(payload, archetypeTypeId);
@@ -218,13 +234,21 @@ public static class EcsQueryEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var archetypeTypeId = BinaryPrimitives.ReadUInt16LittleEndian(payload);
         var optMask = payload[2];
@@ -261,7 +285,7 @@ public static class EcsQueryEventCodec
         }
 
         return new EcsQueryEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
-            archetypeTypeId, optMask, resultCount, scanMode, found, variant);
+            archetypeTypeId, optMask, resultCount, scanMode, found, variant, sourceLocationId);
     }
 }
 

--- a/src/Typhon.Profiler/EcsSpawnEventCodec.cs
+++ b/src/Typhon.Profiler/EcsSpawnEventCodec.cs
@@ -15,6 +15,9 @@ public readonly struct EcsSpawnEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>Required — archetype ID.</summary>
     public ushort ArchetypeId { get; }
 
@@ -31,7 +34,7 @@ public readonly struct EcsSpawnEventData
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public EcsSpawnEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, ushort archetypeId, byte optionalFieldMask, ulong entityId, long tsn)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, ushort archetypeId, byte optionalFieldMask, ulong entityId, long tsn)
     {
         ThreadSlot = threadSlot;
         StartTimestamp = startTimestamp;
@@ -40,6 +43,7 @@ public readonly struct EcsSpawnEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         ArchetypeId = archetypeId;
         OptionalFieldMask = optionalFieldMask;
         EntityId = entityId;
@@ -73,13 +77,20 @@ public static class EcsSpawnEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var archetypeId = BinaryPrimitives.ReadUInt16LittleEndian(payload);
         var optMask = payload[ArchetypeIdSize];
@@ -98,7 +109,7 @@ public static class EcsSpawnEventCodec
             cursor += TsnSize;
         }
 
-        return new EcsSpawnEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new EcsSpawnEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             archetypeId, optMask, entityId, tsn);
     }
 }
@@ -113,6 +124,9 @@ public readonly struct EcsDestroyEventData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
 
     /// <summary>Required — entity ID being destroyed.</summary>
     public ulong EntityId { get; }
@@ -130,7 +144,7 @@ public readonly struct EcsDestroyEventData
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public EcsDestroyEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, ulong entityId, byte optionalFieldMask, int cascadeCount, long tsn)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, ulong entityId, byte optionalFieldMask, int cascadeCount, long tsn)
     {
         ThreadSlot = threadSlot;
         StartTimestamp = startTimestamp;
@@ -139,6 +153,7 @@ public readonly struct EcsDestroyEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         EntityId = entityId;
         OptionalFieldMask = optionalFieldMask;
         CascadeCount = cascadeCount;
@@ -172,13 +187,20 @@ public static class EcsDestroyEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var entityId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
         var optMask = payload[EntityIdSize];
@@ -197,7 +219,7 @@ public static class EcsDestroyEventCodec
             cursor += TsnSize;
         }
 
-        return new EcsDestroyEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new EcsDestroyEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             entityId, optMask, cascadeCount, tsn);
     }
 }
@@ -212,6 +234,9 @@ public readonly struct EcsViewRefreshEventData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
 
     /// <summary>Required — archetype type ID.</summary>
     public ushort ArchetypeTypeId { get; }
@@ -233,7 +258,7 @@ public readonly struct EcsViewRefreshEventData
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public EcsViewRefreshEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, ushort archetypeTypeId, byte optionalFieldMask,
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, ushort archetypeTypeId, byte optionalFieldMask,
         EcsViewRefreshMode mode, int resultCount, int deltaCount)
     {
         ThreadSlot = threadSlot;
@@ -243,6 +268,7 @@ public readonly struct EcsViewRefreshEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         ArchetypeTypeId = archetypeTypeId;
         OptionalFieldMask = optionalFieldMask;
         Mode = mode;
@@ -280,13 +306,20 @@ public static class EcsViewRefreshEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var archetypeTypeId = BinaryPrimitives.ReadUInt16LittleEndian(payload);
         var optMask = payload[ArchetypeTypeIdSize];
@@ -312,7 +345,7 @@ public static class EcsViewRefreshEventCodec
             cursor += DeltaCountSize;
         }
 
-        return new EcsViewRefreshEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new EcsViewRefreshEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             archetypeTypeId, optMask, mode, resultCount, deltaCount);
     }
 }

--- a/src/Typhon.Profiler/EcsViewEventCodec.cs
+++ b/src/Typhon.Profiler/EcsViewEventCodec.cs
@@ -181,11 +181,13 @@ public static class EcsViewEventCodec
             out dur, out spanId, out parentSpanId, out var spanFlags);
         traceIdHi = 0; traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        return source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        // Source-location bytes (#302) are skipped here — Phase 4 will surface siteId in this codec.
+        return source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
     }
 
     // ── RefreshPull (span) ──

--- a/src/Typhon.Profiler/LiveStreamProtocol.cs
+++ b/src/Typhon.Profiler/LiveStreamProtocol.cs
@@ -50,4 +50,21 @@ public enum LiveFrameType : byte
 
     /// <summary>Session end.</summary>
     Shutdown = 3,
+
+    /// <summary>
+    /// File-table frame (#302, Phase 4 of profiler-source-attribution): interned source-file paths.
+    /// Sent once during the init handshake before any Block frames; payload is identical to the
+    /// FileTable section of <c>.typhon-trace</c> files (u32 entryCount, then per-entry: u16 fileId,
+    /// u16 pathLen, UTF-8 path bytes). Absent when the engine has no source attribution to report.
+    /// See claude/design/observability/10-profiler-source-attribution.md §4.7.
+    /// </summary>
+    FileTable = 4,
+
+    /// <summary>
+    /// SourceLocationManifest frame (#302, Phase 4): id → (fileId, line, kind, method) entries.
+    /// Sent once during the init handshake immediately after the FileTable. Payload is identical to the
+    /// SourceLocationManifest section of <c>.typhon-trace</c> files. No delta frames during the session —
+    /// the table is fixed at compile time (per design §4.4).
+    /// </summary>
+    SourceLocationManifest = 5,
 }

--- a/src/Typhon.Profiler/NamedSpanEventCodec.cs
+++ b/src/Typhon.Profiler/NamedSpanEventCodec.cs
@@ -22,13 +22,16 @@ public readonly struct NamedSpanEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>UTF-8-encoded name bytes, sliced from the original record. Caller converts to string on demand.</summary>
     public ReadOnlyMemory<byte> NameUtf8 { get; }
 
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public NamedSpanEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, ReadOnlyMemory<byte> nameUtf8)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, ReadOnlyMemory<byte> nameUtf8)
     {
         ThreadSlot = threadSlot;
         StartTimestamp = startTimestamp;
@@ -37,6 +40,7 @@ public readonly struct NamedSpanEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         NameUtf8 = nameUtf8;
     }
 
@@ -130,18 +134,25 @@ public static class NamedSpanEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(span[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(span[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(span[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = span[headerSize..];
         var nameByteCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(payload);
         var nameMemory = source.Slice(headerSize + NameLengthSize, nameByteCount);
 
-        return new NamedSpanEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, nameMemory);
+        return new NamedSpanEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId, nameMemory);
     }
 }
 

--- a/src/Typhon.Profiler/PageCacheBackpressureCodec.cs
+++ b/src/Typhon.Profiler/PageCacheBackpressureCodec.cs
@@ -32,13 +32,17 @@ public readonly struct PageCacheEventData
     /// <summary>Phase 5: dirty-bit for <see cref="TraceEventKind.PageEvicted"/> (1 if the displaced page was dirty, 0 otherwise).</summary>
     public byte DirtyBit { get; }
 
+    /// <summary>Source-location id assigned by <c>SourceLocationGenerator</c> (#302). Zero when the wire record didn't carry source attribution.</summary>
+    public ushort SourceLocationId { get; }
+
     public bool HasPageCount => (OptionalFieldMask & PageCacheEventCodec.OptPageCount) != 0;
     public bool HasDirtyBit => (OptionalFieldMask & PageCacheEventCodec.OptDirtyBit) != 0;
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
+    public bool HasSourceLocation => SourceLocationId != 0;
 
     public PageCacheEventData(TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks,
         ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo,
-        int filePageIndex, int pageCount, byte optionalFieldMask, byte dirtyBit = 0)
+        int filePageIndex, int pageCount, byte optionalFieldMask, byte dirtyBit = 0, ushort sourceLocationId = 0)
     {
         Kind = kind;
         ThreadSlot = threadSlot;
@@ -52,6 +56,7 @@ public readonly struct PageCacheEventData
         PageCount = pageCount;
         OptionalFieldMask = optionalFieldMask;
         DirtyBit = dirtyBit;
+        SourceLocationId = sourceLocationId;
     }
 }
 
@@ -68,14 +73,20 @@ public readonly struct PageCacheBackpressureEventData
     public int RetryCount { get; }
     public int DirtyCount { get; }
     public int EpochCount { get; }
+
+    /// <summary>Source-location id assigned by <c>SourceLocationGenerator</c> (#302). Zero when the wire record didn't carry source attribution.</summary>
+    public ushort SourceLocationId { get; }
+
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
+    public bool HasSourceLocation => SourceLocationId != 0;
 
     public PageCacheBackpressureEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, int retryCount, int dirtyCount, int epochCount)
+        ulong traceIdHi, ulong traceIdLo, int retryCount, int dirtyCount, int epochCount, ushort sourceLocationId = 0)
     {
         ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks;
         SpanId = spanId; ParentSpanId = parentSpanId; TraceIdHi = traceIdHi; TraceIdLo = traceIdLo;
         RetryCount = retryCount; DirtyCount = dirtyCount; EpochCount = epochCount;
+        SourceLocationId = sourceLocationId;
     }
 }
 
@@ -92,16 +103,21 @@ public static class PageCacheBackpressureCodec
         TraceRecordHeader.ReadCommonHeader(source, out _, out _, out var threadSlot, out var startTimestamp);
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var retryCount = BinaryPrimitives.ReadInt32LittleEndian(payload);
         var dirtyCount = BinaryPrimitives.ReadInt32LittleEndian(payload[4..]);
         var epochCount = BinaryPrimitives.ReadInt32LittleEndian(payload[8..]);
         return new PageCacheBackpressureEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId,
-            traceIdHi, traceIdLo, retryCount, dirtyCount, epochCount);
+            traceIdHi, traceIdLo, retryCount, dirtyCount, epochCount, sourceLocationId);
     }
 }
 
@@ -129,9 +145,10 @@ public static class PageCacheEventCodec
     private const int DirtyBitSize = 1;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int ComputeSize(TraceEventKind kind, bool hasTraceContext, byte optMask)
+    public static int ComputeSize(TraceEventKind kind, bool hasTraceContext, byte optMask, ushort sourceLocationId = 0)
     {
-        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext) + FilePageIndexSize + OptMaskSize;
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation) + FilePageIndexSize + OptMaskSize;
         if ((optMask & OptPageCount) != 0) size += PageCountSize;
         if ((optMask & OptDirtyBit) != 0) size += DirtyBitSize;
         return size;
@@ -141,24 +158,35 @@ public static class PageCacheEventCodec
     // DiskWrite, AllocatePage, Flush) keeps calling this codec because the generator's standard layout doesn't model
     // the always-on optMask byte or the FilePageIndex slot reuse for Flush. EmitPageEvicted in TyphonEvent.cs also
     // calls it. See PageCacheFlushEvent's <remarks> for the full escape-hatch rationale.
+    //
+    // Source attribution (#302): when sourceLocationId != 0, the SpanFlagsHasSourceLocation bit is set and 2 extra
+    // bytes are written after the optional trace context, before the kind payload. EmitPageEvicted always passes
+    // siteId = 0 (private internal emitter — never targeted by the SourceLocationGenerator interceptor).
     internal static void Encode(Span<byte> destination, long endTimestamp, TraceEventKind kind, byte threadSlot, long startTimestamp,
         ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo,
-        int filePageIndex, int pageCount, byte optMask, out int bytesWritten, byte dirtyBit = 0)
+        int filePageIndex, int pageCount, byte optMask, out int bytesWritten, byte dirtyBit = 0, ushort sourceLocationId = 0)
     {
         var hasTraceContext = traceIdHi != 0 || traceIdLo != 0;
-        var size = ComputeSize(kind, hasTraceContext, optMask);
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = ComputeSize(kind, hasTraceContext, optMask, sourceLocationId);
 
         TraceRecordHeader.WriteCommonHeader(destination, (ushort)size, kind, threadSlot, startTimestamp);
-        var spanFlags = hasTraceContext ? TraceRecordHeader.SpanFlagsHasTraceContext : (byte)0;
+        var spanFlags = (byte)0;
+        if (hasTraceContext) spanFlags |= TraceRecordHeader.SpanFlagsHasTraceContext;
+        if (hasSourceLocation) spanFlags |= TraceRecordHeader.SpanFlagsHasSourceLocation;
         TraceRecordHeader.WriteSpanHeaderExtension(destination[TraceRecordHeader.CommonHeaderSize..],
             endTimestamp - startTimestamp, spanId, parentSpanId, spanFlags);
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext);
         if (hasTraceContext)
         {
             TraceRecordHeader.WriteTraceContext(destination[TraceRecordHeader.MinSpanHeaderSize..], traceIdHi, traceIdLo);
         }
+        if (hasSourceLocation)
+        {
+            TraceRecordHeader.WriteSourceLocationId(destination[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..], sourceLocationId);
+        }
 
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = destination[headerSize..];
         BinaryPrimitives.WriteInt32LittleEndian(payload, filePageIndex);
         payload[FilePageIndexSize] = optMask;
@@ -185,13 +213,21 @@ public static class PageCacheEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var filePageIndex = BinaryPrimitives.ReadInt32LittleEndian(payload);
         var optMask = payload[FilePageIndexSize];
@@ -212,7 +248,7 @@ public static class PageCacheEventCodec
         }
 
         return new PageCacheEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
-            filePageIndex, pageCount, optMask, dirtyBit);
+            filePageIndex, pageCount, optMask, dirtyBit, sourceLocationId);
     }
 }
 

--- a/src/Typhon.Profiler/QueryEventCodec.cs
+++ b/src/Typhon.Profiler/QueryEventCodec.cs
@@ -264,11 +264,13 @@ public static class QueryEventCodec
             out dur, out spanId, out parentSpanId, out var spanFlags);
         traceIdHi = 0; traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        return source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        // Source-location bytes (#302) are skipped here — Phase 4 will surface siteId in this codec.
+        return source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
     }
 
     // ── Parse ──

--- a/src/Typhon.Profiler/RuntimeEventCodec.cs
+++ b/src/Typhon.Profiler/RuntimeEventCodec.cs
@@ -131,7 +131,8 @@ public static class RuntimeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new RuntimeTransactionLifecycleData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(p),
             BinaryPrimitives.ReadUInt32LittleEndian(p[2..]),
@@ -144,7 +145,8 @@ public static class RuntimeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new RuntimeSubscriptionOutputExecuteData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             p[8],

--- a/src/Typhon.Profiler/RuntimePhaseSpanEventCodec.cs
+++ b/src/Typhon.Profiler/RuntimePhaseSpanEventCodec.cs
@@ -14,13 +14,16 @@ public readonly struct RuntimePhaseSpanEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>Tick lifecycle phase covered by this span (cast to <c>TickPhase</c> at decode time).</summary>
     public byte Phase { get; }
 
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public RuntimePhaseSpanEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, byte phase)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, byte phase)
     {
         ThreadSlot = threadSlot;
         StartTimestamp = startTimestamp;
@@ -29,6 +32,7 @@ public readonly struct RuntimePhaseSpanEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         Phase = phase;
     }
 }
@@ -52,15 +56,22 @@ public static class RuntimePhaseSpanEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var phase = source[headerSize];
 
-        return new RuntimePhaseSpanEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, phase);
+        return new RuntimePhaseSpanEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId, phase);
     }
 }

--- a/src/Typhon.Profiler/RuntimeSubscriptionEventCodec.cs
+++ b/src/Typhon.Profiler/RuntimeSubscriptionEventCodec.cs
@@ -166,11 +166,13 @@ public static class RuntimeSubscriptionEventCodec
             out dur, out spanId, out parentSpanId, out var spanFlags);
         traceIdHi = 0; traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        return source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        // Source-location bytes (#302) are skipped here — Phase 4 will surface siteId in this codec.
+        return source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
     }
 
     // ── Subscriber ──

--- a/src/Typhon.Profiler/SchedulerChunkEventCodec.cs
+++ b/src/Typhon.Profiler/SchedulerChunkEventCodec.cs
@@ -18,6 +18,9 @@ public readonly struct SchedulerChunkEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>Required — DAG system index.</summary>
     public ushort SystemIndex { get; }
 
@@ -33,7 +36,7 @@ public readonly struct SchedulerChunkEventData
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public SchedulerChunkEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, ushort systemIndex, ushort chunkIndex, ushort totalChunks, int entitiesProcessed)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, ushort systemIndex, ushort chunkIndex, ushort totalChunks, int entitiesProcessed)
     {
         ThreadSlot = threadSlot;
         StartTimestamp = startTimestamp;
@@ -42,6 +45,7 @@ public readonly struct SchedulerChunkEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         SystemIndex = systemIndex;
         ChunkIndex = chunkIndex;
         TotalChunks = totalChunks;
@@ -64,20 +68,27 @@ public static class SchedulerChunkEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var systemIndex = BinaryPrimitives.ReadUInt16LittleEndian(payload);
         var chunkIndex = BinaryPrimitives.ReadUInt16LittleEndian(payload[2..]);
         var totalChunks = BinaryPrimitives.ReadUInt16LittleEndian(payload[4..]);
         var entitiesProcessed = BinaryPrimitives.ReadInt32LittleEndian(payload[6..]);
 
-        return new SchedulerChunkEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new SchedulerChunkEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             systemIndex, chunkIndex, totalChunks, entitiesProcessed);
     }
 }

--- a/src/Typhon.Profiler/SchedulerDependencyEventCodec.cs
+++ b/src/Typhon.Profiler/SchedulerDependencyEventCodec.cs
@@ -69,7 +69,8 @@ public static class SchedulerDependencyEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SchedulerDependencyFanOutData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[2..]),

--- a/src/Typhon.Profiler/SchedulerGraphEventCodec.cs
+++ b/src/Typhon.Profiler/SchedulerGraphEventCodec.cs
@@ -62,7 +62,8 @@ public static class SchedulerGraphEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SchedulerGraphBuildData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[2..]),
@@ -75,7 +76,8 @@ public static class SchedulerGraphEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SchedulerGraphRebuildData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[2..]),

--- a/src/Typhon.Profiler/SchedulerMetronomeEventCodec.cs
+++ b/src/Typhon.Profiler/SchedulerMetronomeEventCodec.cs
@@ -134,7 +134,8 @@ public static class SchedulerMetronomeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SchedulerMetronomeWaitData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             p[8], p[9], p[10]);

--- a/src/Typhon.Profiler/SchedulerSystemEventCodec.cs
+++ b/src/Typhon.Profiler/SchedulerSystemEventCodec.cs
@@ -120,7 +120,8 @@ public static class SchedulerSystemEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SchedulerSystemSingleThreadedData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(p), p[2], BinaryPrimitives.ReadUInt16LittleEndian(p[3..]));
     }

--- a/src/Typhon.Profiler/SchedulerWorkerEventCodec.cs
+++ b/src/Typhon.Profiler/SchedulerWorkerEventCodec.cs
@@ -75,7 +75,8 @@ public static class SchedulerWorkerEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SchedulerWorkerIdleData(threadSlot, startTimestamp, durationTicks,
             p[0], BinaryPrimitives.ReadUInt16LittleEndian(p[1..]), BinaryPrimitives.ReadUInt32LittleEndian(p[3..]));
     }
@@ -102,7 +103,8 @@ public static class SchedulerWorkerEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SchedulerWorkerBetweenTickData(threadSlot, startTimestamp, durationTicks,
             p[0], BinaryPrimitives.ReadUInt32LittleEndian(p[1..]), p[5]);
     }

--- a/src/Typhon.Profiler/SourceLocationManifestEntry.cs
+++ b/src/Typhon.Profiler/SourceLocationManifestEntry.cs
@@ -1,0 +1,34 @@
+namespace Typhon.Profiler;
+
+/// <summary>
+/// One entry in the trailing <c>SourceLocationManifest</c> of a <c>.typhon-trace</c> file.
+/// Maps a compile-time <see cref="Id"/> (the value carried in span records when <c>SpanFlagsHasSourceLocation</c> is set) to a source location: the file path
+/// (via <see cref="FileId"/> indexing into the parallel <c>FileTable</c>), the line number, the kind of factory the call site invoked, and the containing
+/// method name for display.
+/// See claude/design/observability/10-profiler-source-attribution.md §4.7.2.
+/// </summary>
+public readonly struct SourceLocationManifestEntry
+{
+    /// <summary>Site id (1-based, 0 = "unknown source").</summary>
+    public ushort Id { get; }
+    /// <summary>Index into the parallel <c>FileTable</c>.</summary>
+    public ushort FileId { get; }
+    /// <summary>1-based line number within the file.</summary>
+    public uint Line { get; }
+    /// <summary>
+    /// Compile-time hint of the <c>TraceEventKind</c> for this site. May be 0 if the generator chose not to
+    /// emit per-site kinds (the wire's record kind byte is the source of truth at runtime).
+    /// </summary>
+    public byte Kind { get; }
+    /// <summary>Containing-method short name for display ("BTree.Insert", "ChunkedTransaction.CommitChanges", ...).</summary>
+    public string Method { get; }
+
+    public SourceLocationManifestEntry(ushort id, ushort fileId, uint line, byte kind, string method)
+    {
+        Id = id;
+        FileId = fileId;
+        Line = line;
+        Kind = kind;
+        Method = method ?? string.Empty;
+    }
+}

--- a/src/Typhon.Profiler/SpatialMaintainEventCodec.cs
+++ b/src/Typhon.Profiler/SpatialMaintainEventCodec.cs
@@ -96,7 +96,8 @@ public static class SpatialMaintainEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialMaintainInsertData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[8..]),
@@ -109,7 +110,8 @@ public static class SpatialMaintainEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialMaintainUpdateSlowPathData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadInt64LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[8..]),

--- a/src/Typhon.Profiler/SpatialQueryEventCodec.cs
+++ b/src/Typhon.Profiler/SpatialQueryEventCodec.cs
@@ -193,7 +193,8 @@ public static class SpatialQueryEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext)..];
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation)..];
         return new SpatialQueryAabbData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId,
             BinaryPrimitives.ReadUInt16LittleEndian(payload),
             BinaryPrimitives.ReadUInt16LittleEndian(payload[2..]),
@@ -208,7 +209,8 @@ public static class SpatialQueryEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext)..];
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation)..];
         return new SpatialQueryRadiusData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(payload),
             BinaryPrimitives.ReadUInt16LittleEndian(payload[2..]),
@@ -222,7 +224,8 @@ public static class SpatialQueryEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext)..];
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation)..];
         return new SpatialQueryRayData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(payload),
             BinaryPrimitives.ReadUInt16LittleEndian(payload[2..]),
@@ -236,7 +239,8 @@ public static class SpatialQueryEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext)..];
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation)..];
         return new SpatialQueryFrustumData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(payload),
             BinaryPrimitives.ReadUInt16LittleEndian(payload[2..]),
@@ -249,7 +253,8 @@ public static class SpatialQueryEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext)..];
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation)..];
         return new SpatialQueryKnnData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(payload),
             payload[2],
@@ -263,7 +268,8 @@ public static class SpatialQueryEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext)..];
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation)..];
         return new SpatialQueryCountData(threadSlot, startTimestamp, durationTicks,
             payload[0],
             BinaryPrimitives.ReadUInt16LittleEndian(payload[1..]),

--- a/src/Typhon.Profiler/SpatialRTreeEventCodec.cs
+++ b/src/Typhon.Profiler/SpatialRTreeEventCodec.cs
@@ -100,7 +100,8 @@ public static class SpatialRTreeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialRTreeInsertData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadInt64LittleEndian(payload),
             payload[8], payload[9], payload[10]);
@@ -112,7 +113,8 @@ public static class SpatialRTreeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialRTreeRemoveData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadInt64LittleEndian(payload), payload[8]);
     }
@@ -123,7 +125,8 @@ public static class SpatialRTreeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialRTreeNodeSplitData(threadSlot, startTimestamp, durationTicks, payload[0], payload[1], payload[2], payload[3]);
     }
 
@@ -133,7 +136,8 @@ public static class SpatialRTreeEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialRTreeBulkLoadData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadInt32LittleEndian(payload),
             BinaryPrimitives.ReadInt32LittleEndian(payload[4..]));

--- a/src/Typhon.Profiler/SpatialTierIndexEventCodec.cs
+++ b/src/Typhon.Profiler/SpatialTierIndexEventCodec.cs
@@ -49,7 +49,8 @@ public static class SpatialTierIndexEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var payload = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialTierIndexRebuildData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(payload),
             BinaryPrimitives.ReadInt32LittleEndian(payload[2..]),

--- a/src/Typhon.Profiler/SpatialTriggerEventCodec.cs
+++ b/src/Typhon.Profiler/SpatialTriggerEventCodec.cs
@@ -102,7 +102,8 @@ public static class SpatialTriggerEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out _, out _, out var spanFlags);
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new SpatialTriggerEvalData(threadSlot, startTimestamp, durationTicks,
             BinaryPrimitives.ReadUInt16LittleEndian(p),
             BinaryPrimitives.ReadUInt16LittleEndian(p[2..]),

--- a/src/Typhon.Profiler/StatisticsRebuildEventCodec.cs
+++ b/src/Typhon.Profiler/StatisticsRebuildEventCodec.cs
@@ -15,6 +15,9 @@ public readonly struct StatisticsRebuildEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>Required — total entity count in the component table at rebuild time.</summary>
     public int EntityCount { get; }
 
@@ -27,7 +30,7 @@ public readonly struct StatisticsRebuildEventData
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
     public StatisticsRebuildEventData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, int entityCount, int mutationCount, int samplingInterval)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, int entityCount, int mutationCount, int samplingInterval)
     {
         ThreadSlot = threadSlot;
         StartTimestamp = startTimestamp;
@@ -36,6 +39,7 @@ public readonly struct StatisticsRebuildEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         EntityCount = entityCount;
         MutationCount = mutationCount;
         SamplingInterval = samplingInterval;
@@ -60,19 +64,26 @@ public static class StatisticsRebuildEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var entityCount = BinaryPrimitives.ReadInt32LittleEndian(payload);
         var mutationCount = BinaryPrimitives.ReadInt32LittleEndian(payload[EntityCountSize..]);
         var samplingInterval = BinaryPrimitives.ReadInt32LittleEndian(payload[(EntityCountSize + MutationCountSize)..]);
 
-        return new StatisticsRebuildEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new StatisticsRebuildEventData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             entityCount, mutationCount, samplingInterval);
     }
 }

--- a/src/Typhon.Profiler/StorageMiscEventCodec.cs
+++ b/src/Typhon.Profiler/StorageMiscEventCodec.cs
@@ -16,15 +16,18 @@ public readonly struct StoragePageCacheDirtyWalkData
     public ulong ParentSpanId { get; }
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
     public int RangeStart { get; }
     public int RangeLen { get; }
     public int DirtyMs { get; }
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
     public StoragePageCacheDirtyWalkData(byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId,
-        ulong traceIdHi, ulong traceIdLo, int rangeStart, int rangeLen, int dirtyMs)
+        ulong traceIdHi, ulong traceIdLo, ushort sourceLocationId, int rangeStart, int rangeLen, int dirtyMs)
     {
         ThreadSlot = threadSlot; StartTimestamp = startTimestamp; DurationTicks = durationTicks;
         SpanId = spanId; ParentSpanId = parentSpanId; TraceIdHi = traceIdHi; TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         RangeStart = rangeStart; RangeLen = rangeLen; DirtyMs = dirtyMs;
     }
 }
@@ -86,13 +89,19 @@ public static class StorageMiscEventCodec
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
         ulong traceIdHi = 0, traceIdLo = 0;
         var hasTC = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSL = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         if (hasTC)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
-        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC)..];
+        ushort sourceLocationId = 0;
+        if (hasSL)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTC)..]);
+        }
+        var p = source[TraceRecordHeader.SpanHeaderSize(hasTC, hasSL)..];
         return new StoragePageCacheDirtyWalkData(threadSlot, startTimestamp, durationTicks, spanId, parentSpanId,
-            traceIdHi, traceIdLo,
+            traceIdHi, traceIdLo, sourceLocationId,
             BinaryPrimitives.ReadInt32LittleEndian(p),
             BinaryPrimitives.ReadInt32LittleEndian(p[4..]),
             BinaryPrimitives.ReadInt32LittleEndian(p[8..]));

--- a/src/Typhon.Profiler/TraceFileHeader.cs
+++ b/src/Typhon.Profiler/TraceFileHeader.cs
@@ -19,7 +19,7 @@ public struct TraceFileHeader
     /// <summary>File magic: ASCII "TYTR" (0x52_54_59_54 little-endian).</summary>
     public uint Magic;
 
-    /// <summary>Format version. Current: 3 (variable-size typed records replace the fixed-stride 64 B struct of v2).</summary>
+    /// <summary>Format version. See <see cref="CurrentVersion"/> for the current value and an evolution log.</summary>
     public ushort Version;
 
     /// <summary>Flags (reserved for future use).</summary>
@@ -53,15 +53,34 @@ public struct TraceFileHeader
     /// </summary>
     public long SamplingSessionStartQpc;
 
-    /// <summary>Reserved for future use.</summary>
-    public unsafe fixed byte Reserved[9];
+    /// <summary>
+    /// Byte offset of the trailing <c>FileTable</c> (interned source-file paths). 0 when no source-location manifest was written
+    /// (e.g., the source-attribution generator emitted nothing). See claude/design/observability/10-profiler-source-attribution.md §4.6.
+    /// </summary>
+    public long FileTableOffset;
+
+    /// <summary>
+    /// Byte offset of the trailing <c>SourceLocationManifest</c> (id → file/line/method/kind table). 0 when absent.
+    /// Bound to a non-zero <see cref="FileTableOffset"/> when the trace carries source attribution.
+    /// </summary>
+    public long SourceLocationManifestOffset;
+
+    /// <summary>Padding to keep on-disk layout future-extension-friendly. Zero-initialized; readers must ignore.</summary>
+    public ushort Reserved0;
+    /// <summary>Padding (aligning the next field to 4 bytes); zero-initialized.</summary>
+    public ushort Reserved1;
 
     /// <summary>File magic constant: ASCII "TYTR".</summary>
     public const uint MagicValue = 0x52_54_59_54; // 'T','Y','T','R' little-endian
 
     /// <summary>
-    /// Current format version. Bumped to 4 when ThreadInfo records gained the trailing <see cref="ThreadKind"/> byte
-    /// (#289 follow-up). Older v3 files would silently miss the byte; the version gate forces a regenerate.
+    /// Current format version.
+    /// v3: variable-size typed-record layout (Tracy-style profiler rewrite).
+    /// v4: ThreadInfo records gained the trailing <c>ThreadKind</c> byte (#289 follow-up).
+    /// v5 (current): trailer carries <c>FileTable</c> + <c>SourceLocationManifest</c> at offsets in the header
+    ///     (#302 — profiler source attribution). Reader accepts v4 files transparently — their new offset fields
+    ///     are absent in the on-disk header (51 bytes vs 71) and default to 0, which downstream readers interpret
+    ///     as "no source-location manifest".
     /// </summary>
-    public const ushort CurrentVersion = 4;
+    public const ushort CurrentVersion = 5;
 }

--- a/src/Typhon.Profiler/TraceFileReader.cs
+++ b/src/Typhon.Profiler/TraceFileReader.cs
@@ -77,24 +77,50 @@ public sealed class TraceFileReader : IDisposable
         _compressedBuffer = new byte[64 * 1024];
     }
 
+    /// <summary>
+    /// Oldest format version this reader still accepts. v4 traces have no source-location manifest
+    /// (their on-disk header is 20 bytes shorter); we synthesize zeroed offset fields and downstream
+    /// code interprets that as "no manifest". Bump this when removing back-compat for an older v.
+    /// </summary>
+    public const ushort MinSupportedVersion = 4;
+
     /// <summary>Reads and validates the file header. Must be called first.</summary>
     /// <exception cref="InvalidDataException">If magic or version is wrong.</exception>
     public TraceFileHeader ReadHeader()
     {
-        Span<byte> headerBytes = stackalloc byte[Unsafe.SizeOf<TraceFileHeader>()];
-        _stream.ReadExactly(headerBytes);
+        // v4 layout ends at SamplingSessionStartQpc (51 bytes); v5 appends FileTableOffset +
+        // SourceLocationManifestOffset + Reserved0/1 (+20 bytes). v4 files transparently use the
+        // shorter read; their absent fields default to 0 ("no manifest").
+        const int V4HeaderSize = 51;
+        var fullSize = Unsafe.SizeOf<TraceFileHeader>();
+
+        Span<byte> headerBytes = stackalloc byte[fullSize];
+        _stream.ReadExactly(headerBytes[..V4HeaderSize]);
+        var version = BinaryPrimitives.ReadUInt16LittleEndian(headerBytes[4..6]);
+
+        if (version == TraceFileHeader.CurrentVersion)
+        {
+            _stream.ReadExactly(headerBytes[V4HeaderSize..fullSize]);
+        }
+        else if (version < MinSupportedVersion || version > TraceFileHeader.CurrentVersion)
+        {
+            throw new InvalidDataException(
+                $"Unsupported trace file version: {version}. This build reads versions "
+                + $"{MinSupportedVersion}..{TraceFileHeader.CurrentVersion}.");
+        }
+        else
+        {
+            // Older-but-supported (currently only v4) — clear the bytes we didn't read, so the
+            // marshalled struct sees zeroed offset fields.
+            headerBytes[V4HeaderSize..fullSize].Clear();
+        }
+
         Header = MemoryMarshal.Read<TraceFileHeader>(headerBytes);
 
         if (Header.Magic != TraceFileHeader.MagicValue)
         {
             throw new InvalidDataException(
                 $"Invalid trace file magic: 0x{Header.Magic:X8} (expected 0x{TraceFileHeader.MagicValue:X8})");
-        }
-        if (Header.Version != TraceFileHeader.CurrentVersion)
-        {
-            throw new InvalidDataException(
-                $"Unsupported trace file version: {Header.Version}. This build only reads version {TraceFileHeader.CurrentVersion}. " +
-                "The .typhon-trace format was rewritten in the typed-event release; older files are unreadable.");
         }
         return Header;
     }
@@ -207,6 +233,14 @@ public sealed class TraceFileReader : IDisposable
             ReadSpanNames();
             return ReadNextBlock(out records, out recordCount);
         }
+        if (firstWord == TraceFileWriter.FileTableMagic ||
+            firstWord == TraceFileWriter.SourceLocationManifestMagic)
+        {
+            // Trailing source-location manifest sections (#302, Phase 3) — not a block. Rewind so a separate
+            // caller can read the trailer via TryReadSourceLocationManifest, and signal end-of-blocks.
+            _stream.Position -= bytesRead;
+            return false;
+        }
 
         if (bytesRead < TraceBlockEncoder.BlockHeaderSize)
         {
@@ -290,5 +324,83 @@ public sealed class TraceFileReader : IDisposable
         var len = _binaryReader.ReadByte();
         var bytes = _binaryReader.ReadBytes(len);
         return Encoding.UTF8.GetString(bytes);
+    }
+
+    private string ReadVarString()
+    {
+        var len = _binaryReader.ReadUInt16();
+        var bytes = _binaryReader.ReadBytes(len);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Read the trailing source-location manifest (#302, Phase 3 of profiler-source-attribution).
+    /// Returns <c>false</c> if the trace file doesn't carry one (offsets in the header are zero).
+    /// Uses absolute seeks; requires a seekable stream.
+    /// See claude/design/observability/10-profiler-source-attribution.md §4.6.
+    /// </summary>
+    public bool TryReadSourceLocationManifest(out string[] files, out SourceLocationManifestEntry[] entries)
+    {
+        files = Array.Empty<string>();
+        entries = Array.Empty<SourceLocationManifestEntry>();
+
+        if (Header.FileTableOffset == 0 || Header.SourceLocationManifestOffset == 0)
+        {
+            return false;
+        }
+        if (!_stream.CanSeek)
+        {
+            throw new InvalidOperationException("TryReadSourceLocationManifest requires a seekable stream.");
+        }
+
+        var savedPos = _stream.Position;
+        try
+        {
+            // FileTable
+            _stream.Position = Header.FileTableOffset;
+            var fileMagic = _binaryReader.ReadUInt32();
+            if (fileMagic != TraceFileWriter.FileTableMagic)
+            {
+                throw new InvalidDataException(
+                    $"Bad FileTable magic at offset {Header.FileTableOffset}: 0x{fileMagic:X8} (expected 0x{TraceFileWriter.FileTableMagic:X8})");
+            }
+            var fileCount = _binaryReader.ReadUInt32();
+            files = new string[fileCount];
+            for (uint i = 0; i < fileCount; i++)
+            {
+                var fileId = _binaryReader.ReadUInt16();
+                var path = ReadVarString();
+                if (fileId < files.Length)
+                {
+                    files[fileId] = path;
+                }
+            }
+
+            // SourceLocationManifest
+            _stream.Position = Header.SourceLocationManifestOffset;
+            var manifestMagic = _binaryReader.ReadUInt32();
+            if (manifestMagic != TraceFileWriter.SourceLocationManifestMagic)
+            {
+                throw new InvalidDataException(
+                    $"Bad SourceLocationManifest magic at offset {Header.SourceLocationManifestOffset}: 0x{manifestMagic:X8} "
+                    + $"(expected 0x{TraceFileWriter.SourceLocationManifestMagic:X8})");
+            }
+            var entryCount = _binaryReader.ReadUInt32();
+            entries = new SourceLocationManifestEntry[entryCount];
+            for (uint i = 0; i < entryCount; i++)
+            {
+                var id = _binaryReader.ReadUInt16();
+                var fileId = _binaryReader.ReadUInt16();
+                var line = _binaryReader.ReadUInt32();
+                var kind = _binaryReader.ReadByte();
+                var method = ReadShortString();
+                entries[i] = new SourceLocationManifestEntry(id, fileId, line, kind, method);
+            }
+            return true;
+        }
+        finally
+        {
+            _stream.Position = savedPos;
+        }
     }
 }

--- a/src/Typhon.Profiler/TraceFileWriter.cs
+++ b/src/Typhon.Profiler/TraceFileWriter.cs
@@ -149,6 +149,68 @@ public sealed class TraceFileWriter : IDisposable
         _stream.Write(_compressedBuffer.AsSpan(0, compressedSize));
     }
 
+    /// <summary>Magic marker for the trailing FileTable (interned source-file paths). "SFLB" LE.</summary>
+    public const uint FileTableMagic = 0x42_4C_46_53;
+
+    /// <summary>Magic marker for the trailing SourceLocationManifest. "SLMN" LE.</summary>
+    public const uint SourceLocationManifestMagic = 0x4E_4D_4C_53;
+
+    /// <summary>
+    /// Append the source-location manifest to the file. Returns the (fileTableOffset, manifestOffset)
+    /// that the caller MUST patch into the file header via <see cref="RewriteHeader"/>. Phase 3 of the
+    /// profiler-source-attribution feature (see claude/design/observability/10-profiler-source-attribution.md §4.6).
+    /// </summary>
+    public (long fileTableOffset, long manifestOffset) WriteSourceLocationManifest(
+        IReadOnlyList<string> files,
+        IReadOnlyList<SourceLocationManifestEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(files);
+        ArgumentNullException.ThrowIfNull(entries);
+
+        _writer.Flush();
+        var fileTableOffset = _stream.Position;
+        _writer.Write(FileTableMagic);
+        _writer.Write((uint)files.Count);
+        for (ushort i = 0; i < files.Count; i++)
+        {
+            _writer.Write(i);
+            WriteVarString(files[i]);
+        }
+
+        _writer.Flush();
+        var manifestOffset = _stream.Position;
+        _writer.Write(SourceLocationManifestMagic);
+        _writer.Write((uint)entries.Count);
+        foreach (var e in entries)
+        {
+            _writer.Write(e.Id);
+            _writer.Write(e.FileId);
+            _writer.Write(e.Line);
+            _writer.Write(e.Kind);
+            WriteShortString(e.Method);
+        }
+        _writer.Flush();
+        return (fileTableOffset, manifestOffset);
+    }
+
+    /// <summary>
+    /// Rewrite the file header at offset 0 with updated trailer offsets. Required to seek; throws on non-seekable streams.
+    /// Used to record the trailing-section offsets after the manifest is appended.
+    /// </summary>
+    public void RewriteHeader(in TraceFileHeader header)
+    {
+        if (!_stream.CanSeek)
+        {
+            throw new InvalidOperationException("RewriteHeader requires a seekable stream.");
+        }
+        _writer.Flush();
+        var savedPos = _stream.Position;
+        _stream.Position = 0;
+        var span = MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(in header, 1));
+        _stream.Write(span);
+        _stream.Position = savedPos;
+    }
+
     public void Flush() => _stream.Flush();
 
     public void Dispose()
@@ -167,6 +229,18 @@ public sealed class TraceFileWriter : IDisposable
     {
         var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
         var len = (byte)Math.Min(bytes.Length, 255);
+        _writer.Write(len);
+        _writer.Write(bytes, 0, len);
+    }
+
+    /// <summary>
+    /// Variable-length string with a u16 byte-count prefix. Used for FileTable entries where paths can exceed
+    /// 255 bytes (the WriteShortString limit).
+    /// </summary>
+    private void WriteVarString(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+        var len = (ushort)Math.Min(bytes.Length, ushort.MaxValue);
         _writer.Write(len);
         _writer.Write(bytes, 0, len);
     }

--- a/src/Typhon.Profiler/TraceRecordHeader.cs
+++ b/src/Typhon.Profiler/TraceRecordHeader.cs
@@ -65,6 +65,15 @@ public static class TraceRecordHeader
     /// <summary><c>SpanFlags</c> bit 0 — set when the record includes a 16-byte trace context after the span header extension.</summary>
     public const byte SpanFlagsHasTraceContext = 0x01;
 
+    /// <summary>
+    /// <c>SpanFlags</c> bit 1 — set when the record carries a 2-byte source-location id (the compile-time <c>SourceLocationGenerator</c>
+    /// site index) immediately after the optional trace context. See <c>claude/design/observability/10-profiler-source-attribution.md</c>.
+    /// </summary>
+    public const byte SpanFlagsHasSourceLocation = 0x02;
+
+    /// <summary>Optional source-location-id size — 2 bytes (u16 LE), appended after the (optional) trace context when the flag is set.</summary>
+    public const int SourceLocationIdSize = 2;
+
     // ═══════════════════════════════════════════════════════════════════════
     // Encoding
     // ═══════════════════════════════════════════════════════════════════════
@@ -107,6 +116,15 @@ public static class TraceRecordHeader
         BinaryPrimitives.WriteUInt64LittleEndian(destination, traceIdHi);
         BinaryPrimitives.WriteUInt64LittleEndian(destination[8..], traceIdLo);
     }
+
+    /// <summary>
+    /// Write the optional 2-byte source-location id at <paramref name="destination"/>. Caller passes the span starting at the offset just
+    /// past the optional trace context (37 with no trace context, 53 with). Set <see cref="SpanFlagsHasSourceLocation"/> in <c>SpanFlags</c>
+    /// when calling this.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteSourceLocationId(Span<byte> destination, ushort sourceLocationId) 
+        => BinaryPrimitives.WriteUInt16LittleEndian(destination, sourceLocationId);
 
     // ═══════════════════════════════════════════════════════════════════════
     // Decoding
@@ -151,6 +169,14 @@ public static class TraceRecordHeader
         traceIdLo = BinaryPrimitives.ReadUInt64LittleEndian(source[8..]);
     }
 
+    /// <summary>
+    /// Parse the optional 2-byte source-location id at <paramref name="source"/>. Caller has already read <see cref="SpanFlagsHasSourceLocation"/>
+    /// from <c>SpanFlags</c> and is positioning <paramref name="source"/> just past the optional trace context.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ushort ReadSourceLocationId(ReadOnlySpan<byte> source)
+        => BinaryPrimitives.ReadUInt16LittleEndian(source);
+
     // ═══════════════════════════════════════════════════════════════════════
     // Sizing
     // ═══════════════════════════════════════════════════════════════════════
@@ -160,4 +186,20 @@ public static class TraceRecordHeader
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int SpanHeaderSize(bool hasTraceContext) => hasTraceContext ? MaxSpanHeaderSize : MinSpanHeaderSize;
+
+    /// <summary>
+    /// Total header size for a span record including the optional source-location id. Adds 2 bytes when <paramref name="hasSourceLocation"/>
+    /// is <c>true</c>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int SpanHeaderSize(bool hasTraceContext, bool hasSourceLocation)
+        => SpanHeaderSize(hasTraceContext) + (hasSourceLocation ? SourceLocationIdSize : 0);
+
+    /// <summary>
+    /// Byte offset of the optional source-location id within a span record: 37 with no trace context, 53 with.
+    /// Caller passes this to <see cref="WriteSourceLocationId"/> / <see cref="ReadSourceLocationId"/> after slicing
+    /// the destination/source span at the offset.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int SourceLocationIdOffset(bool hasTraceContext) => SpanHeaderSize(hasTraceContext);
 }

--- a/src/Typhon.Profiler/TransactionEventCodec.cs
+++ b/src/Typhon.Profiler/TransactionEventCodec.cs
@@ -60,19 +60,24 @@ public readonly struct TransactionEventData
     /// <summary>Phase 6: row count for CommitComponent (kind 22). Valid iff <see cref="HasRowCount"/>.</summary>
     public int RowCount { get; }
 
+    /// <summary>Source-location id assigned by <c>SourceLocationGenerator</c> (#302). Zero when the wire record didn't carry source attribution.</summary>
+    public ushort SourceLocationId { get; }
+
     public bool HasComponentCount => (OptionalFieldMask & TransactionEventCodec.OptComponentCount) != 0;
     public bool HasConflictDetected => (OptionalFieldMask & TransactionEventCodec.OptConflictDetected) != 0;
     public bool HasWalLsn => Kind == TraceEventKind.TransactionPersist && (OptionalFieldMask & TransactionEventCodec.OptWalLsn) != 0;
     public bool HasReason => (OptionalFieldMask & TransactionEventCodec.OptReason) != 0;
     public bool HasRowCount => (OptionalFieldMask & TransactionEventCodec.OptRowCount) != 0;
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
+    public bool HasSourceLocation => SourceLocationId != 0;
 
     public TransactionEventData(
         TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks,
         ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo,
         long tsn, int componentTypeId, byte optionalFieldMask,
         int componentCount, bool conflictDetected, long walLsn = 0,
-        TransactionRollbackReason reason = TransactionRollbackReason.Explicit, int rowCount = 0)
+        TransactionRollbackReason reason = TransactionRollbackReason.Explicit, int rowCount = 0,
+        ushort sourceLocationId = 0)
     {
         Kind = kind;
         ThreadSlot = threadSlot;
@@ -90,6 +95,7 @@ public readonly struct TransactionEventData
         WalLsn = walLsn;
         Reason = reason;
         RowCount = rowCount;
+        SourceLocationId = sourceLocationId;
     }
 }
 
@@ -143,9 +149,10 @@ public static class TransactionEventCodec
     private const int RowCountSize = 4;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int ComputeSize(TraceEventKind kind, bool hasTraceContext, byte optMask)
+    public static int ComputeSize(TraceEventKind kind, bool hasTraceContext, byte optMask, ushort sourceLocationId = 0)
     {
-        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext) + TsnSize + OptMaskSize;
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation) + TsnSize + OptMaskSize;
         if (kind == TraceEventKind.TransactionCommitComponent)
         {
             size += ComponentTypeIdSize;
@@ -186,22 +193,38 @@ public static class TransactionEventCodec
         bool conflictDetected,
         out int bytesWritten,
         TransactionRollbackReason reason = TransactionRollbackReason.Explicit,
-        int rowCount = 0)
+        int rowCount = 0,
+        ushort sourceLocationId = 0)
     {
         var hasTraceContext = traceIdHi != 0 || traceIdLo != 0;
-        var size = ComputeSize(kind, hasTraceContext, optMask);
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = ComputeSize(kind, hasTraceContext, optMask, sourceLocationId);
 
         TraceRecordHeader.WriteCommonHeader(destination, (ushort)size, kind, threadSlot, startTimestamp);
-        var spanFlags = hasTraceContext ? TraceRecordHeader.SpanFlagsHasTraceContext : (byte)0;
+        var spanFlags = (byte)0;
+        if (hasTraceContext)
+        {
+            spanFlags |= TraceRecordHeader.SpanFlagsHasTraceContext;
+        }
+
+        if (hasSourceLocation)
+        {
+            spanFlags |= TraceRecordHeader.SpanFlagsHasSourceLocation;
+        }
+
         TraceRecordHeader.WriteSpanHeaderExtension(destination[TraceRecordHeader.CommonHeaderSize..],
             endTimestamp - startTimestamp, spanId, parentSpanId, spanFlags);
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext);
         if (hasTraceContext)
         {
             TraceRecordHeader.WriteTraceContext(destination[TraceRecordHeader.MinSpanHeaderSize..], traceIdHi, traceIdLo);
         }
+        if (hasSourceLocation)
+        {
+            TraceRecordHeader.WriteSourceLocationId(destination[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..], sourceLocationId);
+        }
 
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = destination[headerSize..];
         BinaryPrimitives.WriteInt64LittleEndian(payload, tsn);
         var cursor = TsnSize;
@@ -245,13 +268,21 @@ public static class TransactionEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var tsn = BinaryPrimitives.ReadInt64LittleEndian(payload);
         var cursor = TsnSize;
@@ -292,38 +323,57 @@ public static class TransactionEventCodec
         }
 
         return new TransactionEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
-            tsn, componentTypeId, optMask, componentCount, conflictDetected, reason: reason, rowCount: rowCount);
+            tsn, componentTypeId, optMask, componentCount, conflictDetected, 0, reason, rowCount, sourceLocationId);
     }
 
     // ── Persist-specific codec (kind 23) ──
     // Wire layout: [i64 tsn][u8 optMask][i64 walLsn?]
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int ComputePersistSize(bool hasTraceContext, byte optMask)
+    public static int ComputePersistSize(bool hasTraceContext, byte optMask, ushort sourceLocationId = 0)
     {
-        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext) + TsnSize + OptMaskSize;
-        if ((optMask & OptWalLsn) != 0) size += WalLsnSize;
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation) + TsnSize + OptMaskSize;
+        if ((optMask & OptWalLsn) != 0)
+        {
+            size += WalLsnSize;
+        }
+
         return size;
     }
 
-    internal static void EncodePersist(Span<byte> destination, long endTimestamp, byte threadSlot, long startTimestamp,
-        ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo,
-        long tsn, byte optMask, long walLsn, out int bytesWritten)
+    internal static void EncodePersist(Span<byte> destination, long endTimestamp, byte threadSlot, long startTimestamp, ulong spanId, ulong parentSpanId,
+        ulong traceIdHi, ulong traceIdLo, long tsn, byte optMask, long walLsn, out int bytesWritten, ushort sourceLocationId = 0)
     {
         var hasTraceContext = traceIdHi != 0 || traceIdLo != 0;
-        var size = ComputePersistSize(hasTraceContext, optMask);
+        var hasSourceLocation = sourceLocationId != 0;
+        var size = ComputePersistSize(hasTraceContext, optMask, sourceLocationId);
 
         TraceRecordHeader.WriteCommonHeader(destination, (ushort)size, TraceEventKind.TransactionPersist, threadSlot, startTimestamp);
-        var spanFlags = hasTraceContext ? TraceRecordHeader.SpanFlagsHasTraceContext : (byte)0;
+        var spanFlags = (byte)0;
+        if (hasTraceContext)
+        {
+            spanFlags |= TraceRecordHeader.SpanFlagsHasTraceContext;
+        }
+
+        if (hasSourceLocation)
+        {
+            spanFlags |= TraceRecordHeader.SpanFlagsHasSourceLocation;
+        }
+
         TraceRecordHeader.WriteSpanHeaderExtension(destination[TraceRecordHeader.CommonHeaderSize..],
             endTimestamp - startTimestamp, spanId, parentSpanId, spanFlags);
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext);
         if (hasTraceContext)
         {
             TraceRecordHeader.WriteTraceContext(destination[TraceRecordHeader.MinSpanHeaderSize..], traceIdHi, traceIdLo);
         }
+        if (hasSourceLocation)
+        {
+            TraceRecordHeader.WriteSourceLocationId(destination[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..], sourceLocationId);
+        }
 
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = destination[headerSize..];
         BinaryPrimitives.WriteInt64LittleEndian(payload, tsn);
         var cursor = TsnSize;
@@ -344,13 +394,21 @@ public static class TransactionEventCodec
         TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
             out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
+
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
         var tsn = BinaryPrimitives.ReadInt64LittleEndian(payload);
         var cursor = TsnSize;
@@ -365,7 +423,7 @@ public static class TransactionEventCodec
         }
 
         return new TransactionEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
-            tsn, componentTypeId: 0, optMask, componentCount: 0, conflictDetected: false, walLsn: walLsn);
+            tsn, componentTypeId: 0, optMask, componentCount: 0, conflictDetected: false, walLsn: walLsn, sourceLocationId: sourceLocationId);
     }
 }
 

--- a/src/Typhon.Profiler/WalEventCodec.cs
+++ b/src/Typhon.Profiler/WalEventCodec.cs
@@ -20,6 +20,9 @@ public readonly struct WalEventData
     public ulong TraceIdHi { get; }
     public ulong TraceIdLo { get; }
 
+    /// <summary>#302 source-location id (0 = no attribution). Resolved through the trace manifest to file:line.</summary>
+    public ushort SourceLocationId { get; }
+
     /// <summary>Required for <see cref="TraceEventKind.WalFlush"/> — total bytes written in this flush cycle. Zero for other kinds.</summary>
     public int BatchByteCount { get; }
 
@@ -38,11 +41,8 @@ public readonly struct WalEventData
     /// <summary><c>true</c> when <see cref="TraceIdHi"/> and <see cref="TraceIdLo"/> are non-zero (the record carried distributed-trace context).</summary>
     public bool HasTraceContext => TraceIdHi != 0 || TraceIdLo != 0;
 
-    public WalEventData(
-        TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks,
-        ulong spanId, ulong parentSpanId, ulong traceIdHi, ulong traceIdLo,
-        int batchByteCount, int frameCount, long highLsn,
-        int newSegmentIndex, long targetLsn)
+    public WalEventData(TraceEventKind kind, byte threadSlot, long startTimestamp, long durationTicks, ulong spanId, ulong parentSpanId, ulong traceIdHi,
+        ulong traceIdLo, ushort sourceLocationId, int batchByteCount, int frameCount, long highLsn, int newSegmentIndex, long targetLsn)
     {
         Kind = kind;
         ThreadSlot = threadSlot;
@@ -52,6 +52,7 @@ public readonly struct WalEventData
         ParentSpanId = parentSpanId;
         TraceIdHi = traceIdHi;
         TraceIdLo = traceIdLo;
+        SourceLocationId = sourceLocationId;
         BatchByteCount = batchByteCount;
         FrameCount = frameCount;
         HighLsn = highLsn;
@@ -124,16 +125,23 @@ public static class WalEventCodec
     public static WalEventData Decode(ReadOnlySpan<byte> source)
     {
         TraceRecordHeader.ReadCommonHeader(source, out _, out var kind, out var threadSlot, out var startTimestamp);
-        TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..],
-            out var durationTicks, out var spanId, out var parentSpanId, out var spanFlags);
+        TraceRecordHeader.ReadSpanHeaderExtension(source[TraceRecordHeader.CommonHeaderSize..], out var durationTicks, out var spanId, 
+            out var parentSpanId, out var spanFlags);
 
+        var hasTraceContext = (spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0;
+        var hasSourceLocation = (spanFlags & TraceRecordHeader.SpanFlagsHasSourceLocation) != 0;
         ulong traceIdHi = 0, traceIdLo = 0;
-        if ((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0)
+        if (hasTraceContext)
         {
             TraceRecordHeader.ReadTraceContext(source[TraceRecordHeader.MinSpanHeaderSize..], out traceIdHi, out traceIdLo);
         }
+        ushort sourceLocationId = 0;
+        if (hasSourceLocation)
+        {
+            sourceLocationId = TraceRecordHeader.ReadSourceLocationId(source[TraceRecordHeader.SourceLocationIdOffset(hasTraceContext)..]);
+        }
 
-        var headerSize = TraceRecordHeader.SpanHeaderSize((spanFlags & TraceRecordHeader.SpanFlagsHasTraceContext) != 0);
+        var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
         var payload = source[headerSize..];
 
         int batchByteCount = 0, frameCount = 0, newSegmentIndex = 0;
@@ -156,7 +164,7 @@ public static class WalEventCodec
                 break;
         }
 
-        return new WalEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo,
+        return new WalEventData(kind, threadSlot, startTimestamp, durationTicks, spanId, parentSpanId, traceIdHi, traceIdLo, sourceLocationId,
             batchByteCount, frameCount, highLsn, newSegmentIndex, targetLsn);
     }
 }

--- a/test/Typhon.Engine.Tests/Collections/InMemoryHashMapTests.cs
+++ b/test/Typhon.Engine.Tests/Collections/InMemoryHashMapTests.cs
@@ -1,8 +1,6 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Data/ECS/BatchOperationTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/BatchOperationTests.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Data/ECS/ClusterDirtyTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/ClusterDirtyTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Numerics;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Data/ECS/ClusterIndexTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/ClusterIndexTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Numerics;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;

--- a/test/Typhon.Engine.Tests/Data/ECS/SimdKwayMergeTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/SimdKwayMergeTests.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Typhon.Schema.Definition;

--- a/test/Typhon.Engine.Tests/Data/SpatialGrid/SpatialGridTests.cs
+++ b/test/Typhon.Engine.Tests/Data/SpatialGrid/SpatialGridTests.cs
@@ -1,6 +1,5 @@
 using System.Numerics;
 using NUnit.Framework;
-using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialTriggerTests.cs
+++ b/test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialTriggerTests.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Typhon.Schema.Definition;

--- a/test/Typhon.Engine.Tests/Data/StorageModeStressTests.cs
+++ b/test/Typhon.Engine.Tests/Data/StorageModeStressTests.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Profiler/FileExporterIntegrationTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/FileExporterIntegrationTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using NUnit.Framework;
-using Typhon.Engine;
 using Typhon.Engine.Profiler;
 using Typhon.Engine.Profiler.Exporters;
 using Typhon.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/GcEventQueueTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/GcEventQueueTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading;
 using NUnit.Framework;
 using Typhon.Engine.Profiler.Gc;
-using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;
 

--- a/test/Typhon.Engine.Tests/Profiler/GcInstantEventCodecTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/GcInstantEventCodecTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using NUnit.Framework;
-using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/GcSuspensionEventCodecTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/GcSuspensionEventCodecTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using NUnit.Framework;
-using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/MemoryAllocEventCodecTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/MemoryAllocEventCodecTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using NUnit.Framework;
-using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/PerTickSnapshotEventCodecTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/PerTickSnapshotEventCodecTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using NUnit.Framework;
-using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/RecordDecoderContinuationTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/RecordDecoderContinuationTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using NUnit.Framework;
-using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/RecordDecoderGaugeTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/RecordDecoderGaugeTests.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using NUnit.Framework;
-using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/SourceLocationCodecRoundTripTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/SourceLocationCodecRoundTripTests.cs
@@ -1,0 +1,351 @@
+using System;
+using NUnit.Framework;
+using Typhon.Engine.Profiler;
+using Typhon.Profiler;
+
+namespace Typhon.Engine.Tests.Profiler;
+
+/// <summary>
+/// Phase 1 wire-format coverage for the post-#294 source-attribution feature (#302). Each test builds an event ref struct with a non-zero
+/// <c>Header.SourceLocationId</c>, encodes it, then decodes the wire bytes via the codec's <c>Decode</c> and asserts the siteId round-trips.
+/// Covers both the generator-emitted <c>EncodeTo</c> path (events with <c>[TraceEvent(..., EmitEncoder = true)]</c>) and the hand-written codec
+/// path (the 9 events keeping their hand-written <c>EncodeTo</c>: 5× PageCache, 4× Transaction, EcsQueryAny).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The legacy-bytes test (<see cref="ZeroSiteId_ProducesByteIdenticalLegacyOutput"/>) is the backward-compatibility guarantor — it asserts that pre-#302
+/// traces remain byte-identical when source attribution is disabled (<c>Header.SourceLocationId == 0</c>).
+/// </para>
+/// <para>
+/// See <c>claude/design/observability/10-profiler-source-attribution.md</c> §4 for the wire-format design
+/// and <c>TraceRecordHeader.SpanFlagsHasSourceLocation</c> for the flag bit definition.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class SourceLocationCodecRoundTripTests
+{
+    // ═══════════════════════════════════════════════════════════════════════
+    // Generator-emitted EncodeTo path — events with [TraceEvent(EmitEncoder = true)]
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void BTreeInsert_WithSiteId_NoTraceContext_RoundTripsViaCodec()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new BTreeInsertEvent
+        {
+            Header = new TraceSpanHeader
+            {
+                ThreadSlot = 1,
+                StartTimestamp = 1000,
+                SpanId = 0xAABBUL,
+                ParentSpanId = 0xCCDDUL,
+                SourceLocationId = 0x012F,
+            },
+        };
+
+        evt.EncodeTo(buffer, endTimestamp: 1500, out var written);
+        Assert.That(written, Is.EqualTo(TraceRecordHeader.MinSpanHeaderSize + 2),
+            "37-byte span header + 2-byte siteId = 39 bytes");
+
+        var decoded = BTreeEventCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0x012F));
+        Assert.That(decoded.HasSourceLocation, Is.True);
+        Assert.That(decoded.HasTraceContext, Is.False);
+        Assert.That(decoded.SpanId, Is.EqualTo(0xAABBUL));
+        Assert.That(decoded.ParentSpanId, Is.EqualTo(0xCCDDUL));
+    }
+
+    [Test]
+    public void BTreeInsert_WithSiteIdAndTraceContext_RoundTripsViaCodec()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new BTreeInsertEvent
+        {
+            Header = new TraceSpanHeader
+            {
+                ThreadSlot = 1,
+                StartTimestamp = 1000,
+                SpanId = 1,
+                TraceIdHi = 0x1122334455667788UL,
+                TraceIdLo = 0x99AABBCCDDEEFF00UL,
+                SourceLocationId = 0xBEEF,
+            },
+        };
+
+        evt.EncodeTo(buffer, endTimestamp: 1500, out var written);
+        Assert.That(written, Is.EqualTo(TraceRecordHeader.MaxSpanHeaderSize + 2),
+            "53-byte span header (with trace ctx) + 2-byte siteId = 55 bytes");
+
+        var decoded = BTreeEventCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0xBEEF));
+        Assert.That(decoded.HasSourceLocation, Is.True);
+        Assert.That(decoded.HasTraceContext, Is.True);
+        Assert.That(decoded.TraceIdHi, Is.EqualTo(0x1122334455667788UL));
+        Assert.That(decoded.TraceIdLo, Is.EqualTo(0x99AABBCCDDEEFF00UL));
+    }
+
+    [Test]
+    public void ZeroSiteId_ProducesByteIdenticalLegacyOutput()
+    {
+        // Two events: one with SourceLocationId explicitly = 0, one with the field uninitialized.
+        // Both must produce identical wire bytes — no flag bit, no extra payload, byte-identical to pre-#302.
+        Span<byte> withZero = stackalloc byte[128];
+        Span<byte> baseline = stackalloc byte[128];
+
+        var evtZero = new BTreeInsertEvent
+        {
+            Header = new TraceSpanHeader
+            {
+                ThreadSlot = 7,
+                StartTimestamp = 1000,
+                SpanId = 0xAABBUL,
+                ParentSpanId = 0xCCDDUL,
+                SourceLocationId = 0,
+            },
+        };
+        var evtNoField = new BTreeInsertEvent
+        {
+            Header = new TraceSpanHeader
+            {
+                ThreadSlot = 7,
+                StartTimestamp = 1000,
+                SpanId = 0xAABBUL,
+                ParentSpanId = 0xCCDDUL,
+            },
+        };
+
+        evtZero.EncodeTo(withZero, endTimestamp: 2000, out var w1);
+        evtNoField.EncodeTo(baseline, endTimestamp: 2000, out var w2);
+
+        Assert.That(w1, Is.EqualTo(w2));
+        Assert.That(withZero[..w1].ToArray(), Is.EqualTo(baseline[..w2].ToArray()));
+
+        // Round-trip via codec — siteId should decode as 0, no flag bits.
+        var decoded = BTreeEventCodec.Decode(withZero[..w1]);
+        Assert.That(decoded.HasSourceLocation, Is.False);
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Hand-written PageCacheEventCodec path — 5 events
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void PageCacheFetch_WithSiteId_RoundTripsViaCodec()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new PageCacheFetchEvent
+        {
+            Header = new TraceSpanHeader { ThreadSlot = 2, StartTimestamp = 100, SpanId = 5, SourceLocationId = 0x1234 },
+            FilePageIndex = 42,
+        };
+
+        evt.EncodeTo(buffer, endTimestamp: 200, out var written);
+        var decoded = PageCacheEventCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0x1234));
+        Assert.That(decoded.HasSourceLocation, Is.True);
+        Assert.That(decoded.FilePageIndex, Is.EqualTo(42));
+        Assert.That(decoded.Kind, Is.EqualTo(TraceEventKind.PageCacheFetch));
+    }
+
+    [Test]
+    public void PageCacheDiskWrite_WithOptionalsAndSiteIdAndTraceContext_RoundTripsViaCodec()
+    {
+        // Stress test: optional payload field + trace context + source-location all coexisting.
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new PageCacheDiskWriteEvent
+        {
+            Header = new TraceSpanHeader
+            {
+                ThreadSlot = 3, StartTimestamp = 100, SpanId = 7,
+                TraceIdHi = 0xABCD0000UL, TraceIdLo = 0xEF010203UL,
+                SourceLocationId = 0xCAFE,
+            },
+            FilePageIndex = 99,
+        };
+        evt.PageCount = 17; // sets optMask bit
+
+        evt.EncodeTo(buffer, endTimestamp: 200, out var written);
+        var decoded = PageCacheEventCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0xCAFE));
+        Assert.That(decoded.HasSourceLocation, Is.True);
+        Assert.That(decoded.HasTraceContext, Is.True);
+        Assert.That(decoded.HasPageCount, Is.True);
+        Assert.That(decoded.PageCount, Is.EqualTo(17));
+        Assert.That(decoded.FilePageIndex, Is.EqualTo(99));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Hand-written TransactionEventCodec path — 4 events
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void TransactionCommit_WithSiteId_RoundTripsViaCodec()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new TransactionCommitEvent
+        {
+            Header = new TraceSpanHeader { ThreadSlot = 4, StartTimestamp = 100, SpanId = 11, SourceLocationId = 0x9999 },
+            Tsn = 0x1234567890ABCDEFL,
+        };
+
+        evt.EncodeTo(buffer, endTimestamp: 200, out var written);
+        var decoded = TransactionEventCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0x9999));
+        Assert.That(decoded.HasSourceLocation, Is.True);
+        Assert.That(decoded.Tsn, Is.EqualTo(0x1234567890ABCDEFL));
+    }
+
+    [Test]
+    public void TransactionCommitComponent_WithSiteId_DifferentLayout_RoundTripsViaCodec()
+    {
+        // CommitComponent has its own kind-specific payload field (componentTypeId).
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new TransactionCommitComponentEvent
+        {
+            Header = new TraceSpanHeader { ThreadSlot = 4, StartTimestamp = 100, SpanId = 12, SourceLocationId = 0x3333 },
+            Tsn = 42L,
+            ComponentTypeId = 7,
+        };
+
+        evt.EncodeTo(buffer, endTimestamp: 200, out var written);
+        var decoded = TransactionEventCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0x3333));
+        Assert.That(decoded.ComponentTypeId, Is.EqualTo(7));
+        Assert.That(decoded.Kind, Is.EqualTo(TraceEventKind.TransactionCommitComponent));
+    }
+
+    [Test]
+    public void TransactionPersist_WithSiteId_RoundTripsViaPersistDecoder()
+    {
+        // Persist has its own codec path (EncodePersist/DecodePersist).
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new TransactionPersistEvent
+        {
+            Header = new TraceSpanHeader { ThreadSlot = 4, StartTimestamp = 100, SpanId = 13, SourceLocationId = 0x7777 },
+            Tsn = 0xABCD1234L,
+        };
+        evt.WalLsn = 999L; // sets optMask
+
+        evt.EncodeTo(buffer, endTimestamp: 200, out var written);
+        var decoded = TransactionEventCodec.DecodePersist(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0x7777));
+        Assert.That(decoded.HasWalLsn, Is.True);
+        Assert.That(decoded.WalLsn, Is.EqualTo(999L));
+        Assert.That(decoded.Tsn, Is.EqualTo(0xABCD1234L));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Hand-written EcsQueryEventCodec path (EcsQueryAny) — and verify shared
+    // Decode handles generator-emitted EcsQueryExecute too
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void EcsQueryAny_WithSiteId_RoundTripsViaCodec()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new EcsQueryAnyEvent
+        {
+            Header = new TraceSpanHeader { ThreadSlot = 5, StartTimestamp = 100, SpanId = 21, SourceLocationId = 0x5A5A },
+            ArchetypeTypeId = 8,
+        };
+        evt.Found = true; // sets OptFound
+
+        evt.EncodeTo(buffer, endTimestamp: 200, out var written);
+        var decoded = EcsQueryEventCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0x5A5A));
+        Assert.That(decoded.HasFound, Is.True);
+        Assert.That(decoded.Found, Is.True);
+        Assert.That(decoded.ArchetypeTypeId, Is.EqualTo((ushort)8));
+    }
+
+    [Test]
+    public void PageCacheBackpressure_WithSiteId_DecoderHandlesGeneratorEmittedEncodeTo()
+    {
+        // PageCacheBackpressure has [TraceEvent(EmitEncoder = true)] — the EncodeTo is generator-emitted, but
+        // the Decode lives in the hand-written PageCacheBackpressureCodec class. Confirms the decoder reads
+        // the optional source-location bytes that the generator-emitted encoder writes.
+        Span<byte> buffer = stackalloc byte[128];
+        var evt = new PageCacheBackpressureEvent
+        {
+            Header = new TraceSpanHeader { ThreadSlot = 6, StartTimestamp = 100, SpanId = 31, SourceLocationId = 0xF00D },
+            RetryCount = 3,
+            DirtyCount = 7,
+            EpochCount = 11,
+        };
+
+        evt.EncodeTo(buffer, endTimestamp: 200, out var written);
+        var decoded = PageCacheBackpressureCodec.Decode(buffer[..written]);
+
+        Assert.That(decoded.SourceLocationId, Is.EqualTo((ushort)0xF00D));
+        Assert.That(decoded.HasSourceLocation, Is.True);
+        Assert.That(decoded.RetryCount, Is.EqualTo(3));
+        Assert.That(decoded.DirtyCount, Is.EqualTo(7));
+        Assert.That(decoded.EpochCount, Is.EqualTo(11));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Generator-emitted factory pair sanity (compile-time existence check)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void BeginBTreeInsert_PassThroughForwarder_PreservesZeroSiteId()
+    {
+        // The generator emits TyphonEvent.BeginBTreeInsert() as a thin pass-through to BeginBTreeInsert_WithSiteId(0).
+        // When the profiler is inactive (default in tests), the factory returns default(BTreeInsertEvent) —
+        // siteId is 0. This test compiles only because both factories exist (the pair emission worked).
+        var evt = TyphonEvent.BeginBTreeInsert();
+        Assert.That(evt.Header.SourceLocationId, Is.EqualTo((ushort)0));
+    }
+
+    [Test]
+    public void BeginBTreeInsert_WithSiteId_FactoryExistsAndAcceptsLiteral()
+    {
+        // Compile-time existence of the WithSiteId pair. Runtime behavior with a non-zero siteId requires
+        // an active profiler; this test just asserts the factory binds.
+        var evt = TyphonEvent.BeginBTreeInsert_WithSiteId(0x1234);
+        // When inactive, returns default — SourceLocationId is 0. When active, would be 0x1234.
+        Assert.That(evt.Header.SourceLocationId, Is.EqualTo(0).Or.EqualTo((ushort)0x1234));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Wire-format invariants — flag bit, offsets
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void SpanFlagsHasSourceLocation_BitIsDistinctFromTraceContext()
+    {
+        Assert.That(TraceRecordHeader.SpanFlagsHasSourceLocation,
+            Is.Not.EqualTo(TraceRecordHeader.SpanFlagsHasTraceContext),
+            "Flag bits must not collide");
+        Assert.That(TraceRecordHeader.SpanFlagsHasSourceLocation & TraceRecordHeader.SpanFlagsHasTraceContext,
+            Is.Zero, "Flag bits must be in different positions (bitwise AND must be zero)");
+    }
+
+    [Test]
+    public void SpanHeaderSize_AccountsForOptionalSourceLocation()
+    {
+        Assert.That(TraceRecordHeader.SpanHeaderSize(false, false), Is.EqualTo(TraceRecordHeader.MinSpanHeaderSize));
+        Assert.That(TraceRecordHeader.SpanHeaderSize(true, false), Is.EqualTo(TraceRecordHeader.MaxSpanHeaderSize));
+        Assert.That(TraceRecordHeader.SpanHeaderSize(false, true), Is.EqualTo(TraceRecordHeader.MinSpanHeaderSize + 2));
+        Assert.That(TraceRecordHeader.SpanHeaderSize(true, true), Is.EqualTo(TraceRecordHeader.MaxSpanHeaderSize + 2));
+    }
+
+    [Test]
+    public void SourceLocationIdOffset_LandsAfterTraceContext()
+    {
+        Assert.That(TraceRecordHeader.SourceLocationIdOffset(false), Is.EqualTo(TraceRecordHeader.MinSpanHeaderSize),
+            "Without trace ctx, siteId starts at offset 37");
+        Assert.That(TraceRecordHeader.SourceLocationIdOffset(true), Is.EqualTo(TraceRecordHeader.MaxSpanHeaderSize),
+            "With trace ctx, siteId starts at offset 53");
+    }
+}

--- a/test/Typhon.Engine.Tests/Profiler/SourceLocationGeneratorTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/SourceLocationGeneratorTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Typhon.Engine.Profiler.Generated;
+
+namespace Typhon.Engine.Tests.Profiler;
+
+/// <summary>
+/// Phase 2 (#302): tests that the <see cref="SourceLocations"/> table emitted by <c>SourceLocationGenerator</c>
+/// is well-formed — non-empty, deterministic ordering, repo-relative paths, IDs starting at 1, no duplicates.
+/// </summary>
+/// <remarks>
+/// These tests inspect the static table baked into <c>Typhon.Engine.dll</c>. They verify the GENERATOR
+/// PRODUCED CORRECT METADATA. Verifying that interceptors actually redirect at runtime requires an active
+/// profiler session; that's covered by the live-attach round-trip in Phase 4. The compilation succeeding at
+/// all (with the generator's interceptors referencing <c>BeginXxx_WithSiteId</c>) is itself strong evidence
+/// the interceptor wiring is correct — a malformed interceptor signature fails the build.
+/// </remarks>
+[TestFixture]
+public class SourceLocationGeneratorTests
+{
+    [Test]
+    public void TableIsNonEmpty()
+    {
+        Assert.That(SourceLocations.All.Length, Is.GreaterThan(0),
+            "Generator should emit at least one site for the call sites in Typhon.Engine");
+        Assert.That(SourceLocations.Files.Length, Is.GreaterThan(0),
+            "FileTable should have at least one entry");
+    }
+
+    [Test]
+    public void IdsStartAtOneAndAreSequential()
+    {
+        // ID 0 is reserved for "unknown source". Generator assigns IDs starting at 1, sequentially.
+        Assert.That(SourceLocations.All[0].Id, Is.EqualTo((ushort)1),
+            "First site ID must be 1 — 0 is reserved for unknown-source fallback");
+
+        for (int i = 1; i < SourceLocations.All.Length; i++)
+        {
+            Assert.That(SourceLocations.All[i].Id, Is.EqualTo((ushort)(SourceLocations.All[i - 1].Id + 1)),
+                $"Site IDs must be sequential; gap at index {i}");
+        }
+    }
+
+    [Test]
+    public void IdsAreUnique()
+    {
+        var ids = SourceLocations.All.Select(e => e.Id).ToArray();
+        Assert.That(ids.Distinct().Count(), Is.EqualTo(ids.Length),
+            "Site IDs must be unique");
+    }
+
+    [Test]
+    public void FilesAreRepoRelative()
+    {
+        // Per design §4.4: paths must be repo-relative ("/_/..." form), not absolute build-machine paths.
+        // This is the portability + privacy invariant — tests on a different machine should resolve.
+        foreach (var file in SourceLocations.Files)
+        {
+            Assert.That(file, Does.StartWith("/_/"),
+                $"File path '{file}' must use the /_/ repo-relative sentinel; absolute paths leak build-machine state");
+        }
+    }
+
+    [Test]
+    public void EntriesReferenceValidFileIds()
+    {
+        var fileCount = (ushort)SourceLocations.Files.Length;
+        foreach (var entry in SourceLocations.All)
+        {
+            Assert.That(entry.FileId, Is.LessThan(fileCount),
+                $"Entry id={entry.Id} fileId={entry.FileId} is out of range (Files.Length={fileCount})");
+        }
+    }
+
+    [Test]
+    public void EntriesAreSortedDeterministically()
+    {
+        // Generator sorts by (filePath, line, column) before assigning IDs. The sorted order anchors the
+        // deterministic-ID property: site IDs are stable across builds and machines.
+        for (int i = 1; i < SourceLocations.All.Length; i++)
+        {
+            var prev = SourceLocations.All[i - 1];
+            var curr = SourceLocations.All[i];
+
+            // (FileId, Line) must be monotonically non-decreasing — same file → line increases; different file → fileId increases.
+            var prevKey = ((int)prev.FileId, prev.Line);
+            var currKey = ((int)curr.FileId, curr.Line);
+            Assert.That(currKey, Is.GreaterThanOrEqualTo(prevKey),
+                $"Entries must be sorted by (FileId, Line); violation at index {i}: prev={prevKey}, curr={currKey}");
+        }
+    }
+
+    [Test]
+    public void BTreeInsertSiteIsAttributed()
+    {
+        // BTree.cs has at least one TyphonEvent.BeginBTreeInsert call site. After Phase 2's generator wires up,
+        // the table must contain an entry whose file ends with BTree.cs (any of BTree.cs / BTree.Insert.cs / etc.).
+        var btreeFiles = SourceLocations.Files
+            .Select((f, idx) => (path: f, idx: (ushort)idx))
+            .Where(x => x.path.Contains("BTree", StringComparison.Ordinal))
+            .ToArray();
+        Assert.That(btreeFiles, Is.Not.Empty,
+            "Generator should attribute at least one site in a BTree*.cs file");
+    }
+
+    [Test]
+    public void EntriesCarryMethodNames()
+    {
+        // The containing method name is captured for free at attribution time and shown in the Workbench
+        // detail row ("file:line · method"). Empty method names indicate a generator-level regression.
+        foreach (var entry in SourceLocations.All)
+        {
+            Assert.That(entry.Method, Is.Not.Null.And.Not.Empty,
+                $"Entry id={entry.Id} has no method name");
+        }
+    }
+}

--- a/test/Typhon.Engine.Tests/Profiler/SourceLocationManifestRoundTripTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/SourceLocationManifestRoundTripTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using Typhon.Profiler;
+
+namespace Typhon.Engine.Tests.Profiler;
+
+/// <summary>
+/// Phase 2 round-trip: write a trace with a source-location manifest in the trailer, read it back,
+/// confirm contents and that the file header offsets are correctly patched.
+///
+/// NOTE: <see cref="TraceFileWriter.Dispose"/> closes the underlying stream. These tests read the
+/// same MemoryStream after writing, so they explicitly skip Dispose. Production callers writing to
+/// a file path don't hit this — they re-open the file for reading.
+/// </summary>
+[TestFixture]
+public class SourceLocationManifestRoundTripTests
+{
+    [Test]
+    public void Manifest_RoundTripsThroughTraceFile()
+    {
+        var stream = new MemoryStream();
+
+        var files = new[]
+        {
+            "/_/src/Typhon.Engine/Data/Index/BTree.cs",
+            "/_/src/Typhon.Engine/Data/Transaction/Transaction.cs",
+        };
+        var entries = new[]
+        {
+            new SourceLocationManifestEntry(id: 1, fileId: 0, line: 1124, kind: 12, method: "BTree.Add"),
+            new SourceLocationManifestEntry(id: 2, fileId: 1, line: 217, kind: 1, method: "Transaction.Commit"),
+        };
+
+        var writer = new TraceFileWriter(stream);
+        var header = new TraceFileHeader
+        {
+            Magic = TraceFileHeader.MagicValue,
+            Version = TraceFileHeader.CurrentVersion,
+            Flags = 0,
+            TimestampFrequency = 10_000_000,
+            BaseTickRate = 60.0f,
+            WorkerCount = 4,
+            SystemCount = 0,
+            ArchetypeCount = 0,
+            ComponentTypeCount = 0,
+            CreatedUtcTicks = 0,
+            SamplingSessionStartQpc = 0,
+            FileTableOffset = 0,
+            SourceLocationManifestOffset = 0,
+        };
+        writer.WriteHeader(in header);
+        writer.WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord>.Empty);
+        writer.WriteArchetypes(ReadOnlySpan<ArchetypeRecord>.Empty);
+        writer.WriteComponentTypes(ReadOnlySpan<ComponentTypeRecord>.Empty);
+
+        var (fileTableOffset, manifestOffset) = writer.WriteSourceLocationManifest(files, entries);
+
+        header.FileTableOffset = fileTableOffset;
+        header.SourceLocationManifestOffset = manifestOffset;
+        writer.RewriteHeader(in header);
+        writer.Flush();
+
+        Assert.That(fileTableOffset, Is.GreaterThan(0));
+        Assert.That(manifestOffset, Is.GreaterThan(fileTableOffset));
+
+        // Read it back from the same stream.
+        stream.Position = 0;
+        var reader = new TraceFileReader(stream);
+        var readHeader = reader.ReadHeader();
+        Assert.That(readHeader.Version, Is.EqualTo(TraceFileHeader.CurrentVersion));
+        Assert.That(readHeader.FileTableOffset, Is.EqualTo(fileTableOffset));
+        Assert.That(readHeader.SourceLocationManifestOffset, Is.EqualTo(manifestOffset));
+
+        // TryReadSourceLocationManifest seeks absolutely and restores position, so order-independent.
+        var ok = reader.TryReadSourceLocationManifest(out var roundtripFiles, out var roundtripEntries);
+        Assert.That(ok, Is.True);
+        Assert.That(roundtripFiles, Is.EqualTo(files));
+        Assert.That(roundtripEntries.Length, Is.EqualTo(entries.Length));
+        for (int i = 0; i < entries.Length; i++)
+        {
+            Assert.That(roundtripEntries[i].Id, Is.EqualTo(entries[i].Id));
+            Assert.That(roundtripEntries[i].FileId, Is.EqualTo(entries[i].FileId));
+            Assert.That(roundtripEntries[i].Line, Is.EqualTo(entries[i].Line));
+            Assert.That(roundtripEntries[i].Kind, Is.EqualTo(entries[i].Kind));
+            Assert.That(roundtripEntries[i].Method, Is.EqualTo(entries[i].Method));
+        }
+    }
+
+    [Test]
+    public void Manifest_AbsentWhenOffsetsAreZero()
+    {
+        var stream = new MemoryStream();
+        var writer = new TraceFileWriter(stream);
+
+        var header = new TraceFileHeader
+        {
+            Magic = TraceFileHeader.MagicValue,
+            Version = TraceFileHeader.CurrentVersion,
+            Flags = 0,
+            TimestampFrequency = 10_000_000,
+            BaseTickRate = 60.0f,
+            WorkerCount = 1,
+            SystemCount = 0,
+            ArchetypeCount = 0,
+            ComponentTypeCount = 0,
+            CreatedUtcTicks = 0,
+            SamplingSessionStartQpc = 0,
+            FileTableOffset = 0,
+            SourceLocationManifestOffset = 0,
+        };
+        writer.WriteHeader(in header);
+        writer.WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord>.Empty);
+        writer.WriteArchetypes(ReadOnlySpan<ArchetypeRecord>.Empty);
+        writer.WriteComponentTypes(ReadOnlySpan<ComponentTypeRecord>.Empty);
+        writer.Flush();
+
+        stream.Position = 0;
+        var reader = new TraceFileReader(stream);
+        reader.ReadHeader();
+        var ok = reader.TryReadSourceLocationManifest(out var files, out var entries);
+        Assert.That(ok, Is.False);
+        Assert.That(files, Is.Empty);
+        Assert.That(entries, Is.Empty);
+    }
+}

--- a/test/Typhon.Engine.Tests/Profiler/TcpExporterIntegrationTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/TcpExporterIntegrationTests.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using NUnit.Framework;
-using Typhon.Engine;
 using Typhon.Engine.Profiler;
 using Typhon.Engine.Profiler.Exporters;
 using Typhon.Profiler;
@@ -113,14 +112,20 @@ public class TcpExporterIntegrationTests
             var decodedClusterMigration = false;
             var framesRead = 0;
 
-            while (framesRead < 20
+            while (framesRead < 22
                    && (!decodedClusterMigration
                        || kindCounts.GetValueOrDefault(TraceEventKind.BTreeInsert, 0) == 0
                        || kindCounts.GetValueOrDefault(TraceEventKind.BTreeDelete, 0) == 0))
             {
                 var (frameType, framePayload) = ReadFrame(stream);
-                Assert.That(frameType, Is.EqualTo(LiveFrameType.Block), $"Frame {framesRead} after INIT must be a Block");
                 framesRead++;
+                // #302 Phase 4: FileTable + SourceLocationManifest frames are sent during the init handshake,
+                // before the first Block frame. Skip past them — they're optional metadata, not record blocks.
+                if (frameType == LiveFrameType.FileTable || frameType == LiveFrameType.SourceLocationManifest)
+                {
+                    continue;
+                }
+                Assert.That(frameType, Is.EqualTo(LiveFrameType.Block), $"Frame {framesRead} after INIT must be a Block (or FileTable/SourceLocationManifest)");
 
                 var (uncompressedBytes, compressedBytes, recordCount) = TraceBlockEncoder.ReadBlockHeader(framePayload);
                 Assert.That(recordCount, Is.GreaterThan(0), $"Block {framesRead} should carry at least one record");

--- a/test/Typhon.Engine.Tests/Profiler/TraceFileCacheBuilderSplitTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/TraceFileCacheBuilderSplitTests.cs
@@ -3,7 +3,6 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
-using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 
 namespace Typhon.Engine.Tests.Profiler;

--- a/test/Typhon.Engine.Tests/Profiler/TraceRingObserver.cs
+++ b/test/Typhon.Engine.Tests/Profiler/TraceRingObserver.cs
@@ -3,7 +3,6 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using Typhon.Engine;
 using Typhon.Engine.Profiler;
 using Typhon.Profiler;
 

--- a/test/Typhon.Engine.Tests/Runtime/ChangeFilterTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/ChangeFilterTests.cs
@@ -1,8 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Typhon.Schema.Definition;
 

--- a/test/Typhon.Engine.Tests/Runtime/CheckerboardTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/CheckerboardTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
-using System.Collections.Concurrent;
 using System.Numerics;
 using System.Threading;
 using Typhon.Schema.Definition;

--- a/test/Typhon.Engine.Tests/Runtime/DagSchedulerLatencyTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/DagSchedulerLatencyTests.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 

--- a/test/Typhon.Engine.Tests/Runtime/DormancyTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/DormancyTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
-using System.Collections.Concurrent;
 using System.Numerics;
 using System.Threading;
 using Typhon.Schema.Definition;

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/ProtocolTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/ProtocolTests.cs
@@ -1,6 +1,5 @@
 using MemoryPack;
 using NUnit.Framework;
-using Typhon.Engine;
 using Typhon.Protocol;
 
 namespace Typhon.Engine.Tests;

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/SendBufferTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/SendBufferTests.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using System;
-using Typhon.Engine;
 
 namespace Typhon.Engine.Tests;
 

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionTransitionTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionTransitionTests.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using Typhon.Engine;
 using Typhon.Protocol;
 
 namespace Typhon.Engine.Tests;

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs
@@ -1,7 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Linq;
 using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Tests.Runtime;

--- a/test/Typhon.Engine.Tests/Runtime/SystemAccessValidatorTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/SystemAccessValidatorTests.cs
@@ -1,6 +1,5 @@
 using NUnit.Framework;
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/test/Typhon.Engine.Tests/Runtime/TierDispatchTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/TierDispatchTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/test/Typhon.Engine.Tests/Runtime/TyphonRuntimeTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/TyphonRuntimeTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 
 namespace Typhon.Engine.Tests.Runtime;

--- a/test/Typhon.Workbench.Tests/EditorLauncherTests.cs
+++ b/test/Typhon.Workbench.Tests/EditorLauncherTests.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using Typhon.Workbench.Hosting;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// Argv-shape tests for <see cref="EditorLauncher"/> — exercises the <c>BuildXxxProcessStartInfo</c>
+/// helpers without spawning processes. Per-(EditorKind, OS) coverage matches the design's dispatch
+/// table (#302 §5.5). Live <c>Process.Start</c> is intentionally NOT exercised here; that's covered
+/// by manual QA on Windows during release prep — the tests here pin the wire-shape that the OS
+/// shell sees.
+/// </summary>
+[TestFixture]
+public sealed class EditorLauncherTests
+{
+    [Test]
+    public void BuildFileUrl_VsCode_EncodesPathAndAppendsLine()
+    {
+        var url = EditorLauncher.BuildFileUrl("vscode", @"C:\Dev\repo\src\BTree.cs", 42);
+        Assert.That(url, Is.EqualTo("vscode://file/C%3A/Dev/repo/src/BTree.cs:42"));
+    }
+
+    [Test]
+    public void BuildFileUrl_Cursor_UsesCursorScheme()
+    {
+        var url = EditorLauncher.BuildFileUrl("cursor", "/home/user/repo/src/BTree.cs", 17);
+        Assert.That(url, Does.StartWith("cursor://file/"));
+        Assert.That(url, Does.EndWith(":17"));
+    }
+
+    [Test]
+    public void BuildRiderProcessStartInfos_PassesLineAndPathAsDiscreteArgs()
+    {
+        var infos = EditorLauncher.BuildRiderProcessStartInfos("/path/to/File.cs", 99).ToArray();
+        Assert.That(infos, Is.Not.Empty);
+        var first = infos[0];
+        Assert.That(first.UseShellExecute, Is.False);
+        Assert.That(first.ArgumentList, Is.EqualTo(new[] { "--line", "99", "/path/to/File.cs" }));
+
+        var expectedFirst = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "rider.cmd" : "rider";
+        Assert.That(first.FileName, Is.EqualTo(expectedFirst));
+    }
+
+    [Test]
+    public void BuildVisualStudioProcessStartInfo_UsesEditAndCommandArgs()
+    {
+        var psi = EditorLauncher.BuildVisualStudioProcessStartInfo(@"C:\src\Foo.cs", 7);
+        Assert.That(psi.FileName, Is.EqualTo("devenv.exe"));
+        Assert.That(psi.UseShellExecute, Is.False);
+        Assert.That(psi.ArgumentList, Is.EqualTo(new[] { "/Edit", @"C:\src\Foo.cs", "/Command", "Edit.GoTo 7" }));
+    }
+
+    [Test]
+    public void BuildCustomProcessStartInfo_SubstitutesPlaceholdersAsDiscreteArgs()
+    {
+        var psi = EditorLauncher.BuildCustomProcessStartInfo("nvim-qt --remote +{line} {file}", "/tmp/x.cs", 12, column: null);
+        Assert.That(psi, Is.Not.Null);
+        Assert.That(psi.FileName, Is.EqualTo("nvim-qt"));
+        Assert.That(psi.UseShellExecute, Is.False);
+        Assert.That(psi.ArgumentList, Is.EqualTo(new[] { "--remote", "+12", "/tmp/x.cs" }));
+    }
+
+    [Test]
+    public void BuildCustomProcessStartInfo_EmptyTemplate_ReturnsNull()
+    {
+        Assert.That(EditorLauncher.BuildCustomProcessStartInfo("", "/x", 1, null), Is.Null);
+        Assert.That(EditorLauncher.BuildCustomProcessStartInfo("   ", "/x", 1, null), Is.Null);
+    }
+
+    [Test]
+    public void Launch_VisualStudioOnNonWindows_ReturnsErrorWithHint()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.Ignore("Windows-only assertion would actually launch devenv.exe.");
+        }
+        var launcher = new EditorLauncher();
+        var result = launcher.Launch(
+            new EditorOptions { Kind = EditorKind.VisualStudio, CustomCommand = "" },
+            "/tmp/x.cs", 1, null);
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.ErrorMessage, Does.Contain("Visual Studio is not available"));
+        Assert.That(result.Hint, Does.Contain("VS Code, Cursor, or Rider"));
+    }
+}

--- a/test/Typhon.Workbench.Tests/OptionsControllerTests.cs
+++ b/test/Typhon.Workbench.Tests/OptionsControllerTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Typhon.Workbench.Hosting;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// Covers <see cref="Typhon.Workbench.Controllers.OptionsController"/> — GET / PUT / PATCH per-category +
+/// bootstrap-token gating. Round-trip is verified end-to-end (GET → PATCH → GET shows the new value)
+/// and out-of-band file edits get picked up via the <see cref="OptionsStore"/>'s FileSystemWatcher.
+/// </summary>
+[TestFixture]
+public sealed class OptionsControllerTests
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateAuthenticatedClient();
+    }
+
+    [TearDown]
+    public void TearDown() => _factory.Dispose();
+
+    [Test]
+    public async Task Get_WithoutBootstrapToken_Returns401()
+    {
+        using var unauth = _factory.CreateClient();
+        var resp = await unauth.GetAsync("/api/options");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+    }
+
+    [Test]
+    public async Task Get_ReturnsDefaultsOnFreshStore()
+    {
+        var opts = await _client.GetFromJsonAsync<WorkbenchOptions>("/api/options", JsonOpts);
+        Assert.That(opts, Is.Not.Null);
+        Assert.That(opts.Editor.Kind, Is.EqualTo(EditorKind.VsCode));
+        Assert.That(opts.Profiler.WorkspaceRoot, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public async Task PatchEditor_PersistsAndRoundTripsThroughGet()
+    {
+        var newEditor = new EditorOptions { Kind = EditorKind.Rider, CustomCommand = "rider --line {line} {file}" };
+        var patch = await _client.PatchAsJsonAsync("/api/options/editor", newEditor, JsonOpts);
+        Assert.That(patch.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var opts = await _client.GetFromJsonAsync<WorkbenchOptions>("/api/options", JsonOpts);
+        Assert.That(opts.Editor.Kind, Is.EqualTo(EditorKind.Rider));
+        Assert.That(opts.Editor.CustomCommand, Is.EqualTo("rider --line {line} {file}"));
+    }
+
+    [Test]
+    public async Task PatchProfiler_LeavesEditorUntouched()
+    {
+        await _client.PatchAsJsonAsync("/api/options/editor",
+            new EditorOptions { Kind = EditorKind.Cursor, CustomCommand = "" }, JsonOpts);
+
+        await _client.PatchAsJsonAsync("/api/options/profiler",
+            new ProfilerOptions { WorkspaceRoot = "/tmp/ws" }, JsonOpts);
+
+        var opts = await _client.GetFromJsonAsync<WorkbenchOptions>("/api/options", JsonOpts);
+        Assert.That(opts.Editor.Kind, Is.EqualTo(EditorKind.Cursor));
+        Assert.That(opts.Profiler.WorkspaceRoot, Is.EqualTo("/tmp/ws"));
+    }
+
+    [Test]
+    public async Task OutOfBandFileEdit_IsPickedUpByGet()
+    {
+        var store = _factory.Services.GetRequiredService<OptionsStore>();
+        var path = store.FilePath;
+
+        // Edit the file out-of-band — exactly what a user does when they hand-edit options.json.
+        var edited = new WorkbenchOptions
+        {
+            Editor = new EditorOptions { Kind = EditorKind.Custom, CustomCommand = "external" },
+            Profiler = new ProfilerOptions { WorkspaceRoot = "/tmp/edited" },
+        };
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(edited, JsonOpts));
+
+        // Wait for FileSystemWatcher debounce + reload (200 ms watcher debounce + slack for filesystem latency).
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        WorkbenchOptions live = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            live = await _client.GetFromJsonAsync<WorkbenchOptions>("/api/options", JsonOpts);
+            if (live.Editor.Kind == EditorKind.Custom) break;
+            await Task.Delay(50);
+        }
+        Assert.That(live?.Editor.Kind, Is.EqualTo(EditorKind.Custom));
+        Assert.That(live.Profiler.WorkspaceRoot, Is.EqualTo("/tmp/edited"));
+    }
+}

--- a/test/Typhon.Workbench.Tests/ProfilerSourceControllerTests.cs
+++ b/test/Typhon.Workbench.Tests/ProfilerSourceControllerTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using NUnit.Framework;
+using Typhon.Workbench.Controllers;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// Covers <see cref="ProfilerSourceController"/> — workspace-root resolution, path-traversal guard,
+/// absolute-path branch (#302 system attribution), source-window read, OpenInEditor 400 cases.
+/// Live editor launches are NOT exercised here (covered by <see cref="EditorLauncherTests"/>); these
+/// tests focus on the controller's request-shape, response-shape, and the security boundary.
+/// </summary>
+[TestFixture]
+public sealed class ProfilerSourceControllerTests
+{
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+    private string _tempRoot;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateAuthenticatedClient();
+
+        _tempRoot = Path.Combine(Path.GetTempPath(), "typhon-wb-source-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+        // Plant a .git marker so AutoDetectRepoRoot would resolve here if walked up to.
+        Directory.CreateDirectory(Path.Combine(_tempRoot, ".git"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _factory.Dispose();
+        try { if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    [Test]
+    public void ResolveAbsolutePath_RepoRelative_StripsPrefixAndJoinsRoot()
+    {
+        var resolved = ProfilerSourceController.ResolveAbsolutePath("/_/src/Foo.cs", @"C:\repo");
+        // Path.GetFullPath normalizes separators per host OS; just assert the right joining happened.
+        Assert.That(resolved, Does.EndWith("Foo.cs"));
+        Assert.That(resolved, Does.Contain("repo"));
+    }
+
+    [Test]
+    public void ResolveAbsolutePath_AlreadyAbsolute_DoesNotJoinWorkspaceRoot()
+    {
+        var input = OperatingSystem.IsWindows() ? @"C:\Other\repo\Foo.cs" : "/other/repo/Foo.cs";
+        var resolved = ProfilerSourceController.ResolveAbsolutePath(input, @"C:\different\workspace");
+        Assert.That(resolved, Does.Contain("Other").Or.Contain("other"));
+        Assert.That(resolved, Does.Not.Contain("workspace"));
+    }
+
+    [Test]
+    public async Task GetSource_BlocksTraversalOnRepoRelativePaths()
+    {
+        // Request a path that starts /_/ but tries to escape via ../.. — the controller's traversal
+        // guard must reject it because the resolved path lands outside the workspace root.
+        var resp = await _client.GetAsync(
+            "/api/profiler/source?path=" + Uri.EscapeDataString("/_/../../../../../etc/passwd") + "&line=1");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.That(body, Does.Contain("outside the workspace root").IgnoreCase);
+    }
+
+    [Test]
+    public async Task GetSource_AbsolutePath_BypassesWorkspaceGuardAndReadsFile()
+    {
+        // PDB-resolved system attribution paths (e.g. AntHill at C:\Dev\github\Typhon\test\AntHill)
+        // live outside the Typhon workspace. The controller permits absolute paths because they
+        // came from a trace manifest the bootstrap-token-gated server itself ingested.
+        var filePath = Path.Combine(_tempRoot, "abs-target.cs");
+        var content = "line 1\nline 2\nline 3\nline 4\nline 5\n";
+        await File.WriteAllTextAsync(filePath, content);
+
+        var resp = await _client.GetAsync(
+            $"/api/profiler/source?path={Uri.EscapeDataString(filePath)}&line=3&context=1");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK), await resp.Content.ReadAsStringAsync());
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var lines = doc.RootElement.GetProperty("lines").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.That(lines, Is.EqualTo(new[] { "line 2", "line 3", "line 4" }));
+    }
+
+    [Test]
+    public async Task GetSource_MissingFile_Returns404()
+    {
+        var bogus = Path.Combine(_tempRoot, "does-not-exist.cs");
+        var resp = await _client.GetAsync($"/api/profiler/source?path={Uri.EscapeDataString(bogus)}&line=1");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task GetSource_BadLine_Returns400()
+    {
+        var resp = await _client.GetAsync($"/api/profiler/source?path=/_/foo.cs&line=0");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task GetWorkspaceRoot_ReturnsConfiguredOrAutoDetected()
+    {
+        var resp = await _client.GetAsync("/api/profiler/workspace-root");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var effective = doc.RootElement.GetProperty("effective").GetString();
+        var source = doc.RootElement.GetProperty("source").GetString();
+        Assert.That(effective, Is.Not.Null.And.Not.Empty);
+        Assert.That(source, Is.AnyOf("configured", "auto-detected", "cwd-fallback"));
+    }
+
+    [Test]
+    public async Task OpenInEditor_MissingFile_Returns400()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/profiler/open-in-editor", new { file = "", line = 1 });
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task OpenInEditor_BadLine_Returns400()
+    {
+        var resp = await _client.PostAsJsonAsync("/api/profiler/open-in-editor", new { file = "/_/x.cs", line = 0 });
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+}

--- a/test/Typhon.Workbench.Tests/SystemControllerTests.cs
+++ b/test/Typhon.Workbench.Tests/SystemControllerTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using Typhon.Workbench.Controllers;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// Covers <see cref="SystemController.GetOs"/> — the client uses the OS string to disable editor
+/// choices that don't apply (e.g. Visual Studio on macOS). The endpoint is intentionally ungated
+/// (no bootstrap-token attribute) since it leaks zero information beyond the system platform.
+/// </summary>
+[TestFixture]
+public sealed class SystemControllerTests
+{
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateClient();
+    }
+
+    [TearDown]
+    public void TearDown() => _factory.Dispose();
+
+    [Test]
+    public async Task GetOs_ReturnsCurrentPlatform()
+    {
+        var resp = await _client.GetAsync("/api/system/os");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var info = await resp.Content.ReadFromJsonAsync<SystemController.OsInfo>();
+        Assert.That(info, Is.Not.Null);
+
+        var expected =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macos"
+            : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux"
+            : "other";
+        Assert.That(info.Os, Is.EqualTo(expected));
+    }
+}

--- a/test/Typhon.Workbench.Tests/WorkbenchFactory.cs
+++ b/test/Typhon.Workbench.Tests/WorkbenchFactory.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Typhon.Workbench.Hosting;
 using Typhon.Workbench.Security;
 using Typhon.Workbench.Sessions;
 
@@ -26,6 +28,13 @@ public sealed class WorkbenchFactory : WebApplicationFactory<Program>
             // parallel tests. Each factory gets its own in-memory token + its own file.
             services.RemoveAll<BootstrapTokenGate>();
             services.AddSingleton(_ => new BootstrapTokenGate(DemoDirectory));
+
+            // Same isolation for OptionsStore — defaults to %LOCALAPPDATA%\Typhon.Workbench\options.json
+            // which would clobber the real user options file when tests run. Per-factory temp dir.
+            services.RemoveAll<OptionsStore>();
+            services.AddSingleton(sp => new OptionsStore(
+                sp.GetRequiredService<ILogger<OptionsStore>>(),
+                Path.Combine(DemoDirectory, "options")));
         });
     }
 

--- a/tools/Typhon.Workbench/ClientApp/package-lock.json
+++ b/tools/Typhon.Workbench/ClientApp/package-lock.json
@@ -29,6 +29,7 @@
         "react": "^19.1.0",
         "react-arborist": "^3.5.0",
         "react-dom": "^19.1.0",
+        "react-syntax-highlighter": "^16.1.1",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.2"
       },
@@ -39,6 +40,7 @@
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@typescript-eslint/eslint-plugin": "^8.18.0",
         "@typescript-eslint/parser": "^8.18.0",
         "@vitejs/plugin-react": "^5.0.0",
@@ -3955,7 +3957,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -3970,6 +3971,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -3991,11 +3998,20 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4805,6 +4821,36 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -4979,6 +5025,16 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -5238,6 +5294,19 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -5854,6 +5923,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -5934,6 +6016,14 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -6183,6 +6273,51 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -6287,6 +6422,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6298,6 +6457,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -6321,6 +6490,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-number": {
@@ -7233,6 +7412,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7639,6 +7832,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
@@ -7863,6 +8081,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8066,6 +8303,26 @@
         }
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+      "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16.20.2"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/react-window": {
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
@@ -8102,6 +8359,22 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
+    },
+    "node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/remeda": {
       "version": "2.33.7",
@@ -8412,6 +8685,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stackback": {

--- a/tools/Typhon.Workbench/ClientApp/package.json
+++ b/tools/Typhon.Workbench/ClientApp/package.json
@@ -40,6 +40,7 @@
     "react": "^19.1.0",
     "react-arborist": "^3.5.0",
     "react-dom": "^19.1.0",
+    "react-syntax-highlighter": "^16.1.1",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.2"
   },
@@ -50,6 +51,7 @@
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
     "@vitejs/plugin-react": "^5.0.0",

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerSourceLocations.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerSourceLocations.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { useSourceLocationStore } from '@/stores/useSourceLocationStore';
+
+interface SourceLocationManifestDto {
+  files: Array<{ fileId: number; path: string }>;
+  entries: Array<{ id: number; fileId: number; line: number; kind: number; method: string }>;
+}
+
+/**
+ * Fetch the compile-time source-location manifest for a profiler session and hydrate it into
+ * {@link useSourceLocationStore}. The manifest enables the Source row in `ProfilerDetail` to
+ * resolve span `siteId`s into `file:line · method` and offer the "Open in editor" handoff
+ * (issue #293, Phase 3 / 4b).
+ *
+ * The endpoint returns an empty manifest for trace-mode sessions today (the trace file's trailer
+ * is the authoritative source for that path; Workbench wiring deferred). Live-attach sessions
+ * return whatever the engine sent in its init handshake.
+ */
+export function useProfilerSourceLocations(sessionId: string | null): void {
+  const token = useSessionStore((s) => s.token);
+  const setManifest = useSourceLocationStore((s) => s.setManifest);
+
+  const query = useQuery<SourceLocationManifestDto | null, Error>({
+    queryKey: ['profiler', 'source-locations', sessionId],
+    enabled: !!sessionId,
+    retry: false,
+    queryFn: async ({ signal }) => {
+      if (!sessionId) return null;
+      const headers = new Headers();
+      if (token) headers.set('X-Session-Token', token);
+      const res = await fetch(`/api/sessions/${sessionId}/profiler/source-locations`, {
+        signal,
+        headers,
+      });
+      if (!res.ok) return null;
+      return (await res.json()) as SourceLocationManifestDto;
+    },
+  });
+
+  useEffect(() => {
+    if (!query.data) return;
+    const entries = query.data.entries.map((e) => ({
+      id: e.id,
+      fileId: e.fileId,
+      line: e.line,
+      kind: e.kind,
+      method: e.method,
+    }));
+    setManifest(entries, query.data.files);
+  }, [query.data, setManifest]);
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/useKeyboardShortcuts.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/useKeyboardShortcuts.ts
@@ -91,9 +91,11 @@ export function useKeyboardShortcuts(): void {
     // (thumb upper). Shift+Mouse 3 is an alt-forward for lefties / keyboard-heavy users who want a
     // mirrored gesture without reaching for the upper thumb button.
     //
-    // We listen on `mousedown` and preventDefault BEFORE the browser's default back-nav handler
-    // sees the event. Chrome/Edge fire a browser-history back/forward on Mouse 3/4 by default —
-    // without preventDefault the page would navigate away from the Workbench entirely.
+    // The in-app navigation runs on `mousedown`. Chrome / Edge dispatch the BROWSER-history
+    // back/forward on `mouseup` (and `auxclick`) via a non-standard path that doesn't reliably
+    // honour `preventDefault()` from the matching `mousedown` — empirically, with our SPA mounted,
+    // the browser navigates AWAY from the Workbench unless we also `preventDefault()` on those
+    // events. Belt-and-suspenders: suppress on all three.
     function onMouseDown(e: MouseEvent) {
       if (e.button === 3) {
         e.preventDefault();
@@ -105,11 +107,21 @@ export function useKeyboardShortcuts(): void {
       }
     }
 
+    function suppressNavOnly(e: MouseEvent) {
+      if (e.button === 3 || e.button === 4) {
+        e.preventDefault();
+      }
+    }
+
     window.addEventListener('keydown', onKeyDown);
     window.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('mouseup', suppressNavOnly);
+    window.addEventListener('auxclick', suppressNavOnly);
     return () => {
       window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('mouseup', suppressNavOnly);
+      window.removeEventListener('auxclick', suppressNavOnly);
     };
   }, [togglePalette, back, forward, toggleTheme, toggleTree]);
 }

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/decode/__tests__/sourceLocation.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/decode/__tests__/sourceLocation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { decodeChunkBinary } from '@/libs/profiler/decode/chunkDecoder';
+
+/**
+ * Wire-format end-to-end test for the optional source-location-id field (issue #293, Phase 1+3).
+ * Constructs a tiny synthetic chunk holding a single span record with the source-location flag
+ * set, then asserts the decoder's output carries the right `sourceLocationId`.
+ *
+ * The chunk shape mirrors what `TraceFileWriter` produces server-side: one record beginning with
+ * a u16 size, then the common header (12 B) + span extension (25 B) + optional 16 B trace context
+ * + optional 2 B source-location id + kind-specific payload. We use BTreeInsert (kind=12, no
+ * payload) so the record is just the header pieces.
+ */
+describe('chunkDecoder — source-location id (issue #293)', () => {
+  it('decodes a span carrying SpanFlags bit 1 + 2-byte siteId', () => {
+    const SPAN_FLAGS_HAS_SOURCE_LOCATION = 0x02;
+    const KIND_BTREE_INSERT = 40; // TraceEventKind.BTreeInsert
+    const recordSize = 12 + 25 + 2; // common + span ext + source-loc bytes (no trace ctx)
+    const buf = new ArrayBuffer(recordSize + 1); // +1 trailing byte to ensure we don't over-read
+    const view = new DataView(buf);
+    let off = 0;
+
+    // Common header: u16 size, u8 kind, u8 threadSlot, i64 startTs
+    view.setUint16(off, recordSize, true); off += 2;
+    view.setUint8(off, KIND_BTREE_INSERT); off += 1;
+    view.setUint8(off, 7); off += 1; // threadSlot
+    view.setBigInt64(off, 1000n, true); off += 8;
+
+    // Span extension: i64 durationTicks, u64 spanId, u64 parentSpanId, u8 spanFlags
+    view.setBigInt64(off, 500n, true); off += 8;
+    view.setBigUint64(off, 0xAAAA_BBBB_CCCC_DDDDn, true); off += 8;
+    view.setBigUint64(off, 0n, true); off += 8;
+    view.setUint8(off, SPAN_FLAGS_HAS_SOURCE_LOCATION); off += 1;
+
+    // Optional source-location id (u16 LE)
+    view.setUint16(off, 0xABCD, true); off += 2;
+
+    // Decode one tick's worth of records.
+    // ticksPerUs = 10 (i.e. 10 MHz timestamp); the test asserts on integer fields only.
+    const events = decodeChunkBinary(
+      new Uint8Array(buf, 0, recordSize),
+      /* firstTick */ 1,
+      /* ticksPerUs */ 10,
+      /* isContinuation */ true,
+    );
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const span = events.find((e) => e.kind === KIND_BTREE_INSERT);
+    expect(span).toBeDefined();
+    expect(span!.sourceLocationId).toBe(0xABCD);
+    // Don't compare the full spanId decimal — the focus of this test is the source-location field.
+    expect(span!.spanId).toMatch(/^\d+$/);
+  });
+
+  it('omits sourceLocationId when the flag is not set', () => {
+    const KIND_BTREE_INSERT = 40;
+    const recordSize = 12 + 25; // no trace ctx, no source-loc bytes
+    const buf = new ArrayBuffer(recordSize);
+    const view = new DataView(buf);
+    let off = 0;
+
+    view.setUint16(off, recordSize, true); off += 2;
+    view.setUint8(off, KIND_BTREE_INSERT); off += 1;
+    view.setUint8(off, 0); off += 1;
+    view.setBigInt64(off, 0n, true); off += 8;
+    view.setBigInt64(off, 100n, true); off += 8;
+    view.setBigUint64(off, 1n, true); off += 8;
+    view.setBigUint64(off, 0n, true); off += 8;
+    view.setUint8(off, 0); off += 1; // SpanFlags = 0 (neither bit set)
+
+    const events = decodeChunkBinary(
+      new Uint8Array(buf),
+      /* firstTick */ 1,
+      /* ticksPerUs */ 10,
+      /* isContinuation */ true,
+    );
+    const span = events.find((e) => e.kind === KIND_BTREE_INSERT);
+    expect(span).toBeDefined();
+    expect(span!.sourceLocationId).toBeUndefined();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/decode/chunkDecoder.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/decode/chunkDecoder.ts
@@ -32,6 +32,10 @@ const SPAN_HEADER_EXT_SIZE = 25;
 const TRACE_CONTEXT_SIZE = 16;
 /** bit 0 of spanFlags: set when the span record carries an OpenTelemetry-style trace context. */
 const SPAN_FLAGS_HAS_TRACE_CONTEXT = 0x01;
+/** bit 1 of spanFlags: set when the span record carries a 2-byte compile-time source-location id (#302). */
+const SPAN_FLAGS_HAS_SOURCE_LOCATION = 0x02;
+/** Optional 2-byte source-location id, appended after the trace context (when present). */
+const SOURCE_LOCATION_ID_SIZE = 2;
 
 /**
  * Entry point. Decode an LZ4-decompressed record block. <paramref name="firstTick"/> primes the tick counter so events carry the correct
@@ -439,14 +443,17 @@ interface SpanHeader {
   parentSpanId: string;
   traceIdHi: string | null;
   traceIdLo: string | null;
+  /** Compile-time source-location id from `SourceLocationGenerator`, or null when the record didn't carry one. */
+  sourceLocationId: number | null;
   payloadOffset: number;
   /** Absolute end offset of the record in the chunk reader. Lets per-kind decoders validate trailing wire-additive fields. */
   recordEnd: number;
 }
 
 /**
- * Reads the 25-byte span header extension + optional 16-byte trace-context extension, returns the shared span fields plus the offset at
- * which the kind-specific payload begins. All 24 span-kind decoders call this first.
+ * Reads the 25-byte span header extension + optional 16-byte trace-context extension + optional 2-byte
+ * source-location id, returns the shared span fields plus the offset at which the kind-specific payload begins.
+ * All 24 span-kind decoders call this first.
  */
 function readSpanHeader(reader: BinaryReader, recordPos: number, ticksPerUs: number): SpanHeader {
   const recordSize = reader.readU16(recordPos);
@@ -457,6 +464,7 @@ function readSpanHeader(reader: BinaryReader, recordPos: number, ticksPerUs: num
   const parentSpanId = reader.readU64Decimal(extStart + 16);
   const spanFlags = reader.readU8(extStart + 24);
   const hasTraceContext = (spanFlags & SPAN_FLAGS_HAS_TRACE_CONTEXT) !== 0;
+  const hasSourceLocation = (spanFlags & SPAN_FLAGS_HAS_SOURCE_LOCATION) !== 0;
 
   let traceIdHi: string | null = null;
   let traceIdLo: string | null = null;
@@ -468,6 +476,12 @@ function readSpanHeader(reader: BinaryReader, recordPos: number, ticksPerUs: num
     payloadOffset += TRACE_CONTEXT_SIZE;
   }
 
+  let sourceLocationId: number | null = null;
+  if (hasSourceLocation) {
+    sourceLocationId = reader.readU16(payloadOffset);
+    payloadOffset += SOURCE_LOCATION_ID_SIZE;
+  }
+
   return {
     durationUs: durationTicks / ticksPerUs,
     spanId,
@@ -475,6 +489,7 @@ function readSpanHeader(reader: BinaryReader, recordPos: number, ticksPerUs: num
     recordEnd,
     traceIdHi,
     traceIdLo,
+    sourceLocationId,
     payloadOffset,
   };
 }
@@ -492,6 +507,9 @@ function baseSpanEvent(
   if (header.traceIdHi !== null) {
     evt.traceIdHi = header.traceIdHi;
     evt.traceIdLo = header.traceIdLo ?? undefined;
+  }
+  if (header.sourceLocationId !== null) {
+    evt.sourceLocationId = header.sourceLocationId;
   }
   return evt;
 }

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/model/types.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/model/types.ts
@@ -501,6 +501,9 @@ export interface TraceEvent {
   traceIdHi?: string;
   traceIdLo?: string;
 
+  /** #302: compile-time site id from `SourceLocationGenerator`. Resolves via `useSourceLocationStore`. */
+  sourceLocationId?: number;
+
   // Instant-event fields
   phase?: number;
   systemIndex?: number;

--- a/tools/Typhon.Workbench/ClientApp/src/panels/options/EditorForm.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/options/EditorForm.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { useOptionsStore, type EditorKind } from '@/stores/useOptionsStore';
+
+/**
+ * Editor preferences form (issue #293, Phase 4b). Dropdown of editor kinds, custom-command argv
+ * template (visible only when Custom is selected), and a Test button that opens a dummy file via
+ * `/api/profiler/open-in-editor` to verify the launch works.
+ *
+ * Visual Studio is greyed out on macOS — VS for Mac was discontinued in Aug 2024.
+ */
+const EDITOR_KINDS: Array<{ kind: EditorKind; label: string; macOnly?: boolean; windowsOnly?: boolean }> = [
+  { kind: 'vsCode', label: 'VS Code' },
+  { kind: 'cursor', label: 'Cursor' },
+  { kind: 'rider', label: 'Rider' },
+  { kind: 'visualStudio', label: 'Visual Studio', windowsOnly: true },
+  { kind: 'custom', label: 'Custom' },
+];
+
+export function EditorForm(): React.JSX.Element {
+  const editor = useOptionsStore((s) => s.options.editor);
+  const setEditor = useOptionsStore((s) => s.setEditor);
+  const openInEditor = useOptionsStore((s) => s.openInEditor);
+  const os = useOptionsStore((s) => s.os);
+
+  const [pendingKind, setPendingKind] = useState<EditorKind>(editor.kind);
+  const [pendingCmd, setPendingCmd] = useState<string>(editor.customCommand);
+  const [testStatus, setTestStatus] = useState<{ ok: boolean; msg: string } | null>(null);
+  const dirty = pendingKind !== editor.kind || pendingCmd !== editor.customCommand;
+
+  async function handleSave(): Promise<void> {
+    setTestStatus(null);
+    try {
+      await setEditor({ kind: pendingKind, customCommand: pendingCmd });
+    } catch (err) {
+      setTestStatus({ ok: false, msg: (err as Error).message });
+    }
+  }
+
+  async function handleTest(): Promise<void> {
+    // Save first so the launcher uses the user's intended config.
+    if (dirty) {
+      await handleSave();
+    }
+    // Use a sentinel file the user is likely to have — README at workspace root, line 1.
+    const result = await openInEditor('/_/README.md', 1);
+    setTestStatus(
+      result.ok
+        ? { ok: true, msg: 'Editor launched. Check that the file opened.' }
+        : { ok: false, msg: result.error + (result.hint ? ` — ${result.hint}` : '') },
+    );
+  }
+
+  return (
+    <section className="max-w-xl space-y-4">
+      <header>
+        <h2 className="text-[14px] font-semibold text-foreground">Editor</h2>
+        <p className="mt-1 text-[12px] text-muted-foreground">
+          Used by the &quot;Open in editor&quot; button on profiler spans (Source row).
+        </p>
+      </header>
+
+      <label className="block">
+        <span className="block text-[12px] font-medium text-foreground">Editor</span>
+        <select
+          value={pendingKind}
+          onChange={(e) => setPendingKind(e.target.value as EditorKind)}
+          className="mt-1 w-full rounded border border-border bg-background px-2 py-1 text-[12px]"
+        >
+          {EDITOR_KINDS.map((opt) => {
+            const disabled = (opt.windowsOnly === true && os !== 'windows')
+              || (opt.macOnly === true && os !== 'macos');
+            const suffix = opt.windowsOnly === true && os !== 'windows'
+              ? ' (Windows only — Visual Studio for Mac was discontinued)'
+              : '';
+            return (
+              <option key={opt.kind} value={opt.kind} disabled={disabled}>
+                {opt.label}{suffix}
+              </option>
+            );
+          })}
+        </select>
+      </label>
+
+      {pendingKind === 'custom' && (
+        <label className="block">
+          <span className="block text-[12px] font-medium text-foreground">Custom command</span>
+          <input
+            type="text"
+            value={pendingCmd}
+            onChange={(e) => setPendingCmd(e.target.value)}
+            placeholder="nvim-qt --remote +{line} {file}"
+            className="mt-1 w-full rounded border border-border bg-background px-2 py-1 font-mono text-[12px]"
+          />
+          <span className="mt-1 block text-[11px] text-muted-foreground">
+            Tokens: <code>{'{file}'}</code>, <code>{'{line}'}</code>, <code>{'{column}'}</code>. Each token becomes
+            a single argv element — never executed via a shell, so no injection.
+          </span>
+        </label>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty}
+          className="rounded border border-border bg-primary px-3 py-1 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={handleTest}
+          className="rounded border border-border bg-background px-3 py-1 text-[12px] hover:bg-accent"
+        >
+          Test
+        </button>
+        {testStatus && (
+          <span className={`text-[12px] ${testStatus.ok ? 'text-foreground' : 'text-destructive'}`}>
+            {testStatus.msg}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/options/OptionsPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/options/OptionsPanel.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { useOptionsStore } from '@/stores/useOptionsStore';
+import { EditorForm } from './EditorForm';
+import { ProfilerForm } from './ProfilerForm';
+
+/**
+ * Workbench Options panel (issue #293, Phase 4a). Sidebar with category list, main area renders
+ * the active form. Adding a new category is two lines here + a new `<XxxForm.tsx>`.
+ *
+ * Design ref: claude/design/observability/10-profiler-source-attribution.md §5.7.6.
+ */
+type CategoryKey = 'editor' | 'profiler';
+
+interface CategoryDef {
+  key: CategoryKey;
+  label: string;
+}
+
+const CATEGORIES: CategoryDef[] = [
+  { key: 'editor', label: 'Editor' },
+  { key: 'profiler', label: 'Profiler' },
+];
+
+export default function OptionsPanel(): React.JSX.Element {
+  const fetchOptions = useOptionsStore((s) => s.fetch);
+  const loaded = useOptionsStore((s) => s.loaded);
+  const [active, setActive] = useState<CategoryKey>('editor');
+
+  useEffect(() => {
+    if (!loaded) {
+      void fetchOptions();
+    }
+  }, [loaded, fetchOptions]);
+
+  return (
+    <div className="flex h-full w-full overflow-hidden bg-background">
+      {/* Sidebar with category list. */}
+      <nav className="flex w-48 flex-col border-r border-border bg-card">
+        <header className="border-b border-border px-3 py-2 text-[12px] font-semibold text-muted-foreground">
+          Options
+        </header>
+        <ul className="flex flex-col py-1">
+          {CATEGORIES.map((c) => (
+            <li key={c.key}>
+              <button
+                type="button"
+                onClick={() => setActive(c.key)}
+                className={`w-full px-3 py-1.5 text-left text-[12px] hover:bg-accent ${
+                  active === c.key ? 'bg-accent font-medium text-foreground' : 'text-muted-foreground'
+                }`}
+              >
+                {c.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* Active form. */}
+      <main className="flex-1 overflow-auto p-4">
+        {active === 'editor' && <EditorForm />}
+        {active === 'profiler' && <ProfilerForm />}
+      </main>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/options/ProfilerForm.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/options/ProfilerForm.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { useOptionsStore } from '@/stores/useOptionsStore';
+
+interface WorkspaceRootDto {
+  effective: string;
+  source: 'configured' | 'auto-detected' | 'cwd-fallback';
+}
+
+/**
+ * Profiler-related options (issue #293, Phase 4a). The workspace root is used to resolve the
+ * "/_/..." paths from trace manifests to absolute paths on disk. When the user leaves it empty,
+ * the server auto-detects the repo root by walking up from CWD looking for a `.git` entry. The
+ * effective root is fetched from `/api/profiler/workspace-root` and shown so the user can verify
+ * what's being used.
+ */
+export function ProfilerForm(): React.JSX.Element {
+  const profiler = useOptionsStore((s) => s.options.profiler);
+  const setProfiler = useOptionsStore((s) => s.setProfiler);
+  const [pendingRoot, setPendingRoot] = useState<string>(profiler.workspaceRoot);
+  const dirty = pendingRoot !== profiler.workspaceRoot;
+  const [error, setError] = useState<string | null>(null);
+  const [effective, setEffective] = useState<WorkspaceRootDto | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/profiler/workspace-root')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((dto: WorkspaceRootDto | null) => {
+        if (!cancelled && dto) setEffective(dto);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [profiler.workspaceRoot]);
+
+  async function handleSave(): Promise<void> {
+    setError(null);
+    try {
+      await setProfiler({ workspaceRoot: pendingRoot });
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  return (
+    <section className="max-w-xl space-y-4">
+      <header>
+        <h2 className="text-[14px] font-semibold text-foreground">Profiler</h2>
+        <p className="mt-1 text-[12px] text-muted-foreground">
+          Used to resolve repo-relative source paths from trace files.
+        </p>
+      </header>
+
+      <label className="block">
+        <span className="block text-[12px] font-medium text-foreground">Workspace root</span>
+        <input
+          type="text"
+          value={pendingRoot}
+          onChange={(e) => setPendingRoot(e.target.value)}
+          placeholder="C:\Dev\github\Typhon"
+          className="mt-1 w-full rounded border border-border bg-background px-2 py-1 font-mono text-[12px]"
+        />
+        <span className="mt-1 block text-[11px] text-muted-foreground">
+          Absolute path of the repo this trace was recorded against. Leave empty to auto-detect via the
+          nearest <code>.git</code> directory.
+        </span>
+      </label>
+
+      {effective && (
+        <div className="rounded border border-border bg-muted/30 px-2 py-1 text-[11px]">
+          <span className="text-muted-foreground">Effective root ({effective.source}): </span>
+          <span className="font-mono text-foreground">{effective.effective}</span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty}
+          className="rounded border border-border bg-primary px-3 py-1 text-[12px] text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          Save
+        </button>
+        {error && <span className="text-[12px] text-destructive">{error}</span>}
+      </div>
+    </section>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/ProfilerDetail.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/ProfilerDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Activity, Blocks, Clock, Crosshair, Layers, Tag } from 'lucide-react';
+import { Activity, Blocks, Clock, Crosshair, ExternalLink, FileCode, Layers, Tag } from 'lucide-react';
 import type { ChunkSpan, MarkerSelection, PhaseMarker, PhaseSpan, SpanData, TickData } from '@/libs/profiler/model/traceModel';
 import { TraceEventKind } from '@/libs/profiler/model/types';
 import type { TickSummary } from '@/libs/profiler/model/types';
@@ -7,6 +7,9 @@ import type { TimeRange } from '@/libs/profiler/model/uiTypes';
 import type { ProfilerSelection } from '@/stores/useProfilerSelectionStore';
 import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
 import { computeSelectionStats } from '@/libs/profiler/stats/selectionStats';
+import { useSourceLocationStore } from '@/stores/useSourceLocationStore';
+import { useOptionsStore } from '@/stores/useOptionsStore';
+import { openSourcePreview } from '@/shell/commands/openSchemaBrowser';
 
 /**
  * Profiler selection detail — the fourth DetailPanel render branch (Phase 2e). Mirrors the
@@ -72,6 +75,72 @@ const DL_CLASS = 'grid grid-cols-[auto,1fr] gap-x-3 gap-y-1 text-[11px] select-t
 
 // ─── Spans ─────────────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Source-location row for span details (#302). Resolves the span's `sourceLocationId` via the
+ * compile-time table emitted by `SourceLocationGenerator` and offers a one-click "Open in editor"
+ * handoff to the user's configured editor (VS Code / Cursor / Rider / VS / custom).
+ *
+ * Rendered only when the span carries a non-zero `sourceLocationId` AND the manifest is loaded.
+ * For un-attributed spans (siteId = 0 — non-Engine call sites) this row simply doesn't render.
+ */
+function SpanSourceRow({ span }: { span: SpanData }): React.JSX.Element | null {
+  const resolve = useSourceLocationStore((s) => s.resolve);
+  const openInEditor = useOptionsStore((s) => s.openInEditor);
+  const [error, setError] = useState<string | null>(null);
+
+  const siteId = span.rawEvent?.sourceLocationId;
+  const loc = resolve(siteId);
+  if (!loc) return null;
+
+  async function handleOpen(): Promise<void> {
+    setError(null);
+    try {
+      const result = await openInEditor(loc!.file, loc!.line);
+      if (!result.ok) {
+        setError(result.error || 'Editor launch failed');
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  const pathTitle = `${loc.file}:${loc.line}${loc.method ? ` · ${loc.method}` : ''}`;
+  return (
+    <div className="mt-2 flex flex-col gap-1.5 rounded-md border border-border bg-muted/30 p-2 text-[12px]">
+      <div className="flex min-w-0 items-center gap-2">
+        <FileCode className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate select-text font-mono text-foreground" title={pathTitle}>
+          {loc.file}<span className="text-muted-foreground">:{loc.line}</span>
+          {loc.method && <span className="ml-2 text-muted-foreground"> · {loc.method}</span>}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => openSourcePreview(loc.file, loc.line)}
+          className="flex items-center gap-1 rounded border border-border bg-background px-2 py-0.5 text-[11px] hover:bg-accent"
+          title="Open an inline source-code preview around this line"
+        >
+          <FileCode className="h-3 w-3" /> Show inline
+        </button>
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="flex items-center gap-1 rounded border border-border bg-background px-2 py-0.5 text-[11px] hover:bg-accent"
+          title="Open this file at the emission line in your configured editor"
+        >
+          <ExternalLink className="h-3 w-3" /> Open in editor
+        </button>
+        {error && (
+          <span className="ml-2 truncate text-[11px] text-destructive" title={error}>
+            {error.length > 60 ? error.slice(0, 60) + '…' : error}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function SpanDetail({ span }: { span: SpanData }): React.JSX.Element {
   const globalStartUs = useGlobalStartUs();
   return (
@@ -128,7 +197,12 @@ function SpanDetail({ span }: { span: SpanData }): React.JSX.Element {
               <dd className="truncate font-mono text-foreground">{span.traceIdHi}.{span.traceIdLo}</dd>
             </>
           )}
+        </dl>
 
+        {/* #302: source-attribution row — file:line · method + Open in editor / Show inline buttons. */}
+        <SpanSourceRow span={span} />
+
+        <dl className={DL_CLASS}>
           {/* Kind-specific payload surfaced from the rawEvent. ClusterMigration carries archetype +
               entity count + total component instances moved (= entities × per-entity component slots). */}
           {span.kind === TraceEventKind.ClusterMigration && span.rawEvent && (
@@ -191,6 +265,69 @@ function SpanDetail({ span }: { span: SpanData }): React.JSX.Element {
 
 // ─── Chunks ────────────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Source-location row for chunk details (#302 system attribution). Resolves the chunk's source via
+ * the synthesized system id (<c>0x8000 | systemIndex</c>) emitted by <c>RuntimeSourceLocationManifest</c>
+ * on the engine side. Same shape as <see cref="SpanSourceRow"/> — file:line · method on row 1, the two
+ * actions on row 2. Renders nothing when the system has no PDB-resolved attribution.
+ */
+function ChunkSourceRow({ chunk }: { chunk: ChunkSpan }): React.JSX.Element | null {
+  const resolveSystem = useSourceLocationStore((s) => s.resolveSystem);
+  const openInEditor = useOptionsStore((s) => s.openInEditor);
+  const [error, setError] = useState<string | null>(null);
+
+  const loc = resolveSystem(chunk.systemIndex);
+  if (!loc) return null;
+
+  async function handleOpen(): Promise<void> {
+    setError(null);
+    try {
+      const result = await openInEditor(loc!.file, loc!.line);
+      if (!result.ok) {
+        setError(result.error || 'Editor launch failed');
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  const pathTitle = `${loc.file}:${loc.line}${loc.method ? ` · ${loc.method}` : ''}`;
+  return (
+    <div className="mt-2 flex flex-col gap-1.5 rounded-md border border-border bg-muted/30 p-2 text-[12px]">
+      <div className="flex min-w-0 items-center gap-2">
+        <FileCode className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate select-text font-mono text-foreground" title={pathTitle}>
+          {loc.file}<span className="text-muted-foreground">:{loc.line}</span>
+          {loc.method && <span className="ml-2 text-muted-foreground"> · {loc.method}</span>}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => openSourcePreview(loc.file, loc.line)}
+          className="flex items-center gap-1 rounded border border-border bg-background px-2 py-0.5 text-[11px] hover:bg-accent"
+          title="Open an inline source-code preview around this line"
+        >
+          <FileCode className="h-3 w-3" /> Show inline
+        </button>
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="flex items-center gap-1 rounded border border-border bg-background px-2 py-0.5 text-[11px] hover:bg-accent"
+          title="Open this file at the system entry method in your configured editor"
+        >
+          <ExternalLink className="h-3 w-3" /> Open in editor
+        </button>
+        {error && (
+          <span className="ml-2 truncate text-[11px] text-destructive" title={error}>
+            {error.length > 60 ? error.slice(0, 60) + '…' : error}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function ChunkDetail({ chunk }: { chunk: ChunkSpan }): React.JSX.Element {
   const globalStartUs = useGlobalStartUs();
   return (
@@ -221,6 +358,9 @@ function ChunkDetail({ chunk }: { chunk: ChunkSpan }): React.JSX.Element {
           <dt className="text-muted-foreground">Entities</dt>
           <dd className="font-mono tabular-nums text-foreground">{chunk.entitiesProcessed.toLocaleString()}</dd>
         </dl>
+
+        {/* #302 system attribution: source row points to the system's entry method (PDB-resolved). */}
+        <ChunkSourceRow chunk={chunk} />
       </div>
     </div>
   );

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/ProfilerPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/ProfilerPanel.tsx
@@ -10,6 +10,7 @@ import { useProfilerMetadata } from '@/hooks/profiler/useProfilerMetadata';
 import { useProfilerBuildProgress } from '@/hooks/profiler/useProfilerBuildProgress';
 import { useProfilerLiveStream } from '@/hooks/profiler/useProfilerLiveStream';
 import { useProfilerCache } from '@/hooks/profiler/useProfilerCache';
+import { useProfilerSourceLocations } from '@/hooks/profiler/useProfilerSourceLocations';
 import TickOverview from './sections/TickOverview';
 import TimeArea from './sections/TimeArea';
 import OverloadStrip from './sections/OverloadStrip';
@@ -102,6 +103,9 @@ export default function ProfilerPanel() {
   // Build-progress SSE only meaningful for Trace mode; live-stream SSE only for Attach mode.
   useProfilerBuildProgress(isTrace ? sessionId : null);
   useProfilerLiveStream(isAttach ? sessionId : null);
+  // #302 Phase 6: hydrate `useSourceLocationStore` so the Source row in `ProfilerDetail` can
+  // resolve span siteIds. Works for both live-attach (init handshake) and trace (file trailer).
+  useProfilerSourceLocations(isTrace || isAttach ? sessionId : null);
 
   // Tell the store which mode we're in; panels and future renderers can branch off `isLive`.
   // The cleanup wipes every profiler-scoped store so switching sessions (or closing the panel)

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/SourcePreviewPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/SourcePreviewPanel.tsx
@@ -1,0 +1,125 @@
+import { lazy, Suspense, useEffect, useState } from 'react';
+import type { IDockviewPanelProps } from 'dockview-react';
+import { useSessionStore } from '@/stores/useSessionStore';
+
+/**
+ * Inline source-preview panel (issue #293, Phase 5). Lazy-loads `react-syntax-highlighter` so the
+ * Prism bundle isn't paid by the rest of the Workbench. Fetches a window of source lines around
+ * the emission line via `GET /api/profiler/source` and renders with the emission line highlighted.
+ *
+ * Panel params: `{ path: string, line: number }`. The Source row in `ProfilerDetail` opens this
+ * panel via dockview, passing the resolved path + line.
+ */
+interface SourcePreviewParams {
+  path: string;
+  line: number;
+}
+
+interface SourceWindow {
+  file: string;
+  line: number;
+  startLine: number;
+  endLine: number;
+  lines: string[];
+}
+
+// Lazy-load Prism via the top-level export (typed). Bundle ~50 KB gzipped, paid only when this
+// panel mounts. The default export registers all common languages including C# — lighter targeted
+// imports exist (`prism-light` + per-language registration) but their typings are weak; the
+// top-level Prism export keeps types clean and the bundle still split.
+const SyntaxHighlighter = lazy(() =>
+  import('react-syntax-highlighter').then((mod) => ({ default: mod.Prism })),
+);
+
+export default function SourcePreviewPanel(props: IDockviewPanelProps): React.JSX.Element {
+  const params = props.params as unknown as SourcePreviewParams | undefined;
+  const token = useSessionStore((s) => s.token);
+  const [data, setData] = useState<SourceWindow | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const path = params?.path;
+  const line = params?.line ?? 1;
+
+  useEffect(() => {
+    if (!path) return;
+    const ctrl = new AbortController();
+    setError(null);
+    setData(null);
+    (async () => {
+      try {
+        const headers = new Headers();
+        if (token) headers.set('X-Session-Token', token);
+        const url = `/api/profiler/source?path=${encodeURIComponent(path)}&line=${line}&context=20`;
+        const res = await fetch(url, { signal: ctrl.signal, headers });
+        if (!res.ok) {
+          let detail = `${res.status} ${res.statusText}`;
+          try {
+            const body = (await res.json()) as { error?: string };
+            if (body?.error) detail = body.error;
+          } catch { /* non-JSON body */ }
+          setError(detail);
+          return;
+        }
+        setData((await res.json()) as SourceWindow);
+      } catch (err) {
+        if ((err as Error).name !== 'AbortError') {
+          setError((err as Error).message);
+        }
+      }
+    })();
+    return () => ctrl.abort();
+  }, [path, line, token]);
+
+  if (!path) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background text-[12px] text-muted-foreground">
+        No source location selected.
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full w-full flex-col items-start justify-start gap-2 overflow-auto bg-background p-3 text-[12px]">
+        <header className="select-text font-mono text-muted-foreground">{path}:{line}</header>
+        <p className="text-destructive">{error}</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background text-[12px] text-muted-foreground">
+        Loading source…
+      </div>
+    );
+  }
+
+  const code = data.lines.join('\n');
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-background">
+      <header className="select-text border-b border-border px-3 py-2 font-mono text-[12px] text-muted-foreground">
+        {data.file}<span className="text-foreground">:{data.line}</span>
+        <span className="ml-2 text-[11px]">(lines {data.startLine}–{data.endLine})</span>
+      </header>
+      <div className="flex-1 overflow-auto">
+        <Suspense fallback={<pre className="p-3 font-mono text-[12px] text-muted-foreground">Loading highlighter…</pre>}>
+          <SyntaxHighlighter
+            language="csharp"
+            showLineNumbers
+            startingLineNumber={data.startLine}
+            wrapLines
+            lineProps={(lineNumber: number) =>
+              lineNumber === data.line
+                ? { style: { backgroundColor: 'rgba(255, 200, 0, 0.18)', display: 'block' } }
+                : { style: { display: 'block' } }
+            }
+            customStyle={{ margin: 0, padding: '8px 12px', background: 'transparent', fontSize: '12px' }}
+          >
+            {code}
+          </SyntaxHighlighter>
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TimeArea.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TimeArea.tsx
@@ -17,6 +17,8 @@ import { useNavHistoryStore } from '@/stores/useNavHistoryStore';
 import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
 import { useProfilerSelectionStore } from '@/stores/useProfilerSelectionStore';
 import { useProfilerViewStore } from '@/stores/useProfilerViewStore';
+import { useSourceLocationStore } from '@/stores/useSourceLocationStore';
+import { useOptionsStore } from '@/stores/useOptionsStore';
 import { useThemeStore } from '@/stores/useThemeStore';
 
 /**
@@ -583,6 +585,11 @@ export default function TimeArea({ ticks, gaugeData, threadNames: threadNamesMap
   // Double-click a chunk / span / phase / mini-row op → smooth-zoom the viewport to its bounds.
   // Ported verbatim from the old profiler's `onDblClick`. Tick / gutter-chevron hits are ignored —
   // nothing meaningful to zoom to there. The 800 ms ease-out tween lives in `animateToRange`.
+  //
+  // #302: Ctrl+double-click on a span overrides the zoom and instead routes to "Open in editor"
+  // for that span's emission site (when the span carries a sourceLocationId and the manifest has
+  // resolved it). Falls through to the zoom path when source attribution isn't available, so the
+  // gesture is never a dead-end on un-attributed spans (e.g. non-Engine call sites).
   const onDoubleClick = useCallback((e: React.MouseEvent<HTMLCanvasElement>): void => {
     const local = getLocal(e);
     if (!local) return;
@@ -593,6 +600,33 @@ export default function TimeArea({ ticks, gaugeData, threadNames: threadNamesMap
       legendsVisible,
     });
     if (!hit) return;
+
+    if (e.ctrlKey && hit.kind === 'span') {
+      // Resolve the span's emission site via the compile-time manifest. getState() is sufficient —
+      // this is a one-shot action, no need to subscribe to store changes.
+      const siteId = hit.span.rawEvent?.sourceLocationId;
+      const loc = useSourceLocationStore.getState().resolve(siteId);
+      if (loc) {
+        // Fire-and-forget; toast handled inside the store mutation. Don't await — the canvas
+        // shouldn't block on the editor launch.
+        void useOptionsStore.getState().openInEditor(loc.file, loc.line);
+        return;
+      }
+      // No attribution for this span → fall through to the zoom-to-span behavior so the gesture
+      // still does something useful instead of feeling broken.
+    }
+
+    if (e.ctrlKey && hit.kind === 'chunk') {
+      // #302 system attribution: chunk source comes from the synthesized system id
+      // (0x8000 | systemIndex) populated by the engine's RuntimeSourceLocationManifest.
+      const loc = useSourceLocationStore.getState().resolveSystem(hit.chunk.systemIndex);
+      if (loc) {
+        void useOptionsStore.getState().openInEditor(loc.file, loc.line);
+        return;
+      }
+      // No PDB attribution → fall through to zoom-to-chunk.
+    }
+
     switch (hit.kind) {
       case 'chunk':       animateToRange({ startUs: hit.chunk.startUs, endUs: hit.chunk.endUs }); return;
       case 'span':        animateToRange({ startUs: hit.span.startUs,  endUs: hit.span.endUs  }); return;

--- a/tools/Typhon.Workbench/ClientApp/src/shell/DockHost.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/DockHost.tsx
@@ -15,6 +15,8 @@ import SchemaIndexPanel from '@/panels/SchemaInspector/SchemaIndexPanel';
 import SchemaRelationshipsPanel from '@/panels/SchemaInspector/SchemaRelationshipsPanel';
 import ProfilerPanel from '@/panels/profiler/ProfilerPanel';
 import TopSpansPanel from '@/panels/profiler/TopSpansPanel';
+import OptionsPanel from '@/panels/options/OptionsPanel';
+import SourcePreviewPanel from '@/panels/profiler/SourcePreviewPanel';
 import { registerDockApi } from './commands/openSchemaBrowser';
 import { registerProfilerDockApi } from './commands/profilerCommands';
 import MigrationRequiredBanner from './banners/MigrationRequiredBanner';
@@ -36,6 +38,8 @@ const components: Record<string, React.FC<IDockviewPanelProps>> = {
   SchemaRelationships: SchemaRelationshipsPanel,
   Profiler: ProfilerPanel,
   TopSpans: TopSpansPanel,
+  Options: OptionsPanel,
+  SourcePreview: SourcePreviewPanel,
 };
 
 function buildDefaultLayout(api: DockviewReadyEvent['api'], kind: 'none' | 'open' | 'attach' | 'trace') {

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/baseCommands.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/baseCommands.ts
@@ -5,10 +5,12 @@ import { refreshResourceGraph } from '@/hooks/useResourceIndex';
 import {
   openArchetypeBrowser,
   openDetailPanel,
+  openOptions,
   openSchemaArchetypes,
   openSchemaBrowser,
   openSchemaIndexes,
   openSchemaRelationships,
+  openSourcePreviewForCurrentSpan,
 } from './openSchemaBrowser';
 import { buildProfilerPaletteCommands } from './profilerCommands';
 
@@ -41,6 +43,8 @@ export function buildBaseCommands(): CommandItem[] {
     { id: 'schema-indexes', label: 'Open Component Indexes',       keywords: 'schema indexes btree fields',                 action: openSchemaIndexes },
     { id: 'schema-relationships', label: 'Open Component Relationships', keywords: 'schema systems relationships',          action: openSchemaRelationships },
     { id: 'open-detail',   label: 'Open Detail Panel',        keywords: 'detail inspector selection', action: openDetailPanel },
+    { id: 'open-options',  label: 'Open Options',             keywords: 'options preferences settings editor', action: openOptions },
+    { id: 'show-source-current-span', label: 'Show Source for Current Span', keywords: 'source preview profiler span go to attribution', action: openSourcePreviewForCurrentSpan },
     { id: 'toggle-theme',  label: 'Toggle Dark / Light Mode', keywords: 'theme dark light',  action: toggleTheme },
     ...buildProfilerPaletteCommands(),
     { id: 'reload',        label: 'Reload',                   keywords: 'refresh',           action: () => location.reload() },

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/openSchemaBrowser.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/openSchemaBrowser.ts
@@ -1,4 +1,6 @@
 import type { DockviewApi } from 'dockview-react';
+import { useProfilerSelectionStore } from '@/stores/useProfilerSelectionStore';
+import { useSourceLocationStore } from '@/stores/useSourceLocationStore';
 
 /**
  * Module-level dockview api registration — same pattern as refreshResourceGraph. DockHost publishes
@@ -6,9 +8,37 @@ import type { DockviewApi } from 'dockview-react';
  * If the api isn't registered yet (pre-mount), the command is a no-op.
  */
 let registeredApi: DockviewApi | null = null;
+let selectionUnsubscribe: (() => void) | null = null;
 
 export function registerDockApi(api: DockviewApi | null): void {
   registeredApi = api;
+
+  // #302: when the source-preview panel is already open, follow the profiler selection — re-render
+  // the panel with the new file:line on each span click. Deliberately scoped to "panel already open":
+  // we never spawn the panel from a selection, so the user retains control over whether they want
+  // the source-preview real estate. Spans without source attribution preserve the previous content
+  // (last-useful-state wins) instead of clearing to a "no source" placeholder.
+  if (selectionUnsubscribe) {
+    selectionUnsubscribe();
+    selectionUnsubscribe = null;
+  }
+  if (api) {
+    selectionUnsubscribe = useProfilerSelectionStore.subscribe((state, prev) => {
+      if (state.selected === prev.selected) return;
+      const sel = state.selected;
+      if (!sel) return;
+      const panel = api.getPanel('source-preview');
+      if (!panel) return;
+      let loc = null;
+      if (sel.kind === 'span') {
+        loc = useSourceLocationStore.getState().resolve(sel.span.rawEvent?.sourceLocationId);
+      } else if (sel.kind === 'chunk') {
+        loc = useSourceLocationStore.getState().resolveSystem(sel.chunk.systemIndex);
+      }
+      if (!loc) return;
+      panel.api.updateParameters({ path: loc.file, line: loc.line });
+    });
+  }
 }
 
 export function openSchemaBrowser(): void {
@@ -53,6 +83,48 @@ export function openSchemaRelationships(): void {
  */
 export function openDetailPanel(): void {
   openDockPanel('detail', 'Detail', 'Detail');
+}
+
+/** #302 Phase 5: open (or focus) the Options panel — editor preference + workspace root. */
+export function openOptions(): void {
+  openDockPanel('options', 'Options', 'Options');
+}
+
+/**
+ * #302 Phase 7: open the inline source-preview panel for a given file:line. Each invocation reuses
+ * one panel id so opening a second source from the Source row replaces the contents instead of
+ * stacking panels.
+ */
+export function openSourcePreview(path: string, line: number): void {
+  const api = registeredApi;
+  if (!api) return;
+  const existing = api.getPanel('source-preview');
+  if (existing) {
+    existing.api.updateParameters({ path, line });
+    existing.focus();
+    return;
+  }
+  api.addPanel({
+    id: 'source-preview',
+    component: 'SourcePreview',
+    title: 'Source Preview',
+    params: { path, line },
+  });
+}
+
+/**
+ * #302 Phase 7: palette command — open the source-preview for the currently selected span.
+ * No-op when there is no span selected, the selected span carries no source-location id, or the
+ * id can't be resolved against the manifest. The buttons in the Detail panel's Source row remain
+ * the primary entry point; this is for keyboard-driven users.
+ */
+export function openSourcePreviewForCurrentSpan(): void {
+  const selection = useProfilerSelectionStore.getState().selected;
+  if (!selection || selection.kind !== 'span') return;
+  const siteId = selection.span.rawEvent?.sourceLocationId;
+  const loc = useSourceLocationStore.getState().resolve(siteId);
+  if (!loc) return;
+  openSourcePreview(loc.file, loc.line);
 }
 
 function openDockPanel(id: string, componentKey: string, title: string): void {

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useOptionsStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useOptionsStore.ts
@@ -1,0 +1,161 @@
+import { create } from 'zustand';
+
+/**
+ * Mirror of the C# `WorkbenchOptions` schema. Fields stay in sync with
+ * `tools/Typhon.Workbench/Hosting/WorkbenchOptions.cs`. Adding a new category here means
+ * adding the matching record + controller patch endpoint on the server.
+ */
+export type EditorKind = 'vsCode' | 'cursor' | 'rider' | 'visualStudio' | 'custom';
+
+export interface EditorOptions {
+  kind: EditorKind;
+  customCommand: string;
+}
+
+export interface ProfilerOptions {
+  workspaceRoot: string;
+}
+
+export interface WorkbenchOptions {
+  editor: EditorOptions;
+  profiler: ProfilerOptions;
+}
+
+const DEFAULT_OPTIONS: WorkbenchOptions = {
+  editor: { kind: 'vsCode', customCommand: '' },
+  profiler: { workspaceRoot: '' },
+};
+
+interface OptionsState {
+  options: WorkbenchOptions;
+  loaded: boolean;
+  /** Operating system from `/api/system/os` — drives UI affordances (e.g., disabling VS on macOS). */
+  os: 'windows' | 'macos' | 'linux' | 'other';
+
+  /** Fetch the full options document from the server. Replaces local state. */
+  fetch: () => Promise<void>;
+  /** Patch the editor category. Optimistic update with rollback on HTTP error. */
+  setEditor: (editor: EditorOptions) => Promise<void>;
+  /** Patch the profiler category. Optimistic with rollback. */
+  setProfiler: (profiler: ProfilerOptions) => Promise<void>;
+  /** Trigger an editor-launch via the server. Returns the structured result. */
+  openInEditor: (file: string, line: number, column?: number) => Promise<OpenInEditorResult>;
+}
+
+export interface OpenInEditorResult {
+  ok: boolean;
+  error: string;
+  hint: string;
+}
+
+/**
+ * Module-level guard so we open at most one SSE connection per page lifetime even if `fetch()` is
+ * called multiple times (e.g., a re-mount). EventSource is browser-only; in test environments
+ * (`typeof EventSource === 'undefined'`) the subscription is silently skipped.
+ */
+let _optionsStreamHandle: EventSource | null = null;
+
+function ensureOptionsStreamSubscription(set: (partial: Partial<OptionsState>) => void): void {
+  if (typeof EventSource === 'undefined') return;
+  if (_optionsStreamHandle) return;
+  const es = new EventSource('/api/options/stream');
+  es.onmessage = (event) => {
+    try {
+      const next = JSON.parse(event.data) as WorkbenchOptions;
+      set({ options: next });
+    } catch {
+      // Malformed frame — ignore. Server-side serializer is the source of truth; a parse failure
+      // here is a developer-time bug, not a runtime user concern.
+    }
+  };
+  es.onerror = () => {
+    // Browser auto-reconnects on transient failures; reset the handle on permanent close so a
+    // future fetch() can re-subscribe.
+    if (es.readyState === EventSource.CLOSED) {
+      _optionsStreamHandle = null;
+    }
+  };
+  _optionsStreamHandle = es;
+}
+
+export const useOptionsStore = create<OptionsState>()((set, get) => ({
+  options: DEFAULT_OPTIONS,
+  loaded: false,
+  os: 'other',
+
+  fetch: async () => {
+    const [optsResp, osResp] = await Promise.all([
+      fetch('/api/options'),
+      fetch('/api/system/os'),
+    ]);
+    if (optsResp.ok) {
+      const opts = (await optsResp.json()) as WorkbenchOptions;
+      set({ options: opts, loaded: true });
+    }
+    if (osResp.ok) {
+      const osInfo = (await osResp.json()) as { os: 'windows' | 'macos' | 'linux' | 'other' };
+      set({ os: osInfo.os });
+    }
+    // Subscribe to out-of-band changes (file edited by hand, another Workbench window PATCHing).
+    // EventSource lifetime tied to the page; the SSE handler closes server-side on disconnect.
+    ensureOptionsStreamSubscription(set);
+  },
+
+  setEditor: async (editor) => {
+    const prev = get().options;
+    set({ options: { ...prev, editor } });
+    try {
+      const resp = await fetch('/api/options/editor', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(editor),
+      });
+      if (!resp.ok) {
+        set({ options: prev });
+        throw new Error(`PATCH /api/options/editor failed: ${resp.status}`);
+      }
+      const updated = (await resp.json()) as WorkbenchOptions;
+      set({ options: updated });
+    } catch (err) {
+      set({ options: prev });
+      throw err;
+    }
+  },
+
+  setProfiler: async (profiler) => {
+    const prev = get().options;
+    set({ options: { ...prev, profiler } });
+    try {
+      const resp = await fetch('/api/options/profiler', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(profiler),
+      });
+      if (!resp.ok) {
+        set({ options: prev });
+        throw new Error(`PATCH /api/options/profiler failed: ${resp.status}`);
+      }
+      const updated = (await resp.json()) as WorkbenchOptions;
+      set({ options: updated });
+    } catch (err) {
+      set({ options: prev });
+      throw err;
+    }
+  },
+
+  openInEditor: async (file, line, column) => {
+    const resp = await fetch('/api/profiler/open-in-editor', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file, line, column: column ?? null }),
+    });
+    if (!resp.ok) {
+      return {
+        ok: false,
+        error: `HTTP ${resp.status}: ${resp.statusText}`,
+        hint: '',
+      };
+    }
+    return (await resp.json()) as OpenInEditorResult;
+  },
+}));

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useSourceLocationStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useSourceLocationStore.ts
@@ -1,0 +1,79 @@
+import { create } from 'zustand';
+
+/**
+ * One row of the compile-time source-location table emitted by `SourceLocationGenerator`.
+ * Mirrors `Typhon.Profiler.SourceLocationManifestEntry` on the server. See
+ * `claude/design/observability/10-profiler-source-attribution.md`.
+ */
+export interface SourceLocation {
+  /** Site id carried in span records when bit 1 of SpanFlags is set. 0 = unknown source. */
+  id: number;
+  /** Index into the parallel `files` array. */
+  fileId: number;
+  /** 1-based line number within the file. */
+  line: number;
+  /** Compile-time hint of the kind. May be 0 — runtime kind byte is the source of truth. */
+  kind: number;
+  /** Containing-method short name for display. */
+  method: string;
+}
+
+/**
+ * High bit reserved on system source-location ids (#302 system attribution). Compile-time call-site
+ * ids start at 1 and grow sequentially — they will not reach 0x8000 until ~32K distinct sites exist
+ * (we have hundreds today). The synthesized id for a system's chunk-span source is
+ * <c>SOURCE_LOCATION_SYSTEM_ID_MASK | systemIndex</c>. Mirrors <c>RuntimeSourceLocationManifest</c>
+ * on the server.
+ */
+export const SOURCE_LOCATION_SYSTEM_ID_MASK = 0x8000;
+
+interface SourceLocationState {
+  /** Map siteId → resolved location. Lookup miss = unknown source. */
+  locations: Map<number, SourceLocation>;
+  /** Map fileId → repo-relative path. */
+  files: Map<number, string>;
+  /**
+   * Replace the table with a new manifest payload. Called once per session: at session-init
+   * for live-attach (FileTable + SourceLocationManifest frames), or at trace-load for file-mode.
+   */
+  setManifest: (entries: SourceLocation[], files: Array<{ fileId: number; path: string }>) => void;
+  /** Convenience: resolve a siteId to file/line/method, or null if unknown. */
+  resolve: (siteId: number | undefined | null) => ResolvedSourceLocation | null;
+  /** #302 system attribution: resolve a system's source via the synthesized id formula. */
+  resolveSystem: (systemIndex: number | undefined | null) => ResolvedSourceLocation | null;
+  clear: () => void;
+}
+
+/** Materialized lookup result with the file path joined in. */
+export interface ResolvedSourceLocation {
+  file: string;
+  line: number;
+  method: string;
+  kind: number;
+}
+
+export const useSourceLocationStore = create<SourceLocationState>()((set, get) => ({
+  locations: new Map(),
+  files: new Map(),
+  setManifest: (entries, files) => {
+    const locMap = new Map<number, SourceLocation>();
+    for (const e of entries) locMap.set(e.id, e);
+    const fileMap = new Map<number, string>();
+    for (const f of files) fileMap.set(f.fileId, f.path);
+    set({ locations: locMap, files: fileMap });
+  },
+  resolve: (siteId) => {
+    if (!siteId) return null;
+    const { locations, files } = get();
+    const loc = locations.get(siteId);
+    if (!loc) return null;
+    const file = files.get(loc.fileId);
+    if (!file) return null;
+    return { file, line: loc.line, method: loc.method, kind: loc.kind };
+  },
+  resolveSystem: (systemIndex) => {
+    if (systemIndex === null || systemIndex === undefined || systemIndex < 0) return null;
+    return get().resolve(SOURCE_LOCATION_SYSTEM_ID_MASK | (systemIndex & 0x7fff));
+  },
+  clear: () => set({ locations: new Map(), files: new Map() }),
+}));

--- a/tools/Typhon.Workbench/Controllers/OptionsController.cs
+++ b/tools/Typhon.Workbench/Controllers/OptionsController.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Mvc;
+using Typhon.Workbench.Hosting;
+using Typhon.Workbench.Middleware;
+
+namespace Typhon.Workbench.Controllers;
+
+/// <summary>
+/// REST surface for <see cref="WorkbenchOptions"/>: GET (full document), PUT (full replace),
+/// PATCH per-category. Bootstrap-token gated like the rest of the MVC API; unauthenticated
+/// callers from a malicious webpage cannot mutate.
+/// </summary>
+[ApiController]
+[Route("api/options")]
+[RequireBootstrapToken]
+public sealed class OptionsController : ControllerBase
+{
+    private readonly OptionsStore _store;
+
+    public OptionsController(OptionsStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+    }
+
+    /// <summary>Return the full options document.</summary>
+    [HttpGet]
+    public ActionResult<WorkbenchOptions> Get() => Ok(_store.Get());
+
+    /// <summary>Replace the full options document.</summary>
+    [HttpPut]
+    public ActionResult<WorkbenchOptions> Put([FromBody] WorkbenchOptions body)
+    {
+        if (body == null) return BadRequest(new { error = "Body required" });
+        _store.Replace(body);
+        return Ok(_store.Get());
+    }
+
+    /// <summary>Patch the editor category.</summary>
+    [HttpPatch("editor")]
+    public ActionResult<WorkbenchOptions> PatchEditor([FromBody] EditorOptions body)
+    {
+        if (body == null) return BadRequest(new { error = "Body required" });
+        _store.PatchEditor(body);
+        return Ok(_store.Get());
+    }
+
+    /// <summary>Patch the profiler category.</summary>
+    [HttpPatch("profiler")]
+    public ActionResult<WorkbenchOptions> PatchProfiler([FromBody] ProfilerOptions body)
+    {
+        if (body == null) return BadRequest(new { error = "Body required" });
+        _store.PatchProfiler(body);
+        return Ok(_store.Get());
+    }
+}

--- a/tools/Typhon.Workbench/Controllers/ProfilerController.cs
+++ b/tools/Typhon.Workbench/Controllers/ProfilerController.cs
@@ -70,6 +70,37 @@ public sealed class ProfilerController : ControllerBase
     }
 
     /// <summary>
+    /// #302 Phase 4: source-location manifest for the session — maps span <c>siteId</c>s to file/line/method.
+    /// Works for both Attach (received in init handshake) and Trace (read from the file's trailer) sessions.
+    /// Returns an empty manifest when the trace doesn't carry source attribution (engine emitted no
+    /// intercepted call sites). See claude/design/observability/10-profiler-source-attribution.md §4.7.
+    /// </summary>
+    [HttpGet("source-locations")]
+    public ActionResult<SourceLocationManifestDto> GetSourceLocations(Guid sessionId)
+    {
+        var session = HttpContext.Items["Session"];
+
+        if (session is AttachSession attach)
+        {
+            return Ok(attach.Runtime.SourceLocationManifest);
+        }
+
+        if (session is TraceSession trace)
+        {
+            // Manifest was loaded once at build completion in TraceSessionRuntime; we just hand it
+            // back. Pre-feature traces (or traces without attribution) get SourceLocationManifestDto.Empty.
+            return Ok(trace.Runtime.SourceLocationManifest);
+        }
+
+        return Conflict(new ProblemDetails
+        {
+            Title = "session_kind_mismatch",
+            Detail = "Source-location manifest is only available for Trace and Attach sessions.",
+            Status = StatusCodes.Status409Conflict,
+        });
+    }
+
+    /// <summary>
     /// User-initiated disconnect for an Attach session. Drops the TCP connection to the engine and pins the
     /// runtime status to <c>disconnected</c>; the session itself stays alive in the <see cref="SessionManager"/>
     /// so the client can keep inspecting the captured tick buffer. Idempotent — repeated calls are 204 no-ops.

--- a/tools/Typhon.Workbench/Controllers/ProfilerSourceController.cs
+++ b/tools/Typhon.Workbench/Controllers/ProfilerSourceController.cs
@@ -1,0 +1,205 @@
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Typhon.Workbench.Hosting;
+using Typhon.Workbench.Middleware;
+
+namespace Typhon.Workbench.Controllers;
+
+/// <summary>
+/// Workbench-wide profiler operations that aren't tied to a specific session: the
+/// "Open in editor" handoff and the inline source-preview fetch. See
+/// claude/design/observability/10-profiler-source-attribution.md §5.5 + §5.6.
+/// </summary>
+[ApiController]
+[Route("api/profiler")]
+[Tags("Profiler")]
+[RequireBootstrapToken]
+public sealed class ProfilerSourceController : ControllerBase
+{
+    private readonly OptionsStore _options;
+    private readonly EditorLauncher _launcher;
+
+    public ProfilerSourceController(OptionsStore options, EditorLauncher launcher)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _launcher = launcher ?? throw new ArgumentNullException(nameof(launcher));
+    }
+
+    /// <summary>
+    /// Report the workspace root the server will use to resolve repo-relative paths from trace
+    /// manifests. When the user has set <see cref="ProfilerOptions.WorkspaceRoot"/> we return that
+    /// verbatim; otherwise we auto-detect by walking up from CWD looking for a <c>.git</c> entry.
+    /// The Profiler options form displays this so the user can see what will resolve.
+    /// </summary>
+    [HttpGet("workspace-root")]
+    public ActionResult<WorkspaceRootDto> GetWorkspaceRoot()
+    {
+        var configured = _options.Get().Profiler.WorkspaceRoot;
+        if (!string.IsNullOrEmpty(configured))
+        {
+            return Ok(new WorkspaceRootDto(Effective: configured, Source: "configured"));
+        }
+        var detected = AutoDetectRepoRoot();
+        if (detected != null)
+        {
+            return Ok(new WorkspaceRootDto(Effective: detected, Source: "auto-detected"));
+        }
+        return Ok(new WorkspaceRootDto(Effective: Directory.GetCurrentDirectory(), Source: "cwd-fallback"));
+    }
+
+    /// <summary>
+    /// Launch the user's configured editor at the given file:line. <paramref name="file"/> is a
+    /// repo-relative path from the trace manifest (e.g. "/_/src/.../BTree.cs"). The server joins
+    /// it with the configured workspace root and dispatches to <see cref="EditorLauncher"/>.
+    /// </summary>
+    [HttpPost("open-in-editor")]
+    public ActionResult<OpenInEditorResult> OpenInEditor([FromBody] OpenInEditorRequest body)
+    {
+        if (body == null) return BadRequest(new OpenInEditorResult(false, "Body required", ""));
+        if (string.IsNullOrWhiteSpace(body.File))
+        {
+            return BadRequest(new OpenInEditorResult(false, "File path required", ""));
+        }
+        if (body.Line <= 0)
+        {
+            return BadRequest(new OpenInEditorResult(false, "Line must be > 0", ""));
+        }
+
+        var opts = _options.Get();
+        var absolutePath = ResolveAbsolutePath(body.File, opts.Profiler.WorkspaceRoot);
+
+        var result = _launcher.Launch(opts.Editor, absolutePath, body.Line, body.Column);
+        if (!result.Success)
+        {
+            return Ok(new OpenInEditorResult(false, result.ErrorMessage, result.Hint));
+        }
+        return Ok(new OpenInEditorResult(true, "", ""));
+    }
+
+    /// <summary>
+    /// Fetch a window of source lines around <paramref name="line"/> from the file at <paramref name="path"/>.
+    /// <paramref name="path"/> is a repo-relative path from the trace manifest. Path-traversal guarded:
+    /// the resolved absolute path must remain inside the configured workspace root. <paramref name="context"/>
+    /// is the number of lines on each side of <paramref name="line"/> (default 20, capped at 100).
+    /// </summary>
+    [HttpGet("source")]
+    public ActionResult<SourceWindowDto> GetSource([FromQuery] string path, [FromQuery] int line, [FromQuery] int? context)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return BadRequest(new { error = "path query parameter required" });
+        }
+        if (line <= 0)
+        {
+            return BadRequest(new { error = "line must be > 0" });
+        }
+        var ctx = Math.Clamp(context ?? 20, 1, 100);
+
+        var opts = _options.Get();
+        var workspaceRoot = string.IsNullOrEmpty(opts.Profiler.WorkspaceRoot)
+            ? AutoDetectRepoRoot() ?? Directory.GetCurrentDirectory()
+            : opts.Profiler.WorkspaceRoot;
+
+        // #302 system attribution: PDB-resolved paths for user-defined systems (e.g. AntHill) are
+        // absolute and live outside the Typhon workspace root. The traversal guard exists to stop
+        // a relative path with `..` segments from escaping; an absolute path from the trace manifest
+        // is already a deliberate target. This endpoint requires the bootstrap token, so an attacker
+        // can't address arbitrary local files via the browser.
+        // NOTE: Path.IsPathRooted("/_/...") returns true on Windows (any leading /) so we must check
+        // the repo-relative `/_/` prefix BEFORE the rooted-path branch.
+        var isRepoRelative = path.StartsWith("/_/", StringComparison.Ordinal);
+        var isAbsolute = !isRepoRelative && Path.IsPathRooted(path)
+            && (path.Length >= 2 && (path[1] == ':' || path.StartsWith("\\\\", StringComparison.Ordinal) || path.StartsWith("//", StringComparison.Ordinal)));
+        var fullPath = Path.GetFullPath(ResolveAbsolutePath(path, workspaceRoot));
+        if (!isAbsolute)
+        {
+            var fullRoot = Path.GetFullPath(workspaceRoot);
+            if (!fullPath.StartsWith(fullRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                return BadRequest(new { error = "path is outside the workspace root", workspaceRoot = fullRoot });
+            }
+        }
+        if (!System.IO.File.Exists(fullPath))
+        {
+            return NotFound(new { error = $"File not found: {fullPath}" });
+        }
+
+        var allLines = System.IO.File.ReadAllLines(fullPath, Encoding.UTF8);
+        var startLine = Math.Max(1, line - ctx);
+        var endLine = Math.Min(allLines.Length, line + ctx);
+        var window = new string[endLine - startLine + 1];
+        Array.Copy(allLines, startLine - 1, window, 0, window.Length);
+
+        return Ok(new SourceWindowDto(
+            File: path,
+            Line: line,
+            StartLine: startLine,
+            EndLine: endLine,
+            Lines: window));
+    }
+
+    /// <summary>
+    /// Strip the design's "/_/" repo-relative prefix and join with the workspace root. Trim leading
+    /// path separators on the relative portion to keep <see cref="Path.Combine"/> well-behaved.
+    /// When <paramref name="workspaceRoot"/> is empty, auto-detects the repo root by walking up from
+    /// CWD looking for a <c>.git</c> directory; otherwise falls back to CWD itself. The Workbench's
+    /// CWD is typically <c>tools/Typhon.Workbench/</c> when launched via <c>dotnet run</c>, which
+    /// would resolve <c>/_/src/Typhon.Engine/...</c> to a non-existent path — auto-detect avoids that.
+    /// </summary>
+    public static string ResolveAbsolutePath(string repoRelative, string workspaceRoot)
+    {
+        // /_/ prefix from PathMap = repo-relative; strip and join with workspace root. Must run
+        // BEFORE the IsPathRooted check — Path.IsPathRooted("/_/...") returns true on Windows.
+        if (repoRelative.StartsWith("/_/", StringComparison.Ordinal))
+        {
+            var relative = repoRelative.Substring(3).TrimStart('/', '\\');
+            if (string.IsNullOrEmpty(workspaceRoot))
+            {
+                workspaceRoot = AutoDetectRepoRoot() ?? Directory.GetCurrentDirectory();
+            }
+            return Path.GetFullPath(Path.Combine(workspaceRoot, relative));
+        }
+        // True absolute path (drive letter or UNC) — PDB-resolved system paths (#302) live outside
+        // the Typhon workspace root (e.g. AntHill at C:\Dev\github\Typhon\test\AntHill\…).
+        if (Path.IsPathRooted(repoRelative)
+            && repoRelative.Length >= 2
+            && (repoRelative[1] == ':'
+                || repoRelative.StartsWith("\\\\", StringComparison.Ordinal)
+                || repoRelative.StartsWith("//", StringComparison.Ordinal)))
+        {
+            return Path.GetFullPath(repoRelative);
+        }
+        // Bare relative — keep prior behavior.
+        var rel = repoRelative.TrimStart('/', '\\');
+        if (string.IsNullOrEmpty(workspaceRoot))
+        {
+            workspaceRoot = AutoDetectRepoRoot() ?? Directory.GetCurrentDirectory();
+        }
+        return Path.GetFullPath(Path.Combine(workspaceRoot, rel));
+    }
+
+    /// <summary>
+    /// Walk up from <see cref="Directory.GetCurrentDirectory"/> looking for a directory that
+    /// contains a <c>.git</c> entry (file or folder — submodules and worktrees use a file). Returns
+    /// the matching directory or <c>null</c> if none is found.
+    /// </summary>
+    public static string AutoDetectRepoRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null)
+        {
+            var gitPath = Path.Combine(dir.FullName, ".git");
+            if (Directory.Exists(gitPath) || System.IO.File.Exists(gitPath))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    public sealed record OpenInEditorRequest(string File, int Line, int? Column);
+    public sealed record OpenInEditorResult(bool Ok, string Error, string Hint);
+    public sealed record SourceWindowDto(string File, int Line, int StartLine, int EndLine, string[] Lines);
+    public sealed record WorkspaceRootDto(string Effective, string Source);
+}

--- a/tools/Typhon.Workbench/Controllers/SystemController.cs
+++ b/tools/Typhon.Workbench/Controllers/SystemController.cs
@@ -1,0 +1,34 @@
+using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Typhon.Workbench.Controllers;
+
+/// <summary>
+/// System-introspection endpoints used by the client to render OS-aware UI (e.g., disabling
+/// "Visual Studio" in the editor dropdown on macOS).
+/// </summary>
+[ApiController]
+[Route("api/system")]
+public sealed class SystemController : ControllerBase
+{
+    /// <summary>Return the running OS as a stable lowercase string: "windows" | "macos" | "linux" | "other".</summary>
+    [HttpGet("os")]
+    public ActionResult<OsInfo> GetOs()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Ok(new OsInfo("windows"));
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Ok(new OsInfo("macos"));
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return Ok(new OsInfo("linux"));
+        }
+        return Ok(new OsInfo("other"));
+    }
+
+    public sealed record OsInfo(string Os);
+}

--- a/tools/Typhon.Workbench/Dtos/Profiler/SourceLocationManifestDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Profiler/SourceLocationManifestDto.cs
@@ -1,0 +1,19 @@
+namespace Typhon.Workbench.Sessions;
+
+/// <summary>
+/// Compile-time source-location manifest received from the engine in the live-attach init handshake
+/// (issue #293, Phase 3). Same wire shape as the trailing sections in a <c>.typhon-trace</c> file —
+/// the client uses both arrays together to resolve a span's <c>siteId</c> to a file:line:method.
+/// </summary>
+public sealed record SourceLocationManifestDto(
+    SourceLocationFileDto[] Files,
+    SourceLocationEntryDto[] Entries)
+{
+    public static SourceLocationManifestDto Empty { get; } = new(System.Array.Empty<SourceLocationFileDto>(), System.Array.Empty<SourceLocationEntryDto>());
+}
+
+/// <summary>One entry in the FileTable: a fileId-indexed source path.</summary>
+public sealed record SourceLocationFileDto(ushort FileId, string Path);
+
+/// <summary>One entry in the SourceLocationManifest: a site descriptor.</summary>
+public sealed record SourceLocationEntryDto(ushort Id, ushort FileId, uint Line, byte Kind, string Method);

--- a/tools/Typhon.Workbench/Hosting/EditorLauncher.cs
+++ b/tools/Typhon.Workbench/Hosting/EditorLauncher.cs
@@ -1,0 +1,247 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Workbench.Hosting;
+
+/// <summary>
+/// Launches the user's configured editor at a given file:line via <c>Process.Start</c>. Per-OS
+/// dispatch table — see claude/design/observability/10-profiler-source-attribution.md §5.5.
+///
+/// Officially supported platforms: Windows + macOS (matches the design's scope cut). Linux is
+/// implemented best-effort but documented as untested-on-this-machine.
+///
+/// Cross-platform launching:
+/// - URL schemes (vscode://, cursor://): on Windows uses <c>UseShellExecute=true</c> against the
+///   registered protocol handler; on macOS goes through <c>open &lt;url&gt;</c> for stability.
+/// - Native commands (rider64.exe, devenv.exe): direct <c>Process.Start</c> with explicit argv.
+/// - Custom argv template: tokens <c>{file}</c>, <c>{line}</c>, <c>{column}</c> substituted as
+///   discrete argv elements — never executed via a shell, so no injection.
+/// </summary>
+public sealed class EditorLauncher
+{
+    /// <summary>
+    /// Launch the configured editor at the given file:line. Returns success or a structured error
+    /// the controller can surface to the client.
+    /// </summary>
+    public LaunchResult Launch(EditorOptions options, string absolutePath, int line, int? column)
+    {
+        if (options == null) return LaunchResult.Error("No editor options configured");
+        if (string.IsNullOrWhiteSpace(absolutePath))
+        {
+            return LaunchResult.Error("No file path provided");
+        }
+        try
+        {
+            return options.Kind switch
+            {
+                EditorKind.VsCode => LaunchUrlScheme("vscode", absolutePath, line),
+                EditorKind.Cursor => LaunchUrlScheme("cursor", absolutePath, line),
+                EditorKind.Rider => LaunchRider(absolutePath, line),
+                EditorKind.VisualStudio => LaunchVisualStudio(absolutePath, line),
+                EditorKind.Custom => LaunchCustom(options.CustomCommand, absolutePath, line, column),
+                _ => LaunchResult.Error($"Unknown editor kind: {options.Kind}"),
+            };
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            return ex.NativeErrorCode switch
+            {
+                2 => LaunchResult.Error($"Editor binary not found on PATH: {ex.Message}",
+                    "Check that the configured editor is installed and accessible. "
+                    + "On Windows the JetBrains Toolbox installs `rider.cmd` as a PATH shim; on macOS, the JetBrains Toolbox installs `rider`."),
+                1155 => LaunchResult.Error($"No app registered for the URL scheme: {ex.Message}",
+                    "Open the editor's Settings → URL Handler (VS Code), Toolbox (Rider), or reinstall."),
+                _ => LaunchResult.Error($"Process.Start failed: {ex.Message}"),
+            };
+        }
+        catch (Exception ex)
+        {
+            return LaunchResult.Error($"Editor launch failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// VS Code / Cursor URL-scheme path. <c>vscode://file/&lt;abs&gt;:&lt;line&gt;</c> is the
+    /// documented syntax. Forward slashes in the URL on both OSes.
+    /// </summary>
+    private static LaunchResult LaunchUrlScheme(string scheme, string absolutePath, int line)
+    {
+        var psi = BuildUrlSchemeProcessStartInfo(scheme, absolutePath, line);
+        using var p = Process.Start(psi);
+        return LaunchResult.Ok();
+    }
+
+    /// <summary>
+    /// Build the <see cref="ProcessStartInfo"/> for a URL-scheme launch — split out so tests can
+    /// assert argv shape without spawning. On Windows we set <c>FileName</c> to the URL itself
+    /// (<c>UseShellExecute=true</c>); on macOS / Linux we invoke <c>open</c> / <c>xdg-open</c>.
+    /// </summary>
+    public static ProcessStartInfo BuildUrlSchemeProcessStartInfo(string scheme, string absolutePath, int line)
+    {
+        var url = BuildFileUrl(scheme, absolutePath, line);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var opener = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "open" : "xdg-open";
+            var psi = new ProcessStartInfo(opener) { UseShellExecute = false };
+            psi.ArgumentList.Add(url);
+            return psi;
+        }
+        return new ProcessStartInfo { FileName = url, UseShellExecute = true };
+    }
+
+    /// <summary>
+    /// Rider: native command-line launch. JetBrains Toolbox installs different shims on different
+    /// platforms — <c>rider.cmd</c> on Windows, <c>rider</c> on macOS / Linux. We try the well-known
+    /// names in order so any install layout works.
+    /// </summary>
+    /// <remarks>
+    /// <b>Focus:</b> the CLI signals an existing Rider instance via Toolbox's IPC pipe or launches a
+    /// new one — it does NOT bring an existing window to the foreground when Kestrel is the launcher,
+    /// because Windows Focus Stealing Prevention denies focus to children of background processes.
+    /// Rider's taskbar icon flashes instead. We tried browser-side <c>jetbrains://</c> URL dispatch
+    /// to grant foreground rights from the browser context, but the Toolbox URL handler only listens
+    /// for Code-With-Me invitations and silently drops <c>navigate/reference</c> — no documented
+    /// user-space fix exists. The flashing-taskbar gesture is the convention; users click it.
+    /// </remarks>
+    private static LaunchResult LaunchRider(string absolutePath, int line)
+    {
+        System.ComponentModel.Win32Exception lastNotFound = null;
+        foreach (var psi in BuildRiderProcessStartInfos(absolutePath, line))
+        {
+            try
+            {
+                using var p = Process.Start(psi);
+                return LaunchResult.Ok();
+            }
+            catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 2)
+            {
+                lastNotFound = ex;
+                // Try next candidate.
+            }
+        }
+        throw lastNotFound ?? new System.ComponentModel.Win32Exception(2, "rider not found on PATH");
+    }
+
+    /// <summary>
+    /// Yield candidate <see cref="ProcessStartInfo"/>s for Rider in priority order. Split out for
+    /// argv-shape tests; the live <see cref="LaunchRider"/> tries each in turn until one starts.
+    /// </summary>
+    public static IEnumerable<ProcessStartInfo> BuildRiderProcessStartInfos(string absolutePath, int line)
+    {
+        string[] candidates = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new[] { "rider.cmd", "rider64.exe", "rider.exe", "rider.bat" }
+            : new[] { "rider" };
+        foreach (var binary in candidates)
+        {
+            var psi = new ProcessStartInfo(binary) { UseShellExecute = false };
+            psi.ArgumentList.Add("--line");
+            psi.ArgumentList.Add(line.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            psi.ArgumentList.Add(absolutePath);
+            yield return psi;
+        }
+    }
+
+    /// <summary>
+    /// Visual Studio: <c>devenv.exe /Edit "&lt;file&gt;" /Command "Edit.GoTo &lt;line&gt;"</c>.
+    /// Windows-only. On macOS this returns an error (VS for Mac was discontinued Aug 2024).
+    /// </summary>
+    private static LaunchResult LaunchVisualStudio(string absolutePath, int line)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return LaunchResult.Error(
+                "Visual Studio is not available on this OS.",
+                "Use VS Code, Cursor, or Rider. (Visual Studio for Mac was discontinued in August 2024.)");
+        }
+        using var p = Process.Start(BuildVisualStudioProcessStartInfo(absolutePath, line));
+        return LaunchResult.Ok();
+    }
+
+    /// <summary>Build the <see cref="ProcessStartInfo"/> for <c>devenv.exe</c> — split for testability.</summary>
+    public static ProcessStartInfo BuildVisualStudioProcessStartInfo(string absolutePath, int line)
+    {
+        var psi = new ProcessStartInfo("devenv.exe") { UseShellExecute = false };
+        psi.ArgumentList.Add("/Edit");
+        psi.ArgumentList.Add(absolutePath);
+        psi.ArgumentList.Add("/Command");
+        psi.ArgumentList.Add($"Edit.GoTo {line}");
+        return psi;
+    }
+
+    /// <summary>
+    /// Custom argv template. Splits the template on whitespace into discrete argv elements,
+    /// substituting <c>{file}</c>, <c>{line}</c>, <c>{column}</c> as separate elements — never
+    /// invokes a shell, so no injection vector.
+    /// </summary>
+    private static LaunchResult LaunchCustom(string template, string absolutePath, int line, int? column)
+    {
+        var psi = BuildCustomProcessStartInfo(template, absolutePath, line, column);
+        if (psi == null)
+        {
+            return LaunchResult.Error("Custom command template is empty",
+                "Set Options → Editor → Custom command (e.g., 'nvim-qt --remote +{line} {file}').");
+        }
+        using var p = Process.Start(psi);
+        return LaunchResult.Ok();
+    }
+
+    /// <summary>
+    /// Build the <see cref="ProcessStartInfo"/> for a Custom command template. Returns null when the
+    /// template is empty (caller maps to a structured <see cref="LaunchResult"/> error). Tokens are
+    /// kept as discrete argv elements — no shell, no quoting injection.
+    /// </summary>
+    public static ProcessStartInfo BuildCustomProcessStartInfo(string template, string absolutePath, int line, int? column)
+    {
+        if (string.IsNullOrWhiteSpace(template)) return null;
+        var tokens = template.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length == 0) return null;
+        var psi = new ProcessStartInfo(tokens[0]) { UseShellExecute = false };
+        for (int i = 1; i < tokens.Length; i++)
+        {
+            var arg = tokens[i]
+                .Replace("{file}", absolutePath)
+                .Replace("{line}", line.ToString(System.Globalization.CultureInfo.InvariantCulture))
+                .Replace("{column}", (column ?? 1).ToString(System.Globalization.CultureInfo.InvariantCulture));
+            psi.ArgumentList.Add(arg);
+        }
+        return psi;
+    }
+
+    /// <summary>
+    /// Build a <c>vscode://file/&lt;abs&gt;:&lt;line&gt;</c>-style URL. Path is URL-encoded enough
+    /// to survive the URI; backslashes are converted to forward-slashes (URL convention).
+    /// </summary>
+    public static string BuildFileUrl(string scheme, string absolutePath, int line)
+    {
+        var path = absolutePath.Replace('\\', '/');
+        // URL-escape spaces and other special chars in the path. We use Uri.EscapeDataString on the
+        // path component but preserve the leading '/' segments for readability.
+        var parts = path.Split('/');
+        for (int i = 0; i < parts.Length; i++)
+        {
+            parts[i] = Uri.EscapeDataString(parts[i]);
+        }
+        var encodedPath = string.Join('/', parts);
+        return $"{scheme}://file/{encodedPath}:{line}";
+    }
+}
+
+/// <summary>Result of an editor launch — either Ok or a structured error with optional hint.</summary>
+public readonly struct LaunchResult
+{
+    public bool Success { get; }
+    public string ErrorMessage { get; }
+    public string Hint { get; }
+
+    private LaunchResult(bool success, string error, string hint)
+    {
+        Success = success;
+        ErrorMessage = error ?? string.Empty;
+        Hint = hint ?? string.Empty;
+    }
+
+    public static LaunchResult Ok() => new(true, null, null);
+    public static LaunchResult Error(string message) => new(false, message, null);
+    public static LaunchResult Error(string message, string hint) => new(false, message, hint);
+}

--- a/tools/Typhon.Workbench/Hosting/OptionsStore.cs
+++ b/tools/Typhon.Workbench/Hosting/OptionsStore.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace Typhon.Workbench.Hosting;
+
+/// <summary>
+/// File-backed persistence + hot-reload for <see cref="WorkbenchOptions"/>. Atomic write via
+/// temp file + rename so a crash mid-save can't corrupt the JSON. <see cref="FileSystemWatcher"/>
+/// handles out-of-band edits (e.g., user editing the JSON by hand): debounced 200 ms to coalesce
+/// the multi-event burst most editors emit on save.
+///
+/// Storage path: <c>%LOCALAPPDATA%\Typhon.Workbench\options.json</c> on Windows,
+/// <c>~/Library/Application Support/Typhon.Workbench/options.json</c> on macOS.
+/// </summary>
+/// <remarks>
+/// <b>Concurrency:</b> two locks. <c>_lock</c> guards <c>_current</c> and is held only for the
+/// brief in-memory swap; reads serialize behind it but never block on disk. <c>_writeLock</c>
+/// serializes the atomic file-replacement so two concurrent <c>PATCH</c> requests can't collide on
+/// the temp-file rename. Writes happen <i>outside</i> <c>_lock</c>, so a slow disk doesn't stall
+/// <see cref="Get"/>.
+/// </remarks>
+public sealed partial class OptionsStore : IDisposable
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+    };
+
+    private readonly string _filePath;
+    private readonly ILogger<OptionsStore> _logger;
+    private readonly FileSystemWatcher _watcher;
+    private readonly object _lock = new();
+    private readonly object _writeLock = new();
+    private readonly System.Threading.Timer _debounceTimer;
+    private WorkbenchOptions _current;
+
+    /// <summary>Fired when the on-disk file changes (after debounce + reload).</summary>
+    public event Action<WorkbenchOptions> OptionsChanged;
+
+    public OptionsStore(ILogger<OptionsStore> logger) : this(logger, DefaultDirectory()) { }
+
+    /// <summary>Test-friendly constructor: store options in <paramref name="directory"/> instead of LocalApplicationData.</summary>
+    public OptionsStore(ILogger<OptionsStore> logger, string directory)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        var dir = directory ?? throw new ArgumentNullException(nameof(directory));
+        Directory.CreateDirectory(dir);
+        _filePath = Path.Combine(dir, "options.json");
+
+        _current = TryLoad() ?? new WorkbenchOptions();
+
+        var watcherDir = dir;
+        _watcher = new FileSystemWatcher(watcherDir, "options.json")
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+            EnableRaisingEvents = true,
+        };
+        _watcher.Changed += OnFileChanged;
+        _watcher.Created += OnFileChanged;
+        _watcher.Renamed += (s, e) => OnFileChanged(s, e);
+
+        _debounceTimer = new System.Threading.Timer(_ => DebouncedReload(), null, Timeout.Infinite, Timeout.Infinite);
+    }
+
+    public string FilePath => _filePath;
+
+    public WorkbenchOptions Get()
+    {
+        lock (_lock) { return _current; }
+    }
+
+    /// <summary>Replace the whole options document. Atomic on disk; broadcasts to subscribers.</summary>
+    public void Replace(WorkbenchOptions next)
+    {
+        if (next == null) throw new ArgumentNullException(nameof(next));
+        lock (_lock) { _current = next; }
+        OptionsChanged?.Invoke(next);
+        WriteAtomic(next);
+    }
+
+    /// <summary>Patch the Editor sub-record. Other categories untouched.</summary>
+    public void PatchEditor(EditorOptions editor)
+    {
+        if (editor == null) throw new ArgumentNullException(nameof(editor));
+        WorkbenchOptions next;
+        lock (_lock)
+        {
+            next = _current with { Editor = editor };
+            _current = next;
+        }
+        OptionsChanged?.Invoke(next);
+        WriteAtomic(next);
+    }
+
+    /// <summary>Patch the Profiler sub-record. Other categories untouched.</summary>
+    public void PatchProfiler(ProfilerOptions profiler)
+    {
+        if (profiler == null) throw new ArgumentNullException(nameof(profiler));
+        WorkbenchOptions next;
+        lock (_lock)
+        {
+            next = _current with { Profiler = profiler };
+            _current = next;
+        }
+        OptionsChanged?.Invoke(next);
+        WriteAtomic(next);
+    }
+
+    private WorkbenchOptions TryLoad()
+    {
+        try
+        {
+            if (!File.Exists(_filePath)) return null;
+            using var stream = File.OpenRead(_filePath);
+            return JsonSerializer.Deserialize<WorkbenchOptions>(stream, JsonOpts);
+        }
+        catch (Exception ex)
+        {
+            // Treat parse / IO errors as "no file" — keep defaults rather than crashing the host.
+            LogLoadFailed(ex, _filePath);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Atomic write: serialize to a temp file, then rename over the target. A crash mid-write leaves
+    /// either the old file (if temp not yet renamed) or the new file (rename is atomic on most FSes).
+    /// Serialized via <see cref="_writeLock"/> so concurrent <c>PATCH</c>es don't collide on the
+    /// temp-file path; readers (<see cref="Get"/>) hold the in-memory <see cref="_lock"/> only and
+    /// never block on disk.
+    /// </summary>
+    private void WriteAtomic(WorkbenchOptions options)
+    {
+        lock (_writeLock)
+        {
+            try
+            {
+                var tempPath = _filePath + ".tmp";
+                using (var stream = File.Create(tempPath))
+                {
+                    JsonSerializer.Serialize(stream, options, JsonOpts);
+                }
+                // File.Move with overwrite is the closest cross-platform atomic-rename .NET offers.
+                File.Move(tempPath, _filePath, overwrite: true);
+            }
+            catch (Exception ex)
+            {
+                LogPersistFailed(ex, _filePath);
+                throw;
+            }
+        }
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        // Debounce — editors typically emit multiple change events on save (write, flush, attribute).
+        _debounceTimer.Change(dueTime: 200, period: Timeout.Infinite);
+    }
+
+    private void DebouncedReload()
+    {
+        WorkbenchOptions next;
+        lock (_lock)
+        {
+            var loaded = TryLoad();
+            if (loaded == null || loaded.Equals(_current))
+            {
+                return;
+            }
+            next = loaded;
+            _current = loaded;
+        }
+        OptionsChanged?.Invoke(next);
+    }
+
+    public void Dispose()
+    {
+        _watcher.Dispose();
+        _debounceTimer.Dispose();
+    }
+
+    /// <summary>Default options directory: <c>%LOCALAPPDATA%\Typhon.Workbench</c> on Windows, equivalents on macOS / Linux.</summary>
+    public static string DefaultDirectory() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Typhon.Workbench");
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to load options from {Path}; using defaults.")]
+    private partial void LogLoadFailed(Exception ex, string path);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to persist options to {Path}.")]
+    private partial void LogPersistFailed(Exception ex, string path);
+}

--- a/tools/Typhon.Workbench/Hosting/ServiceExtensions.cs
+++ b/tools/Typhon.Workbench/Hosting/ServiceExtensions.cs
@@ -15,6 +15,11 @@ public static class ServiceExtensions
         services.AddSingleton<DemoDataProvider>();
         services.AddSingleton<FileBrowserService>();
         services.AddSingleton<SchemaService>();
+        // #302 Phase 5: file-backed user options (editor preference, workspace root). Singleton because the
+        // FileSystemWatcher hot-reload + atomic-write semantics need a single shared instance.
+        services.AddSingleton<OptionsStore>();
+        // #302 Phase 6: editor handoff dispatcher (per-OS adapters: VS Code / Cursor / Rider / VS / Custom).
+        services.AddSingleton<EditorLauncher>();
         return services;
     }
 
@@ -28,6 +33,8 @@ public static class ServiceExtensions
            .WithTags("Profiler");
         app.MapGet("/api/sessions/{sessionId:guid}/profiler/stream", ProfilerLiveStream.HandleAsync)
            .WithTags("Profiler");
+        app.MapGet("/api/options/stream", OptionsChangedStream.HandleAsync)
+           .WithTags("Options");
         return app;
     }
 

--- a/tools/Typhon.Workbench/Hosting/WorkbenchOptions.cs
+++ b/tools/Typhon.Workbench/Hosting/WorkbenchOptions.cs
@@ -1,0 +1,51 @@
+namespace Typhon.Workbench.Hosting;
+
+/// <summary>
+/// User-facing Workbench options, persisted to JSON in the OS user-data folder.
+/// See claude/design/observability/10-profiler-source-attribution.md §5.7 for the design.
+/// </summary>
+/// <remarks>
+/// Records (immutable + value equality) + sparse JSON: only fields the user has changed are
+/// persisted; missing fields default-construct via the record's <c>= new()</c> initializer.
+/// New categories or properties added in future versions auto-default in old user files.
+/// </remarks>
+public sealed record WorkbenchOptions
+{
+    public EditorOptions Editor { get; init; } = new();
+    public ProfilerOptions Profiler { get; init; } = new();
+}
+
+/// <summary>Editor handoff preferences for the "Open in editor" feature on profiler spans.</summary>
+public sealed record EditorOptions
+{
+    /// <summary>Editor to launch when the user clicks "Open in editor" on a span. Default: VS Code.</summary>
+    public EditorKind Kind { get; init; } = EditorKind.VsCode;
+
+    /// <summary>
+    /// argv template used when <see cref="Kind"/> is <see cref="EditorKind.Custom"/>. Tokens:
+    /// <c>{file}</c>, <c>{line}</c>, <c>{column}</c>. Tokenized into discrete argv elements before
+    /// <c>Process.Start</c> — never executed via a shell.
+    /// </summary>
+    public string CustomCommand { get; init; } = "";
+}
+
+/// <summary>Profiler-related preferences (workspace root, future fields).</summary>
+public sealed record ProfilerOptions
+{
+    /// <summary>
+    /// Absolute path of the workspace root used to resolve repo-relative source paths from trace
+    /// files (the "/_/..." form produced by <c>SourceLocationGenerator</c>). When empty, the
+    /// Workbench falls back to the directory it was launched from.
+    /// </summary>
+    public string WorkspaceRoot { get; init; } = "";
+}
+
+/// <summary>Editor target enumeration. Wire-stable; never renumber.</summary>
+public enum EditorKind
+{
+    VsCode = 0,
+    Cursor = 1,
+    Rider = 2,
+    VisualStudio = 3,
+    Custom = 4,
+}

--- a/tools/Typhon.Workbench/Program.cs
+++ b/tools/Typhon.Workbench/Program.cs
@@ -22,6 +22,10 @@ builder.Services
     {
         o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         o.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        // String-encode enums camelCase (matches the TS client which uses 'vsCode' | 'rider' …).
+        // Without this, PATCH /api/options/editor 400s because the server can't deserialize "rider"
+        // to the EditorKind enum.
+        o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     });
 
 builder.Services.AddOpenApi();

--- a/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.cs
+++ b/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.cs
@@ -108,6 +108,13 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
     /// <summary>Cached metadata snapshot — invalidated on every state change, lazily rebuilt on access.</summary>
     private volatile ProfilerMetadataDto _metadataSnapshot;
 
+    /// <summary>
+    /// Compile-time source-location manifest received from the engine in the init handshake (#302, Phase 4).
+    /// Parsed once per Init and made available via <see cref="SourceLocationManifest"/>. Empty when the
+    /// engine ran without an intercepted call site (e.g. test-only configurations).
+    /// </summary>
+    private SourceLocationManifestDto _sourceLocationManifest = SourceLocationManifestDto.Empty;
+
     private Timer _flushChunkTimer;
     private Timer _trailingTickTimer;
     private Timer _globalMetricsTimer;
@@ -137,6 +144,12 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
 
     /// <summary>Resolves with the metadata DTO once the first Init frame arrives. Faults if the runtime is disposed before that.</summary>
     public Task<ProfilerMetadataDto> MetadataReady => _metadataTcs.Task;
+
+    /// <summary>
+    /// Compile-time source-location manifest from the engine's init handshake (#302).
+    /// Returns an empty manifest until the FileTable + SourceLocationManifest frames have arrived.
+    /// </summary>
+    public SourceLocationManifestDto SourceLocationManifest => _sourceLocationManifest;
 
     /// <summary>Number of finalized ticks currently in the metadata snapshot.</summary>
     public long TickCount
@@ -626,6 +639,17 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
                         HandleBlock(payload, length);
                         break;
 
+                    case LiveFrameType.FileTable:
+                        // #302 Phase 4: parse the engine's compile-time FileTable into the pending manifest.
+                        // Combined with the SourceLocationManifest frame that follows (or has already
+                        // arrived), it lets the client resolve span siteIds.
+                        HandleFileTable(payload, length);
+                        break;
+
+                    case LiveFrameType.SourceLocationManifest:
+                        HandleSourceLocationManifest(payload, length);
+                        break;
+
                     case LiveFrameType.Shutdown:
                         LogShutdownReceived();
                         ShutdownReceived?.Invoke("engine_shutdown");
@@ -716,6 +740,67 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
         // reconnect, so subsequent TickStart records resume the same tickNumber sequence.
         LogInitReceived(reader.Systems.Count, reader.Header.WorkerCount, reader.Header.BaseTickRate);
         return true;
+    }
+
+    /// <summary>
+    /// Parse the engine's FileTable frame payload (#302, Phase 4). Wire layout matches the file-format
+    /// trailer's FileTable section: u32 entryCount, then per-entry u16 fileId, u16 pathLen, UTF-8 bytes.
+    /// Updates the pending manifest's <c>Files</c>; the partner SourceLocationManifest frame fills entries.
+    /// </summary>
+    private void HandleFileTable(byte[] payload, int length)
+    {
+        try
+        {
+            using var ms = new MemoryStream(payload, 0, length, writable: false);
+            using var br = new BinaryReader(ms, System.Text.Encoding.UTF8, leaveOpen: true);
+            var count = br.ReadUInt32();
+            var files = new SourceLocationFileDto[count];
+            for (uint i = 0; i < count; i++)
+            {
+                var fileId = br.ReadUInt16();
+                var pathLen = br.ReadUInt16();
+                var pathBytes = br.ReadBytes(pathLen);
+                files[i] = new SourceLocationFileDto(fileId, System.Text.Encoding.UTF8.GetString(pathBytes));
+            }
+            _sourceLocationManifest = _sourceLocationManifest with { Files = files };
+        }
+        catch (Exception ex)
+        {
+            LogMalformedFrame(LiveFrameType.FileTable.ToString(), ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Parse the engine's SourceLocationManifest frame payload (#302, Phase 4). Wire layout: u32 entryCount,
+    /// then per-entry u16 id, u16 fileId, u32 line, u8 kind, u8 methodLen, UTF-8 method-name bytes.
+    /// Combined with the partner FileTable frame, gives the client a full siteId → (file, line, method, kind)
+    /// lookup.
+    /// </summary>
+    private void HandleSourceLocationManifest(byte[] payload, int length)
+    {
+        try
+        {
+            using var ms = new MemoryStream(payload, 0, length, writable: false);
+            using var br = new BinaryReader(ms, System.Text.Encoding.UTF8, leaveOpen: true);
+            var count = br.ReadUInt32();
+            var entries = new SourceLocationEntryDto[count];
+            for (uint i = 0; i < count; i++)
+            {
+                var id = br.ReadUInt16();
+                var fileId = br.ReadUInt16();
+                var line = br.ReadUInt32();
+                var kind = br.ReadByte();
+                var methodLen = br.ReadByte();
+                var methodBytes = br.ReadBytes(methodLen);
+                entries[i] = new SourceLocationEntryDto(
+                    id, fileId, line, kind, System.Text.Encoding.UTF8.GetString(methodBytes));
+            }
+            _sourceLocationManifest = _sourceLocationManifest with { Entries = entries };
+        }
+        catch (Exception ex)
+        {
+            LogMalformedFrame(LiveFrameType.SourceLocationManifest.ToString(), ex.Message);
+        }
     }
 
     private void HandleBlock(byte[] payload, int length)

--- a/tools/Typhon.Workbench/Sessions/TraceSessionRuntime.cs
+++ b/tools/Typhon.Workbench/Sessions/TraceSessionRuntime.cs
@@ -76,6 +76,15 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
     /// <summary>Source timestamp frequency (ticks/second from the source header). 0 until build completes.</summary>
     public long TimestampFrequency => _timestampFrequency;
 
+    /// <summary>
+    /// #302 — source-location manifest read from the source <c>.typhon-trace</c>'s trailer at build
+    /// completion. Empty for traces that don't carry attribution (engine emitted no intercepted call
+    /// sites) and for replay files (their source data path differs and isn't wired here yet).
+    /// Mirrors <see cref="AttachSessionRuntime.SourceLocationManifest"/> so the controller can serve
+    /// both session kinds through the same property without re-opening files per request.
+    /// </summary>
+    public SourceLocationManifestDto SourceLocationManifest { get; private set; } = SourceLocationManifestDto.Empty;
+
     /// <summary>Fires every ~200 ms during build with progress counters. Also fires at phase transitions (done / error).</summary>
     public event Action<BuildProgressEventArgs> BuildProgressChanged;
 
@@ -241,6 +250,13 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
                 : ReadSourceTimestampFrequency(_filePath);
             var metadata = BuildMetadataDto(_reader, _filePath, _timestampFrequency, fingerprint, _isReplayFile);
 
+            // #302: load the source-location manifest from the trace trailer once, keep on the runtime
+            // for cheap reuse by the controller. Skipped for replay files (no source trace to read).
+            if (!_isReplayFile)
+            {
+                SourceLocationManifest = TryLoadSourceLocationManifest(_filePath);
+            }
+
             Metadata = metadata;
             _metadataTcs.TrySetResult(metadata);
             BuildCompleted?.Invoke(metadata);
@@ -284,6 +300,42 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
         using var reader = new TraceFileReader(fs);
         var header = reader.ReadHeader();
         return header.TimestampFrequency;
+    }
+
+    /// <summary>
+    /// Reads the <c>FileTable</c> + <c>SourceLocationManifest</c> trailers from the source
+    /// <c>.typhon-trace</c> and projects them into the wire DTO shape. Returns <see cref="SourceLocationManifestDto.Empty"/>
+    /// for traces without attribution (engine emitted no intercepted call sites) and on any read
+    /// failure (we surface absent attribution rather than failing the whole session over it).
+    /// </summary>
+    private static SourceLocationManifestDto TryLoadSourceLocationManifest(string sourcePath)
+    {
+        try
+        {
+            using var fs = File.OpenRead(sourcePath);
+            using var reader = new TraceFileReader(fs);
+            reader.ReadHeader();
+            if (!reader.TryReadSourceLocationManifest(out var files, out var entries))
+            {
+                return SourceLocationManifestDto.Empty;
+            }
+            var fileDtos = new SourceLocationFileDto[files.Length];
+            for (ushort i = 0; i < files.Length; i++)
+            {
+                fileDtos[i] = new SourceLocationFileDto(i, files[i] ?? string.Empty);
+            }
+            var entryDtos = new SourceLocationEntryDto[entries.Length];
+            for (var i = 0; i < entries.Length; i++)
+            {
+                var e = entries[i];
+                entryDtos[i] = new SourceLocationEntryDto(e.Id, e.FileId, e.Line, e.Kind, e.Method);
+            }
+            return new SourceLocationManifestDto(fileDtos, entryDtos);
+        }
+        catch
+        {
+            return SourceLocationManifestDto.Empty;
+        }
     }
 
     /// <summary>

--- a/tools/Typhon.Workbench/Streams/OptionsChangedStream.cs
+++ b/tools/Typhon.Workbench/Streams/OptionsChangedStream.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Channels;
+using Typhon.Workbench.Hosting;
+
+namespace Typhon.Workbench.Streams;
+
+/// <summary>
+/// SSE channel that pushes <see cref="WorkbenchOptions"/> changes to the client (#302 Phase 5).
+/// The browser opens an <c>EventSource</c> at <c>GET /api/options/stream</c> on app start and stays
+/// connected for the session — when the on-disk options file changes (out-of-band edit, or another
+/// Workbench window <c>PATCH</c>ing) the store's <c>OptionsChanged</c> event fires and we serialize
+/// the new document into a single <c>data:</c> frame.
+/// </summary>
+/// <remarks>
+/// Bootstrap-token-gated via the URL prefix; <c>EventSource</c> can't send custom headers, so the
+/// security boundary is whatever Vite's dev proxy injects on the way through (matching how
+/// <see cref="HeartbeatStream"/> handles the same constraint). A 30-second keepalive comment frame
+/// keeps NAT / proxy idle-timeouts from killing otherwise-quiet streams.
+/// </remarks>
+public static class OptionsChangedStream
+{
+    private static readonly TimeSpan KeepaliveInterval = TimeSpan.FromSeconds(30);
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    public static async Task HandleAsync(
+        HttpContext ctx,
+        OptionsStore store,
+        CancellationToken ct)
+    {
+        ctx.Response.Headers.ContentType = "text/event-stream";
+        ctx.Response.Headers.CacheControl = "no-cache";
+        ctx.Response.Headers.Connection = "keep-alive";
+
+        // Buffer changes via a bounded channel — handler awaits ReadAsync and writes one SSE frame
+        // per options snapshot. Bounded(1, DropOldest) coalesces bursts: if two PATCHes fire while
+        // the writer is mid-flush, the client only sees the latest (eventually-consistent UX is fine
+        // for an options panel; nobody cares about intermediate states).
+        var channel = Channel.CreateBounded<WorkbenchOptions>(new BoundedChannelOptions(1)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+        void Listener(WorkbenchOptions next)
+        {
+            channel.Writer.TryWrite(next);
+        }
+
+        store.OptionsChanged += Listener;
+        try
+        {
+            // Send the current snapshot immediately so the client can sanity-check its store on connect.
+            channel.Writer.TryWrite(store.Get());
+
+            using var keepalive = new PeriodicTimer(KeepaliveInterval);
+            while (!ct.IsCancellationRequested)
+            {
+                var readTask = channel.Reader.ReadAsync(ct).AsTask();
+                var keepaliveTask = keepalive.WaitForNextTickAsync(ct).AsTask();
+                var winner = await Task.WhenAny(readTask, keepaliveTask);
+                if (winner == readTask)
+                {
+                    var snapshot = await readTask;
+                    var payload = JsonSerializer.Serialize(snapshot, JsonOpts);
+                    await ctx.Response.WriteAsync($"data: {payload}\n\n", ct);
+                    await ctx.Response.Body.FlushAsync(ct);
+                }
+                else
+                {
+                    // Comment-only frame keeps idle proxies from harvesting the connection.
+                    await ctx.Response.WriteAsync(": keepalive\n\n", ct);
+                    await ctx.Response.Body.FlushAsync(ct);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected — normal exit.
+        }
+        finally
+        {
+            store.OptionsChanged -= Listener;
+            channel.Writer.TryComplete();
+        }
+    }
+}

--- a/wb-dev.ps1
+++ b/wb-dev.ps1
@@ -1,0 +1,284 @@
+<#
+.SYNOPSIS
+  Manage the Typhon Workbench dev servers (Kestrel :5200 + Vite :5173).
+
+.DESCRIPTION
+  Single-shot replacement for the multi-step `/wb-dev` skill workflow. Tracks PIDs in
+  `.claude/state/wb-dev.json` so a later invocation can stop servers it didn't start.
+  All actions complete in one PowerShell session — no per-step Bash round-trips.
+
+  Keys to the speedup over the old skill:
+    - `Start-Process -PassThru` returns the launched PID directly. No netstat-then-
+      Get-CimInstance dance to walk from listener -> root.
+    - `Get-NetTCPConnection` queries the kernel's TCP table — no string-parsing of
+      `netstat -ano` output.
+    - PowerShell-native JSON via ConvertTo-Json / ConvertFrom-Json. No Python hop.
+    - Tight in-script poll for port binding (250 ms) — no per-iteration tool round-
+      trip cost.
+
+.PARAMETER Action
+  start | stop | status | restart | help. Default: start.
+
+.EXAMPLE
+  pwsh -File wb-dev.ps1 start
+  pwsh -File wb-dev.ps1 status
+  pwsh -File wb-dev.ps1 stop
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('start', 'stop', 'status', 'restart', 'help', '--help', '-h')]
+    [string]$Action = 'start'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── Paths ──────────────────────────────────────────────────────────────────────
+$RepoRoot       = $PSScriptRoot
+$StateDir       = Join-Path $RepoRoot '.claude/state'
+$StateFile      = Join-Path $StateDir 'wb-dev.json'
+$KestrelLog     = Join-Path $StateDir 'wb-dev.kestrel.log'
+$KestrelErrLog  = Join-Path $StateDir 'wb-dev.kestrel.err.log'
+$ViteLog        = Join-Path $StateDir 'wb-dev.vite.log'
+$ViteErrLog     = Join-Path $StateDir 'wb-dev.vite.err.log'
+$WorkbenchProj  = Join-Path $RepoRoot 'tools/Typhon.Workbench'
+$ClientApp      = Join-Path $WorkbenchProj 'ClientApp'
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+function Read-DevState {
+    if (-not (Test-Path $StateFile)) { return $null }
+    return Get-Content $StateFile -Raw | ConvertFrom-Json
+}
+
+function Write-DevState($state) {
+    if (-not (Test-Path $StateDir)) {
+        New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+    }
+    $state | ConvertTo-Json -Depth 4 | Set-Content -Path $StateFile -Encoding UTF8
+}
+
+function Test-ProcAlive($processId) {
+    if (-not $processId) { return $false }
+    return $null -ne (Get-Process -Id $processId -ErrorAction SilentlyContinue)
+}
+
+function Get-PortOwner($port) {
+    return (Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty OwningProcess)
+}
+
+function Test-PortBound($port) {
+    return $null -ne (Get-PortOwner $port)
+}
+
+function Wait-PortBound($port, $timeoutSec = 30) {
+    $deadline = (Get-Date).AddSeconds($timeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-PortBound $port) { return $true }
+        Start-Sleep -Milliseconds 250
+    }
+    return $false
+}
+
+function Stop-ProcTree($processId) {
+    if (-not $processId) { return }
+    # /T cascades to descendants (dotnet watch -> Typhon.Workbench.exe; npm.cmd -> node.exe).
+    # /F forces. Swallow output — already-dead PIDs return non-zero with a "not found" message
+    # which we don't care about at this layer.
+    taskkill /F /T /PID $processId 2>&1 | Out-Null
+}
+
+# ── Actions ────────────────────────────────────────────────────────────────────
+
+function Invoke-Help {
+    @'
+wb-dev.ps1 [start | stop | status | restart | help]
+
+  Manage the Typhon Workbench dev servers (Kestrel :5200 + Vite :5173).
+  Single-shot — replaces the 7-9 round-trip /wb-dev skill flow.
+
+Actions:
+  start     Launch Kestrel + Vite, wait for binding, write state JSON
+  stop      Read state, kill process trees, delete state, verify
+  status    Read state, check liveness + port binding
+  restart   Stop then start (1 s pause between)
+  help      Show this help
+
+State:    .claude/state/wb-dev.json
+Logs:     .claude/state/wb-dev.kestrel.log, wb-dev.vite.log
+          .claude/state/wb-dev.kestrel.err.log, wb-dev.vite.err.log
+
+Endpoints (after start):
+  Backend:  http://localhost:5200/health
+  Frontend: http://localhost:5173
+  OpenAPI:  http://localhost:5200/openapi.json
+'@
+}
+
+function Invoke-Status {
+    $state = Read-DevState
+    if (-not $state) {
+        Write-Host 'no state file — wb-dev is not tracked'
+        $p1 = Get-PortOwner 5200
+        $p2 = Get-PortOwner 5173
+        if ($p1 -or $p2) {
+            Write-Host 'WARN: untracked process bound to wb-dev ports:'
+            if ($p1) { Write-Host "  :5200 -> pid $p1" }
+            if ($p2) { Write-Host "  :5173 -> pid $p2" }
+        }
+        return
+    }
+
+    $kAlive   = Test-ProcAlive $state.kestrelPid
+    $vAlive   = Test-ProcAlive $state.vitePid
+    $port5200 = Get-PortOwner 5200
+    $port5173 = Get-PortOwner 5173
+
+    Write-Host "Kestrel  pid $($state.kestrelPid)  $(if ($kAlive) { 'alive' } else { 'dead' })"
+    Write-Host "         :5200  $(if ($port5200) { "bound (pid $port5200)" } else { 'unbound' })"
+    Write-Host "Vite     pid $($state.vitePid)  $(if ($vAlive) { 'alive' } else { 'dead' })"
+    Write-Host "         :5173  $(if ($port5173) { "bound (pid $port5173)" } else { 'unbound' })"
+    Write-Host "Started: $($state.startedAt)"
+
+    # Stale-state warning: port bound to a different PID than what we recorded.
+    if ($port5200 -and $port5200 -ne $state.kestrelPid -and -not $kAlive) {
+        Write-Host "WARN: :5200 owner pid $port5200 differs from recorded pid $($state.kestrelPid) — state is stale (reboot? manual kill?)"
+    }
+    if ($port5173 -and $port5173 -ne $state.vitePid -and -not $vAlive) {
+        Write-Host "WARN: :5173 owner pid $port5173 differs from recorded pid $($state.vitePid) — state is stale (reboot? manual kill?)"
+    }
+}
+
+function Invoke-Start {
+    $state = Read-DevState
+    if ($state) {
+        if ((Test-ProcAlive $state.kestrelPid) -and (Test-ProcAlive $state.vitePid)) {
+            Write-Host 'wb-dev already running:'
+            Write-Host "  Kestrel pid $($state.kestrelPid)  ->  http://localhost:5200/health"
+            Write-Host "  Vite    pid $($state.vitePid)  ->  http://localhost:5173"
+            return
+        }
+        Write-Host 'stale state file — clearing'
+        Remove-Item $StateFile -ErrorAction SilentlyContinue
+    }
+
+    if ((Test-PortBound 5200) -or (Test-PortBound 5173)) {
+        Write-Host 'ERROR: port already bound by an untracked process:'
+        $p1 = Get-PortOwner 5200; if ($p1) { Write-Host "  :5200 -> pid $p1" }
+        $p2 = Get-PortOwner 5173; if ($p2) { Write-Host "  :5173 -> pid $p2" }
+        Write-Host 'kill the owning process(es) first; do not invoke wb-dev start until clear'
+        exit 1
+    }
+
+    if (-not (Test-Path $StateDir)) {
+        New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+    }
+
+    # Kestrel — `dotnet watch` drives hot-reload; killing it cascades to Typhon.Workbench.exe via /T.
+    # Start-Process returns the dotnet pid via -PassThru. Stdout/stderr go to log files via OS-level
+    # file handles (not pipes) so the children survive this script's exit.
+    $kestrel = Start-Process -FilePath 'dotnet' `
+        -ArgumentList @('watch', '--project', $WorkbenchProj) `
+        -WorkingDirectory $RepoRoot `
+        -RedirectStandardOutput $KestrelLog `
+        -RedirectStandardError $KestrelErrLog `
+        -NoNewWindow -PassThru
+
+    # Vite — npm.cmd is a batch wrapper around node; killing the cmd tree cascades to the node child.
+    $vite = Start-Process -FilePath 'npm.cmd' `
+        -ArgumentList @('run', 'dev') `
+        -WorkingDirectory $ClientApp `
+        -RedirectStandardOutput $ViteLog `
+        -RedirectStandardError $ViteErrLog `
+        -NoNewWindow -PassThru
+
+    Write-Host "launching: Kestrel pid $($kestrel.Id) + Vite pid $($vite.Id)"
+    Write-Host 'waiting for ports to bind (timeout 30 s)...'
+
+    $kBound = Wait-PortBound 5200 30
+    $vBound = Wait-PortBound 5173 30
+
+    if (-not ($kBound -and $vBound)) {
+        Write-Host 'ERROR: timeout waiting for binding'
+        Write-Host "  :5200 $(if ($kBound) { 'bound' } else { 'NOT BOUND' })"
+        Write-Host "  :5173 $(if ($vBound) { 'bound' } else { 'NOT BOUND' })"
+        Write-Host '--- last 30 lines: Kestrel stdout ---'
+        if (Test-Path $KestrelLog)    { Get-Content $KestrelLog    -Tail 30 }
+        Write-Host '--- last 30 lines: Kestrel stderr ---'
+        if (Test-Path $KestrelErrLog) { Get-Content $KestrelErrLog -Tail 30 }
+        Write-Host '--- last 30 lines: Vite stdout ---'
+        if (Test-Path $ViteLog)    { Get-Content $ViteLog    -Tail 30 }
+        Write-Host '--- last 30 lines: Vite stderr ---'
+        if (Test-Path $ViteErrLog) { Get-Content $ViteErrLog -Tail 30 }
+        # Best-effort cleanup of zombies we just launched.
+        Stop-ProcTree $kestrel.Id
+        Stop-ProcTree $vite.Id
+        exit 1
+    }
+
+    $newState = [pscustomobject]@{
+        kestrelPid = $kestrel.Id
+        vitePid    = $vite.Id
+        startedAt  = (Get-Date).ToString('o')
+        kestrelLog = $KestrelLog
+        viteLog    = $ViteLog
+    }
+    Write-DevState $newState
+
+    Write-Host 'started successfully:'
+    Write-Host "  Kestrel pid $($kestrel.Id)  ->  http://localhost:5200/health"
+    Write-Host "  Vite    pid $($vite.Id)  ->  http://localhost:5173"
+    Write-Host "  Logs:   $KestrelLog"
+    Write-Host "          $ViteLog"
+}
+
+function Invoke-Stop {
+    $state = Read-DevState
+    if (-not $state) {
+        Write-Host 'no state file — nothing to stop'
+        $p1 = Get-PortOwner 5200
+        $p2 = Get-PortOwner 5173
+        if ($p1 -or $p2) {
+            Write-Host 'WARN: untracked process bound to wb-dev ports:'
+            if ($p1) { Write-Host "  :5200 -> pid $p1 (run: taskkill /F /PID $p1)" }
+            if ($p2) { Write-Host "  :5173 -> pid $p2 (run: taskkill /F /PID $p2)" }
+        }
+        return
+    }
+
+    Stop-ProcTree $state.kestrelPid
+    Stop-ProcTree $state.vitePid
+
+    Remove-Item $StateFile -ErrorAction SilentlyContinue
+
+    Start-Sleep -Milliseconds 300
+    $stillBound = @()
+    if (Test-PortBound 5200) { $stillBound += "5200 (pid $(Get-PortOwner 5200))" }
+    if (Test-PortBound 5173) { $stillBound += "5173 (pid $(Get-PortOwner 5173))" }
+    if ($stillBound.Count -gt 0) {
+        Write-Host "WARN: ports still bound after kill: $($stillBound -join ', ')"
+        Write-Host 'manual taskkill /F /PID <pid> may be required'
+    } else {
+        Write-Host "stopped Kestrel (pid $($state.kestrelPid)) + Vite (pid $($state.vitePid))"
+    }
+}
+
+function Invoke-Restart {
+    Invoke-Stop
+    Start-Sleep -Seconds 1
+    Invoke-Start
+}
+
+# ── Dispatch ───────────────────────────────────────────────────────────────────
+
+switch ($Action) {
+    'help'    { Invoke-Help }
+    '--help'  { Invoke-Help }
+    '-h'      { Invoke-Help }
+    'start'   { Invoke-Start }
+    'stop'    { Invoke-Stop }
+    'status'  { Invoke-Status }
+    'restart' { Invoke-Restart }
+}


### PR DESCRIPTION
Closes #302.

## Summary

- Per-span `file:line · method` in the Workbench detail panel, plus one-click "Open in editor" (VS Code / Cursor / Rider / Visual Studio / Custom) and a syntax-highlighted inline preview.
- Capture is build-time: `SourceLocationGenerator` (Roslyn `IIncrementalGenerator` + C# 14 interceptors) discovers every `TyphonEvent.Begin*` call site, sorts by `(file, line, column)`, assigns deterministic `ushort` site IDs, and emits per-call-site `[InterceptsLocation]` wrappers that thread a literal `ushort` through `MakeHeader` — zero hot-path cost.
- System attribution: `DagBuilder` registration resolves each system delegate's PDB sequence points (with a `<Unknown>`-mono fallback that searches by `AssemblyName` + version), so chunk spans (e.g. AntHill `MoveAll`, `FoodDetect`) get the same source row.
- Wire format: `SpanFlagsHasSourceLocation` + 2-byte `u16 SourceLocationId` after the optional trace context. `TraceFileHeader` v4→v5 with new `FileTableOffset` / `SourceLocationManifestOffset` trailer pointers; reader is backward-compatible with v4 (treats absent fields as "no manifest").
- Manifest shipped via the trace-file trailer and the live TCP init handshake; client `useSourceLocationStore` resolves both static call-site IDs and synthesized system IDs (`0x8000 | systemIndex`) through the same lookup.
- Workbench Options system: file-backed JSON + `FileSystemWatcher` hot-reload + SSE `OptionsChangedStream`; `OptionsStore` uses `[LoggerMessage]` partial methods and a separate `_writeLock` so disk I/O doesn't block readers.
- New `EditorLauncher` with per-`(EditorKind, OS)` adapters, `ProfilerSourceController` with workspace-root auto-detection and a path-traversal guard that allows already-absolute PDB paths.
- Detail-pane Source row + "Show Source for Current Span" palette command + Ctrl+double-click on span/chunk bars to open editor + Source Preview panel auto-follows selection when open.

## Test plan
- [x] `dotnet build Typhon.slnx -c Debug` — 0 errors
- [x] `dotnet test test/Typhon.Engine.Tests/...` — Profiler-scoped fixtures all green (517 tests)
- [x] `dotnet test test/Typhon.Workbench.Tests/...` — 4 new fixtures (`OptionsControllerTests`, `SystemControllerTests`, `EditorLauncherTests`, `ProfilerSourceControllerTests`) all green; existing fixtures unaffected
- [x] Live attach + recorded trace open: BTreeInsert spans show `file:line · method`, AntHill `MoveAll` chunk shows its system source, "Open in editor" opens Rider on Windows, "Show inline" renders ±20 lines highlighted
- [x] BenchmarkDotNet: per-emission overhead vs baseline is unmeasurable (literal `ushort` move)
- [ ] macOS QA on `EditorLauncher` (deferred — no Mac in the loop this pass)