### PR TITLE
Fix #297: OLC B+Tree concurrent insert/remove key loss

### DIFF
--- a/src/Typhon.Engine/Data/Index/BTree.BaseNodeStorage.cs
+++ b/src/Typhon.Engine/Data/Index/BTree.BaseNodeStorage.cs
@@ -71,12 +71,11 @@ public abstract partial class BTree<TKey, TStore>
                 return default;
             }
 
-            var child = index < 0 ? GetLeftNode(node, ref accessor) : new NodeWrapper(this, GetItem(node, index, true, ref accessor).Value);
-            
-            // Read child's StateFlags to cache IsLeaf — the child chunk will be accessed
-            // immediately after (by BinarySearch/Find), so this read is essentially free.
-            bool isLeaf = (GetNodeStates(child, ref accessor) & NodeStates.IsLeaf) != 0;
-            return new NodeWrapper(this, child.ChunkId, isLeaf);
+            // CAUTION: do NOT dereference the child chunk here (e.g., to prefetch isLeaf). OLC readers call this on a parent whose version has not yet been
+            // validated (Find→GetChild happens before ValidateVersion in the descent loops). If the parent is concurrently mid-modification, the child chunk-id
+            // we read can be torn/stale, and dereferencing it would crash before validation can signal "restart". Only read from the parent here; let callers
+            // access the child after they validate the parent's version. Issue #297.
+            return index < 0 ? GetLeftNode(node, ref accessor) : new NodeWrapper(this, GetItem(node, index, true, ref accessor).Value);
         }
         public abstract void IncrementStart(NodeWrapper node, ref ChunkAccessor<TStore> accessor);
         public abstract void DecrementStart(NodeWrapper node, ref ChunkAccessor<TStore> accessor);

--- a/src/Typhon.Engine/Data/Index/BTree.Insert.cs
+++ b/src/Typhon.Engine/Data/Index/BTree.Insert.cs
@@ -51,12 +51,21 @@ public abstract partial class BTree<TKey, TStore>
         // 1. Empty tree initialization.
         //    An empty tree has no root node, so OLC readers/writers have nothing to latch on.
         //    CAS on _rootChunkId atomically races to claim the init slot; loser sees non-zero root and proceeds.
+        //
+        // Issue #297: hold newRoot's OLC write lock around the initial PushLast and metadata writes. Without the lock, a concurrent thread that observes the
+        // just-published _rootChunkId and races through TryInsertOlc's general path can acquire newRoot's latch (initial OlcVersion=4 reports unlocked) and
+        // concurrently mutate the chunk, producing torn writes / out-of-order keys. SpinWriteLock takes newRoot's bit-0 lock; ReadVersion observes 0 for any
+        // concurrent reader, who restarts; WriteUnlock at the end bumps the version so the next op sees the new state.
         if (IsEmpty())
         {
             var newRoot = AllocNode(NodeStates.IsLeaf, ref accessor);
+            newRoot.PreDirtyForWrite(ref accessor);
+            var newRootLatch = newRoot.GetLatch(ref accessor);
+            SpinWriteLock(newRootLatch);  // exclude any concurrent OLC reader/writer touching newRoot
             if (Interlocked.CompareExchange(ref _rootChunkId, newRoot.ChunkId, 0) == 0)
             {
-                // We won the race — initialize root, LinkList, ReverseLinkList
+                // We won the race — initialize root, LinkList, ReverseLinkList while still holding newRoot's lock. Concurrent threads that observe _rootChunkId
+                // set will spin or restart on newRoot's locked latch until WriteUnlock below.
                 _linkList = newRoot;
                 _reverseLinkList = newRoot;
                 Height++;
@@ -65,12 +74,14 @@ public abstract partial class BTree<TKey, TStore>
                 IncCount();
                 _cachedLastKey = args.Key;
                 _hasCachedLastKey = true;
+                newRootLatch.WriteUnlock();
 
                 // Phase 6: Data:Index:BTree:Root instant (op=0 / Init).
                 Profiler.TyphonEvent.EmitDataIndexBTreeRoot(0, newRoot.ChunkId, (byte)Math.Min(Height, byte.MaxValue));
                 return;
             }
-            // Another thread initialized the root — free our unused node and fall through
+            // Another thread initialized the root — release our lock (no version bump, we didn't mutate anything visible) and free our unused node.
+            newRootLatch.AbortWriteLock();
             _segment.FreeChunk(newRoot.ChunkId);
         }
 
@@ -165,6 +176,16 @@ public abstract partial class BTree<TKey, TStore>
                             latch.AbortWriteLock();
                             return isFull ? OlcInsertResult.LeafFull : OlcInsertResult.Restart;
                         }
+                        // Issue #297: re-verify ordering against the actual leaf content under the lock. The pre-lock check above used `lastKey` which can come
+                        // from `_cachedLastKey` — a per-tree global updated on every successful append, but NOT atomically with `_reverseLinkList`. After a
+                        // split, a concurrent reader can observe the new `_reverseLinkList` while still seeing the old cached last key (or vice versa), making
+                        // the cached `args.Key > lastKey` check pass when actually `args.Key <= rl.GetLast().Key`. Without this guard, PushLast appends out of
+                        // order, and binary-search lookups silently miss the misplaced key.
+                        if (rl.GetCount(ref accessor) > 0 && args.Compare(args.Key, rl.GetLast(ref accessor).Key) <= 0)
+                        {
+                            latch.AbortWriteLock();
+                            return OlcInsertResult.Restart;
+                        }
                         int value = CreateInsertValue(ref args, ref accessor);
                         rl.PushLast(new KeyValueItem(args.Key, value), ref accessor);
                         _cachedLastKey = args.Key;
@@ -188,7 +209,15 @@ public abstract partial class BTree<TKey, TStore>
                                 latch.AbortWriteLock();
                                 return OlcInsertResult.Restart;
                             }
-                            var bufferRootId = rl.GetLast(ref accessor).Value;
+                            // Issue #297: re-verify the duplicate-key claim under the lock — `lastKey` came from `_cachedLastKey` which can be stale after a
+                            // split. Without this, we'd append the value to the wrong buffer (or to a buffer whose key isn't actually the same as args.Key).
+                            var actualLast = rl.GetCount(ref accessor) > 0 ? rl.GetLast(ref accessor) : default;
+                            if (rl.GetCount(ref accessor) == 0 || args.Compare(args.Key, actualLast.Key) != 0)
+                            {
+                                latch.AbortWriteLock();
+                                return OlcInsertResult.Restart;
+                            }
+                            var bufferRootId = actualLast.Value;
                             args.ElementId = _storage.Append(bufferRootId, args.GetValue(), ref args.SiblingAccessor);
                             args.BufferRootId = bufferRootId;
                             latch.WriteUnlock();
@@ -347,95 +376,107 @@ public abstract partial class BTree<TKey, TStore>
             }
 
             // Append fast path: lock the last leaf and insert if key > lastKey and leaf not full.
-            // Bypass when leaf is contended and sufficiently populated — fall through to InsertIterative
-            // which has the path recording needed for contention split propagation.
-            // Capture local refs to avoid races from concurrent ReverseLinkList/LinkList updates.
+            // Bypass when leaf is contended and sufficiently populated — fall through to InsertIterative which has the path recording needed for contention
+            // split propagation. Capture local refs to avoid races from concurrent ReverseLinkList/LinkList updates. Issue #297: skip the append fast-path
+            // entirely when `_reverseLinkList` is not yet published. The OLC empty-tree CAS at AddOrUpdateCore writes _rootChunkId
+            // BEFORE _linkList/_reverseLinkList — a concurrent thread that won the race to enter the pessimistic path can therefore observe `IsEmpty()=false`
+            // (rootChunkId set) while `rl=default`, making `rl.GetLast()` NRE on `_storage`. CAUTION: capture the field into a local FIRST, then test IsValid
+            // on the local. Testing the field directly and assigning separately is a TOCTOU race (concurrent thread can swap _reverseLinkList between the two
+            // reads, leaving `rl=default` even though the if-check passed). The whole block must be guarded.
             {
                 var rl = _reverseLinkList;
-                var bypassAppendFastPath = rl.IsValid && rl.GetContentionHint(ref accessor) >= ContentionSplitThreshold && rl.GetCount(ref accessor) > rl.GetCapacity() / 2;
-                var order = IsEmpty() ? 1 : args.Compare(args.Key, _hasCachedLastKey ? _cachedLastKey : rl.GetLast(ref accessor).Key);
-                if (!bypassAppendFastPath && order > 0 && !rl.GetIsFull(ref accessor))
+                if (rl.IsValid)
                 {
-                    rl.PreDirtyForWrite(ref accessor);
-                    var rlLatch = rl.GetLatch(ref accessor);
-                    SpinWriteLock(rlLatch);
-                    // Re-validate under lock: leaf may now be full, another writer inserted a larger key,
-                    // or a concurrent split made this leaf no longer the rightmost (GetNext becomes valid).
-                    if (!rl.GetIsFull(ref accessor) && !rl.GetNext(ref accessor).IsValid && args.Compare(args.Key, rl.GetLast(ref accessor).Key) > 0)
+                    var bypassAppendFastPath = rl.GetContentionHint(ref accessor) >= ContentionSplitThreshold && rl.GetCount(ref accessor) > rl.GetCapacity() / 2;
+                    var order = IsEmpty() ? 1 : args.Compare(args.Key, _hasCachedLastKey ? _cachedLastKey : rl.GetLast(ref accessor).Key);
+                    if (!bypassAppendFastPath && order > 0 && !rl.GetIsFull(ref accessor))
                     {
-                        int value = CreateInsertValue(ref args, ref accessor);
-                        rl.PushLast(new KeyValueItem(args.Key, value), ref accessor);
-                        _cachedLastKey = args.Key;
-                        _hasCachedLastKey = true;
-                        rlLatch.WriteUnlock();
-                        IncCount();
-                        return;
+                        rl.PreDirtyForWrite(ref accessor);
+                        var rlLatch = rl.GetLatch(ref accessor);
+                        SpinWriteLock(rlLatch);
+                        // Re-validate under lock: leaf may now be full, another writer inserted a larger key,
+                        // or a concurrent split made this leaf no longer the rightmost (GetNext becomes valid).
+                        if (!rl.GetIsFull(ref accessor) && !rl.GetNext(ref accessor).IsValid && args.Compare(args.Key, rl.GetLast(ref accessor).Key) > 0)
+                        {
+                            int value = CreateInsertValue(ref args, ref accessor);
+                            rl.PushLast(new KeyValueItem(args.Key, value), ref accessor);
+                            _cachedLastKey = args.Key;
+                            _hasCachedLastKey = true;
+                            rlLatch.WriteUnlock();
+                            IncCount();
+                            return;
+                        }
+                        rlLatch.AbortWriteLock();
+                        // Fall through to general path
                     }
-                    rlLatch.AbortWriteLock();
-                    // Fall through to general path
-                }
-                else if (order == 0 && AllowMultiple)
-                {
-                    rl.PreDirtyForWrite(ref accessor);
-                    var rlLatch = rl.GetLatch(ref accessor);
-                    SpinWriteLock(rlLatch);
-                    var lastEntry = rl.GetLast(ref accessor);
-                    if (args.Compare(args.Key, lastEntry.Key) == 0)
+                    else if (order == 0 && AllowMultiple)
                     {
-                        args.ElementId = _storage.Append(lastEntry.Value, args.GetValue(), ref args.SiblingAccessor);
-                        args.BufferRootId = lastEntry.Value;
-                        rlLatch.WriteUnlock();
-                        return;
+                        rl.PreDirtyForWrite(ref accessor);
+                        var rlLatch = rl.GetLatch(ref accessor);
+                        SpinWriteLock(rlLatch);
+                        var lastEntry = rl.GetLast(ref accessor);
+                        if (args.Compare(args.Key, lastEntry.Key) == 0)
+                        {
+                            args.ElementId = _storage.Append(lastEntry.Value, args.GetValue(), ref args.SiblingAccessor);
+                            args.BufferRootId = lastEntry.Value;
+                            rlLatch.WriteUnlock();
+                            return;
+                        }
+                        rlLatch.AbortWriteLock();
+                        // Fall through
                     }
-                    rlLatch.AbortWriteLock();
-                    // Fall through
-                }
-                else if (order == 0)
-                {
-                    ThrowHelper.ThrowUniqueConstraintViolation();
+                    else if (order == 0)
+                    {
+                        ThrowHelper.ThrowUniqueConstraintViolation();
+                    }
                 }
             }
 
             // Prepend fast path: lock the first leaf and insert if key < firstKey and leaf not full.
+            // Issue #297: same publication-ordering caveat as the append path above — capture ll into a local first, then test IsValid on the
+            // local (avoiding TOCTOU race).
             if (!IsEmpty())
             {
                 var ll = _linkList;
-                int order = args.Compare(args.Key, ll.GetFirst(ref accessor).Key);
-                if (order < 0 && !ll.GetIsFull(ref accessor))
+                if (ll.IsValid)
                 {
-                    ll.PreDirtyForWrite(ref accessor);
-                    var llLatch = ll.GetLatch(ref accessor);
-                    SpinWriteLock(llLatch);
-                    if (!ll.GetIsFull(ref accessor) && args.Compare(args.Key, ll.GetFirst(ref accessor).Key) < 0)
+                    int order = args.Compare(args.Key, ll.GetFirst(ref accessor).Key);
+                    if (order < 0 && !ll.GetIsFull(ref accessor))
                     {
-                        int value = CreateInsertValue(ref args, ref accessor);
-                        ll.PushFirst(new KeyValueItem(args.Key, value), ref accessor);
-                        llLatch.WriteUnlock();
-                        IncCount();
-                        return;
+                        ll.PreDirtyForWrite(ref accessor);
+                        var llLatch = ll.GetLatch(ref accessor);
+                        SpinWriteLock(llLatch);
+                        if (!ll.GetIsFull(ref accessor) && args.Compare(args.Key, ll.GetFirst(ref accessor).Key) < 0)
+                        {
+                            int value = CreateInsertValue(ref args, ref accessor);
+                            ll.PushFirst(new KeyValueItem(args.Key, value), ref accessor);
+                            llLatch.WriteUnlock();
+                            IncCount();
+                            return;
+                        }
+                        llLatch.AbortWriteLock();
+                        // Fall through
                     }
-                    llLatch.AbortWriteLock();
-                    // Fall through
-                }
-                else if (order == 0 && AllowMultiple)
-                {
-                    ll.PreDirtyForWrite(ref accessor);
-                    var llLatch = ll.GetLatch(ref accessor);
-                    SpinWriteLock(llLatch);
-                    var firstEntry = ll.GetFirst(ref accessor);
-                    if (args.Compare(args.Key, firstEntry.Key) == 0)
+                    else if (order == 0 && AllowMultiple)
                     {
-                        args.ElementId = _storage.Append(firstEntry.Value, args.GetValue(), ref args.SiblingAccessor);
-                        args.BufferRootId = firstEntry.Value;
-                        llLatch.WriteUnlock();
-                        return;
+                        ll.PreDirtyForWrite(ref accessor);
+                        var llLatch = ll.GetLatch(ref accessor);
+                        SpinWriteLock(llLatch);
+                        var firstEntry = ll.GetFirst(ref accessor);
+                        if (args.Compare(args.Key, firstEntry.Key) == 0)
+                        {
+                            args.ElementId = _storage.Append(firstEntry.Value, args.GetValue(), ref args.SiblingAccessor);
+                            args.BufferRootId = firstEntry.Value;
+                            llLatch.WriteUnlock();
+                            return;
+                        }
+                        llLatch.AbortWriteLock();
+                        // Fall through
                     }
-                    llLatch.AbortWriteLock();
-                    // Fall through
-                }
-                else if (order == 0)
-                {
-                    ThrowHelper.ThrowUniqueConstraintViolation();
+                    else if (order == 0)
+                    {
+                        ThrowHelper.ThrowUniqueConstraintViolation();
+                    }
                 }
             }
 
@@ -462,13 +503,23 @@ public abstract partial class BTree<TKey, TStore>
                 ThrowHelper.ThrowUniqueConstraintViolation();
             }
 
-            var next = _reverseLinkList.GetNext(ref accessor);
-            if (next.IsValid)
+            // Issue #297: snapshot the field once and guard on IsValid. AddOrUpdateCore writes _rootChunkId via CAS BEFORE writing _linkList/_reverseLinkList;
+            // on x86 TSO, another thread can observe IsEmpty()=false while still seeing _reverseLinkList=default. Skip the cache update on that race — the
+            // next Add will re-read and refresh.
             {
-                _reverseLinkList = next;
+                var tail = _reverseLinkList;
+                if (tail.IsValid)
+                {
+                    var next = tail.GetNext(ref accessor);
+                    if (next.IsValid)
+                    {
+                        _reverseLinkList = next;
+                        tail = next;
+                    }
+                    _cachedLastKey = tail.GetLast(ref accessor).Key;
+                    _hasCachedLastKey = true;
+                }
             }
-            _cachedLastKey = GetLast(ref accessor).Key;
-            _hasCachedLastKey = true;
         }
         finally
         {
@@ -521,6 +572,15 @@ public abstract partial class BTree<TKey, TStore>
             {
                 return;
             }
+
+            // Defensive: a torn-but-validated read should be impossible after the version check above, but treat zero/invalid child as restart rather than
+            // crashing when the next iteration tries to deref it. Issue #297.
+            if (!child.IsValid)
+            {
+                return;
+            }
+
+            OlcDescentTrace.RecordStep?.Invoke(OlcDescentTrace.OpInsert, node.ChunkId, version, index, child.ChunkId);
 
             NodeRelatives.Create(child, index, node, parentCount, ref relatives, out var childRelatives, ref accessor, ref sibAccessor);
 
@@ -588,7 +648,13 @@ public abstract partial class BTree<TKey, TStore>
                 args.Compare(args.Key, nextNode.GetFirst(ref accessor).Key) < 0)
             {
                 nextNode.GetLatch(ref accessor).AbortWriteLock();
-                break; // Key falls in a gap — belongs in current leaf (will split via slow path)
+                // Issue #297: a gap means K lies between node.HighKey and nextNode.firstKey, i.e., not in EITHER leaf. The historical fix here `break`d and
+                // let the next code path insert K into `node`, which silently violates node.HighKey — future searches use the parent's separator (which still
+                // routes K to the next sibling/ or beyond) and never reach our (now invariant-violating) leaf. The key is lost. Treat the gap as a transient
+                // structural inconsistency (a concurrent split's separator hasn't propagated up yet): release node and restart from the root. NOTE: requires
+                // storage to maintain B-link invariant node.HighKey == nextNode.firstKey across splits/merges — L16/L32/L64 + String64 (since #297) all do.
+                node.GetLatch(ref accessor).AbortWriteLock();
+                return; // completed=false → outer retry, next pass should see a closed-up tree.
             }
 
             node.GetLatch(ref accessor).AbortWriteLock();    // release current
@@ -816,13 +882,21 @@ public abstract partial class BTree<TKey, TStore>
 
         // Phase 4: Root split — create new root while holding old root's write lock.
         // This prevents concurrent InsertIterative calls from racing to create multiple roots.
+        //
+        // Issue #297: hold newRoot's write lock around the structural writes (SetLeft + Insert). Without it, a concurrent thread reading the just-published
+        // `Root` field can observe newRoot with count=0 (Insert(0, promoted) hasn't written yet) and descend through the leftmost child path, missing the
+        // promoted subtree entirely. The lock forces the racer to restart on a locked latch until WriteUnlock publishes a consistent state.
         if (promoted != null)
         {
             var newRoot = AllocNode(NodeStates.None, ref accessor);
+            newRoot.PreDirtyForWrite(ref accessor);
+            var newRootLatch = newRoot.GetLatch(ref accessor);
+            SpinWriteLock(newRootLatch);
             newRoot.SetLeft(Root, ref accessor);
             newRoot.Insert(0, promoted.Value, ref accessor);
             Root = newRoot;
             Height++;
+            newRootLatch.WriteUnlock();
             node.GetLatch(ref accessor).WriteUnlock(); // release old root after publishing new root
         }
 

--- a/src/Typhon.Engine/Data/Index/BTree.NodeWrapper.cs
+++ b/src/Typhon.Engine/Data/Index/BTree.NodeWrapper.cs
@@ -129,6 +129,48 @@ public abstract partial class BTree<TKey, TStore>
         // Insert/Remove dispatch removed — BTree.InsertIterative/RemoveIterative handle
         // the full root-to-leaf descent and upward propagation iteratively.
 
+        // Issue #297: spill-LEFT pushes our smallest to prev's last. For sort to remain valid,/ prev's current last must be < our current first.
+        // If invariant is broken (concurrent op left tree in a transient state), spill would corrupt prev's sort — return false to/ route the operation to
+        // split, which is range-self-contained.
+        internal bool SpillLeftSortInvariantHolds(NodeWrapper prev, ref ChunkAccessor<TStore> sibCa, ref ChunkAccessor<TStore> ca)
+        {
+            if (!prev.IsValid)
+            {
+                return false;
+            }
+
+            int prevCount = prev.GetCount(ref sibCa);
+            int curCount = GetCount(ref ca);
+            if (prevCount == 0 || curCount == 0)
+            {
+                return true; // no comparison possible — let spill proceed
+            }
+
+            var prevLast = prev.GetLast(ref sibCa).Key;
+            var curFirst = GetFirst(ref ca).Key;
+            return _storage.Owner.Comparer.Compare(prevLast, curFirst) < 0;
+        }
+
+        // Issue #297: symmetric check for spill-RIGHT — our last must be < next's first.
+        internal bool SpillRightSortInvariantHolds(NodeWrapper next, ref ChunkAccessor<TStore> sibCa, ref ChunkAccessor<TStore> ca)
+        {
+            if (!next.IsValid)
+            {
+                return false;
+            }
+
+            int nextCount = next.GetCount(ref sibCa);
+            int curCount = GetCount(ref ca);
+            if (nextCount == 0 || curCount == 0)
+            {
+                return true;
+            }
+
+            var curLast = GetLast(ref ca).Key;
+            var nextFirst = next.GetFirst(ref sibCa).Key;
+            return _storage.Owner.Comparer.Compare(curLast, nextFirst) < 0;
+        }
+
         /// <summary>
         /// Splits a leaf right and updates the doubly-linked list pointers.
         /// Used by both regular full-leaf splits and contention splits.
@@ -177,7 +219,16 @@ public abstract partial class BTree<TKey, TStore>
                 else // cant add, spill or split
                 {
                     // Sibling operations use sibAccessor to avoid evicting parent path pages from primary CA
-                    if (!forceSplit && CanSpillTo(GetPrevious(ref accessor), ref sibAccessor))
+                    //
+                    // Issue #297: VerifySpillInvariant — only spill when prev/next ranges are consistent with `this` (i.e., the B-link sort invariant hasn't
+                    // been temporarily violated by a concurrent operation). If broken, fall through to split which is range-self-contained.
+                    var prevForSpill = GetPrevious(ref accessor);
+                    var nextForSpill = GetNext(ref accessor);
+                    bool spillLeftOk = !forceSplit && CanSpillTo(prevForSpill, ref sibAccessor)
+                                       && SpillLeftSortInvariantHolds(prevForSpill, ref sibAccessor, ref accessor);
+                    bool spillRightOk = !forceSplit && CanSpillTo(nextForSpill, ref sibAccessor)
+                                        && SpillRightSortInvariantHolds(nextForSpill, ref sibAccessor, ref accessor);
+                    if (spillLeftOk)
                     {
                         var first = InsertPopFirst(index, item, ref accessor);
                         var prev = GetPrevious(ref accessor);
@@ -207,11 +258,8 @@ public abstract partial class BTree<TKey, TStore>
 
                         // Left's HighKey must match the new separator (spill moved the boundary).
                         prev.SetHighKey(newSeparator, ref sibAccessor);
-
-                        Validate();
-                        Validate();
                     }
-                    else if (!forceSplit && CanSpillTo(GetNext(ref accessor), ref sibAccessor))
+                    else if (spillRightOk)
                     {
                         var last = InsertPopLast(index, item, ref accessor);
                         var next = GetNext(ref accessor);
@@ -238,9 +286,6 @@ public abstract partial class BTree<TKey, TStore>
 
                         // Current's HighKey must match the new separator (spill moved the boundary).
                         SetHighKey(newSeparator, ref accessor);
-
-                        Validate();
-                        Validate();
                     }
                     else // split, then promote middle item
                     {
@@ -259,10 +304,9 @@ public abstract partial class BTree<TKey, TStore>
                         }
 
                         rightLeaf = new KeyValueItem(rightNode.GetFirst(ref accessor).Key, rightNode.ChunkId);
-
-                        Validate();
-                        Validate();
                     }
+
+                    Validate();
                 }
 
                 // splits right side to new node and keeps left side for current node.

--- a/src/Typhon.Engine/Data/Index/BTree.Remove.cs
+++ b/src/Typhon.Engine/Data/Index/BTree.Remove.cs
@@ -1,5 +1,6 @@
 // unset
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Typhon.Engine;
@@ -82,7 +83,25 @@ public abstract partial class BTree<TKey, TStore>
             int order = args.Compare(args.Key, firstKey);
             if (order < 0)
             {
-                return OlcRemoveResult.NotFound; // key < first key → definitely not in tree
+                // Issue #297: ll might no longer be the leftmost leaf (concurrent merge moved the head).
+                // Snapshot ll's previous AND validate ll's version after — only conclude NotFound if ll is still leftmost (no previous sibling) AND data is
+                // consistent. Otherwise restart.
+                var llPrev = ll.GetPrevious(ref accessor);
+                if (!llLatch.ValidateVersion(llVersion))
+                {
+                    return OlcRemoveResult.Restart;
+                }
+                if (llPrev.IsValid)
+                {
+                    return OlcRemoveResult.Restart; // ll has a previous sibling → not leftmost; restart with fresh head
+                }
+                if (OlcDescentTrace.OnRemoveNotFound != null && typeof(TKey) == typeof(int))
+                {
+                    var ak = args.Key; var fk = firstKey;
+                    OlcDescentTrace.OnRemoveNotFound(OlcDescentTrace.RemoveBranchBeginFastPathLessThanFirst,
+                        Unsafe.As<TKey, int>(ref ak), ll.ChunkId, Unsafe.As<TKey, int>(ref fk), ll.GetCount(ref accessor));
+                }
+                return OlcRemoveResult.NotFound; // key < first key AND ll is leftmost → definitely not in tree
             }
 
             if (order == 0)
@@ -154,7 +173,25 @@ public abstract partial class BTree<TKey, TStore>
             int order = args.Compare(args.Key, lastKey);
             if (order > 0)
             {
-                return OlcRemoveResult.NotFound; // key > last key → definitely not in tree
+                // Issue #297: rll might no longer be the rightmost leaf (concurrent merge moved the tail, OR concurrent split added a new rightmost).
+                // Snapshot rll's next AND validate rll's version after — only conclude NotFound if rll is still rightmost (no next sibling) AND data is
+                // consistent. Otherwise restart.
+                var rllNext = rll.GetNext(ref accessor);
+                if (!rllLatch.ValidateVersion(rllVersion))
+                {
+                    return OlcRemoveResult.Restart;
+                }
+                if (rllNext.IsValid)
+                {
+                    return OlcRemoveResult.Restart; // rll has a next sibling → not rightmost; restart with fresh tail
+                }
+                if (OlcDescentTrace.OnRemoveNotFound != null && typeof(TKey) == typeof(int))
+                {
+                    var ak = args.Key; var lk = lastKey;
+                    OlcDescentTrace.OnRemoveNotFound(OlcDescentTrace.RemoveBranchEndFastPathGreaterThanLast,
+                        Unsafe.As<TKey, int>(ref ak), rll.ChunkId, Unsafe.As<TKey, int>(ref lk), rllCount);
+                }
+                return OlcRemoveResult.NotFound; // key > last key AND rll is rightmost → definitely not in tree
             }
 
             if (order == 0)
@@ -211,6 +248,19 @@ public abstract partial class BTree<TKey, TStore>
             {
                 return OlcRemoveResult.Restart;
             }
+            if (OlcDescentTrace.OnRemoveNotFound != null && typeof(TKey) == typeof(int))
+            {
+                var nfCount = nfLeaf.GetCount(ref accessor);
+                int firstKeyInt = 0;
+                if (nfCount > 0)
+                {
+                    var fk = nfLeaf.GetFirst(ref accessor).Key;
+                    firstKeyInt = Unsafe.As<TKey, int>(ref fk);
+                }
+                var ak = args.Key;
+                OlcDescentTrace.OnRemoveNotFound(OlcDescentTrace.RemoveBranchGeneralKeyIndexNegative, Unsafe.As<TKey, int>(ref ak), leafChunkId,
+                    firstKeyInt, nfCount);
+            }
             return OlcRemoveResult.NotFound;
         }
 
@@ -243,6 +293,19 @@ public abstract partial class BTree<TKey, TStore>
                 var reIndex = leaf.Find(args.Key, args.Comparer, ref accessor);
                 if (reIndex < 0)
                 {
+                    if (OlcDescentTrace.OnRemoveNotFound != null && typeof(TKey) == typeof(int))
+                    {
+                        var leafCount = leaf.GetCount(ref accessor);
+                        int firstKeyInt = 0;
+                        if (leafCount > 0)
+                        {
+                            var fk = leaf.GetFirst(ref accessor).Key;
+                            firstKeyInt = Unsafe.As<TKey, int>(ref fk);
+                        }
+                        var ak = args.Key;
+                        OlcDescentTrace.OnRemoveNotFound(OlcDescentTrace.RemoveBranchUnderLockReFindNegative, Unsafe.As<TKey, int>(ref ak), leafChunkId,
+                            firstKeyInt, leafCount);
+                    }
                     leafLatch.WriteUnlock();
                     return OlcRemoveResult.NotFound; // concurrent writer already removed it
                 }
@@ -277,27 +340,39 @@ public abstract partial class BTree<TKey, TStore>
                 var ll = _linkList;
                 ll.PreDirtyForWrite(ref accessor);
                 SpinWriteLock(ll.GetLatch(ref accessor));
-                int order = args.Compare(args.Key, ll.GetFirst(ref accessor).Key);
-                if (order < 0)
-                {
-                    ll.GetLatch(ref accessor).AbortWriteLock(); // key not in tree — didn't modify node
-                    return;
-                }
 
-                if (order == 0 && (Root == ll || ll.GetCount(ref accessor) > ll.GetCapacity() / 2))
+                // Issue #297: ll might no longer be the leftmost leaf if a concurrent split inserted a new
+                // left-side leaf, OR if we observed a stale `_linkList` field. If ll has a valid previous,
+                // the key could live in that earlier leaf — fall through to the general path.
+                // Mirrors the symmetric end-fast-path safety at the rll branch below.
+                if (ll.GetPrevious(ref accessor).IsValid)
                 {
-                    args.SetRemovedValue(ll.PopFirstInternal(ref accessor).Value);
-                    ll.GetLatch(ref accessor).WriteUnlock();
-                    _hasCachedLastKey = false;
-                    DecCount();
-                    if (IsEmpty())
-                    {
-                        Root = _linkList = _reverseLinkList = default;
-                        Height--;
-                    }
-                    return;
+                    ll.GetLatch(ref accessor).AbortWriteLock();
                 }
-                ll.GetLatch(ref accessor).AbortWriteLock(); // condition failed — didn't modify node
+                else
+                {
+                    int order = args.Compare(args.Key, ll.GetFirst(ref accessor).Key);
+                    if (order < 0)
+                    {
+                        ll.GetLatch(ref accessor).AbortWriteLock(); // key not in tree — didn't modify node
+                        return;
+                    }
+
+                    if (order == 0 && (Root == ll || ll.GetCount(ref accessor) > ll.GetCapacity() / 2))
+                    {
+                        args.SetRemovedValue(ll.PopFirstInternal(ref accessor).Value);
+                        ll.GetLatch(ref accessor).WriteUnlock();
+                        _hasCachedLastKey = false;
+                        DecCount();
+                        if (IsEmpty())
+                        {
+                            Root = _linkList = _reverseLinkList = default;
+                            Height--;
+                        }
+                        return;
+                    }
+                    ll.GetLatch(ref accessor).AbortWriteLock(); // condition failed — didn't modify node
+                }
             }
 
             // End-remove fast path
@@ -364,9 +439,19 @@ public abstract partial class BTree<TKey, TStore>
                 Height--;
             }
 
-            if (_reverseLinkList.IsValid && _reverseLinkList.GetPrevious(ref accessor).IsValid && _reverseLinkList.GetPrevious(ref accessor).GetNext(ref accessor).IsValid == false)
+            // Issue #297: avoid TOCTOU on `_reverseLinkList`. Snapshot the field once and operate on
+            // the local — without this, four reads of the field could each see a different value
+            // when concurrent removers race here, ending up assigning a stale or non-tail leaf.
             {
-                _reverseLinkList = _reverseLinkList.GetPrevious(ref accessor);
+                var rl = _reverseLinkList;
+                if (rl.IsValid)
+                {
+                    var prev = rl.GetPrevious(ref accessor);
+                    if (prev.IsValid && !prev.GetNext(ref accessor).IsValid)
+                    {
+                        _reverseLinkList = prev;
+                    }
+                }
             }
         }
         finally
@@ -419,6 +504,16 @@ public abstract partial class BTree<TKey, TStore>
                 return false; // node modified between version read and data read — restart
             }
 
+            // Defensive: a torn-but-validated read should be impossible after the version
+            // check above, but treat zero/invalid child as restart rather than crashing
+            // when the next iteration tries to deref it. Issue #297.
+            if (!child.IsValid)
+            {
+                return false;
+            }
+
+            OlcDescentTrace.RecordStep?.Invoke(OlcDescentTrace.OpRemove, node.ChunkId, version, index, child.ChunkId);
+
             NodeRelatives.Create(child, index, node, parentCount, ref relatives, out var childRelatives, ref accessor, ref sibAccessor);
 
             ctx.PathNodes[ctx.Depth] = node;
@@ -453,10 +548,25 @@ public abstract partial class BTree<TKey, TStore>
             return false; // restart — leaf was modified between descent and lock
         }
 
+        // Issue #297: stale-separator detection. Pessimistic descent does NOT follow B-link right-pointers (unlike OptimisticDescendToLeaf at BTree.cs:1700-1738).
+        // Under heavy concurrency, when a leaf has been split but the parent separator hasn't propagated yet, our descent lands at the LEFT half while our key
+        // actually lives in the right sibling. Detect that exact signature (key >= leaf.HighKey AND a right sibling exists) and restart from root rather than
+        // wrongly returning NotFound. Restart is safe (we hold leaf write lock — release via AbortWriteLock without version bump). Liveness: bounded by
+        // parent-separator propagation, which Insert's Phase 3 performs immediately after the split. We do NOT mirror Insert's full move-right loop/ here
+        // because the moved-to leaf would have stale `relatives` (computed for the original leaf), and lock-coupling to nextNode under heavy retry pressure has
+        // surfaced a latent AV in InsertIterative.SpinWriteLock — separate engine investigation.
+        if (node.GetNext(ref accessor).IsValid && args.Compare(args.Key, node.GetHighKey(ref accessor)) >= 0)
+        {
+            leafLatch.AbortWriteLock(); // we held the lock without modifying the node
+            return false; // restart — parent separator hasn't propagated; descent landed at wrong leaf
+        }
+
         // Check if key exists in this leaf
         var keyIndex = node.Find(args.Key, args.Comparer, ref accessor);
         if (keyIndex < 0)
         {
+            // After the stale-separator guard above, a NotFound here means key is genuinely not in the tree (or the tree's rightmost leaf, where
+            // GetNext().IsValid == false).
             node.GetLatch(ref accessor).AbortWriteLock(); // key not found — didn't modify leaf
             completed = true;
             return false; // key not found — no merge

--- a/src/Typhon.Engine/Data/Index/BTree.cs
+++ b/src/Typhon.Engine/Data/Index/BTree.cs
@@ -907,7 +907,11 @@ public abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TKey
     private NodeWrapper Root
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _rootChunkId == 0 ? default : new NodeWrapper(_storage, _rootChunkId, _height == 1);
+        // Issue #297: do NOT cache isLeaf via `_height == 1`. _rootChunkId and _height are written separately during root split/collapse
+        // (e.g., Root = ... ; Height++/--). A concurrent reader that lands between the two writes can observe new _rootChunkId + stale _height, and would cache
+        // the wrong isLeaf value — causing the descent to treat a leaf root as internal, read user values as child chunk-ids, and crash with bogus reads.
+        // Pay the extra chunk read on the descent's first GetIsLeaf instead.
+        get => _rootChunkId == 0 ? default : new NodeWrapper(_storage, _rootChunkId);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set => _rootChunkId = value.IsValid ? value.ChunkId : 0;
     }
@@ -984,9 +988,8 @@ public abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TKey
 
                 if (_count > 0)
                 {
-                    // Use the non-caching NodeWrapper constructor: the Root property uses _height == 1
-                    // to determine isLeaf, but _height is not yet established during load bootstrap.
-                    // The 2-param constructor leaves _flags = 0, forcing GetIsLeaf to read from chunk data.
+                    // Equivalent to `Root` (which is also non-caching since #297) — kept explicit because we are about to compute and assign Height inside the
+                    // loop below, so reading the property here (which was the historical cache source) would be misleading.
                     var rootNode = new NodeWrapper(_storage, _rootChunkId);
 
                     // Traverse the leftmost path to find Height and LinkList (leftmost leaf)
@@ -1670,11 +1673,12 @@ public abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TKey
             }
 
             // Move to child
-            node = child;
-            if (!node.IsValid)
+            if (!child.IsValid)
             {
                 return (0, 0, -1); // invalid child — restart
             }
+            OlcDescentTrace.RecordStep?.Invoke(OlcDescentTrace.OpDescend, node.ChunkId, version, index, child.ChunkId);
+            node = child;
             latch = node.GetLatch(ref accessor);
             version = latch.ReadVersion();
             if (version == 0)
@@ -1686,46 +1690,51 @@ public abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TKey
         // At leaf: search for key
         var keyIndex = node.Find(key, Comparer, ref accessor);
 
-        // B-link right-link following: if key not found and beyond this leaf's range, the leaf may have split and the parent separator is stale. Follow
-        // right links until we find the leaf containing the key or exhaust the chain.
-        // Multiple hops may be needed when consecutive forceSplit operations left several unpropagated separators in a row.
-        // Disabled for inserts (followRightLink=false): version validation handles restarts.
+        // B-link right-link following: if key not found in this leaf, walk forward in the chain until we find the key or hit a leaf whose actual content places
+        // key strictly within its range (key <= leaf.GetItem(count-1).Key). This is more robust than relying on the cached HighKey, which can be transiently
+        // out-of-sync with the actual chain ordering/ under concurrent operations.
         if (followRightLink && keyIndex < 0)
         {
             const int maxHops = 16;
             for (int hop = 0; hop < maxHops && node.GetCount(ref accessor) > 0; hop++)
             {
-                if (Comparer.Compare(key, node.GetHighKey(ref accessor)) < 0)
+                int leafCount = node.GetCount(ref accessor);
+                int cmpToLast = leafCount > 0 ? Comparer.Compare(key, node.GetItem(leafCount - 1, ref accessor).Key) : 1; // empty leaf — treat key as beyond
+                if (cmpToLast <= 0)
                 {
-                    break; // key is within this leaf's range (high key is exclusive upper bound)
+                    // key <= leaf's last → key would be in this leaf if anywhere on this side of the chain. Re-validate to guard against torn reads (key/last
+                    // from inconsistent version snapshot), then conclude NotFound.
+                    if (!latch.ValidateVersion(version))
+                    {
+                        return (0, 0, -1);
+                    }
+                    break;
                 }
-
                 if (!latch.ValidateVersion(version))
                 {
-                    return (0, 0, -1); // leaf modified — restart from root
+                    return (0, 0, -1);
                 }
 
                 var nextNode = node.GetNext(ref accessor);
                 if (!nextNode.IsValid)
                 {
-                    break; // no right sibling — key doesn't exist
+                    break; // chain exhausted
                 }
 
                 var nextLatch = nextNode.GetLatch(ref accessor);
                 int nextVersion = nextLatch.ReadVersion();
                 if (nextVersion == 0)
                 {
-                    return (0, 0, -1); // right sibling locked/obsolete — restart
+                    return (0, 0, -1);
                 }
 
                 node = nextNode;
                 latch = nextLatch;
                 version = nextVersion;
                 keyIndex = node.Find(key, Comparer, ref accessor);
-
                 if (keyIndex >= 0)
                 {
-                    break; // found the key
+                    break;
                 }
             }
         }

--- a/src/Typhon.Engine/Data/Index/OlcDescentTrace.cs
+++ b/src/Typhon.Engine/Data/Index/OlcDescentTrace.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Diagnostic hooks for OLC B+Tree descent paths. Tests/harnesses can wire <see cref="RecordStep"/>
+/// to capture per-step state, and <see cref="OnInvalidChunkId"/> to dump captured state when the
+/// page-cache rejects a bogus chunk-id (issue #297).
+///
+/// Production cost when unwired: one null-check per descent step + one null-check on the
+/// invalid-chunk-id error path. The JIT short-circuits the null checks; no allocations.
+///
+/// LEAVE THIS CLASS WIRED UP IN TESTS ONLY. With all hooks null (default), the production
+/// behavior is byte-for-byte identical to having no instrumentation.
+/// </summary>
+public static class OlcDescentTrace
+{
+    /// <summary>
+    /// Op codes for <see cref="RecordStep"/>. Differentiates which descent path emitted the step.
+    /// </summary>
+    public const int OpInsert = 0;
+    public const int OpRemove = 1;
+    public const int OpDescend = 2;  // OptimisticDescendToLeaf (used by lookups, Move, OLC insert general path)
+
+    /// <summary>
+    /// Called once per descent step, AFTER reading the child chunk-id from the parent and AFTER
+    /// validating the parent's OLC version (so when called, the child chunk-id is the value the
+    /// caller intends to use).
+    /// </summary>
+    public static Action<int, int, int, int, int> RecordStep;
+
+    /// <summary>
+    /// Called from <see cref="Storage.Segments.ChunkBasedSegment{TStore}.GetChunkLocation"/> right
+    /// before it throws on an out-of-range chunk-id. Lets tests dump captured descent traces with
+    /// a deterministic forensic record of how the bogus id propagated to the page-cache lookup.
+    /// </summary>
+    public static Action<int, string> OnInvalidChunkId;
+
+    // === Remove NotFound branch instrumentation (issue #297 follow-up) ===
+
+    /// <summary>Branch id for <see cref="OnRemoveNotFound"/>.</summary>
+    public const int RemoveBranchBeginFastPathLessThanFirst = 1;
+    public const int RemoveBranchEndFastPathGreaterThanLast = 2;
+    public const int RemoveBranchGeneralKeyIndexNegative = 3;
+    public const int RemoveBranchUnderLockReFindNegative = 4;
+
+    /// <summary>
+    /// Called every time the OLC remove path concludes "key not in tree." Args:
+    /// (branch, keyAsInt, leafChunkId, leafFirstOrLastKeyAsInt, leafCount). For non-int trees
+    /// (e.g., String64) the int casts are nonsensical — wire only for int-keyed test trees.
+    /// </summary>
+    public static Action<int, int, int, int, int> OnRemoveNotFound;
+}

--- a/src/Typhon.Engine/Data/Index/OlcLatch.cs
+++ b/src/Typhon.Engine/Data/Index/OlcLatch.cs
@@ -15,7 +15,7 @@ internal readonly ref struct OlcLatch
 {
     private readonly ref int _version;  // ref to chunk's OlcVersion field
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)] 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public OlcLatch(ref int olcVersion) => _version = ref olcVersion;
 
     // --- Reader API (zero writes to shared state) ---

--- a/src/Typhon.Engine/Data/Index/String64BTree.cs
+++ b/src/Typhon.Engine/Data/Index/String64BTree.cs
@@ -26,6 +26,7 @@ unsafe public struct IndexString64Chunk
     public int PrevChunk;
     public int NextChunk;
     public int LeftValue;
+    public fixed byte HighKey[64];                  // B-link upper bound (issue #297) — exclusive; sentinel = all 0xFF
     public fixed int Values[Capacity];
     public fixed byte Keys[64*Capacity];
 
@@ -38,6 +39,24 @@ unsafe public struct IndexString64Chunk
                 var strings = (String64*)k;
                 return new Span<String64>(strings, Capacity);
             }
+        }
+    }
+
+    /// <summary>Reads the explicit B-link HighKey (issue #297). Sentinel "infinity" is all 0xFF bytes.</summary>
+    public readonly String64 GetHighKey()
+    {
+        fixed (byte* h = HighKey)
+        {
+            return new String64(h);
+        }
+    }
+
+    /// <summary>Writes the explicit B-link HighKey (issue #297).</summary>
+    public void SetHighKey(String64 key)
+    {
+        fixed (byte* h = HighKey)
+        {
+            key.AsSpan().CopyTo(new Span<byte>(h, 64));
         }
     }
 
@@ -219,6 +238,12 @@ public abstract class String64BTree<TStore> : BTree<String64, TStore> where TSto
             chunk.PrevChunk = 0;
             chunk.NextChunk = 0;
             chunk.LeftValue = 0;
+            // Issue #297: HighKey = all 0xFF (sentinel "infinity") so move-right gap-check
+            // does not false-fire on freshly allocated rightmost-leaf with no keys yet.
+            fixed (byte* h = chunk.HighKey)
+            {
+                new Span<byte>(h, 64).Fill(0xFF);
+            }
         }
 
         public override int GetNodeCapacity() => IndexString64Chunk.Capacity;
@@ -325,6 +350,23 @@ public abstract class String64BTree<TStore> : BTree<String64, TStore> where TSto
         {
             ref var chunk = ref accessor.GetChunk<IndexString64Chunk>(node.ChunkId, true);
             chunk.ContentionHint = value;
+        }
+
+        // Issue #297: explicit HighKey override (B-link upper bound). Without this override,
+        // BaseNodeStorage.GetHighKey defaults to "last key in node", which makes
+        // node.HighKey != nextNode.firstKey by design — creating a permanent "gap" that
+        // breaks the move-right gap-check restart. With the override, the invariant
+        // node.HighKey == nextNode.firstKey holds across splits, matching L16/L32/L64.
+        public override String64 GetHighKey(NodeWrapper node, ref ChunkAccessor<TStore> accessor)
+        {
+            ref readonly var chunk = ref accessor.GetChunkReadOnly<IndexString64Chunk>(node.ChunkId);
+            return chunk.GetHighKey();
+        }
+
+        public override void SetHighKey(NodeWrapper node, String64 key, ref ChunkAccessor<TStore> accessor)
+        {
+            ref var chunk = ref accessor.GetChunk<IndexString64Chunk>(node.ChunkId, true);
+            chunk.SetHighKey(key);
         }
 
         #endregion
@@ -556,6 +598,8 @@ public abstract class String64BTree<TStore> : BTree<String64, TStore> where TSto
             }
 
             leftChunk.Count += right.GetCount(ref accessor); // correct array length.
+            // Issue #297: merged node inherits right's upper bound (mirrors L32 SplitRight invariant).
+            leftChunk.SetHighKey(rightChunk.GetHighKey());
         }
 
         public override NodeWrapper GetLastChild(NodeWrapper node, ref ChunkAccessor<TStore> accessor)
@@ -708,6 +752,9 @@ public abstract class String64BTree<TStore> : BTree<String64, TStore> where TSto
         private NodeWrapper SplitRight(int leftChunkId, NodeStates states, ref ChunkAccessor<TStore> accessor)
         {
             ref var left = ref accessor.GetChunk<IndexString64Chunk>(leftChunkId, true);
+            // Issue #297: snapshot left's old HighKey BEFORE the split, so right can inherit it.
+            // Capture in a local because span/ref operations below may invalidate inline reads.
+            var oldHighKey = left.GetHighKey();
 
             var rightNode = Owner.AllocNode(states, ref accessor);
 
@@ -753,6 +800,12 @@ public abstract class String64BTree<TStore> : BTree<String64, TStore> where TSto
                 lv.Slice(0, remaining).CopyTo(rv.Slice(length, remaining));
                 lv.Slice(0, remaining).Clear();
             }
+
+            // Issue #297: update HighKeys to maintain the B-link invariant
+            // (left.HighKey == right.firstKey, right.HighKey == old left.HighKey).
+            // Right.Start is 0 after AllocNode, so right.GetKey(0) is its first key.
+            right.SetHighKey(oldHighKey);
+            left.SetHighKey(right.GetKey(0));
 
             return rightNode;
         }

--- a/src/Typhon.Engine/Storage/Segments/ChunkBasedSegment.cs
+++ b/src/Typhon.Engine/Storage/Segments/ChunkBasedSegment.cs
@@ -1045,10 +1045,12 @@ public class ChunkBasedSegment<TStore> : LogicalSegment<TStore> where TStore : s
         var segmentLength = Length;
         if (resultPageIndex >= segmentLength)
         {
-            throw new InvalidOperationException(
-                $"ChunkBasedSegment.GetChunkLocation: Computed page index {resultPageIndex} >= segment length {segmentLength}. " +
+            var msg = $"ChunkBasedSegment.GetChunkLocation: Computed page index {resultPageIndex} >= segment length {segmentLength}. " +
                 $"ChunkId={index}, rootChunkCount={_rootChunkCount}, otherChunkCount={_otherChunkCount}, " +
-                $"Capacity={ChunkCapacity}. This may indicate accessing a chunk ID that was never allocated or segment corruption.");
+                $"Capacity={ChunkCapacity}. This may indicate accessing a chunk ID that was never allocated or segment corruption.";
+            // Issue #297: let tests capture the descent trace that produced this bogus chunk-id BEFORE we throw.
+            OlcDescentTrace.OnInvalidChunkId?.Invoke(index, msg);
+            throw new InvalidOperationException(msg);
         }
 
         return (resultPageIndex, offset);

--- a/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
+++ b/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
@@ -1,0 +1,786 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// Time-bounded race-stress harness for OLC B+Tree (issue #297).
+/// Loops the five flaky concurrency scenarios from <see cref="OlcBTreeTests"/> in parallel under saturating CPU noise to maximize repro density.
+/// Different from <see cref="OlcBTreeStressTests"/> (high-thread single-shot scenarios) — this one is for "fail fast on a known race."
+/// [Explicit] — never runs in CI; invoke via filter or env-tuned local runs.
+/// Configure via env vars:
+///   OLC_STRESS_SECONDS — wall duration of the run (default 30)
+///   OLC_STRESS_NOISE   — count of CPU-saturating noise threads (default = ProcessorCount/2)
+/// One ManagedPagedMMF per scenario, reused across iterations (fresh segment per iter) — avoids per-iter file I/O cost.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+[Explicit("Long-running race-stress harness for issue #297 — invoke manually")]
+public class OlcBTreeRaceStressTests
+{
+    private static int _scenarioId;
+
+    [Test]
+    [CancelAfter(600_000)]  // 10 min — caller sets the actual duration via OLC_STRESS_SECONDS
+    public unsafe void OlcRaceStress_FourScenariosUnderCpuNoise()
+    {
+        var seconds = ParseEnvInt("OLC_STRESS_SECONDS", 30);
+        var noiseCount = ParseEnvInt("OLC_STRESS_NOISE", Math.Max(1, Environment.ProcessorCount / 2));
+        var deadline = TimeSpan.FromSeconds(seconds);
+
+        TestContext.WriteLine($"OLC race stress: duration={seconds}s noiseThreads={noiseCount} cores={Environment.ProcessorCount}");
+
+        // Wire up OLC descent diagnostic capture for the duration of the harness.
+        OlcDescentTrace.RecordStep = DescentTraceRecord;
+        OlcDescentTrace.OnInvalidChunkId = DescentTraceOnInvalidChunkId;
+        OlcDescentTrace.OnRemoveNotFound = OnRemoveNotFoundCapture;
+        for (int i = 0; i < _removeNotFoundByBranch.Length; i++) { _removeNotFoundByBranch[i] = 0; }
+        _removeNotFoundDetailsCaptured = 0;
+        _rdNotRemoved = 0; _rdWrongValue = 0;
+        while (_rdSamples.TryTake(out _)) { }
+        try
+        {
+
+        using var stop = new ManualResetEventSlim(false);
+        var noiseTasks = StartNoise(noiseCount, stop);
+
+        var scenarios = new[]
+        {
+            new Scenario("Add_Splits",      AddSplitsBody),
+            new Scenario("Add_Disjoint",    AddDisjointBody),
+            new Scenario("Remove_Disjoint", RemoveDisjointBody),
+            new Scenario("Remove_Merges",   RemoveMergesBody),
+            new Scenario("Remove_Mixed",    RemoveMixedBody),
+        };
+
+        var sw = Stopwatch.StartNew();
+        var scenarioTasks = scenarios.Select(s => Task.Factory.StartNew(() => RunScenarioLoop(s, stop), TaskCreationOptions.LongRunning)).ToArray();
+
+        Thread.Sleep(deadline);
+        stop.Set();
+
+        Task.WaitAll(scenarioTasks);
+        Task.WaitAll(noiseTasks);
+        sw.Stop();
+
+        var report = new StringBuilder();
+        report.AppendLine();
+        report.AppendLine($"=== OLC race stress report — wall {sw.Elapsed.TotalSeconds:F1}s ===");
+        long totalIters = 0, totalFails = 0;
+        foreach (var s in scenarios)
+        {
+            int iters = Volatile.Read(ref s.Iterations);
+            int fails = s.Failures.Count;
+            totalIters += iters;
+            totalFails += fails;
+            report.AppendLine($"  {s.Name,-18} iter={iters,6}  fail={fails,4}  rate={(iters == 0 ? 0 : (double)fails / iters):P2}");
+        }
+        report.AppendLine($"  {"TOTAL",-18} iter={totalIters,6}  fail={totalFails,4}");
+
+        if (totalFails > 0)
+        {
+            report.AppendLine();
+            report.AppendLine("=== first failure per scenario ===");
+            foreach (var s in scenarios)
+            {
+                if (s.Failures.IsEmpty)
+                {
+                    continue;
+                }
+                var first = s.Failures.OrderBy(f => f.Iteration).First();
+                report.AppendLine($"--- {s.Name} (iter {first.Iteration}) ---");
+                report.AppendLine(first.Detail);
+                report.AppendLine();
+            }
+        }
+        // Append Remove NotFound branch summary BEFORE writing report to test context.
+        var rnfTotal = 0L;
+        for (int i = 1; i < _removeNotFoundByBranch.Length; i++) { rnfTotal += _removeNotFoundByBranch[i]; }
+        if (rnfTotal > 0)
+        {
+            report.AppendLine();
+            report.AppendLine("=== Remove NotFound branch counts ===");
+            report.AppendLine($"  begin-fast-path (key < ll.firstKey)    : {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchBeginFastPathLessThanFirst]}");
+            report.AppendLine($"  end-fast-path   (key > rll.lastKey)    : {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchEndFastPathGreaterThanLast]}");
+            report.AppendLine($"  general path    (descend keyIndex<0)   : {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchGeneralKeyIndexNegative]}");
+            report.AppendLine($"  under-lock re-find (concurrent removed): {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchUnderLockReFindNegative]}");
+            report.AppendLine($"  TOTAL: {rnfTotal}");
+        }
+        if (_rdNotRemoved > 0 || _rdWrongValue > 0)
+        {
+            report.AppendLine();
+            report.AppendLine("=== Remove_Disjoint failure split ===");
+            report.AppendLine($"  not_removed (Remove returned false)    : {_rdNotRemoved}");
+            report.AppendLine($"  wrong_value (Remove returned bad value): {_rdWrongValue}");
+            report.AppendLine($"  Sample failures:");
+            int n = 0;
+            foreach (var sample in _rdSamples) { if (++n > 10) break; report.AppendLine($"    {sample}"); }
+        }
+
+        TestContext.WriteLine(report.ToString());
+
+        Assert.That(totalFails, Is.Zero, () => $"OLC race stress observed {totalFails} failures across {totalIters} iterations.\n{report}");
+        }
+        finally
+        {
+            OlcDescentTrace.RecordStep = null;
+            OlcDescentTrace.OnInvalidChunkId = null;
+            OlcDescentTrace.OnRemoveNotFound = null;
+        }
+    }
+
+    // === Remove NotFound branch capture ===
+    private static readonly long[] _removeNotFoundByBranch = new long[5];
+    private static int _removeNotFoundDetailsCaptured;
+    private static readonly object _rnfLock = new();
+    private static readonly string _rnfDetailsPath = (Environment.GetEnvironmentVariable("OLC_STRESS_LOG")
+        ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "olc-race-stress.log"))
+        .Replace(".log", ".rnf.log");
+
+    private static void OnRemoveNotFoundCapture(int branch, int key, int leafChunkId, int firstOrLastKey, int leafCount)
+    {
+        if (branch >= 0 && branch < _removeNotFoundByBranch.Length)
+        {
+            Interlocked.Increment(ref _removeNotFoundByBranch[branch]);
+        }
+        // Cap detailed dumps to keep the log tractable.
+        if (Interlocked.Increment(ref _removeNotFoundDetailsCaptured) > 30)
+        {
+            return;
+        }
+        var line = $"{DateTime.UtcNow:HH:mm:ss.fff} branch={branch} key={key} leaf={leafChunkId} pivot={firstOrLastKey} count={leafCount}\n";
+        lock (_rnfLock)
+        {
+            try { System.IO.File.AppendAllText(_rnfDetailsPath, line); } catch { }
+        }
+    }
+
+    // ====== Descent diagnostic capture ======
+
+    [ThreadStatic] private static DescentStep[] _descentRing;
+    [ThreadStatic] private static int _descentRingHead;
+    private const int DescentRingSize = 64;
+    private static int _descentDumpsCaptured;
+
+    private readonly record struct DescentStep(int Op, int ParentChunkId, int ParentVersion, int ChildIndex, int ChildChunkId);
+
+    private static void DescentTraceRecord(int op, int parentChunkId, int parentVersion, int childIndex, int childChunkId)
+    {
+        var ring = _descentRing ??= new DescentStep[DescentRingSize];
+        ring[_descentRingHead] = new DescentStep(op, parentChunkId, parentVersion, childIndex, childChunkId);
+        _descentRingHead = (_descentRingHead + 1) % DescentRingSize;
+    }
+
+    private static void DescentTraceOnInvalidChunkId(int badChunkId, string segmentMessage)
+    {
+        // Cap dumps so we don't drown the log under a sustained crash storm.
+        if (Interlocked.Increment(ref _descentDumpsCaptured) > 5)
+        {
+            return;
+        }
+        var ring = _descentRing;
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine($"=== OLC DESCENT TRACE on invalid chunkId={badChunkId} (thread {Environment.CurrentManagedThreadId}) ===");
+        sb.AppendLine(segmentMessage);
+        if (ring == null)
+        {
+            sb.AppendLine("(no descent steps recorded on this thread — bug originated outside instrumented descent)");
+        }
+        else
+        {
+            sb.AppendLine($"Last {DescentRingSize} descent steps (oldest first; head idx={_descentRingHead}):");
+            for (int i = 0; i < DescentRingSize; i++)
+            {
+                int idx = (_descentRingHead + i) % DescentRingSize;
+                var s = ring[idx];
+                if (s.ParentChunkId == 0 && s.ChildChunkId == 0)
+                {
+                    continue;  // unwritten slot
+                }
+                var opName = s.Op switch { OlcDescentTrace.OpInsert => "INS", OlcDescentTrace.OpRemove => "REM", OlcDescentTrace.OpDescend => "DSC", _ => "?" };
+                sb.AppendLine($"  [{idx,2}] {opName} parentChunk={s.ParentChunkId} parentVer=0x{s.ParentVersion:x} childIdx={s.ChildIndex} childChunk={s.ChildChunkId}");
+            }
+        }
+        WriteDescentDump(sb.ToString());
+    }
+
+    private static readonly string _descentDumpPath = (Environment.GetEnvironmentVariable("OLC_STRESS_LOG")
+        ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "olc-race-stress.log"))
+        .Replace(".log", ".descent.log");
+
+    private static void WriteDescentDump(string text)
+    {
+        lock (_progressLogLock)
+        {
+            try
+            {
+                System.IO.File.AppendAllText(_descentDumpPath, text);
+            }
+            catch { /* best-effort */ }
+        }
+    }
+
+    // ====== Scenario bodies (mirror OlcBTreeTests bodies, allocate fresh segment per iter) ======
+
+    private static unsafe void AddSplitsBody(ScenarioContext ctx)
+    {
+        var mpmmf = ctx.Mpmmf;
+        var em = ctx.EpochManager;
+        var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 100, sizeof(Index32Chunk));
+
+        const int threadCount = 4;
+        const int keysPerThread = 500;
+        var setupDepth = em.EnterScope();
+        try
+        {
+            var setupA = segment.CreateChunkAccessor();
+            var tree = new IntSingleBTree<PersistentStore>(segment);
+            setupA.Dispose();
+
+            using var barrier = new Barrier(threadCount);
+            var exceptions = new ConcurrentBag<Exception>();
+            var tasks = new Task[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int tid = t;
+                tasks[t] = Task.Factory.StartNew(() =>
+                {
+                    var d = em.EnterScope();
+                    try
+                    {
+                        var wa = segment.CreateChunkAccessor();
+                        barrier.SignalAndWait();
+                        for (int i = 0; i < keysPerThread; i++)
+                        {
+                            int key = i * threadCount + tid + 1;
+                            tree.Add(key, key * 10, ref wa);
+                        }
+                        wa.CommitChanges();
+                        wa.Dispose();
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                    finally { em.ExitScope(d); }
+                }, TaskCreationOptions.LongRunning);
+            }
+            Task.WaitAll(tasks);
+            ThrowIfAny(exceptions, "Add_Splits workers threw");
+
+            int expected = threadCount * keysPerThread;
+            if (tree.EntryCount != expected)
+            {
+                throw new Exception($"Add_Splits: EntryCount={tree.EntryCount} expected={expected}");
+            }
+            var va = segment.CreateChunkAccessor();
+            for (int i = 1; i <= expected; i++)
+            {
+                var r = tree.TryGet(i, ref va);
+                if (!r.IsSuccess || r.Value != i * 10)
+                {
+                    va.Dispose();
+                    throw new Exception($"Add_Splits: key {i} success={r.IsSuccess} value={r.Value} expected={i * 10}");
+                }
+            }
+            va.Dispose();
+        }
+        finally { em.ExitScope(setupDepth); }
+    }
+
+    private static unsafe void AddDisjointBody(ScenarioContext ctx)
+    {
+        var mpmmf = ctx.Mpmmf;
+        var em = ctx.EpochManager;
+        var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 50, sizeof(Index32Chunk));
+
+        const int threadCount = 4;
+        const int keysPerThread = 200;
+        var setupDepth = em.EnterScope();
+        try
+        {
+            var setupA = segment.CreateChunkAccessor();
+            var tree = new IntSingleBTree<PersistentStore>(segment);
+            setupA.Dispose();
+
+            using var barrier = new Barrier(threadCount);
+            var exceptions = new ConcurrentBag<Exception>();
+            var tasks = new Task[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int tid = t;
+                tasks[t] = Task.Factory.StartNew(() =>
+                {
+                    var d = em.EnterScope();
+                    try
+                    {
+                        var wa = segment.CreateChunkAccessor();
+                        barrier.SignalAndWait();
+                        int start = tid * keysPerThread + 1;
+                        for (int i = start; i < start + keysPerThread; i++)
+                        {
+                            tree.Add(i, i * 10, ref wa);
+                        }
+                        wa.CommitChanges();
+                        wa.Dispose();
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                    finally { em.ExitScope(d); }
+                }, TaskCreationOptions.LongRunning);
+            }
+            Task.WaitAll(tasks);
+            ThrowIfAny(exceptions, "Add_Disjoint workers threw");
+
+            int expected = threadCount * keysPerThread;
+            if (tree.EntryCount != expected)
+            {
+                throw new Exception($"Add_Disjoint: EntryCount={tree.EntryCount} expected={expected}");
+            }
+            var va = segment.CreateChunkAccessor();
+            for (int i = 1; i <= expected; i++)
+            {
+                var r = tree.TryGet(i, ref va);
+                if (!r.IsSuccess || r.Value != i * 10)
+                {
+                    va.Dispose();
+                    throw new Exception($"Add_Disjoint: key {i} success={r.IsSuccess} value={r.Value} expected={i * 10}");
+                }
+            }
+            va.Dispose();
+        }
+        finally { em.ExitScope(setupDepth); }
+    }
+
+    // Issue #297 follow-up: distinguish "Remove returned false" from "Remove returned true with wrong value"
+    private static int _rdNotRemoved;
+    private static int _rdWrongValue;
+    private static readonly System.Collections.Concurrent.ConcurrentBag<string> _rdSamples = new();
+
+    private static unsafe void RemoveDisjointBody(ScenarioContext ctx)
+    {
+        var mpmmf = ctx.Mpmmf;
+        var em = ctx.EpochManager;
+        var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 50, sizeof(Index32Chunk));
+
+        const int threadCount = 4;
+        const int keysPerThread = 100;
+        const int totalKeys = threadCount * keysPerThread;
+        var setupDepth = em.EnterScope();
+        try
+        {
+            var sa = segment.CreateChunkAccessor();
+            var tree = new IntSingleBTree<PersistentStore>(segment);
+            for (int i = 1; i <= totalKeys; i++)
+            {
+                tree.Add(i, i * 10, ref sa);
+            }
+            sa.Dispose();
+
+            using var barrier = new Barrier(threadCount);
+            var exceptions = new ConcurrentBag<Exception>();
+            int errors = 0;
+            var tasks = new Task[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int tid = t;
+                tasks[t] = Task.Factory.StartNew(() =>
+                {
+                    var d = em.EnterScope();
+                    try
+                    {
+                        var wa = segment.CreateChunkAccessor();
+                        barrier.SignalAndWait();
+                        int start = tid * keysPerThread + 1;
+                        for (int i = start; i < start + keysPerThread; i++)
+                        {
+                            bool removed = tree.Remove(i, out var v, ref wa);
+                            if (!removed)
+                            {
+                                Interlocked.Increment(ref errors);
+                                Interlocked.Increment(ref _rdNotRemoved);
+                                if (_rdSamples.Count < 30) { _rdSamples.Add($"NOT_REMOVED key={i}"); }
+                            }
+                            else if (v != i * 10)
+                            {
+                                Interlocked.Increment(ref errors);
+                                Interlocked.Increment(ref _rdWrongValue);
+                                if (_rdSamples.Count < 30) { _rdSamples.Add($"WRONG_VALUE key={i} got={v} expected={i * 10}"); }
+                            }
+                        }
+                        wa.CommitChanges();
+                        wa.Dispose();
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                    finally { em.ExitScope(d); }
+                }, TaskCreationOptions.LongRunning);
+            }
+            Task.WaitAll(tasks);
+            ThrowIfAny(exceptions, "Remove_Disjoint workers threw");
+            if (errors != 0)
+            {
+                throw new Exception($"Remove_Disjoint: errors={errors}");
+            }
+            if (tree.EntryCount != 0)
+            {
+                throw new Exception($"Remove_Disjoint: EntryCount={tree.EntryCount} expected=0");
+            }
+        }
+        finally { em.ExitScope(setupDepth); }
+    }
+
+    private static unsafe void RemoveMergesBody(ScenarioContext ctx)
+    {
+        var mpmmf = ctx.Mpmmf;
+        var em = ctx.EpochManager;
+        var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 100, sizeof(Index32Chunk));
+
+        const int threadCount = 4;
+        const int totalKeys = 2000;
+        const int keysToRemovePerThread = 200;
+        var setupDepth = em.EnterScope();
+        try
+        {
+            var sa = segment.CreateChunkAccessor();
+            var tree = new IntSingleBTree<PersistentStore>(segment);
+            for (int i = 1; i <= totalKeys; i++)
+            {
+                tree.Add(i, i * 10, ref sa);
+            }
+            sa.Dispose();
+
+            using var barrier = new Barrier(threadCount);
+            var exceptions = new ConcurrentBag<Exception>();
+            var tasks = new Task[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int tid = t;
+                tasks[t] = Task.Factory.StartNew(() =>
+                {
+                    var d = em.EnterScope();
+                    try
+                    {
+                        var wa = segment.CreateChunkAccessor();
+                        barrier.SignalAndWait();
+                        for (int i = 0; i < keysToRemovePerThread; i++)
+                        {
+                            int key = i * threadCount + tid + 1;
+                            if (key <= totalKeys)
+                            {
+                                tree.Remove(key, out _, ref wa);
+                            }
+                        }
+                        wa.CommitChanges();
+                        wa.Dispose();
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                    finally { em.ExitScope(d); }
+                }, TaskCreationOptions.LongRunning);
+            }
+            Task.WaitAll(tasks);
+            ThrowIfAny(exceptions, "Remove_Merges workers threw");
+
+            int expected = totalKeys - threadCount * keysToRemovePerThread;
+            if (tree.EntryCount != expected)
+            {
+                throw new Exception($"Remove_Merges: EntryCount={tree.EntryCount} expected={expected}");
+            }
+            var va = segment.CreateChunkAccessor();
+            tree.CheckConsistency(ref va);
+            va.Dispose();
+        }
+        finally { em.ExitScope(setupDepth); }
+    }
+
+    private static unsafe void RemoveMixedBody(ScenarioContext ctx)
+    {
+        var mpmmf = ctx.Mpmmf;
+        var em = ctx.EpochManager;
+        var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 100, sizeof(Index32Chunk));
+
+        const int initialEntries = 500;
+        const int writerCount = 2;
+        const int removerCount = 2;
+        const int insertsPerWriter = 300;
+        const int removesPerRemover = 100;
+        var setupDepth = em.EnterScope();
+        try
+        {
+            var sa = segment.CreateChunkAccessor();
+            var tree = new IntSingleBTree<PersistentStore>(segment);
+            for (int i = 1; i <= initialEntries; i++)
+            {
+                tree.Add(i, i * 10, ref sa);
+            }
+            sa.Dispose();
+
+            using var startSignal = new ManualResetEventSlim(false);
+            var exceptions = new ConcurrentBag<Exception>();
+
+            var insertTasks = new Task[writerCount];
+            for (int w = 0; w < writerCount; w++)
+            {
+                int wid = w;
+                insertTasks[w] = Task.Factory.StartNew(() =>
+                {
+                    var d = em.EnterScope();
+                    try
+                    {
+                        var wa = segment.CreateChunkAccessor();
+                        startSignal.Wait();
+                        int start = 10_000 + wid * insertsPerWriter;
+                        for (int i = start; i < start + insertsPerWriter; i++)
+                        {
+                            tree.Add(i, i * 10, ref wa);
+                        }
+                        wa.CommitChanges();
+                        wa.Dispose();
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                    finally { em.ExitScope(d); }
+                }, TaskCreationOptions.LongRunning);
+            }
+            var removeTasks = new Task[removerCount];
+            for (int r = 0; r < removerCount; r++)
+            {
+                int rid = r;
+                removeTasks[r] = Task.Factory.StartNew(() =>
+                {
+                    var d = em.EnterScope();
+                    try
+                    {
+                        var wa = segment.CreateChunkAccessor();
+                        startSignal.Wait();
+                        int start = rid * removesPerRemover + 1;
+                        for (int i = start; i < start + removesPerRemover; i++)
+                        {
+                            tree.Remove(i, out _, ref wa);
+                        }
+                        wa.CommitChanges();
+                        wa.Dispose();
+                    }
+                    catch (Exception ex) { exceptions.Add(ex); }
+                    finally { em.ExitScope(d); }
+                }, TaskCreationOptions.LongRunning);
+            }
+            startSignal.Set();
+            Task.WaitAll(insertTasks.Concat(removeTasks).ToArray());
+            ThrowIfAny(exceptions, "Remove_Mixed workers threw");
+
+            int expected = initialEntries + writerCount * insertsPerWriter - removerCount * removesPerRemover;
+            if (tree.EntryCount != expected)
+            {
+                throw new Exception($"Remove_Mixed: EntryCount={tree.EntryCount} expected={expected}");
+            }
+            var va = segment.CreateChunkAccessor();
+            tree.CheckConsistency(ref va);
+            va.Dispose();
+        }
+        finally { em.ExitScope(setupDepth); }
+    }
+
+    // ====== Plumbing ======
+
+    private sealed class ScenarioContext
+    {
+        public ManagedPagedMMF Mpmmf;
+        public EpochManager EpochManager;
+    }
+
+    private sealed class Scenario
+    {
+        public readonly string Name;
+        public readonly Action<ScenarioContext> Body;
+        public int Iterations;
+        public int DetailsCaptured;
+        public readonly ConcurrentBag<FailureRecord> Failures = new();
+
+        public Scenario(string name, Action<ScenarioContext> body)
+        {
+            Name = name;
+            Body = body;
+        }
+    }
+
+    private readonly record struct FailureRecord(int Iteration, string Detail);
+
+    private static void RunScenarioLoop(Scenario s, ManualResetEventSlim stop)
+    {
+        // Fresh service provider + MMF per iteration — the MMF tracks BTree indexes
+        // in a per-segment directory capped at 20 entries, so reusing the MMF runs out fast.
+        // Per-iter rebuild is also closer to what the regular test fixtures do (matches CI).
+        while (!stop.IsSet)
+        {
+            int iter = Interlocked.Increment(ref s.Iterations);
+            var sp = BuildScenarioProvider();
+            bool hadHangInThisIter = false;
+            try
+            {
+                var mpmmf = sp.GetRequiredService<ManagedPagedMMF>();
+                var em = sp.GetRequiredService<EpochManager>();
+                var ctx = new ScenarioContext { Mpmmf = mpmmf, EpochManager = em };
+                try
+                {
+                    // File-based progress: written BEFORE iteration. If process crashes mid-iter,
+                    // we know which scenario+iteration was running. Crucial because OLC bugs may
+                    // produce AccessViolation that bypasses managed try/catch.
+                    WriteProgress(s.Name, iter, "start");
+                    try
+                    {
+                        // Run on a worker thread so we can put a wall-clock deadline on it.
+                        // If the iteration deadlocks (livelock in OLC retry loops, etc.), we
+                        // record a "hang" outcome and break — otherwise the whole harness wedges.
+                        var iterTask = Task.Factory.StartNew(() => s.Body(ctx), TaskCreationOptions.LongRunning);
+                        if (!iterTask.Wait(IterationDeadline))
+                        {
+                            s.Failures.Add(new FailureRecord(iter, $"HANG: scenario body did not complete within {IterationDeadline.TotalSeconds}s"));
+                            WriteProgress(s.Name, iter, "HANG");
+                            // Workers may still be alive — touching the MMF after Dispose() would AV.
+                            // Skip cleanup; let the orphan workers churn against live (epoch-protected) memory
+                            // until the process exits. Memory leak across HANG iters is bounded by the stress
+                            // duration and acceptable for a diagnostic harness. See issue #297 follow-up.
+                            hadHangInThisIter = true;
+                            break;
+                        }
+                        if (iterTask.IsFaulted)
+                        {
+                            throw iterTask.Exception?.InnerException ?? iterTask.Exception ?? new Exception("Unknown fault");
+                        }
+                        WriteProgress(s.Name, iter, "ok");
+                    }
+                    catch (Exception ex)
+                    {
+                        // Unwrap the AggregateException Wait() introduced.
+                        var inner = ex is AggregateException agg ? (agg.InnerException ?? ex) : ex;
+                        s.Failures.Add(new FailureRecord(iter, inner.ToString()));
+                        // First line of message is enough to spot patterns in the live log.
+                        var msg = inner.Message?.Split('\n')[0] ?? "";
+                        WriteProgress(s.Name, iter, $"fail: {inner.GetType().Name}: {msg}");
+                        // Capture full detail for the first 3 failures per scenario — survives test-abort.
+                        if (Interlocked.Increment(ref s.DetailsCaptured) <= 3)
+                        {
+                            WriteDetails(s.Name, iter, inner);
+                        }
+                    }
+                }
+                finally
+                {
+                    if (!hadHangInThisIter)
+                    {
+                        em.Dispose();
+                        mpmmf.Dispose();
+                    }
+                    // On HANG: skip Dispose() — orphan workers continue to run safely against the live MMF.
+                }
+            }
+            finally
+            {
+                if (!hadHangInThisIter)
+                {
+                    (sp as IDisposable)?.Dispose();
+                }
+                // On HANG: skip SP.Dispose() too — it would tear down the scoped MMF and AV the orphan workers.
+                // Acceptable leak (bounded by stress duration).
+            }
+        }
+    }
+
+    private static readonly TimeSpan IterationDeadline = TimeSpan.FromSeconds(ParseEnvInt("OLC_STRESS_ITER_DEADLINE_SECONDS", 10));
+
+    private static readonly string _progressLogPath = Environment.GetEnvironmentVariable("OLC_STRESS_LOG")
+        ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "olc-race-stress.log");
+
+    private static readonly object _progressLogLock = new();
+
+    private static void WriteProgress(string scenario, int iter, string state)
+    {
+        lock (_progressLogLock)
+        {
+            try
+            {
+                System.IO.File.AppendAllText(_progressLogPath, $"{DateTime.UtcNow:HH:mm:ss.fff} {scenario,-18} iter={iter,6} {state}\n");
+            }
+            catch { /* best-effort */ }
+        }
+    }
+
+    private static readonly string _detailsLogPath = (Environment.GetEnvironmentVariable("OLC_STRESS_LOG")
+        ?? System.IO.Path.Combine(System.IO.Path.GetTempPath(), "olc-race-stress.log"))
+        .Replace(".log", ".details.log");
+
+    private static void WriteDetails(string scenario, int iter, Exception ex)
+    {
+        lock (_progressLogLock)
+        {
+            try
+            {
+                System.IO.File.AppendAllText(_detailsLogPath,
+                    $"\n=== {DateTime.UtcNow:HH:mm:ss.fff} {scenario} iter={iter} ===\n{ex}\n");
+            }
+            catch { /* best-effort */ }
+        }
+    }
+
+    private static IServiceProvider BuildScenarioProvider()
+    {
+        // Unique DB name per scenario invocation so concurrent loops don't collide on the file.
+        int id = Interlocked.Increment(ref _scenarioId);
+        var sc = new ServiceCollection()
+            .AddLogging()
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddScopedManagedPagedMemoryMappedFile(o =>
+            {
+                o.DatabaseName = $"olcrs_{id:x}";
+                // Generously sized — many segments per scenario over a long run.
+                o.DatabaseCacheSize = (ulong)(PagedMMF.DefaultMemPageCount * PagedMMF.PageSize);
+                o.PagesDebugPattern = true;
+            });
+        var sp = sc.BuildServiceProvider();
+        sp.EnsureFileDeleted<ManagedPagedMMFOptions>();
+        return sp;
+    }
+
+    private static Task[] StartNoise(int count, ManualResetEventSlim stop)
+    {
+        var noise = new Task[count];
+        for (int i = 0; i < count; i++)
+        {
+            noise[i] = Task.Factory.StartNew(() =>
+            {
+                // CPU-bound spinner — keeps cores hot so OLC workers face frequent preemption.
+                ulong acc = 1;
+                while (!stop.IsSet)
+                {
+                    for (int k = 0; k < 4096; k++)
+                    {
+                        acc = acc * 6364136223846793005UL + 1442695040888963407UL;
+                    }
+                }
+                GC.KeepAlive(acc);
+            }, TaskCreationOptions.LongRunning);
+        }
+        return noise;
+    }
+
+    private static int ParseEnvInt(string name, int fallback)
+    {
+        var v = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(v, out var n) ? n : fallback;
+    }
+
+    private static void ThrowIfAny(ConcurrentBag<Exception> exceptions, string label)
+    {
+        if (exceptions.IsEmpty)
+        {
+            return;
+        }
+        var first = exceptions.First();
+        throw new Exception($"{label} ({exceptions.Count} total); first:\n{first}");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #297 — OLC B+Tree concurrent inserts/removes silently losing keys under heavy parallel CPU pressure.

### Engine fixes (`src/Typhon.Engine/Data/Index/`)

- **`BTree.Remove.cs`** — Option D stale-separator detection in `RemoveIterative`: after Phase 1.5A version validation, if `node.Next` is valid and key ≥ `HighKey`, abort the write lock and restart. Stale-head/tail OLC checks in begin/end fast paths and pessimistic begin-fast-path. Snapshot-once on `_reverseLinkList` updates.
- **`BTree.Insert.cs`** — CAS-init lock around the initial `PushLast` (prevents unsynchronized writes when concurrent threads observe a just-published `_rootChunkId`); root-split lock around `newRoot` writes (prevents descent through a partially-constructed new root); defensive `_reverseLinkList` null guard in tail-cache update.
- **`BTree.cs`** — B-link follow uses the actual leaf last key instead of stale `HighKey`.
- **`BTree.NodeWrapper.cs`** — `SpillLeftSortInvariantHolds` / `SpillRightSortInvariantHolds` for spill-path correctness asserts.
- **`String64BTree.cs`** — explicit `HighKey[64]` field + `GetHighKey` / `SetHighKey` to maintain `node.HighKey == nextNode.firstKey` for `String64` keys (parity with `Index64Chunk` / L16/L32/L64).
- **`OlcDescentTrace.cs`** (new) — minimal diagnostic hooks (`RecordStep`, `OnInvalidChunkId`, `OnRemoveNotFound`). JIT short-circuits when null; near-zero production cost.

### Test infrastructure

- **`OlcBTreeRaceStressTests.cs`** — new stress fixture, 5 scenarios under heavy parallel CPU pressure. HANG-safe iter cleanup, file-based progress logging, descent-ring dump on `OnInvalidChunkId`, `OnRemoveNotFound` capture.

### Results

| Scenario | Baseline | After |
|---|---|---|
| `Remove_Disjoint` silent key loss | 7.4% | **0.00%** |
| AV crashes during stress | recurring | **eliminated** |
| Full unit test suite | flaky under load | **3748/3748 stable** |

### Known residual

`Add_*` scenarios show a ~0.08–0.40% silent-loss rate, suspected origin in `HandlePromotedInsert` spill paths for internal nodes. Out of scope for this PR — recommend follow-up issue once a deterministic repro lands.

## Test plan

- [x] 100 standalone runs of previously-flaky tests pass
- [x] 10 back-to-back full-suite runs clean for `Remove_*` and AV regressions
- [x] Full suite: 3748/3748

🤖 Generated with [Claude Code](https://claude.com/claude-code)