### PR TITLE
Workbench: Internal Data API + System DAG view (closes #306, #314)

### DIFF
--- a/src/Typhon.Engine/Observability/TelemetryConfig.cs
+++ b/src/Typhon.Engine/Observability/TelemetryConfig.cs
@@ -393,6 +393,15 @@ public static class TelemetryConfig
     /// <summary>Combined flag for the SchedulerMetronomeWait span (kind 241).</summary>
     public static readonly bool SchedulerMetronomeWaitActive;
 
+    // Scheduler:Queue subtree (#311 — surfaces per-tick queue depth telemetry)
+    /// <summary>Combined gate for the Scheduler:Queue subtree.</summary>
+    public static readonly bool SchedulerQueueActive;
+    /// <summary>
+    /// Combined flag for the QueueTickEnd instant (kind 244). Per-(tick, queue) rollup emitted at end-of-tick;
+    /// drives the Workbench Data API <c>queue/&lt;name&gt;</c> tracks (#311 / DAG view backpressure edges).
+    /// </summary>
+    public static readonly bool SchedulerQueueTickEndActive;
+
     // Scheduler:Graph leaves (kinds 159-160)
     public static readonly bool SchedulerGraphBuildActive;
     public static readonly bool SchedulerGraphRebuildActive;
@@ -933,6 +942,10 @@ public static class TelemetryConfig
             [
                 new Node("Wait"),
             ]),
+            new Node("Queue",
+            [
+                new Node("TickEnd"),
+            ]),
             new Node("Graph",
             [
                 new Node("Build"),
@@ -976,6 +989,10 @@ public static class TelemetryConfig
         // Metronome subtree (issue #289 follow-up)
         SchedulerMetronomeActive     = schedulerDepthMap["Scheduler:Metronome"];
         SchedulerMetronomeWaitActive = schedulerDepthMap["Scheduler:Metronome:Wait"];
+
+        // Queue subtree (#311 — per-tick queue depth telemetry)
+        SchedulerQueueActive         = schedulerDepthMap["Scheduler:Queue"];
+        SchedulerQueueTickEndActive  = schedulerDepthMap["Scheduler:Queue:TickEnd"];
 
         // Graph leaves
         SchedulerGraphBuildActive   = schedulerDepthMap["Scheduler:Graph:Build"];

--- a/src/Typhon.Engine/Profiler/Exporters/FileExporter.cs
+++ b/src/Typhon.Engine/Profiler/Exporters/FileExporter.cs
@@ -78,6 +78,7 @@ public sealed class FileExporter : ResourceNode, IProfilerExporter
         _writer.WriteSystemDefinitions(metadata.Systems);
         _writer.WriteArchetypes(metadata.Archetypes);
         _writer.WriteComponentTypes(metadata.ComponentTypes);
+        _writer.WritePhases(metadata.Phases);
     }
 
     /// <summary>

--- a/src/Typhon.Engine/Profiler/Exporters/TcpExporter.cs
+++ b/src/Typhon.Engine/Profiler/Exporters/TcpExporter.cs
@@ -503,6 +503,21 @@ public sealed class TcpExporter : ResourceNode, IProfilerExporter
             {
                 bw.Write(succ);
             }
+
+            WriteShortString(bw, sys.PhaseName ?? string.Empty);
+            bw.Write(sys.IsExclusivePhase);
+            WriteStringArray(bw, sys.Reads);
+            WriteStringArray(bw, sys.ReadsFresh);
+            WriteStringArray(bw, sys.ReadsSnapshot);
+            WriteStringArray(bw, sys.AdditionalReads);
+            WriteStringArray(bw, sys.Writes);
+            WriteStringArray(bw, sys.SideWrites);
+            WriteStringArray(bw, sys.WritesEvents);
+            WriteStringArray(bw, sys.ReadsEvents);
+            WriteStringArray(bw, sys.WritesResources);
+            WriteStringArray(bw, sys.ReadsResources);
+            WriteStringArray(bw, sys.ExplicitAfter);
+            WriteStringArray(bw, sys.ExplicitBefore);
         }
 
         // Archetype table
@@ -521,8 +536,29 @@ public sealed class TcpExporter : ResourceNode, IProfilerExporter
             WriteShortString(bw, c.Name);
         }
 
+        // Phases table (v6+) — RuntimeOptions.Phases names in declaration order.
+        bw.Write((ushort)_metadata.Phases.Length);
+        foreach (var p in _metadata.Phases)
+        {
+            WriteShortString(bw, p ?? string.Empty);
+        }
+
         bw.Flush();
         return ms.ToArray();
+    }
+
+    private static void WriteStringArray(BinaryWriter bw, string[] values)
+    {
+        if (values == null)
+        {
+            bw.Write((ushort)0);
+            return;
+        }
+        bw.Write((ushort)values.Length);
+        for (var i = 0; i < values.Length; i++)
+        {
+            WriteShortString(bw, values[i] ?? string.Empty);
+        }
     }
 
     /// <summary>

--- a/src/Typhon.Engine/Profiler/ProfilerSessionMetadata.cs
+++ b/src/Typhon.Engine/Profiler/ProfilerSessionMetadata.cs
@@ -44,8 +44,15 @@ public sealed class ProfilerSessionMetadata
     /// </summary>
     public long SamplingSessionStartQpc { get; }
 
+    /// <summary>
+    /// User-defined phase order from <c>RuntimeOptions.Phases</c> (RFC 07 §Q3). Surfaced through the trace v6 PhasesTable section and the
+    /// Workbench Data API <c>/topology</c> endpoint so DAG-view consumers can render phase columns. Empty array when the host runs without a
+    /// scheduler (e.g., standalone profiling) or with no phase declarations.
+    /// </summary>
+    public string[] Phases { get; }
+
     public ProfilerSessionMetadata(SystemDefinitionRecord[] systems, ArchetypeRecord[] archetypes, ComponentTypeRecord[] componentTypes, int workerCount,
-        float baseTickRate, long startTimestamp, long stopwatchFrequency, DateTime startedUtc, long samplingSessionStartQpc = 0)
+        float baseTickRate, long startTimestamp, long stopwatchFrequency, DateTime startedUtc, long samplingSessionStartQpc = 0, string[] phases = null)
     {
         Systems = systems ?? [];
         Archetypes = archetypes ?? [];
@@ -56,5 +63,6 @@ public sealed class ProfilerSessionMetadata
         StopwatchFrequency = stopwatchFrequency;
         StartedUtc = startedUtc;
         SamplingSessionStartQpc = samplingSessionStartQpc;
+        Phases = phases ?? [];
     }
 }

--- a/src/Typhon.Engine/Profiler/SystemDefinitionRecordBuilder.cs
+++ b/src/Typhon.Engine/Profiler/SystemDefinitionRecordBuilder.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using Typhon.Profiler;
+
+namespace Typhon.Engine.Profiler;
+
+/// <summary>
+/// Bridges <see cref="SystemDefinition"/> (engine) to <see cref="SystemDefinitionRecord"/> (wire format) — single source of truth so every host
+/// (AntHill, IOProfileRunner, future production embeddings) emits identical RFC 07 access declarations without copy-pasting projection code.
+/// </summary>
+/// <remarks>
+/// Component type names are taken from <see cref="Type.FullName"/> so the Workbench can correlate them against <see cref="ComponentTypeRecord.Name"/> entries
+/// (which use the same convention). Event-queue and resource names are passed through verbatim from <see cref="SystemAccessDescriptor"/>.
+/// </remarks>
+public static class SystemDefinitionRecordBuilder
+{
+    /// <summary>
+    /// Builds the wire records for an entire DAG. Predecessors are derived from each system's <see cref="SystemDefinition.Successors"/>
+    /// — the SOA the engine maintains internally — so callers don't need a separate predecessor map.
+    /// </summary>
+    public static SystemDefinitionRecord[] BuildAll(SystemDefinition[] systems)
+    {
+        ArgumentNullException.ThrowIfNull(systems);
+        if (systems.Length == 0)
+        {
+            return [];
+        }
+
+        // Invert successors → predecessors. O(systems + edges); cheap at session-start scale.
+        var predecessors = new List<ushort>[systems.Length];
+        for (var i = 0; i < systems.Length; i++)
+        {
+            predecessors[i] = [];
+        }
+        for (var i = 0; i < systems.Length; i++)
+        {
+            foreach (var succ in systems[i].Successors)
+            {
+                predecessors[succ].Add((ushort)i);
+            }
+        }
+
+        var records = new SystemDefinitionRecord[systems.Length];
+        for (var i = 0; i < systems.Length; i++)
+        {
+            records[i] = Build(systems[i], predecessors[i].ToArray());
+        }
+        return records;
+    }
+
+    /// <summary>
+    /// Builds a single wire record. Lower-level escape hatch — most callers should use <see cref="BuildAll"/>.
+    /// </summary>
+    public static SystemDefinitionRecord Build(SystemDefinition sys, ushort[] predecessors)
+    {
+        ArgumentNullException.ThrowIfNull(sys);
+
+        var succUshort = new ushort[sys.Successors.Length];
+        for (var s = 0; s < sys.Successors.Length; s++)
+        {
+            succUshort[s] = (ushort)sys.Successors[s];
+        }
+
+        var access = sys.Access;
+
+        return new SystemDefinitionRecord
+        {
+            Index = (ushort)sys.Index,
+            Name = sys.Name,
+            Type = (byte)sys.Type,
+            Priority = (byte)sys.Priority,
+            IsParallel = sys.IsParallelQuery,
+            TierFilter = (byte)sys.TierFilter,
+            Predecessors = predecessors ?? [],
+            Successors = succUshort,
+            PhaseName = sys.Phase.Name ?? string.Empty,
+            IsExclusivePhase = access.ExclusivePhase,
+            Reads = TypeNames(access.Reads),
+            ReadsFresh = TypeNames(access.ReadsFresh),
+            ReadsSnapshot = TypeNames(access.ReadsSnapshot),
+            AdditionalReads = TypeNames(access.AdditionalReads),
+            Writes = TypeNames(access.Writes),
+            SideWrites = TypeNames(access.SideWrites),
+            WritesEvents = QueueNames(access.WritesEvents),
+            ReadsEvents = QueueNames(access.ReadsEvents),
+            WritesResources = ToArray(access.WritesResources),
+            ReadsResources = ToArray(access.ReadsResources),
+            // RFC 07 §Q5 explicit edges aren't separately tracked on Access today (they fold into Successors at Build time);
+            // surface as empty until the descriptor exposes them. Workbench treats empty arrays as "no explicit hint".
+            ExplicitAfter = [],
+            ExplicitBefore = [],
+        };
+    }
+
+    private static string[] TypeNames(HashSet<Type> set)
+    {
+        if (set.Count == 0)
+        {
+            return [];
+        }
+        var arr = new string[set.Count];
+        var i = 0;
+        foreach (var t in set)
+        {
+            arr[i++] = t.FullName ?? t.Name;
+        }
+        return arr;
+    }
+
+    private static string[] QueueNames(HashSet<EventQueueBase> set)
+    {
+        if (set.Count == 0)
+        {
+            return [];
+        }
+        var arr = new string[set.Count];
+        var i = 0;
+        foreach (var q in set)
+        {
+            arr[i++] = q.Name;
+        }
+        return arr;
+    }
+
+    private static string[] ToArray(HashSet<string> set)
+    {
+        if (set.Count == 0)
+        {
+            return [];
+        }
+        var arr = new string[set.Count];
+        set.CopyTo(arr);
+        return arr;
+    }
+}

--- a/src/Typhon.Engine/Profiler/TyphonEvent.cs
+++ b/src/Typhon.Engine/Profiler/TyphonEvent.cs
@@ -3368,4 +3368,35 @@ public static partial class TyphonEvent
         ring.Publish();
     }
 
+    // ── Scheduler:Queue (kind 244 — #311) ───────────────────────────────────
+
+    /// <summary>
+    /// Emit <see cref="TraceEventKind.QueueTickEnd"/> — per-(tick, queue) rollup at end-of-tick. Captures the queue's
+    /// tick-local accumulators (peak depth, end-of-tick depth, overflow count, produced/consumed counts) for the
+    /// Workbench Data API <c>queue/&lt;name&gt;</c> tracks. Called from <c>DagScheduler.OnTickEnd</c> for each active
+    /// event queue; gated by <see cref="TelemetryConfig.SchedulerQueueTickEndActive"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void EmitQueueTickEnd(uint tickNumber, ushort queueId, uint peakDepth, uint endOfTickDepth, uint overflowCount, uint produced, uint consumed)
+    {
+        if (!TelemetryConfig.SchedulerQueueTickEndActive)
+        {
+            return;
+        }
+
+        var slotIdx = ThreadSlotRegistry.GetOrAssignSlot();
+        if (slotIdx < 0)
+        {
+            return;
+        }
+
+        var ring = ThreadSlotRegistry.GetSlot(slotIdx).Buffer;
+        if (ring == null || !ring.TryReserve(QueueTickEndCodec.Size, out var dst))
+        {
+            return;
+        }
+
+        QueueTickEndCodec.Write(dst, (byte)slotIdx, Stopwatch.GetTimestamp(), tickNumber, queueId, peakDepth, endOfTickDepth, overflowCount, produced, consumed);
+        ring.Publish();
+    }
 }

--- a/src/Typhon.Engine/Runtime/DagScheduler.Diagnostic.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.Diagnostic.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Text;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Hang-watchdog diagnostic. Renders the live per-system scheduler state as a human-readable
+/// table — predecessor count, ready flag, chunk progress, completion-skip reason. Consumers
+/// (the bridge / app code) call <see cref="DumpHangDiagnostic"/> when they suspect the tick
+/// loop is stuck so the engine state at the moment of the hang can be inspected without a
+/// debugger attach.
+/// </summary>
+public sealed partial class DagScheduler
+{
+    // Per-system "most recent exception" capture. Populated by the system-execution catch
+    // blocks via <see cref="CaptureSystemException"/>; surfaced in <see cref="DumpHangDiagnostic"/>
+    // so a hang caused by a runaway exception gives the user the actual stack trace, not just a
+    // "Skip=Exception" enum value. Lazy-allocated so DAG schedulers built without diagnostic
+    // need don't pay the per-system slot cost.
+    private Exception[] _lastSystemException;
+
+    internal void CaptureSystemException(int sysIdx, Exception ex)
+    {
+        var arr = _lastSystemException ??= new Exception[_systemCount];
+        if ((uint)sysIdx < (uint)arr.Length) arr[sysIdx] = ex;
+    }
+
+    /// <summary>
+    /// Returns a multi-line snapshot of the scheduler's current tick state, suitable for
+    /// logging when a tick fails to complete. Cheap enough to call ad-hoc — O(systemCount)
+    /// reads of internal counters.
+    /// </summary>
+    public string DumpHangDiagnostic()
+    {
+        var sb = new StringBuilder();
+        sb.Append("DagScheduler hang diagnostic — tick ").Append(_currentTickNumber)
+          .Append(", systemsRemaining=").Append(_systemsRemaining.Value)
+          .Append(", tickInProgress=").Append(_tickInProgress)
+          .AppendLine();
+
+        sb.AppendLine();
+        sb.AppendLine("Idx Phase                Name                            Pred  Deps  Ready  Chunks       Skip");
+        sb.AppendLine("─── ──────────────────── ─────────────────────────────── ───── ───── ────── ──────────── ────");
+
+        for (var i = 0; i < _systemCount; i++)
+        {
+            var sys = Systems[i];
+            var deps = _remainingDeps[i].Value;
+            var ready = _isReady[i].Value;
+            var nextChunk = _nextChunk[i].Value;
+            var totalChunks = sys.TotalChunks;
+            var skip = _currentTickSystemMetrics[i].SkipReason;
+            var phase = sys.Phase.Name.ToString();
+
+            sb.AppendFormat("{0,3} {1,-20} {2,-31} {3,5} {4,5} {5,6} {6,4}/{7,-5}    {8}",
+                i,
+                phase.Length > 20 ? phase[..20] : phase,
+                sys.Name.Length > 31 ? sys.Name[..31] : sys.Name,
+                sys.PredecessorCount,
+                deps,
+                ready == 1 ? "yes" : "no",
+                nextChunk,
+                totalChunks > 0 ? totalChunks.ToString() : "-",
+                skip == SkipReason.NotSkipped ? "" : skip.ToString());
+            sb.AppendLine();
+        }
+
+        // List the stuck-systems' predecessor chains — most useful when one system fails to
+        // decrement deps for some reason.
+        sb.AppendLine();
+        sb.AppendLine("Stuck systems (deps>0 OR ready==1 with chunks remaining):");
+        var anyStuck = false;
+        for (var i = 0; i < _systemCount; i++)
+        {
+            var deps = _remainingDeps[i].Value;
+            var ready = _isReady[i].Value;
+            var nextChunk = _nextChunk[i].Value;
+            var totalChunks = Systems[i].TotalChunks;
+            var stuck = deps > 0 || (ready == 1 && nextChunk < totalChunks);
+            if (!stuck) continue;
+            anyStuck = true;
+            sb.Append("  ").Append(Systems[i].Name).Append("  pred=[");
+            var first = true;
+            for (var j = 0; j < _systemCount; j++)
+            {
+                foreach (var s in Systems[j].Successors)
+                {
+                    if (s != i) continue;
+                    if (!first) sb.Append(", ");
+                    first = false;
+                    sb.Append(Systems[j].Name).Append(_currentTickSystemMetrics[j].SkipReason == SkipReason.NotSkipped && _remainingDeps[j].Value == 0 && _isReady[j].Value == 0 ? "(done)" : "(not done)");
+                }
+            }
+            sb.Append("]").AppendLine();
+        }
+        if (!anyStuck)
+        {
+            sb.AppendLine("  (none — every system either completed or is unblocked but waiting for a worker)");
+        }
+
+        // Surface any captured exceptions so a hang caused by a system throwing surfaces the
+        // stack trace inline — without this the user would have to check the logger output
+        // (which may be filtered) to know what went wrong.
+        if (_lastSystemException != null)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Captured exceptions (most recent per system):");
+            var anyEx = false;
+            for (var i = 0; i < _systemCount; i++)
+            {
+                var ex = _lastSystemException[i];
+                if (ex == null) continue;
+                anyEx = true;
+                sb.Append("  System ").Append(i).Append(" '").Append(Systems[i].Name).Append("':").AppendLine();
+                sb.AppendLine(ex.ToString());
+            }
+            if (!anyEx)
+            {
+                sb.AppendLine("  (no exceptions captured)");
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Typhon.Engine/Runtime/DagScheduler.Telemetry.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.Telemetry.cs
@@ -83,11 +83,16 @@ public sealed partial class DagScheduler
             }
         }
 
-        // Capture event queue depth for telemetry and overload detection
+        // Capture event queue depth for telemetry and overload detection. Also emit per-(tick, queue)
+        // QueueTickEnd records (#311) so the cache builder can fold them into the v12 QueueTickSummaries
+        // section. Reading the accumulators here happens BEFORE the next tick's Reset() clears them.
         var queueDepth = 0;
         for (var i = 0; i < _eventQueues.Length; i++)
         {
-            queueDepth += _eventQueues[i].Count;
+            var q = _eventQueues[i];
+            var endOfTickDepth = (uint)q.Count;
+            queueDepth += (int)endOfTickDepth;
+            Profiler.TyphonEvent.EmitQueueTickEnd((uint)_currentTickNumber, q.QueueId, q.PeakDepth, endOfTickDepth, q.OverflowCount, q.Produced, q.Consumed);
         }
 
         // Update overload state machine — uses the EFFECTIVE ratio (vs current multiplier-adjusted target) so the detector can recognise headroom at high

--- a/src/Typhon.Engine/Runtime/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.cs
@@ -267,6 +267,12 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         _systemCount = systems.Length;
         _options = options;
         _eventQueues = eventQueues ?? [];
+        // Assign stable queue IDs (#311) so the per-queue telemetry path can carry a small u16 instead of the queue's name on the wire.
+        // QueueId == array index here; the cache builder writes a parallel `QueueNameTable` section so consumers can map index → name.
+        for (var qi = 0; qi < _eventQueues.Length; qi++)
+        {
+            _eventQueues[qi].QueueId = (ushort)qi;
+        }
         _logger = logger ?? NullLogger.Instance;
         _workerCount = options.ResolveWorkerCount();
 

--- a/src/Typhon.Engine/Runtime/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/DagScheduler.cs
@@ -651,7 +651,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                                 chunkFailed = true;
                                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                                 _systemFailed[sysIdx] = true;
-                                LogSystemException(sysIdx, sys.Name, ex);
+                                LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
                                 foreach (var succ in sys.Successors)
                                 {
                                     _systemFailed[succ] = true;
@@ -683,7 +683,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                         {
                             _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                             _systemFailed[sysIdx] = true;
-                            LogSystemException(sysIdx, sys.Name, ex);
+                            LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
                             foreach (var succ in sys.Successors)
                             {
                                 _systemFailed[succ] = true;
@@ -709,7 +709,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                         success = false;
                         _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                         _systemFailed[sysIdx] = true;
-                        LogSystemException(sysIdx, sys.Name, ex);
+                        LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
                         // Propagate failure to successors
                         foreach (var succ in sys.Successors)
                         {
@@ -971,7 +971,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             success = false;
             _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
             _systemFailed[sysIdx] = true;
-            LogSystemException(sysIdx, Systems[sysIdx].Name, ex);
+            LogSystemException(sysIdx, Systems[sysIdx].Name, ex); CaptureSystemException(sysIdx, ex);
         }
         finally
         {
@@ -1000,10 +1000,18 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
         while (true)
         {
-            // Early-exit: stop grabbing chunks if a prior chunk already failed — remaining work would be discarded
+            // Failure-drain: a prior chunk threw. We must NOT just break — `FindReadySystem`
+            // still returns this sysIdx as long as `_nextChunk < TotalChunks` (chunks unclaimed),
+            // so workers would loop into `ProcessPipeline`, hit this branch, break, and spin —
+            // a full-CPU wedge that never fires `OnSystemComplete` and never dispatches successors.
+            // Instead, claim the remaining chunks via `_nextChunk` (advancing it past TotalChunks
+            // closes the FindReadySystem gate) and decrement `_remainingChunks` for each so the
+            // last decrementer can fire `OnSystemComplete`. The chunks themselves stay unrun —
+            // remaining work is discarded as before.
             if (_systemFailed[sysIdx])
             {
-                break;
+                DrainFailedSystemChunks(sysIdx, workerId, trackUtilization);
+                return;
             }
 
             var chunk = Interlocked.Increment(ref _nextChunk[sysIdx].Value) - 1;
@@ -1029,7 +1037,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             {
                 _systemFailed[sysIdx] = true;
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
-                LogSystemException(sysIdx, sys.Name, ex);
+                LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
             }
             finally
             {
@@ -1055,6 +1063,48 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         }
     }
 
+    /// <summary>
+    /// Drain mode for a failed multi-chunk system. Claims every chunk that was never grabbed
+    /// (advances <c>_nextChunk</c> past <c>TotalChunks</c> via repeated <c>Increment</c>), and
+    /// decrements <c>_remainingChunks</c> once per claim — without running the chunk body. The
+    /// last decrementer (whichever worker happens to drive remaining to zero, possibly the same
+    /// worker that hit the original exception) fires <see cref="OnSystemComplete"/> so successors
+    /// get dispatched and the tick can finish.
+    /// </summary>
+    /// <remarks>
+    /// Why drain instead of break-and-bail: <see cref="FindReadySystem"/> uses
+    /// <c>_nextChunk[i].Value &lt; TotalChunks</c> as the "still has work" signal. Without
+    /// advancing <c>_nextChunk</c>, every worker that picks this sysIdx after the failure walks
+    /// into <see cref="ProcessPipeline"/> / <see cref="ProcessParallelQuery"/>, sees
+    /// <c>_systemFailed</c>, breaks, and immediately re-enters the worker loop — a tight
+    /// full-CPU spin that never fires <c>OnSystemComplete</c>. Multiple workers can race here
+    /// concurrently; <c>Interlocked.Increment</c> + <c>Interlocked.Decrement</c> give us a clean
+    /// claim/decrement protocol where exactly one worker observes <c>remaining == 0</c>.
+    /// </remarks>
+    private void DrainFailedSystemChunks(int sysIdx, int workerId, bool trackUtilization)
+    {
+        var totalChunks = Systems[sysIdx].TotalChunks;
+        while (true)
+        {
+            var chunk = Interlocked.Increment(ref _nextChunk[sysIdx].Value) - 1;
+            if (chunk >= totalChunks)
+            {
+                // No more chunks to claim. Either we already drove _remainingChunks to zero
+                // (handled below) or another worker did — either way, this worker's job is done.
+                return;
+            }
+            // Successfully claimed `chunk` without running it. Decrement remaining so the last
+            // claim fires OnSystemComplete and unblocks successor dispatch.
+            var remaining = Interlocked.Decrement(ref _remainingChunks[sysIdx].Value);
+            if (remaining == 0)
+            {
+                RecordSystemDone(sysIdx, Stopwatch.GetTimestamp());
+                OnSystemComplete(sysIdx, workerId, trackUtilization);
+                return;
+            }
+        }
+    }
+
     // ═══════════════════════════════════════════════════════════════
     // Parallel QuerySystem dispatch
     // ═══════════════════════════════════════════════════════════════
@@ -1068,10 +1118,13 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         var sys = Systems[sysIdx];
         while (true)
         {
-            // Early-exit: stop grabbing chunks if a prior chunk already failed — remaining work would be discarded
+            // See `ProcessPipeline` for the full rationale — same wedge applies here. Drain the
+            // remaining chunks so `FindReadySystem` stops returning this sysIdx and the last
+            // decrementer fires `OnSystemComplete` to dispatch successors.
             if (_systemFailed[sysIdx])
             {
-                break;
+                DrainFailedSystemChunks(sysIdx, workerId, trackUtilization);
+                return;
             }
 
             var chunk = Interlocked.Increment(ref _nextChunk[sysIdx].Value) - 1;
@@ -1097,7 +1150,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             {
                 _systemFailed[sysIdx] = true;
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
-                LogSystemException(sysIdx, sys.Name, ex);
+                LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
             }
             finally
             {
@@ -1273,7 +1326,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             success = false;
             _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
             _systemFailed[sysIdx] = true;
-            LogSystemException(sysIdx, Systems[sysIdx].Name, ex);
+            LogSystemException(sysIdx, Systems[sysIdx].Name, ex); CaptureSystemException(sysIdx, ex);
         }
         finally
         {

--- a/src/Typhon.Engine/Runtime/EventQueue.cs
+++ b/src/Typhon.Engine/Runtime/EventQueue.cs
@@ -6,6 +6,11 @@ namespace Typhon.Engine;
 /// <summary>
 /// Non-generic base class for typed event queues. Allows the scheduler to reset all queues at tick start without knowing their generic type.
 /// </summary>
+/// <remarks>
+/// Per-tick telemetry accumulators (peak depth, overflow count, produced/consumed counts) live here so the scheduler can read them without
+/// caring about <typeparamref name="T"/>. The accumulators are reset at tick start by <see cref="Reset"/>; readers that want the previous
+/// tick's data must read before <c>Reset</c> runs (the scheduler reads them in its end-of-tick QueueTickEnd emission, then resets).
+/// </remarks>
 [PublicAPI]
 public abstract class EventQueueBase
 {
@@ -18,8 +23,29 @@ public abstract class EventQueueBase
     /// <summary>True if the queue has no items.</summary>
     public abstract bool IsEmpty { get; }
 
-    /// <summary>Resets the queue to empty. Called at the start of each tick.</summary>
+    /// <summary>Resets the queue to empty. Called at the start of each tick. Also clears the per-tick telemetry accumulators.</summary>
     public abstract void Reset();
+
+    // ─── Per-tick telemetry accumulators (#311) ─────────────────────────────────
+
+    /// <summary>Maximum number of items observed in the queue at any point during the current tick (after each <c>Push</c>).</summary>
+    public uint PeakDepth { get; protected set; }
+
+    /// <summary>Number of overflow events during the current tick — each is a <c>Push</c> against a full queue.</summary>
+    public uint OverflowCount { get; protected set; }
+
+    /// <summary>Number of <c>Push</c> calls that succeeded during the current tick.</summary>
+    public uint Produced { get; protected set; }
+
+    /// <summary>Total items returned by <c>Drain</c> calls during the current tick.</summary>
+    public uint Consumed { get; protected set; }
+
+    /// <summary>
+    /// Stable identifier assigned by the runtime at registration. Used as <see cref="QueueTickSummary.QueueId"/> and as the index into
+    /// the <see cref="CacheSectionId.QueueNameTable"/>. Set by the runtime when the queue is registered with the scheduler;
+    /// 0xFFFF means "unassigned" (queue created outside a scheduler context — telemetry not emitted for it).
+    /// </summary>
+    public ushort QueueId { get; internal set; } = ushort.MaxValue;
 }
 
 /// <summary>
@@ -80,10 +106,16 @@ public sealed class EventQueue<T> : EventQueueBase
     {
         if (_count >= _capacity)
         {
+            OverflowCount++;
             throw new InvalidOperationException($"Event queue '{Name}' is full (capacity: {_capacity}).");
         }
 
         _buffer[_count++] = item;
+        Produced++;
+        if ((uint)_count > PeakDepth)
+        {
+            PeakDepth = (uint)_count;
+        }
     }
 
     /// <summary>
@@ -109,6 +141,7 @@ public sealed class EventQueue<T> : EventQueueBase
             Array.Clear(_buffer, 0, count);
         }
 
+        Consumed += (uint)count;
         return count;
     }
 
@@ -126,5 +159,10 @@ public sealed class EventQueue<T> : EventQueueBase
         }
 
         _count = 0;
+        // Clear per-tick telemetry accumulators (#311). Scheduler reads them in OnTickEnd before Reset() is called at the next tick start.
+        PeakDepth = 0;
+        OverflowCount = 0;
+        Produced = 0;
+        Consumed = 0;
     }
 }

--- a/src/Typhon.Engine/Runtime/SystemAccessDescriptor.cs
+++ b/src/Typhon.Engine/Runtime/SystemAccessDescriptor.cs
@@ -9,9 +9,10 @@ namespace Typhon.Engine;
 /// </summary>
 /// <remarks>
 /// Unit 2 of the auto-DAG migration: storage only. Conflict detection (W×W errors, R×W-plain errors, derived edges) lands in Unit 3. All sets default to
-/// empty; entries are deduped automatically by the underlying <see cref="HashSet{T}"/>.
+/// empty; entries are deduped automatically by the underlying <see cref="HashSet{T}"/>. Public so tooling (Workbench Schema Inspector, Profiler topology
+/// surfacing — RFC 07 Unit 6) can project the declarations onto its DTO surface without bouncing through reflection.
 /// </remarks>
-internal sealed class SystemAccessDescriptor
+public sealed class SystemAccessDescriptor
 {
     /// <summary>Component types declared with <c>b.Reads&lt;T&gt;()</c>. Ambiguous about same-tick freshness — Unit 3 errors if a same-phase writer of T exists.</summary>
     public readonly HashSet<Type> Reads = [];

--- a/src/Typhon.Engine/Runtime/SystemDefinition.cs
+++ b/src/Typhon.Engine/Runtime/SystemDefinition.cs
@@ -36,9 +36,10 @@ public sealed class SystemDefinition
 
     /// <summary>
     /// Declared read/write access for this system (RFC 07 — Unit 2). Populated from <see cref="SystemBuilder"/> declaration methods.
-    /// Storage only at the Unit 2 stage — Unit 3 will consume this for conflict detection and DAG-edge derivation.
+    /// Storage only at the Unit 2 stage — Unit 3 consumes this for conflict detection and DAG-edge derivation.
+    /// Public read so tooling (Workbench RFC 07 Unit 6 surfacing) can project declarations into wire records; only the engine sets it.
     /// </summary>
-    internal SystemAccessDescriptor Access { get; set; } = new();
+    public SystemAccessDescriptor Access { get; internal set; } = new();
 
     // ═══════════════════════════════════════════════════════════════
     // Execution delegates

--- a/src/Typhon.Engine/Runtime/TyphonRuntime.cs
+++ b/src/Typhon.Engine/Runtime/TyphonRuntime.cs
@@ -125,6 +125,23 @@ public sealed partial class TyphonRuntime : IDisposable
     /// <summary>Static DAG system definitions (name, type, priority, dependencies).</summary>
     public SystemDefinition[] Systems => Scheduler.Systems;
 
+    /// <summary>
+    /// Phase order from <see cref="RuntimeOptions.Phases"/>. Returned as a fresh string array so
+    /// callers (notably profiler exporters that ship the list to the Workbench) can hand it
+    /// straight to <c>ProfilerSessionMetadata</c> without having to know about the
+    /// <see cref="Phase"/> struct or the underlying options object.
+    /// </summary>
+    public string[] PhaseNames
+    {
+        get
+        {
+            var phases = _options.Phases;
+            var names = new string[phases.Length];
+            for (var i = 0; i < phases.Length; i++) names[i] = phases[i].Name.ToString();
+            return names;
+        }
+    }
+
     /// <summary>Fires when overload reaches <see cref="OverloadLevel.PlayerShedding"/>. Game code decides what to do (migrate, disconnect, split).</summary>
     public event Action<TyphonRuntime> OnCriticalOverload;
 

--- a/src/Typhon.Profiler/AppendOnlyChunkSink.cs
+++ b/src/Typhon.Profiler/AppendOnlyChunkSink.cs
@@ -83,7 +83,11 @@ public sealed class AppendOnlyChunkSink : ICacheChunkSink
         IReadOnlyList<ChunkManifestEntry> chunkManifest,
         IReadOnlyDictionary<int, string> spanNames,
         ReadOnlySpan<byte> sourceMetadataBytes,
-        in CacheHeader headerTemplate)
+        in CacheHeader headerTemplate,
+        IReadOnlyList<SystemTickSummary> systemTickSummaries,
+        IReadOnlyList<QueueTickSummary> queueTickSummaries,
+        IReadOnlyList<PostTickSummary> postTickSummaries,
+        IReadOnlyDictionary<ushort, string> queueIdToName)
     {
         throw new NotSupportedException("AppendOnlyChunkSink does not support a trailer (live mode keeps metadata in memory).");
     }

--- a/src/Typhon.Profiler/FileCacheSink.cs
+++ b/src/Typhon.Profiler/FileCacheSink.cs
@@ -51,7 +51,11 @@ public sealed class FileCacheSink : ICacheChunkSink
         IReadOnlyList<ChunkManifestEntry> chunkManifest,
         IReadOnlyDictionary<int, string> spanNames,
         ReadOnlySpan<byte> sourceMetadataBytes,
-        in CacheHeader headerTemplate)
+        in CacheHeader headerTemplate,
+        IReadOnlyList<SystemTickSummary> systemTickSummaries,
+        IReadOnlyList<QueueTickSummary> queueTickSummaries,
+        IReadOnlyList<PostTickSummary> postTickSummaries,
+        IReadOnlyDictionary<ushort, string> queueIdToName)
     {
         if (_trailerWritten)
         {
@@ -67,16 +71,16 @@ public sealed class FileCacheSink : ICacheChunkSink
 
         _writer.BeginSection(CacheSectionId.TickSummaries);
         var summaryArr = ToArray(tickSummaries);
-        _writer.WriteArray<TickSummary>(summaryArr);
+        _writer.WriteArray(summaryArr);
 
         _writer.BeginSection(CacheSectionId.GlobalMetrics);
         _writer.WriteStruct(globalMetrics);
         var aggArr = ToArray(systemAggregates);
-        _writer.WriteArray<SystemAggregateDuration>(aggArr);
+        _writer.WriteArray(aggArr);
 
         _writer.BeginSection(CacheSectionId.ChunkManifest);
         var manifestArr = ToArray(chunkManifest);
-        _writer.WriteArray<ChunkManifestEntry>(manifestArr);
+        _writer.WriteArray(manifestArr);
 
         _writer.BeginSection(CacheSectionId.SpanNameTable);
         _writer.WriteSpanNameTable(spanNames);
@@ -86,6 +90,19 @@ public sealed class FileCacheSink : ICacheChunkSink
             _writer.BeginSection(CacheSectionId.SourceMetadata);
             _writer.Write(sourceMetadataBytes);
         }
+
+        // v12 sections (#311) — always emit, even if empty, so v12 readers can rely on their presence.
+        _writer.BeginSection(CacheSectionId.SystemTickSummaries);
+        _writer.WriteArray(ToArray(systemTickSummaries));
+
+        _writer.BeginSection(CacheSectionId.QueueTickSummaries);
+        _writer.WriteArray(ToArray(queueTickSummaries));
+
+        _writer.BeginSection(CacheSectionId.PostTickSummaries);
+        _writer.WriteArray(ToArray(postTickSummaries));
+
+        _writer.BeginSection(CacheSectionId.QueueNameTable);
+        _writer.WriteQueueNameTable(queueIdToName);
 
         _writer.Finalize(headerTemplate);
         _trailerWritten = true;

--- a/src/Typhon.Profiler/ICacheChunkSink.cs
+++ b/src/Typhon.Profiler/ICacheChunkSink.cs
@@ -31,12 +31,60 @@ public interface ICacheChunkSink : IDisposable
     /// Write trailer sections + finalize the cache header. Replay sinks (<see cref="FileCacheSink"/>) implement this; live sinks throw.
     /// Idempotent guard not required — builder calls this at most once on dispose.
     /// </summary>
+    /// <param name="tickSummaries">
+    /// Per-tick overview rows (one entry per tick processed). Written to the <see cref="CacheSectionId.TickSummaries"/> section.
+    /// Order is the order in which the builder accumulated them — typically tick-number ascending; the cache reader does not
+    /// re-sort.
+    /// </param>
+    /// <param name="globalMetrics">
+    /// Session-wide aggregates (start/end µs, max/p95 tick durations, total events, total ticks, per-system invocation counts).
+    /// Computed once at finalize and written to the <see cref="CacheSectionId.GlobalMetrics"/> section.
+    /// </param>
+    /// <param name="systemAggregates">
+    /// Per-system invocation count + cumulative duration across the whole session. Companion to
+    /// <paramref name="globalMetrics"/>; written into the <see cref="CacheSectionId.GlobalMetrics"/> section as a fixed-size table.
+    /// </param>
+    /// <param name="chunkManifest">
+    /// Byte-offset index into the trailing <see cref="CacheSectionId.FoldedChunkData"/> blob — one entry per chunk previously
+    /// produced by <see cref="AppendChunk"/>. Drives random-access tick-range fetches at read time.
+    /// </param>
+    /// <param name="spanNames">
+    /// SpanId → display-name lookup table for trace events that carry a <c>SpanId</c> reference. Written to the
+    /// <see cref="CacheSectionId.SpanNameTable"/> section. Empty dictionary is valid.
+    /// </param>
     /// <param name="sourceMetadataBytes">
     /// Optional verbatim source metadata (header + system / archetype / component-type tables, in <c>TraceFileWriter</c> wire format). When
     /// non-empty, the sink emits a <see cref="CacheSectionId.SourceMetadata"/> section; the caller must set
     /// <see cref="CacheHeaderFlags.IsSelfContained"/> on <paramref name="headerTemplate"/> so loaders project metadata from these bytes
     /// instead of opening a sibling source file. Pass <see cref="ReadOnlySpan{T}.Empty"/> for source-derived caches.
     /// </param>
+    /// <param name="headerTemplate">
+    /// Cache-file header to finalize. The sink fills in section-table offsets / lengths and writes the result at the file head;
+    /// caller-supplied fields (magic, version, chunker version, identifier, flags) are preserved verbatim.
+    /// </param>
+    /// <param name="systemTickSummaries">
+    /// v12 (#311). Per-tick per-system rollup rows (duration, ready/start/end µs, entities processed, etc.) backing the Workbench
+    /// Data API's <c>system/&lt;name&gt;</c> tracks. Written to the <see cref="CacheSectionId.SystemTickSummaries"/> section.
+    /// Empty list is valid for v11-derived caches and produces an empty section that readers tolerate.
+    /// </param>
+    /// <param name="queueTickSummaries">
+    /// v12 (#311). Per-tick per-event-queue rollup rows (peak depth, end-of-tick depth, overflow count, produced/consumed)
+    /// backing the <c>queue/&lt;name&gt;</c> tracks. Written to the <see cref="CacheSectionId.QueueTickSummaries"/> section.
+    /// Empty list is valid for v11-derived caches.
+    /// </param>
+    /// <param name="postTickSummaries">
+    /// v12 (#311). Per-tick post-serial-block rollup rows (WAL flush, write-tick-fence, subscription output, etc.) backing the
+    /// <c>posttick/&lt;phase&gt;</c> tracks. Written to the <see cref="CacheSectionId.PostTickSummaries"/> section. Empty list
+    /// is valid for v11-derived caches.
+    /// </param>
+    /// <param name="queueIdToName">
+    /// v12 (#311). QueueId → display-name lookup for the entries in <paramref name="queueTickSummaries"/>. Written to the
+    /// <see cref="CacheSectionId.QueueNameTable"/> section. Empty dictionary is valid.
+    /// </param>
+    /// <exception cref="NotSupportedException">
+    /// Thrown by live sinks (e.g. <c>AppendOnlyChunkSink</c>) — see <see cref="SupportsTrailer"/>. Callers should gate on that
+    /// flag rather than catching the exception.
+    /// </exception>
     void WriteTrailer(
         IReadOnlyList<TickSummary> tickSummaries,
         in GlobalMetricsFixed globalMetrics,
@@ -44,5 +92,10 @@ public interface ICacheChunkSink : IDisposable
         IReadOnlyList<ChunkManifestEntry> chunkManifest,
         IReadOnlyDictionary<int, string> spanNames,
         ReadOnlySpan<byte> sourceMetadataBytes,
-        in CacheHeader headerTemplate);
+        in CacheHeader headerTemplate,
+        // v12 (#311) — Workbench Data API per-system / per-queue / post-tick rollups. May be empty for v11-derived caches.
+        IReadOnlyList<SystemTickSummary> systemTickSummaries,
+        IReadOnlyList<QueueTickSummary> queueTickSummaries,
+        IReadOnlyList<PostTickSummary> postTickSummaries,
+        IReadOnlyDictionary<ushort, string> queueIdToName);
 }

--- a/src/Typhon.Profiler/IncrementalCacheBuilder.cs
+++ b/src/Typhon.Profiler/IncrementalCacheBuilder.cs
@@ -51,6 +51,46 @@ public sealed class IncrementalCacheBuilder : IDisposable
     private readonly Dictionary<int, (uint InvocationCount, double TotalDurationUs)> _systemAggregates = new();
     private readonly List<ChunkManifestEntry> _chunkManifest = new(capacity: 256);
 
+    // ── v12 accumulators (#311) ─────────────────────────────────────────────
+    // Per-tick scratch state for SystemTickSummary[]. Keyed by systemIndex; flushed at FinalizeCurrentTick().
+    private readonly Dictionary<ushort, SystemTickAccumulator> _currentTickSystems = new();
+    private readonly List<SystemTickSummary> _systemTickSummaries = new(capacity: 4096);
+    // Per-tick scratch state for QueueTickSummary[]. Keyed by queueId; flushed at tick-finalize.
+    private readonly Dictionary<ushort, QueueTickEndData> _currentTickQueues = new();
+    private readonly List<QueueTickSummary> _queueTickSummaries = new(capacity: 1024);
+    private readonly Dictionary<ushort, string> _queueIdToName = new();
+    // Per-tick scratch state for PostTickSummary. One row per tick; mutated as each RuntimePhaseSpan arrives.
+    private PostTickSummary _currentTickPostMarkers;
+    private bool _currentTickPostMarkersHasData;
+    private readonly List<PostTickSummary> _postTickSummaries = new(capacity: 4096);
+
+    /// <summary>Per-system per-tick scratch row, accumulated as <c>SystemReady</c> / <c>SystemSkipped</c> / <c>SchedulerChunk</c> events arrive.</summary>
+    private struct SystemTickAccumulator
+    {
+        public long ReadyTs;          // Stopwatch ticks (0 = unobserved)
+        public long FirstChunkStartTs; // 0 = no chunk yet
+        public long LastChunkEndTs;    // 0 = no chunk yet
+        public uint EntitiesProcessed;
+        public ushort ChunksProcessed;
+        public uint WorkersTouchedMask; // bit per threadSlot, capped at 32 (good enough for "distinct workers" diagnostic)
+        public byte SkipReasonCode;     // 0 = NotSkipped
+    }
+
+    /// <summary>Read-only view of finalized per-(tick, system) rows.</summary>
+    public IReadOnlyList<SystemTickSummary> SystemTickSummaries => _systemTickSummaries;
+
+    /// <summary>Read-only view of finalized per-(tick, queue) rows.</summary>
+    public IReadOnlyList<QueueTickSummary> QueueTickSummaries => _queueTickSummaries;
+
+    /// <summary>Read-only view of finalized per-tick post-tick markers.</summary>
+    public IReadOnlyList<PostTickSummary> PostTickSummaries => _postTickSummaries;
+
+    /// <summary>Queue-id → display-name map captured from the engine's Init metadata (set externally by the live / replay paths).</summary>
+    public IReadOnlyDictionary<ushort, string> QueueIdToName => _queueIdToName;
+
+    /// <summary>Register a queue's display name. Called by live / replay paths after parsing the engine Init metadata.</summary>
+    public void RegisterQueueName(ushort queueId, string name) => _queueIdToName[queueId] = name ?? string.Empty;
+
     private bool _tickActive;
     private readonly MemoryStream _preTickBuffer = new(capacity: 4096);
     private uint _preTickEventCount;
@@ -353,7 +393,10 @@ public sealed class IncrementalCacheBuilder : IDisposable
                     // Allow it to update (it nudges DurationUs to include post-TickEnd setup time), then seal so
                     // nothing after the wait-start is counted.
                     if (startTs > _currentTickLastTs)
+                    {
                         _currentTickLastTs = startTs;
+                    }
+
                     _tickEndSeen = true;
                 }
                 else if (!_tickEndSeen && startTs > _currentTickLastTs)
@@ -398,6 +441,9 @@ public sealed class IncrementalCacheBuilder : IDisposable
                     _currentConsecutiveOverrun = BinaryPrimitives.ReadUInt16LittleEndian(records[(p + 12)..]);
                     _currentConsecutiveUnderrun = BinaryPrimitives.ReadUInt16LittleEndian(records[(p + 14)..]);
                 }
+
+                // ── v12 fold (#311) ─────────────────────────────────────────────────
+                FoldV12Event(kind, records, pos, size, startTs);
 
                 if (IsCompletionKind(kind) && size >= CommonHeaderSize + SpanHeaderExtSize)
                 {
@@ -451,8 +497,16 @@ public sealed class IncrementalCacheBuilder : IDisposable
                 if (_preTickBuffer.Length + size <= PreTickBufferCap)
                 {
                     _preTickBuffer.Write(records.Slice(pos, size));
-                    if (startTs < _preTickFirstTs) _preTickFirstTs = startTs;
-                    if (startTs > _preTickLastTs) _preTickLastTs = startTs;
+                    if (startTs < _preTickFirstTs)
+                    {
+                        _preTickFirstTs = startTs;
+                    }
+
+                    if (startTs > _preTickLastTs)
+                    {
+                        _preTickLastTs = startTs;
+                    }
+
                     _preTickEventCount++;
                 }
                 else
@@ -548,29 +602,37 @@ public sealed class IncrementalCacheBuilder : IDisposable
         }
         _disposed = true;
 
-        FinalizePendingState();
-
-        if (_sink.SupportsTrailer)
+        try
         {
-            // Source-derived close path: no embedded SourceMetadata, no IsSelfContained flag, fingerprint from constructor.
-            // (The live save-as-replay flow does NOT go through this; it builds + writes its own trailer against a fresh sink with a
-            //  RELOCATED manifest — see AttachSessionRuntime.SaveSessionCore.)
-            var metrics = BuildGlobalMetricsSnapshot();
-            var aggArr = GetSystemAggregatesSnapshot();
-            var cacheHeader = new CacheHeader
+            FinalizePendingState();
+
+            if (_sink.SupportsTrailer)
             {
-                Flags = 0,
-                SourceVersion = _header.Version,
-                ChunkerVersion = TraceFileCacheConstants.CurrentChunkerVersion,
-                CreatedUtcTicks = DateTime.UtcNow.Ticks,
-            };
-            CacheHeader.SetIdentifier(ref cacheHeader, _fingerprint);
-            _sink.WriteTrailer(_tickSummaries, metrics, aggArr, _chunkManifest, _spanNames, sourceMetadataBytes: default, cacheHeader);
+                // Source-derived close path: no embedded SourceMetadata, no IsSelfContained flag, fingerprint from constructor.
+                // (The live save-as-replay flow does NOT go through this; it builds + writes its own trailer against a fresh sink with a
+                //  RELOCATED manifest — see AttachSessionRuntime.SaveSessionCore.)
+                var metrics = BuildGlobalMetricsSnapshot();
+                var aggArr = GetSystemAggregatesSnapshot();
+                var cacheHeader = new CacheHeader
+                {
+                    Flags = 0,
+                    SourceVersion = _header.Version,
+                    ChunkerVersion = TraceFileCacheConstants.CurrentChunkerVersion,
+                    CreatedUtcTicks = DateTime.UtcNow.Ticks,
+                };
+                CacheHeader.SetIdentifier(ref cacheHeader, _fingerprint);
+                _sink.WriteTrailer(_tickSummaries, metrics, aggArr, _chunkManifest, _spanNames, default, cacheHeader,
+                    _systemTickSummaries, _queueTickSummaries, _postTickSummaries, _queueIdToName);
+            }
         }
-
-        if (_ownsSink)
+        finally
         {
-            _sink.Dispose();
+            // Always release the sink even if trailer-write throws — otherwise the OS file handle leaks and the file stays
+            // locked, masking the real exception with a downstream "file in use" error in the test harness or save flow.
+            if (_ownsSink)
+            {
+                _sink.Dispose();
+            }
         }
     }
 
@@ -619,6 +681,7 @@ public sealed class IncrementalCacheBuilder : IDisposable
         reader.ReadSystemDefinitions();
         reader.ReadArchetypes();
         reader.ReadComponentTypes();
+        reader.ReadPhases(); // v6+ section; reader returns empty for v5 traces without consuming bytes.
 
         var profilerHeader = new ProfilerHeader
         {
@@ -722,7 +785,11 @@ public sealed class IncrementalCacheBuilder : IDisposable
         }
 
         var durationUs = (_currentTickLastTs - _currentTickFirstTs) / _ticksPerUs;
-        if (durationUs < 0) durationUs = 0;
+        if (durationUs < 0)
+        {
+            durationUs = 0;
+        }
+
         var maxSysUs = _currentMaxSystemDurationTicks / _ticksPerUs;
         var startUs = _currentTickFirstTs / _ticksPerUs;
 
@@ -755,7 +822,254 @@ public sealed class IncrementalCacheBuilder : IDisposable
             _globalMaxSystemDurationUs = maxSysUs;
         }
 
+        // v12 (#311): flush per-tick scratch state into the dense rollup lists.
+        FlushV12CurrentTick();
+
         TickFinalized?.Invoke(summary);
+    }
+
+    /// <summary>
+    /// Flush per-tick v12 scratch state — system rows, queue rows, post-tick row — into the cumulative section lists.
+    /// Called from <see cref="FinalizeCurrentTick"/> immediately after the v11 <see cref="TickSummary"/> entry is appended, so the per-tick rows appear in
+    /// tick-monotonic order. Called even when none of the v12-specific events arrived in this tick (e.g. legacy v11 traces replayed against a v12 reader): the
+    /// system/queue/post-tick rows are simply empty for that tick and consumers see zero per-tick records.
+    /// </summary>
+    private void FlushV12CurrentTick()
+    {
+        var ticksPerUs = _ticksPerUs;
+        var tickStartTs = _currentTickFirstTs;
+        var tickNumber = _currentTickNumber;
+
+        // Per-system rows. Order by SystemIndex for deterministic output (binary-search friendly).
+        if (_currentTickSystems.Count > 0)
+        {
+            // Reusable temp list — small (≤ N systems) — populated, sorted, appended.
+            var sysIdxBuf = new ushort[_currentTickSystems.Count];
+            var sk = 0;
+            foreach (var key in _currentTickSystems.Keys)
+            {
+                sysIdxBuf[sk++] = key;
+            }
+
+            Array.Sort(sysIdxBuf);
+            for (var i = 0; i < sysIdxBuf.Length; i++)
+            {
+                var sysIdx = sysIdxBuf[i];
+                var acc = _currentTickSystems[sysIdx];
+
+                var skipped = acc.SkipReasonCode != 0;
+                var startUs = (acc.FirstChunkStartTs > 0) ? (acc.FirstChunkStartTs - tickStartTs) / ticksPerUs : 0;
+                var endUs = (acc.LastChunkEndTs > 0) ? (acc.LastChunkEndTs - tickStartTs) / ticksPerUs : 0;
+                var readyUs = (acc.ReadyTs > 0) ? (acc.ReadyTs - tickStartTs) / ticksPerUs : 0;
+                var durationUs = endUs > startUs ? endUs - startUs : 0;
+                if (skipped)
+                {
+                    startUs = 0; endUs = 0; durationUs = 0;
+                }
+                _systemTickSummaries.Add(new SystemTickSummary
+                {
+                    TickNumber = tickNumber,
+                    SystemIndex = sysIdx,
+                    SkipReasonCode = acc.SkipReasonCode,
+                    Flags = 0,
+                    StartUs = startUs,
+                    EndUs = endUs,
+                    ReadyUs = readyUs,
+                    DurationUs = (float)durationUs,
+                    EntitiesProcessed = acc.EntitiesProcessed,
+                    WorkersTouched = (byte)System.Numerics.BitOperations.PopCount(acc.WorkersTouchedMask),
+                    ChunksProcessed = acc.ChunksProcessed,
+                    _reserved = 0,
+                });
+            }
+            _currentTickSystems.Clear();
+        }
+
+        // Per-queue rows. Order by QueueId.
+        if (_currentTickQueues.Count > 0)
+        {
+            var qIdxBuf = new ushort[_currentTickQueues.Count];
+            var qk = 0;
+            foreach (var key in _currentTickQueues.Keys)
+            {
+                qIdxBuf[qk++] = key;
+            }
+
+            Array.Sort(qIdxBuf);
+            for (var i = 0; i < qIdxBuf.Length; i++)
+            {
+                var qid = qIdxBuf[i];
+                var data = _currentTickQueues[qid];
+                _queueTickSummaries.Add(new QueueTickSummary
+                {
+                    TickNumber = tickNumber,
+                    QueueId = qid,
+                    _reserved = 0,
+                    PeakDepth = data.PeakDepth,
+                    EndOfTickDepth = data.EndOfTickDepth,
+                    OverflowCount = data.OverflowCount,
+                    Produced = data.Produced,
+                    Consumed = data.Consumed,
+                });
+            }
+            _currentTickQueues.Clear();
+        }
+
+        // Post-tick row. Always emit one row per tick — zero µs for phases that didn't fire — so consumers can index by tick.
+        if (_currentTickPostMarkersHasData)
+        {
+            _currentTickPostMarkers.TickNumber = tickNumber;
+            _currentTickPostMarkers._reserved = 0;
+            _postTickSummaries.Add(_currentTickPostMarkers);
+        }
+        _currentTickPostMarkers = default;
+        _currentTickPostMarkersHasData = false;
+    }
+
+    /// <summary>
+    /// Per-event v12 fold (#311). Pure observer — does not mutate the chunk byte stream. Called from the inner dispatch loop
+    /// for every record that lands during an active tick. Cheap: dictionary updates + a few BinaryPrimitives reads. Records that
+    /// fall outside the v12 fold's interest set (most events) hit the default branch and return immediately.
+    /// </summary>
+    private void FoldV12Event(TraceEventKind kind, ReadOnlySpan<byte> records, int pos, int size, long startTs)
+    {
+        switch (kind)
+        {
+            case TraceEventKind.SystemReady:
+            {
+                // Payload: u16 systemIdx (offset 12). Total record = 16 B.
+                if (size < CommonHeaderSize + 2)
+                {
+                    return;
+                }
+
+                var sysIdx = BinaryPrimitives.ReadUInt16LittleEndian(records[(pos + CommonHeaderSize)..]);
+                ref var acc = ref GetOrCreateSystemAcc(sysIdx);
+                if (acc.ReadyTs == 0)
+                {
+                    acc.ReadyTs = startTs; // First observation wins (same-tick re-ready shouldn't happen).
+                }
+
+                break;
+            }
+            case TraceEventKind.SystemSkipped:
+            {
+                // Payload: u16 systemIdx, u8 skipReason (offset 14). Total = 19 B.
+                if (size < CommonHeaderSize + 3)
+                {
+                    return;
+                }
+
+                var sysIdx = BinaryPrimitives.ReadUInt16LittleEndian(records[(pos + CommonHeaderSize)..]);
+                var skipReason = records[pos + CommonHeaderSize + 2];
+                ref var acc = ref GetOrCreateSystemAcc(sysIdx);
+                if (skipReason != 0)
+                {
+                    acc.SkipReasonCode = skipReason;
+                }
+
+                break;
+            }
+            case TraceEventKind.SchedulerChunk:
+            {
+                // Span event. Header: 12 B common + 25 B span ext = 37 B. Payload after that:
+                //   u16 systemIdx, u16 chunkIdx, u16 totalChunks, i32 entitiesProcessed = 10 B.
+                if (size < CommonHeaderSize + SpanHeaderExtSize + 10)
+                {
+                    return;
+                }
+
+                var spanFlags = records[pos + 36];
+                var hasTraceContext = (spanFlags & 0x01) != 0;
+                var payloadOffset = pos + CommonHeaderSize + SpanHeaderExtSize + (hasTraceContext ? TraceContextSize : 0);
+                if (payloadOffset + 10 > pos + size)
+                {
+                    return;
+                }
+
+                var sysIdx = BinaryPrimitives.ReadUInt16LittleEndian(records[payloadOffset..]);
+                var entities = BinaryPrimitives.ReadInt32LittleEndian(records[(payloadOffset + 6)..]);
+                var durationTicks = BinaryPrimitives.ReadInt64LittleEndian(records[(pos + CommonHeaderSize)..]);
+                var threadSlot = records[pos + 3]; // common header byte 3 (after size + kind)
+
+                ref var acc = ref GetOrCreateSystemAcc(sysIdx);
+                var endTs = startTs + durationTicks;
+                if (acc.FirstChunkStartTs == 0 || startTs < acc.FirstChunkStartTs)
+                {
+                    acc.FirstChunkStartTs = startTs;
+                }
+
+                if (endTs > acc.LastChunkEndTs)
+                {
+                    acc.LastChunkEndTs = endTs;
+                }
+
+                acc.EntitiesProcessed += (uint)Math.Max(0, entities);
+                if (acc.ChunksProcessed < ushort.MaxValue)
+                {
+                    acc.ChunksProcessed++;
+                }
+
+                if (threadSlot < 32)
+                {
+                    acc.WorkersTouchedMask |= 1u << threadSlot;
+                }
+
+                break;
+            }
+            case TraceEventKind.QueueTickEnd:
+            {
+                if (size < QueueTickEndCodec.Size)
+                {
+                    return;
+                }
+
+                var data = QueueTickEndCodec.Read(records.Slice(pos, size));
+                _currentTickQueues[data.QueueId] = data;
+                break;
+            }
+            case TraceEventKind.RuntimePhaseSpan:
+            {
+                // Span event with u8 phase payload. Need durationTicks + the trailing phase byte.
+                if (size < CommonHeaderSize + SpanHeaderExtSize + 1)
+                {
+                    return;
+                }
+
+                var spanFlags = records[pos + 36];
+                var hasTraceContext = (spanFlags & 0x01) != 0;
+                var hasSourceLocation = (spanFlags & 0x02) != 0;
+                var headerSize = TraceRecordHeader.SpanHeaderSize(hasTraceContext, hasSourceLocation);
+                if (pos + headerSize + 1 > pos + size)
+                {
+                    return;
+                }
+
+                var phase = records[pos + headerSize];
+                var durationTicks = BinaryPrimitives.ReadInt64LittleEndian(records[(pos + CommonHeaderSize)..]);
+                var durationUs = (float)(durationTicks / _ticksPerUs);
+                _currentTickPostMarkersHasData = true;
+                switch ((TickPhase)phase)
+                {
+                    case TickPhase.WriteTickFence: _currentTickPostMarkers.WriteTickFenceUs += durationUs; break;
+                    case TickPhase.UowFlush:        _currentTickPostMarkers.WalFlushUs += durationUs; break;
+                    case TickPhase.OutputPhase:     _currentTickPostMarkers.SubscriptionOutputUs += durationUs; break;
+                    case TickPhase.TierIndexRebuild:_currentTickPostMarkers.TierIndexRebuildUs += durationUs; break;
+                    case TickPhase.DormancySweep:   _currentTickPostMarkers.DormancySweepUs += durationUs; break;
+                    // SystemDispatch is the system DAG itself — not part of the post-tick serial block.
+                    default: _currentTickPostMarkersHasData = (_currentTickPostMarkers.WriteTickFenceUs + _currentTickPostMarkers.WalFlushUs
+                        + _currentTickPostMarkers.SubscriptionOutputUs + _currentTickPostMarkers.TierIndexRebuildUs
+                        + _currentTickPostMarkers.DormancySweepUs) > 0; break;
+                }
+                break;
+            }
+        }
+    }
+
+    private ref SystemTickAccumulator GetOrCreateSystemAcc(ushort systemIndex)
+    {
+        ref var acc = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(_currentTickSystems, systemIndex, out _);
+        return ref acc;
     }
 
     private void FlushChunkInternal(uint toTick)

--- a/src/Typhon.Profiler/QueueTickEndCodec.cs
+++ b/src/Typhon.Profiler/QueueTickEndCodec.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Typhon.Profiler;
+
+/// <summary>
+/// Wire codec for <see cref="TraceEventKind.QueueTickEnd"/> (kind 244) — per-(tick, queue) rollup emitted at end-of-tick.
+/// Surfaces queue-depth telemetry (peak, end-of-tick, overflow, produced, consumed) for the Workbench Data API <c>queue/&lt;name&gt;</c> tracks (#311).
+/// </summary>
+/// <remarks>
+/// Folded by <see cref="IncrementalCacheBuilder"/> into the v12 <see cref="CacheSectionId.QueueTickSummaries"/> cache section. One emission per active queue
+/// per tick — small, fixed-size record (no payload variability), so we hand-code the codec and skip the source-generated path.
+/// </remarks>
+public static class QueueTickEndCodec
+{
+    /// <summary>Total record size in bytes (common header + payload).</summary>
+    public const int Size = TraceRecordHeader.CommonHeaderSize + 4 + 2 + 2 + 4 + 4 + 4 + 4 + 4; // 12 + 28 = 40
+
+    /// <summary>
+    /// Encode a <see cref="TraceEventKind.QueueTickEnd"/> instant record. Caller is responsible for reserving exactly
+    /// <see cref="Size"/> bytes from the producer ring.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Write(Span<byte> destination, byte threadSlot, long timestamp, uint tickNumber, ushort queueId, uint peakDepth, uint endOfTickDepth, 
+        uint overflowCount, uint produced, uint consumed)
+    {
+        TraceRecordHeader.WriteCommonHeader(destination, Size, TraceEventKind.QueueTickEnd, threadSlot, timestamp);
+        var p = destination[TraceRecordHeader.CommonHeaderSize..];
+        BinaryPrimitives.WriteUInt32LittleEndian(p, tickNumber);
+        BinaryPrimitives.WriteUInt16LittleEndian(p[4..], queueId);
+        // Padding (2 bytes) to align the following u32s on a 4-byte boundary; readers ignore.
+        BinaryPrimitives.WriteUInt16LittleEndian(p[6..], 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(p[8..], peakDepth);
+        BinaryPrimitives.WriteUInt32LittleEndian(p[12..], endOfTickDepth);
+        BinaryPrimitives.WriteUInt32LittleEndian(p[16..], overflowCount);
+        BinaryPrimitives.WriteUInt32LittleEndian(p[20..], produced);
+        BinaryPrimitives.WriteUInt32LittleEndian(p[24..], consumed);
+    }
+
+    /// <summary>Decode a <see cref="TraceEventKind.QueueTickEnd"/> record back into structured form.</summary>
+    public static QueueTickEndData Read(ReadOnlySpan<byte> source)
+    {
+        TraceRecordHeader.ReadCommonHeader(source, out _, out _, out var threadSlot, out var timestamp);
+        var p = source[TraceRecordHeader.CommonHeaderSize..];
+        return new QueueTickEndData(
+            threadSlot,
+            timestamp,
+            BinaryPrimitives.ReadUInt32LittleEndian(p),
+            BinaryPrimitives.ReadUInt16LittleEndian(p[4..]),
+            BinaryPrimitives.ReadUInt32LittleEndian(p[8..]),
+            BinaryPrimitives.ReadUInt32LittleEndian(p[12..]),
+            BinaryPrimitives.ReadUInt32LittleEndian(p[16..]),
+            BinaryPrimitives.ReadUInt32LittleEndian(p[20..]),
+            BinaryPrimitives.ReadUInt32LittleEndian(p[24..]));
+    }
+}
+
+/// <summary>Decoded form of a <see cref="TraceEventKind.QueueTickEnd"/> record.</summary>
+public readonly record struct QueueTickEndData(
+    byte ThreadSlot,
+    long Timestamp,
+    uint TickNumber,
+    ushort QueueId,
+    uint PeakDepth,
+    uint EndOfTickDepth,
+    uint OverflowCount,
+    uint Produced,
+    uint Consumed);

--- a/src/Typhon.Profiler/SystemDefinitionRecord.cs
+++ b/src/Typhon.Profiler/SystemDefinitionRecord.cs
@@ -4,6 +4,10 @@ namespace Typhon.Profiler;
 /// Describes a system in the DAG, stored in the system definition table of a <c>.typhon-trace</c> file.
 /// Variable-length record (name is UTF-8 encoded).
 /// </summary>
+/// <remarks>
+/// RFC 07 access declaration fields (Phase / Reads / Writes / etc.) were added in trace format v6.
+/// Older v5 traces yield empty defaults — readers do not throw.
+/// </remarks>
 public sealed class SystemDefinitionRecord
 {
     /// <summary>System index in the DAG array.</summary>
@@ -29,4 +33,48 @@ public sealed class SystemDefinitionRecord
 
     /// <summary>Indices of successor systems in the DAG.</summary>
     public ushort[] Successors { get; init; } = [];
+
+    // ─── RFC 07 access declarations (trace format v6+) ───────────────────────
+
+    /// <summary>Phase token name (RFC 07 §Q3) the system runs in. Empty string when no phase was declared.</summary>
+    public string PhaseName { get; init; } = string.Empty;
+
+    /// <summary>True iff the system runs alone in its phase (no concurrent peers; <see cref="SystemBuilder.ExclusivePhase"/>).</summary>
+    public bool IsExclusivePhase { get; init; }
+
+    /// <summary>Component type names declared with <c>Reads&lt;T&gt;()</c> — ambiguous-staleness reads.</summary>
+    public string[] Reads { get; init; } = [];
+
+    /// <summary>Component type names declared with <c>ReadsFresh&lt;T&gt;()</c> — ordered after writers in the same phase.</summary>
+    public string[] ReadsFresh { get; init; } = [];
+
+    /// <summary>Component type names declared with <c>ReadsSnapshot&lt;T&gt;()</c> — ordered before writers in the same phase.</summary>
+    public string[] ReadsSnapshot { get; init; } = [];
+
+    /// <summary>Component type names read beyond the system's primary input view (cross-entity reads).</summary>
+    public string[] AdditionalReads { get; init; } = [];
+
+    /// <summary>Component type names mutated via <c>Writes&lt;T&gt;()</c>.</summary>
+    public string[] Writes { get; init; } = [];
+
+    /// <summary>Component type names written via Immediate side-transactions. Surfaced for tooling; does not affect scheduler order.</summary>
+    public string[] SideWrites { get; init; } = [];
+
+    /// <summary>Names of event queues this system publishes to.</summary>
+    public string[] WritesEvents { get; init; } = [];
+
+    /// <summary>Names of event queues this system consumes from.</summary>
+    public string[] ReadsEvents { get; init; } = [];
+
+    /// <summary>Names of named resources this system mutates.</summary>
+    public string[] WritesResources { get; init; } = [];
+
+    /// <summary>Names of named resources this system reads.</summary>
+    public string[] ReadsResources { get; init; } = [];
+
+    /// <summary>Names of systems this one is explicitly ordered AFTER (escape-hatch edge — RFC 07 §Q5).</summary>
+    public string[] ExplicitAfter { get; init; } = [];
+
+    /// <summary>Names of systems this one is explicitly ordered BEFORE.</summary>
+    public string[] ExplicitBefore { get; init; } = [];
 }

--- a/src/Typhon.Profiler/TraceEventKind.cs
+++ b/src/Typhon.Profiler/TraceEventKind.cs
@@ -1012,7 +1012,13 @@ public static class TraceEventKindExtensions
         // Phase 4 follow-up (#289):
         //   241 (SchedulerMetronomeWait) — span (falls through to `return true`).
         //   242 (SchedulerOverloadDetector) — instant.
-        if (v == 242)
+        //   243 (RuntimePhaseSpan) — span (falls through; replaces the PhaseStart+PhaseEnd instant pair).
+        //   244 (QueueTickEnd) — instant rollup. Hand-coded by `QueueTickEndCodec` with a 28-byte
+        //         payload after the 12-byte common header — NO 25-byte span-header extension. Without
+        //         this carve-out, span-aware decoders read 25 payload bytes as a fake span header,
+        //         producing garbage `durationUs`/`spanId`/`parentSpanId` and rendering the rollup as
+        //         a phantom nested span on the TickDriver thread lane.
+        if (v == 242 || v == 244)
         {
             return false;
         }

--- a/src/Typhon.Profiler/TraceEventKind.cs
+++ b/src/Typhon.Profiler/TraceEventKind.cs
@@ -906,6 +906,16 @@ public enum TraceEventKind : byte
     /// </summary>
     RuntimePhaseSpan = 243,
 
+    /// <summary>
+    /// Per-(tick, queue) rollup emitted at end-of-tick. Captures queue-depth telemetry that's local to the engine's
+    /// <c>EventQueueBase</c> accumulators (peak depth, end-of-tick depth, overflow count, produced/consumed counts).
+    /// Folded by <see cref="IncrementalCacheBuilder"/> into the v12 <see cref="CacheSectionId.QueueTickSummaries"/> section
+    /// for the Workbench Data API <c>queue/&lt;name&gt;</c> tracks (#311).
+    /// Payload: <c>tick: u32, queueId: u16, peakDepth: u32, endOfTickDepth: u32, overflowCount: u32, produced: u32, consumed: u32</c>
+    /// = 26 bytes after the common header.
+    /// </summary>
+    QueueTickEnd = 244,
+
     // ── Fallback ──
 
     /// <summary>User-defined span with inline UTF-8 null-terminated name. Used for dynamic-string call sites (tests, demo code). Payload: null-terminated UTF-8 bytes.</summary>

--- a/src/Typhon.Profiler/TraceFileCache.cs
+++ b/src/Typhon.Profiler/TraceFileCache.cs
@@ -172,6 +172,33 @@ public enum CacheSectionId : ushort
     /// <c>.typhon-trace</c> at open time.
     /// </summary>
     SourceMetadata = 7,
+
+    /// <summary>
+    /// Per-(tick, system) rollup records (<see cref="SystemTickSummary"/>[]) added in v12 for the Workbench Data API per-system
+    /// tracks (RFC 07 surfacing). Sorted by (TickNumber, SystemIndex) for deterministic binary search. Always dense across systems
+    /// in a tick (skipped systems present, with `SkipReason != NotSkipped`). Folded by <see cref="IncrementalCacheBuilder"/> from
+    /// the existing <c>SystemReady</c> / <c>SystemSkipped</c> / <c>SchedulerChunk</c> wire events — no new wire-format kind needed.
+    /// </summary>
+    SystemTickSummaries = 8,
+
+    /// <summary>
+    /// Per-(tick, queue) rollup records (<see cref="QueueTickSummary"/>[]) added in v12. Sorted by (TickNumber, QueueId). Folded
+    /// from a new <c>QueueTickEnd</c> wire event the engine emits at end-of-tick per active event queue.
+    /// </summary>
+    QueueTickSummaries = 9,
+
+    /// <summary>
+    /// Per-tick post-tick serial markers (<see cref="PostTickSummary"/>[]) added in v12 — one record per tick, capturing the durations
+    /// of each <see cref="TickPhase"/> region that runs serially after the system DAG completes. Folded from the existing
+    /// <c>RuntimePhaseSpan</c> wire events (kind 243); no new wire-format kind needed.
+    /// </summary>
+    PostTickSummaries = 10,
+
+    /// <summary>
+    /// Queue-name intern table written in v12. Variable-length: <c>u16 count</c> followed by <c>count × (u16 queueId + short-string name)</c>.
+    /// QueueId is the index assigned at engine startup; readers map <see cref="QueueTickSummary.QueueId"/> → display name through this section.
+    /// </summary>
+    QueueNameTable = 11,
 }
 
 /// <summary>
@@ -440,8 +467,15 @@ public static class TraceFileCacheConstants
     ///      <c>SchedulerOverloadDetector</c> instant (kind 242). Drives the Workbench OverloadStrip tooltip so users can see the
     ///      deescalation streak climb toward 20 (or reset on any overrun) — the answer to "why didn't multiplier go down?".
     ///      v10 caches must rebuild against v11.
+    /// v12 (current): four new sections added (<see cref="CacheSectionId.SystemTickSummaries"/>, <see cref="CacheSectionId.QueueTickSummaries"/>,
+    ///      <see cref="CacheSectionId.PostTickSummaries"/>, <see cref="CacheSectionId.QueueNameTable"/>) populated by
+    ///      <see cref="IncrementalCacheBuilder"/> from existing wire events plus a new <c>QueueTickEnd</c> event for the per-queue path.
+    ///      Drives the Workbench Data API v2 tracks (#311) — <c>system/&lt;name&gt;</c>, <c>queue/&lt;name&gt;</c>, <c>posttick/*</c>.
+    ///      <see cref="TickSummary.ActiveSystemsBitmask"/> is no longer populated in v12 builds (zeroed) — the per-system rows in
+    ///      <see cref="CacheSectionId.SystemTickSummaries"/> are the authoritative answer to "which systems ran in tick T", with no
+    ///      u64 cap. The field is retained on disk for v11 reader back-compat but consumers should migrate. v11 caches must rebuild.
     /// </summary>
-    public const ushort CurrentChunkerVersion = 11;
+    public const ushort CurrentChunkerVersion = 12;
 
     /// <summary>Sidecar file extension, appended to the source path (e.g., <c>foo.typhon-trace</c> → <c>foo.typhon-trace-cache</c>).</summary>
     public const string CacheFileExtension = "-cache";

--- a/src/Typhon.Profiler/TraceFileCacheReader.cs
+++ b/src/Typhon.Profiler/TraceFileCacheReader.cs
@@ -37,14 +37,19 @@ public sealed class TraceFileCacheReader : IDisposable
     /// </summary>
     private readonly object _readFallbackLock = new();
     private readonly Dictionary<CacheSectionId, SectionTableEntry> _sectionsByid = new();
-    private readonly List<TickIndexEntry> _tickIndex = new();
-    private readonly List<TickSummary> _tickSummaries = new();
-    private readonly List<ChunkManifestEntry> _chunkManifest = new();
+    private readonly List<TickIndexEntry> _tickIndex = [];
+    private readonly List<TickSummary> _tickSummaries = [];
+    private readonly List<ChunkManifestEntry> _chunkManifest = [];
     // NOTE: the former `_chunkIndexByFromTick` dictionary was removed in chunker v8 when intra-tick splitting became supported — FromTick is
     // no longer unique across entries (a split tick produces multiple chunks with the same [FromTick, ToTick)). Chunk endpoints now take a
     // `chunkIdx` parameter and index directly into `_chunkManifest` instead, which is both simpler and strictly more expressive.
-    private readonly List<SystemAggregateDuration> _systemAggregates = new();
+    private readonly List<SystemAggregateDuration> _systemAggregates = [];
     private readonly Dictionary<int, string> _spanNames = new();
+    // ── v12 (#311) ──────────────────────────────────────────────────────
+    private readonly List<SystemTickSummary> _systemTickSummaries = [];
+    private readonly List<QueueTickSummary> _queueTickSummaries = [];
+    private readonly List<PostTickSummary> _postTickSummaries = [];
+    private readonly Dictionary<ushort, string> _queueIdToName = new();
     private byte[] _sourceMetadataBytes;
     private GlobalMetricsFixed _globalMetrics;
     private CacheHeader _header;
@@ -105,6 +110,18 @@ public sealed class TraceFileCacheReader : IDisposable
     public IReadOnlyList<SystemAggregateDuration> SystemAggregates => _systemAggregates;
     public IReadOnlyDictionary<int, string> SpanNames => _spanNames;
 
+    /// <summary>v12 per-(tick, system) rollup rows. Empty for v11-or-older caches.</summary>
+    public IReadOnlyList<SystemTickSummary> SystemTickSummaries => _systemTickSummaries;
+
+    /// <summary>v12 per-(tick, queue) rollup rows. Empty for v11-or-older caches.</summary>
+    public IReadOnlyList<QueueTickSummary> QueueTickSummaries => _queueTickSummaries;
+
+    /// <summary>v12 per-tick post-tick markers. Empty for v11-or-older caches.</summary>
+    public IReadOnlyList<PostTickSummary> PostTickSummaries => _postTickSummaries;
+
+    /// <summary>v12 queue-id → display-name map. Empty for v11-or-older caches.</summary>
+    public IReadOnlyDictionary<ushort, string> QueueIdToName => _queueIdToName;
+
     /// <summary>
     /// True when <see cref="CacheHeaderFlags.IsSelfContained"/> is set in the header. A self-contained cache carries the source metadata tables
     /// (header / systems / archetypes / component types) inside its <see cref="CacheSectionId.SourceMetadata"/> section, so the loader does not
@@ -140,7 +157,7 @@ public sealed class TraceFileCacheReader : IDisposable
         var dst = compressedDestination[..(int)entry.CacheByteLength];
         if (_fileHandle is not null)
         {
-            ReadAtExact(_fileHandle, dst, (long)entry.CacheByteOffset);
+            ReadAtExact(_fileHandle, dst, entry.CacheByteOffset);
         }
         else
         {
@@ -190,7 +207,7 @@ public sealed class TraceFileCacheReader : IDisposable
         var compressed = compressedScratch[..(int)entry.CacheByteLength];
         if (_fileHandle is not null)
         {
-            ReadAtExact(_fileHandle, compressed, (long)entry.CacheByteOffset);
+            ReadAtExact(_fileHandle, compressed, entry.CacheByteOffset);
         }
         else
         {
@@ -349,6 +366,43 @@ public sealed class TraceFileCacheReader : IDisposable
         if (_sectionsByid.TryGetValue(CacheSectionId.SourceMetadata, out var sourceMetaSec))
         {
             LoadSourceMetadata(sourceMetaSec);
+        }
+
+        // v12 sections (#311). All optional — older caches simply omit them and the lists stay empty.
+        if (_sectionsByid.TryGetValue(CacheSectionId.SystemTickSummaries, out var sysSec))
+        {
+            LoadStructArray(sysSec, _systemTickSummaries);
+        }
+        if (_sectionsByid.TryGetValue(CacheSectionId.QueueTickSummaries, out var qSec))
+        {
+            LoadStructArray(qSec, _queueTickSummaries);
+        }
+        if (_sectionsByid.TryGetValue(CacheSectionId.PostTickSummaries, out var ptSec))
+        {
+            LoadStructArray(ptSec, _postTickSummaries);
+        }
+        if (_sectionsByid.TryGetValue(CacheSectionId.QueueNameTable, out var qnameSec))
+        {
+            LoadQueueNameTable(qnameSec);
+        }
+    }
+
+    private void LoadQueueNameTable(SectionTableEntry section)
+    {
+        _stream.Position = section.Offset;
+        Span<byte> u16Buf = stackalloc byte[2];
+        Span<byte> lenBuf = stackalloc byte[1];
+        _stream.ReadExactly(u16Buf);
+        var count = BinaryPrimitives.ReadUInt16LittleEndian(u16Buf);
+        for (var i = 0; i < count; i++)
+        {
+            _stream.ReadExactly(u16Buf);
+            var queueId = BinaryPrimitives.ReadUInt16LittleEndian(u16Buf);
+            _stream.ReadExactly(lenBuf);
+            var nameLen = lenBuf[0];
+            var nameBytes = new byte[nameLen];
+            _stream.ReadExactly(nameBytes);
+            _queueIdToName[queueId] = Encoding.UTF8.GetString(nameBytes);
         }
     }
 

--- a/src/Typhon.Profiler/TraceFileCacheV12.cs
+++ b/src/Typhon.Profiler/TraceFileCacheV12.cs
@@ -1,0 +1,138 @@
+using System.Runtime.InteropServices;
+
+namespace Typhon.Profiler;
+
+// ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+// Cache schema v12 — per-system + per-queue + post-tick rollup sections.
+//
+// Drives the Workbench Data API v2 tracks (`system/<name>`, `queue/<name>`, `posttick/*`) per `claude/design/workbench/10-internal-data-api.md §7.3`.
+// Folded by `IncrementalCacheBuilder` from existing wire events plus the new `QueueTickEnd` event for the per-queue path.
+//
+// All structs are [Sequential, Pack=1] and 8-byte-aligned-on-disk. Field ordering chosen so longs/doubles sit on natural alignment (no internal
+// padding holes) and the trailing pad bytes round each record up to 8.
+// ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Per-(tick, system) rollup row in <see cref="CacheSectionId.SystemTickSummaries"/>. One row per system per tick — dense across systems so binary-search by
+/// tick yields a contiguous slice of all systems for that tick. Skipped systems are present with <see cref="SkipReasonCode"/> != 0; consumers filter on that.
+/// </summary>
+/// <remarks>
+/// Folded from the existing wire events:
+/// <list type="bullet">
+///   <item><c>SystemReady(systemIdx, predecessorCount, ts)</c> → <see cref="ReadyUs"/>.</item>
+///   <item><c>SystemSkipped(systemIdx, skipReason, ts, ...)</c> → <see cref="SkipReasonCode"/> + <see cref="StartUs"/>=0.</item>
+///   <item><c>SchedulerChunk(systemIdx, chunkIdx, totalChunks, startTs, endTs, entitiesProcessed)</c> → <see cref="StartUs"/>
+///       (min over chunks), <see cref="EndUs"/> (max over chunks), <see cref="DurationUs"/> (end - start), <see cref="EntitiesProcessed"/>
+///       (sum), <see cref="WorkersTouched"/> (distinct thread slots), <see cref="ChunksProcessed"/> (count).</item>
+/// </list>
+/// </remarks>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct SystemTickSummary
+{
+    /// <summary>Tick number (matches <see cref="TickSummary.TickNumber"/>).</summary>
+    public uint TickNumber;
+
+    /// <summary>System index in the DAG (matches <see cref="SystemDefinitionRecord.Index"/>).</summary>
+    public ushort SystemIndex;
+
+    /// <summary>
+    /// Skip reason byte (mirrors engine <c>SkipReason</c> enum). 0 = NotSkipped (system ran), non-zero = skipped this tick;
+    /// other fields then reflect the skip event (StartUs/EndUs zero, DurationUs zero, EntitiesProcessed zero).
+    /// </summary>
+    public byte SkipReasonCode;
+
+    /// <summary>Reserved for future use (e.g. bit flags for fresh/snapshot run, change-filter triggered, etc.). Zero on disk.</summary>
+    public byte Flags;
+
+    /// <summary>Tick-relative µs at which the first chunk grab happened (or callback start). Zero if skipped.</summary>
+    public double StartUs;
+
+    /// <summary>Tick-relative µs at which the last chunk completed (or callback finish). Zero if skipped.</summary>
+    public double EndUs;
+
+    /// <summary>
+    /// Tick-relative µs at which the system became ready (all predecessors done). Zero if skipped or unobserved (e.g. a root
+    /// system whose ready time coincides with TickStart). Used by the DAG view's worker-claim-wait diagnostic.
+    /// </summary>
+    public double ReadyUs;
+
+    /// <summary>Wall-clock execution duration in µs (<c>EndUs - StartUs</c>). Zero if skipped.</summary>
+    public float DurationUs;
+
+    /// <summary>Number of entities processed (sum across chunks). Zero for callbacks / skipped systems.</summary>
+    public uint EntitiesProcessed;
+
+    /// <summary>Number of distinct worker threads that ran chunks for this system this tick. Zero if skipped.</summary>
+    public byte WorkersTouched;
+
+    /// <summary>Number of chunks completed (1 for callbacks; >=1 for parallel queries / pipelines).</summary>
+    public ushort ChunksProcessed;
+
+    /// <summary>Padding to round the record up to a multiple of 8 bytes on disk.</summary>
+    public byte _reserved;
+}
+
+/// <summary>
+/// Per-(tick, queue) rollup row in <see cref="CacheSectionId.QueueTickSummaries"/>. One row per queue per tick. Folded from the new <c>QueueTickEnd</c> wire
+/// event the engine emits at end-of-tick per active event queue.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct QueueTickSummary
+{
+    /// <summary>Tick number.</summary>
+    public uint TickNumber;
+
+    /// <summary>Queue identifier — index into the <see cref="CacheSectionId.QueueNameTable"/> for display-name resolution.</summary>
+    public ushort QueueId;
+
+    /// <summary>Padding to align <see cref="PeakDepth"/> on a 4-byte boundary.</summary>
+    public ushort _reserved;
+
+    /// <summary>Maximum number of items present in the queue at any point during the tick (after <c>Enqueue</c>, before <c>Drain</c>).</summary>
+    public uint PeakDepth;
+
+    /// <summary>Item count remaining at end-of-tick (after <c>Drain</c>). Sustained &gt;0 means consumer is chronically lagging.</summary>
+    public uint EndOfTickDepth;
+
+    /// <summary>Number of <c>Push</c> calls that were rejected because the queue was at capacity (overflow).</summary>
+    public uint OverflowCount;
+
+    /// <summary>Number of items successfully enqueued during the tick.</summary>
+    public uint Produced;
+
+    /// <summary>Number of items drained (consumed) during the tick.</summary>
+    public uint Consumed;
+}
+
+/// <summary>
+/// Per-tick post-tick serial markers in <see cref="CacheSectionId.PostTickSummaries"/>. One row per tick, capturing the duration of each <see cref="TickPhase"/>
+/// region that runs after the system DAG completes — wraps the existing <c>InspectorPhase</c> blocks in <c>TyphonRuntime.OnTickEndInternal</c>. Zero µs means
+/// the phase ran with no measurable work (e.g. no subscriptions active for <see cref="SubscriptionOutputUs"/>).
+/// </summary>
+[StructLayout(LayoutKind.Sequential, Pack = 1)]
+public struct PostTickSummary
+{
+    /// <summary>Tick number.</summary>
+    public uint TickNumber;
+
+    /// <summary>Padding for 8-byte alignment of the following floats. Zero on disk.</summary>
+    public uint _reserved;
+
+    /// <summary>Duration in µs of <see cref="TickPhase.WriteTickFence"/>. Cluster migrations + WAL publish + spatial index update.</summary>
+    public float WriteTickFenceUs;
+
+    /// <summary>Duration in µs of <see cref="TickPhase.UowFlush"/>. Includes <c>WaitForDurable</c> on the WAL fsync — typically the largest "where did my tick go" surprise.</summary>
+    public float WalFlushUs;
+
+    /// <summary>Duration in µs of <see cref="TickPhase.OutputPhase"/>. Refresh published Views, compute deltas, push via TCP.</summary>
+    public float SubscriptionOutputUs;
+
+    /// <summary>Duration in µs of <see cref="TickPhase.TierIndexRebuild"/>. Rebuild per-archetype tier cluster indexes at tick start (rolled into post-tick for now per design §10).</summary>
+    public float TierIndexRebuildUs;
+
+    /// <summary>Duration in µs of <see cref="TickPhase.DormancySweep"/>. Advance sleep counters, transition idle clusters.</summary>
+    public float DormancySweepUs;
+
+    /// <summary>Reserved for the per-tier budget metrics phase (not yet wrapped in <c>InspectorPhase</c>; tracks at zero until the engine wraps it). Design §5.3.</summary>
+    public float TierBudgetUs;
+}

--- a/src/Typhon.Profiler/TraceFileCacheWriter.cs
+++ b/src/Typhon.Profiler/TraceFileCacheWriter.cs
@@ -24,8 +24,14 @@ namespace Typhon.Profiler;
 /// </remarks>
 public sealed class TraceFileCacheWriter : IDisposable
 {
-    /// <summary>Number of distinct section slots reserved in the table. Bumping this requires re-reserving more placeholder space.</summary>
-    public const int MaxSections = 8;
+    /// <summary>
+    /// Number of distinct section slots reserved in the table. Bumping this requires re-reserving more placeholder space —
+    /// the section table sits at a fixed offset (128) and the subsequent <see cref="SectionsStartOffset"/> derives from this
+    /// constant, so changing it shifts where the very first section is written.
+    /// v12 (#311) bumped this from 8 → 16 to accommodate the four new sections (SystemTickSummaries, QueueTickSummaries,
+    /// PostTickSummaries, QueueNameTable) plus headroom for future v13/v14 extensions without another invalidation pass.
+    /// </summary>
+    public const int MaxSections = 16;
 
     /// <summary>
     /// Fixed offset where section writes begin. Header (128) + section table (<see cref="MaxSections"/> × 24 = 192) = 320.
@@ -180,6 +186,41 @@ public sealed class TraceFileCacheWriter : IDisposable
             System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(u16Buf, (ushort)id);
             _stream.Write(u16Buf);
             WriteShortString(name);
+        }
+    }
+
+    /// <summary>
+    /// Write the v12 queue-name intern table — count u16 + entries of (u16 queueId, shortString name). Null or empty input emits a zero count and returns.
+    /// Used by <see cref="CacheSectionId.QueueNameTable"/>.
+    /// </summary>
+    public void WriteQueueNameTable(IReadOnlyDictionary<ushort, string> queueIdToName)
+    {
+        ThrowIfNoSection();
+        if (_currentSection != CacheSectionId.QueueNameTable)
+        {
+            throw new InvalidOperationException($"WriteQueueNameTable only valid within the QueueNameTable section; current is {_currentSection}.");
+        }
+
+        var count = queueIdToName?.Count ?? 0;
+        if (count > ushort.MaxValue)
+        {
+            throw new InvalidOperationException($"QueueNameTable has {count} entries, exceeds u16 limit.");
+        }
+
+        Span<byte> u16Buf = stackalloc byte[2];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(u16Buf, (ushort)count);
+        _stream.Write(u16Buf);
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        foreach (var (id, name) in queueIdToName!)
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(u16Buf, id);
+            _stream.Write(u16Buf);
+            WriteShortString(name ?? string.Empty);
         }
     }
 

--- a/src/Typhon.Profiler/TraceFileHeader.cs
+++ b/src/Typhon.Profiler/TraceFileHeader.cs
@@ -77,10 +77,15 @@ public struct TraceFileHeader
     /// Current format version.
     /// v3: variable-size typed-record layout (Tracy-style profiler rewrite).
     /// v4: ThreadInfo records gained the trailing <c>ThreadKind</c> byte (#289 follow-up).
-    /// v5 (current): trailer carries <c>FileTable</c> + <c>SourceLocationManifest</c> at offsets in the header
+    /// v5: trailer carries <c>FileTable</c> + <c>SourceLocationManifest</c> at offsets in the header
     ///     (#302 — profiler source attribution). Reader accepts v4 files transparently — their new offset fields
     ///     are absent in the on-disk header (51 bytes vs 71) and default to 0, which downstream readers interpret
     ///     as "no source-location manifest".
+    /// v6 (current): SystemDefinitionTable carries RFC 07 access declarations (Phase, Reads, ReadsFresh,
+    ///     ReadsSnapshot, AdditionalReads, Writes, SideWrites, ReadsEvents, WritesEvents, ReadsResources,
+    ///     WritesResources, ExplicitAfter, ExplicitBefore, IsExclusivePhase). New PhasesTable section follows
+    ///     ComponentTypeTable, listing the RuntimeOptions.Phases names in order. Reader accepts v5 files
+    ///     transparently — RFC 07 fields default to empty arrays and PhasesTable is treated as absent.
     /// </summary>
-    public const ushort CurrentVersion = 5;
+    public const ushort CurrentVersion = 6;
 }

--- a/src/Typhon.Profiler/TraceFileReader.cs
+++ b/src/Typhon.Profiler/TraceFileReader.cs
@@ -88,9 +88,9 @@ public sealed class TraceFileReader : IDisposable
     /// <exception cref="InvalidDataException">If magic or version is wrong.</exception>
     public TraceFileHeader ReadHeader()
     {
-        // v4 layout ends at SamplingSessionStartQpc (51 bytes); v5 appends FileTableOffset +
-        // SourceLocationManifestOffset + Reserved0/1 (+20 bytes). v4 files transparently use the
-        // shorter read; their absent fields default to 0 ("no manifest").
+        // v4 layout ends at SamplingSessionStartQpc (51 bytes); v5+ appends FileTableOffset + SourceLocationManifestOffset + Reserved0/1 (+20 bytes).
+        // v4 files transparently use the shorter read; their absent fields default to 0 ("no manifest").
+        // v6 keeps the same struct shape as v5 — only data sections after the header changed (RFC 07 fields + Phases table).
         const int V4HeaderSize = 51;
         var fullSize = Unsafe.SizeOf<TraceFileHeader>();
 
@@ -98,20 +98,21 @@ public sealed class TraceFileReader : IDisposable
         _stream.ReadExactly(headerBytes[..V4HeaderSize]);
         var version = BinaryPrimitives.ReadUInt16LittleEndian(headerBytes[4..6]);
 
-        if (version == TraceFileHeader.CurrentVersion)
-        {
-            _stream.ReadExactly(headerBytes[V4HeaderSize..fullSize]);
-        }
-        else if (version < MinSupportedVersion || version > TraceFileHeader.CurrentVersion)
+        if (version < MinSupportedVersion || version > TraceFileHeader.CurrentVersion)
         {
             throw new InvalidDataException(
                 $"Unsupported trace file version: {version}. This build reads versions "
                 + $"{MinSupportedVersion}..{TraceFileHeader.CurrentVersion}.");
         }
+
+        if (version >= 5)
+        {
+            // v5+ has the full 71-byte header (FileTable + SourceLocationManifest offsets included).
+            _stream.ReadExactly(headerBytes[V4HeaderSize..fullSize]);
+        }
         else
         {
-            // Older-but-supported (currently only v4) — clear the bytes we didn't read, so the
-            // marshalled struct sees zeroed offset fields.
+            // v4 — clear the bytes we didn't read so the marshalled struct sees zeroed offset fields.
             headerBytes[V4HeaderSize..fullSize].Clear();
         }
 
@@ -126,9 +127,14 @@ public sealed class TraceFileReader : IDisposable
     }
 
     /// <summary>Reads the system definition table. Call after <see cref="ReadHeader"/>.</summary>
+    /// <remarks>
+    /// Format v6+ appends RFC 07 access declarations per system. v5 traces lack the trailing fields;
+    /// the reader returns empty defaults for them.
+    /// </remarks>
     public IReadOnlyList<SystemDefinitionRecord> ReadSystemDefinitions()
     {
         _systems.Clear();
+        var hasAccessDecls = Header.Version >= 6;
         var count = _binaryReader.ReadUInt16();
 
         for (var i = 0; i < count; i++)
@@ -154,6 +160,29 @@ public sealed class TraceFileReader : IDisposable
                 successors[s] = _binaryReader.ReadUInt16();
             }
 
+            var phaseName = string.Empty;
+            var isExclusivePhase = false;
+            string[] reads = [], readsFresh = [], readsSnapshot = [], additionalReads = [], writes = [], sideWrites = [];
+            string[] writesEvents = [], readsEvents = [], writesResources = [], readsResources = [];
+            string[] explicitAfter = [], explicitBefore = [];
+            if (hasAccessDecls)
+            {
+                phaseName = ReadShortString();
+                isExclusivePhase = _binaryReader.ReadBoolean();
+                reads = ReadStringArray();
+                readsFresh = ReadStringArray();
+                readsSnapshot = ReadStringArray();
+                additionalReads = ReadStringArray();
+                writes = ReadStringArray();
+                sideWrites = ReadStringArray();
+                writesEvents = ReadStringArray();
+                readsEvents = ReadStringArray();
+                writesResources = ReadStringArray();
+                readsResources = ReadStringArray();
+                explicitAfter = ReadStringArray();
+                explicitBefore = ReadStringArray();
+            }
+
             _systems.Add(new SystemDefinitionRecord
             {
                 Index = index,
@@ -163,10 +192,51 @@ public sealed class TraceFileReader : IDisposable
                 IsParallel = isParallel,
                 TierFilter = tierFilter,
                 Predecessors = predecessors,
-                Successors = successors
+                Successors = successors,
+                PhaseName = phaseName,
+                IsExclusivePhase = isExclusivePhase,
+                Reads = reads,
+                ReadsFresh = readsFresh,
+                ReadsSnapshot = readsSnapshot,
+                AdditionalReads = additionalReads,
+                Writes = writes,
+                SideWrites = sideWrites,
+                WritesEvents = writesEvents,
+                ReadsEvents = readsEvents,
+                WritesResources = writesResources,
+                ReadsResources = readsResources,
+                ExplicitAfter = explicitAfter,
+                ExplicitBefore = explicitBefore,
             });
         }
         return _systems;
+    }
+
+    /// <summary>
+    /// Phase order list (RFC 07 §Q3 — <c>RuntimeOptions.Phases</c>), available after <see cref="ReadPhases"/>.
+    /// Empty for v5 traces (the section is absent and not read).
+    /// </summary>
+    public IReadOnlyList<string> Phases => _phases;
+    private readonly List<string> _phases = [];
+
+    /// <summary>
+    /// Reads the phases table (v6+). Call after <see cref="ReadComponentTypes"/>. For v5 traces this is a
+    /// no-op — the section does not exist and no bytes are consumed.
+    /// </summary>
+    public IReadOnlyList<string> ReadPhases()
+    {
+        _phases.Clear();
+        if (Header.Version < 6)
+        {
+            return _phases;
+        }
+
+        var count = _binaryReader.ReadUInt16();
+        for (var i = 0; i < count; i++)
+        {
+            _phases.Add(ReadShortString());
+        }
+        return _phases;
     }
 
     /// <summary>Reads the archetype table. Call after <see cref="ReadSystemDefinitions"/>.</summary>
@@ -324,6 +394,21 @@ public sealed class TraceFileReader : IDisposable
         var len = _binaryReader.ReadByte();
         var bytes = _binaryReader.ReadBytes(len);
         return Encoding.UTF8.GetString(bytes);
+    }
+
+    private string[] ReadStringArray()
+    {
+        var count = _binaryReader.ReadUInt16();
+        if (count == 0)
+        {
+            return [];
+        }
+        var arr = new string[count];
+        for (var i = 0; i < count; i++)
+        {
+            arr[i] = ReadShortString();
+        }
+        return arr;
     }
 
     private string ReadVarString()

--- a/src/Typhon.Profiler/TraceFileWriter.cs
+++ b/src/Typhon.Profiler/TraceFileWriter.cs
@@ -54,6 +54,10 @@ public sealed class TraceFileWriter : IDisposable
     }
 
     /// <summary>Writes the system definition table. Must be called exactly once after the header.</summary>
+    /// <remarks>
+    /// Format v6 (current) appends RFC 07 access declarations per system. Reader negotiates: v5 traces lack
+    /// the trailing fields and the reader fills them with empty defaults.
+    /// </remarks>
     public void WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord> systems)
     {
         _writer.Write((ushort)systems.Length);
@@ -77,6 +81,36 @@ public sealed class TraceFileWriter : IDisposable
             {
                 _writer.Write(succ);
             }
+
+            // ── RFC 07 access declarations (v6+) ─────────────────────────────
+            WriteShortString(sys.PhaseName ?? string.Empty);
+            _writer.Write(sys.IsExclusivePhase);
+            WriteStringArray(sys.Reads);
+            WriteStringArray(sys.ReadsFresh);
+            WriteStringArray(sys.ReadsSnapshot);
+            WriteStringArray(sys.AdditionalReads);
+            WriteStringArray(sys.Writes);
+            WriteStringArray(sys.SideWrites);
+            WriteStringArray(sys.WritesEvents);
+            WriteStringArray(sys.ReadsEvents);
+            WriteStringArray(sys.WritesResources);
+            WriteStringArray(sys.ReadsResources);
+            WriteStringArray(sys.ExplicitAfter);
+            WriteStringArray(sys.ExplicitBefore);
+        }
+        _writer.Flush();
+    }
+
+    /// <summary>
+    /// Writes the phases table (v6+). One entry per <c>RuntimeOptions.Phases</c> name in declaration order.
+    /// Empty array is valid (legacy session with no phase declarations); the reader returns an empty list.
+    /// </summary>
+    public void WritePhases(ReadOnlySpan<string> phaseNames)
+    {
+        _writer.Write((ushort)phaseNames.Length);
+        foreach (var p in phaseNames)
+        {
+            WriteShortString(p ?? string.Empty);
         }
         _writer.Flush();
     }
@@ -231,6 +265,21 @@ public sealed class TraceFileWriter : IDisposable
         var len = (byte)Math.Min(bytes.Length, 255);
         _writer.Write(len);
         _writer.Write(bytes, 0, len);
+    }
+
+    /// <summary>u16 length prefix followed by that many <see cref="WriteShortString"/> entries.</summary>
+    private void WriteStringArray(string[] values)
+    {
+        if (values == null)
+        {
+            _writer.Write((ushort)0);
+            return;
+        }
+        _writer.Write((ushort)values.Length);
+        for (var i = 0; i < values.Length; i++)
+        {
+            WriteShortString(values[i] ?? string.Empty);
+        }
     }
 
     /// <summary>

--- a/test/AntHill/ECS/AntEvents.cs
+++ b/test/AntHill/ECS/AntEvents.cs
@@ -1,0 +1,29 @@
+namespace AntHill;
+
+/// <summary>
+/// Telemetry events emitted by the simulation. Replace the previous <c>Interlocked.Increment</c>
+/// counter writes with proper RFC 07 event flow: producers declare <c>WritesEvents</c> on the
+/// queue, the consumer (<c>AntStatsAggregator</c>) declares <c>ReadsEvents</c>, and the auto-DAG
+/// renders the producer→consumer arrow in the Workbench System DAG view.
+/// </summary>
+public readonly struct AntDiedEvent
+{
+    public readonly uint EntityId;
+    public readonly int NestIdx;
+    public AntDiedEvent(uint entityId, int nestIdx) { EntityId = entityId; NestIdx = nestIdx; }
+}
+
+public readonly struct FoodPickedUpEvent
+{
+    public readonly uint EntityId;
+    public readonly int FoodIdx;
+    public FoodPickedUpEvent(uint entityId, int foodIdx) { EntityId = entityId; FoodIdx = foodIdx; }
+}
+
+public readonly struct FoodDeliveredEvent
+{
+    public readonly uint EntityId;
+    public readonly int NestIdx;
+    public readonly int Amount;
+    public FoodDeliveredEvent(uint entityId, int nestIdx, int amount) { EntityId = entityId; NestIdx = nestIdx; Amount = amount; }
+}

--- a/test/AntHill/ECS/AntPhases.cs
+++ b/test/AntHill/ECS/AntPhases.cs
@@ -1,0 +1,33 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// AntHill custom phases — extends the engine-shipped <see cref="Phase.Input"/>, etc., with the
+/// six tick stages that drive ant simulation. Phases form a total order (per RFC 07 / Q3); the
+/// ordered list is wired into <c>RuntimeOptions.Phases</c> at engine bootstrap.
+///
+/// Pipeline (top → bottom):
+/// <list type="bullet">
+///   <item><see cref="Phase.Input"/> — TierAssignment (camera → spatial-grid tiers)</item>
+///   <item><see cref="Movement"/> — MoveAll (apply velocity to bounds)</item>
+///   <item><see cref="Lifecycle"/> — Metabolism (energy decay, death/respawn) per tier</item>
+///   <item><see cref="Sense"/> — FoodDetect (food smell + pickup + nest drop)</item>
+///   <item><see cref="Brain"/> — pheromone steering + wander, per tier</item>
+///   <item><see cref="Trail"/> — pheromone deposit + decay</item>
+///   <item><see cref="Render"/> — Prepare/Fill/Publish render buffers + stats aggregation</item>
+/// </list>
+///
+/// Splitting Sense / Brain / Trail rather than collapsing into one "Simulation" phase is
+/// deliberate — each phase boundary becomes a visible stripe in the Workbench System DAG and
+/// Critical-Path views, which is the showcase value of the migration.
+/// </summary>
+public static class AntPhases
+{
+    public static readonly Phase Movement  = new("Movement");
+    public static readonly Phase Lifecycle = new("Lifecycle");
+    public static readonly Phase Sense     = new("Sense");
+    public static readonly Phase Brain     = new("Brain");
+    public static readonly Phase Trail     = new("Trail");
+    public static readonly Phase Render    = new("Render");
+}

--- a/test/AntHill/ECS/Archetypes.cs
+++ b/test/AntHill/ECS/Archetypes.cs
@@ -6,7 +6,8 @@ namespace AntHill;
 [Archetype(100)]
 partial class Ant : Archetype<Ant>
 {
-    public static readonly Comp<Position> Position = Register<Position>();
+    public static readonly Comp<WorldBounds> Bounds = Register<WorldBounds>();
+    public static readonly Comp<Velocity> Velocity = Register<Velocity>();
     public static readonly Comp<Genetics> Genetics = Register<Genetics>();
     public static readonly Comp<AntState> State = Register<AntState>();
 }

--- a/test/AntHill/ECS/Components.cs
+++ b/test/AntHill/ECS/Components.cs
@@ -4,17 +4,21 @@ using Typhon.Schema.Definition;
 namespace AntHill;
 
 // ── Ant components ─────────────────────────────────────────────────────────
+//
+// Position used to bundle (Bounds, VelocityX, VelocityY) into one component. RFC 07 enforces
+// W×W conflicts at component granularity (Q2) — bundling them meant the velocity-writers
+// (Brain, FoodDetect, Metabolism on respawn) and the position-writers (MoveAll) couldn't run in
+// the same phase even though they touch logically distinct fields. Splitting into WorldBounds
+// (the AABB the spatial index hangs off) and Velocity (the integration delta) makes the
+// dependency graph reflect what actually flows where.
 
-[Component("AntHill.Position", 2, StorageMode = StorageMode.SingleVersion)]
+[Component("AntHill.WorldBounds", 1, StorageMode = StorageMode.SingleVersion)]
 [StructLayout(LayoutKind.Sequential)]
-public struct Position
+public struct WorldBounds
 {
     [Field]
     [SpatialIndex(1.0f)]
     public AABB2F Bounds;
-
-    [Field] public float VelocityX;  // ready-to-use: already includes speed multiplier
-    [Field] public float VelocityY;
 
     public float X
     {
@@ -27,6 +31,14 @@ public struct Position
         readonly get => Bounds.MinY;
         set { Bounds.MinY = value; Bounds.MaxY = value; }
     }
+}
+
+[Component("AntHill.Velocity", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+public struct Velocity
+{
+    [Field] public float X;  // ready-to-use: already includes speed multiplier
+    [Field] public float Y;
 }
 
 [Component("AntHill.Genetics", 1, StorageMode = StorageMode.SingleVersion)]

--- a/test/AntHill/ECS/Systems/BrainSystems.cs
+++ b/test/AntHill/ECS/Systems/BrainSystems.cs
@@ -1,0 +1,64 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// Pheromone-driven steering + wander. Reads bounds (sensor positions) + velocity (current
+/// heading) + state (foraging vs returning) + genetics (home nest), reads the pheromone grid
+/// resource, writes velocity (new heading). Tier-amortized like Metabolism — chained via
+/// <c>.After</c> within <see cref="AntPhases.Brain"/> for W×W disambiguation on velocity.
+/// </summary>
+internal abstract class BrainSystemBase : QuerySystem
+{
+    protected readonly TyphonBridge Bridge;
+    protected BrainSystemBase(TyphonBridge bridge) { Bridge = bridge; }
+
+    protected void ConfigureCommon(SystemBuilder b, string name, SimTier tier, int cellAmortize, string[] after) => b
+        .Name(name)
+        .Phase(AntPhases.Brain)
+        .Tier(tier)
+        .CellAmortize(cellAmortize)
+        .Parallel()
+        .Reads<WorldBounds>()
+        .Writes<Velocity>()
+        .ReadsSnapshot<AntState>()
+        .ReadsSnapshot<Genetics>()
+        .ReadsResource("PheromoneGrid")
+        .Input(() => Bridge._antView)
+        .AfterAll(after);
+
+    protected override void Execute(TickContext ctx) => Bridge.AntBrainTick(ctx);
+}
+
+// All-pairs ordering on every Brain_T* — the four systems all `Writes<Velocity>`, so the
+// AccessDagDeriver requires a direct edge between every pair (it doesn't transitively close a
+// chain). The Metabolism_T* refs are leftover from the original DAG (Brain reads what
+// Metabolism wrote on respawn, but Metabolism is in an earlier phase so phase ordering already
+// covers that — keeping them here doesn't hurt though).
+internal sealed class BrainT0System : BrainSystemBase
+{
+    public BrainT0System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b)
+        => ConfigureCommon(b, "Brain_T0", SimTier.Tier0, 1, ["FoodDetect"]);
+}
+
+internal sealed class BrainT1System : BrainSystemBase
+{
+    public BrainT1System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b)
+        => ConfigureCommon(b, "Brain_T1", SimTier.Tier1, 8, ["Brain_T0"]);
+}
+
+internal sealed class BrainT2System : BrainSystemBase
+{
+    public BrainT2System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b)
+        => ConfigureCommon(b, "Brain_T2", SimTier.Tier2, 30, ["Brain_T0", "Brain_T1"]);
+}
+
+internal sealed class BrainT3System : BrainSystemBase
+{
+    public BrainT3System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b)
+        => ConfigureCommon(b, "Brain_T3", SimTier.Tier3, 60, ["Brain_T0", "Brain_T1", "Brain_T2"]);
+}

--- a/test/AntHill/ECS/Systems/FoodDetectSystem.cs
+++ b/test/AntHill/ECS/Systems/FoodDetectSystem.cs
@@ -1,0 +1,34 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// Food smell + pickup + nest drop. Reads bounds (positional query against the food grid +
+/// nest cache) and velocity (re-orientation toward smelled food); writes velocity (heading)
+/// and ant state (foraging ↔ returning). Atomically mutates the food + nest inventories;
+/// emits the food-pickup / food-delivered events that <see cref="AntStatsAggregator"/>
+/// consumes downstream.
+/// </summary>
+internal sealed class FoodDetectSystem : QuerySystem
+{
+    private readonly TyphonBridge _bridge;
+    public FoodDetectSystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("FoodDetect")
+        .Phase(AntPhases.Sense)
+        .Parallel()
+        .Reads<WorldBounds>()
+        .Writes<Velocity>()
+        .Writes<AntState>()
+        .ReadsSnapshot<Genetics>()
+        .ReadsResource("FoodGrid")
+        .WritesResource("FoodInventory")
+        .WritesResource("NestInventory")
+        .WritesEvents(_bridge._foodPickedUpQueue)
+        .WritesEvents(_bridge._foodDeliveredQueue)
+        .Input(() => _bridge._antView)
+        .After("MoveAll");
+
+    protected override void Execute(TickContext ctx) => _bridge.FoodDetectTick(ctx);
+}

--- a/test/AntHill/ECS/Systems/MetabolismSystems.cs
+++ b/test/AntHill/ECS/Systems/MetabolismSystems.cs
@@ -1,0 +1,61 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// Energy decay + death/respawn. Tier-discriminated: T0 every tick, T1 every 8, T2 every 30,
+/// T3 every 60. All four systems share the same execute body and the same write set
+/// (<c>AntState</c>, <c>WorldBounds</c>, <c>Velocity</c> on respawn) — RFC 07 / Q5 forces a
+/// W×W chain via <c>.After</c> within <see cref="AntPhases.Lifecycle"/>. The chain is logically
+/// safe because tier filters ensure disjoint clusters per tick, but the scheduler can't prove
+/// it; the chain is the cost of the showcase.
+/// </summary>
+internal abstract class MetabolismSystemBase : QuerySystem
+{
+    protected readonly TyphonBridge Bridge;
+    protected MetabolismSystemBase(TyphonBridge bridge) { Bridge = bridge; }
+
+    // RFC 07 / Q5 W×W disambiguation requires DIRECT pairwise edges between every pair of writers
+    // — a linear chain T0→T1→T2→T3 isn't enough, the deriver doesn't compute transitive closure.
+    // Each tier declares .AfterAll over every prior tier so the all-pairs constraint is satisfied.
+    protected void ConfigureCommon(SystemBuilder b, string name, SimTier tier, int cellAmortize, string[] after) => b
+        .Name(name)
+        .Phase(AntPhases.Lifecycle)
+        .Tier(tier)
+        .CellAmortize(cellAmortize)
+        .Parallel()
+        .ReadsSnapshot<Genetics>()
+        .Writes<AntState>()
+        .Writes<WorldBounds>()
+        .Writes<Velocity>()
+        .WritesResource("NestInventory")
+        .WritesEvents(Bridge._antDiedQueue)
+        .Input(() => Bridge._antView)
+        .AfterAll(after);
+
+    protected override void Execute(TickContext ctx) => Bridge.MetabolismTick(ctx);
+}
+
+internal sealed class MetabolismT0System : MetabolismSystemBase
+{
+    public MetabolismT0System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "Metabolism_T0", SimTier.Tier0, 1, ["TierAssignment"]);
+}
+
+internal sealed class MetabolismT1System : MetabolismSystemBase
+{
+    public MetabolismT1System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "Metabolism_T1", SimTier.Tier1, 8, ["Metabolism_T0"]);
+}
+
+internal sealed class MetabolismT2System : MetabolismSystemBase
+{
+    public MetabolismT2System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "Metabolism_T2", SimTier.Tier2, 30, ["Metabolism_T0", "Metabolism_T1"]);
+}
+
+internal sealed class MetabolismT3System : MetabolismSystemBase
+{
+    public MetabolismT3System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "Metabolism_T3", SimTier.Tier3, 60, ["Metabolism_T0", "Metabolism_T1", "Metabolism_T2"]);
+}

--- a/test/AntHill/ECS/Systems/MoveAllSystem.cs
+++ b/test/AntHill/ECS/Systems/MoveAllSystem.cs
@@ -1,0 +1,28 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// Integrates velocity into world bounds and reflects on world-edge collisions. Sole writer of
+/// <c>WorldBounds</c> in <see cref="AntPhases.Movement"/>; also writes <c>Velocity</c> on
+/// reflection (sign flip), so it owns the velocity slot for this phase too.
+/// </summary>
+internal sealed class MoveAllSystem : QuerySystem
+{
+    private readonly TyphonBridge _bridge;
+    public MoveAllSystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("MoveAll")
+        .Phase(AntPhases.Movement)
+        .Parallel()
+        // No WritesVersioned — components are StorageMode.SingleVersion. Adding it would force
+        // the per-chunk Transaction fallback path which does NOT populate ctx.Accessor, breaking
+        // every cluster enumerator call in the body.
+        .Writes<WorldBounds>()
+        .Writes<Velocity>()
+        .Input(() => _bridge._antView)
+        .After("TierAssignment");
+
+    protected override void Execute(TickContext ctx) => _bridge.MoveAllAnts(ctx);
+}

--- a/test/AntHill/ECS/Systems/RenderSystems.cs
+++ b/test/AntHill/ECS/Systems/RenderSystems.cs
@@ -1,0 +1,106 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// Resets per-worker render buffers + pre-computes the food/nest overlay + downsamples the
+/// pheromone grid into the heatmap RGBA buffer. Pure callback.
+/// </summary>
+internal sealed class PrepareRenderBufferSystem : CallbackSystem
+{
+    private readonly TyphonBridge _bridge;
+    public PrepareRenderBufferSystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("PrepareRenderBuffer")
+        .Phase(AntPhases.Render)
+        .ReadsResource("PheromoneGrid")
+        .ReadsResource("FoodInventory")
+        .ReadsResource("NestInventory")
+        .WritesResource("RenderBuffers")
+        .WritesResource("Heatmap")
+        .AfterAll("Brain_T0", "Brain_T1", "Brain_T2", "Brain_T3", "PheroDecay");
+
+    protected override void Execute(TickContext ctx) => _bridge.PrepareRender(ctx);
+}
+
+/// <summary>
+/// Per-worker fill of the render buffer (transform, color, alpha per visible ant). Reads
+/// bounds + state + genetics; per-worker writes to the worker's slot in
+/// <c>RenderBuffers</c> — declared as <c>WritesResource("RenderBuffers")</c> with
+/// <c>.WritesVersioned()</c>. Sole consumer of <c>TierMirror</c> + <c>CameraAABB</c> in this
+/// phase for clipping.
+/// </summary>
+internal sealed class FillRenderBufferSystem : QuerySystem
+{
+    private readonly TyphonBridge _bridge;
+    public FillRenderBufferSystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("FillRenderBuffer")
+        .Phase(AntPhases.Render)
+        .Parallel()
+        .Reads<WorldBounds>()
+        .Reads<AntState>()
+        .ReadsSnapshot<Genetics>()
+        .ReadsResource("CameraAABB")
+        .ReadsResource("TierMirror")
+        .WritesResource("RenderBuffers")
+        .Input(() => _bridge._antView)
+        .After("PrepareRenderBuffer");
+
+    protected override void Execute(TickContext ctx) => _bridge.FillRender(ctx);
+}
+
+/// <summary>
+/// Snapshots the worker buffers + heatmap + overlay into a frame and publishes to the render
+/// bridge. Swaps the heatmap double buffer + clears worker buffers for the next tick.
+/// </summary>
+internal sealed class PublishRenderFrameSystem : CallbackSystem
+{
+    private readonly TyphonBridge _bridge;
+    public PublishRenderFrameSystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("PublishRenderFrame")
+        .Phase(AntPhases.Render)
+        .WritesResource("RenderBuffers")
+        .WritesResource("Heatmap")
+        // Three writers of RenderBuffers (Prepare, Fill, this) — the deriver requires direct
+        // pairwise edges between every writer, no transitive closure. Same constraint applies
+        // to Heatmap (Prepare + this). AfterAll declares both at once.
+        .AfterAll("PrepareRenderBuffer", "FillRenderBuffer");
+
+    protected override void Execute(TickContext ctx) => _bridge.PublishRender(ctx);
+}
+
+/// <summary>
+/// Drains the three telemetry queues (deaths, food pickups, food deliveries) and updates the
+/// public counters (<c>DeathCount</c>, <c>FoodDelivered</c>) the UI exposes. Replaces the
+/// previous <c>Interlocked.Increment</c> calls in Metabolism / FoodDetect — same totals, but
+/// the data flow is visible in the System DAG view as queue-edges.
+/// </summary>
+internal sealed class AntStatsAggregatorSystem : CallbackSystem
+{
+    private readonly TyphonBridge _bridge;
+    public AntStatsAggregatorSystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("AntStatsAggregator")
+        .Phase(AntPhases.Render)
+        .ReadsEvents(_bridge._antDiedQueue)
+        .ReadsEvents(_bridge._foodPickedUpQueue)
+        .ReadsEvents(_bridge._foodDeliveredQueue)
+        .After("FoodDetect")
+        // Run before the renderer's stats dump so the published counters reflect this tick.
+        .Before("PrepareRenderBuffer");
+
+    protected override void Execute(TickContext ctx)
+    {
+        _bridge._deathCount += _bridge._antDiedQueue.Count;
+        _bridge._foodDelivered += _bridge._foodDeliveredQueue.Count;
+        // FoodPickedUpEvent isn't surfaced as a counter today; consumed only to advance the
+        // queue (the next tick's Reset clears it). Kept on the wire for future stats panels.
+        _ = _bridge._foodPickedUpQueue.Count;
+    }
+}

--- a/test/AntHill/ECS/Systems/TierAssignmentSystem.cs
+++ b/test/AntHill/ECS/Systems/TierAssignmentSystem.cs
@@ -1,0 +1,24 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// Resets the spatial-grid tier assignment from the camera AABB. Pure callback — no entity
+/// access. Owns the only writer of <c>SpatialGrid</c> (tier flags) and the <c>TierMirror</c>
+/// resource consumed by the renderer; reads <c>CameraAABB</c> from the UI thread.
+/// </summary>
+internal sealed class TierAssignmentSystem : CallbackSystem
+{
+    private readonly TyphonBridge _bridge;
+    public TierAssignmentSystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("TierAssignment")
+        .Phase(Phase.Input)
+        .Priority(SystemPriority.High)
+        .ReadsResource("CameraAABB")
+        .WritesResource("SpatialGrid")
+        .WritesResource("TierMirror");
+
+    protected override void Execute(TickContext ctx) => _bridge.TierAssignment(ctx);
+}

--- a/test/AntHill/ECS/Systems/TrailSystems.cs
+++ b/test/AntHill/ECS/Systems/TrailSystems.cs
@@ -1,0 +1,71 @@
+using Typhon.Engine;
+
+namespace AntHill;
+
+/// <summary>
+/// Pheromone deposit (food trail when returning, faint home trail when foraging). All four
+/// tiered deposit systems share <c>WritesResource("PheromoneGrid")</c> with PheroDecay → the
+/// AccessDagDeriver requires direct pairwise edges between every writer (no transitive closure),
+/// so every PheroDep_Tn declares <c>.AfterAll</c> over every prior tier and PheroDecay runs
+/// after all four.
+/// </summary>
+internal abstract class PheroDepSystemBase : QuerySystem
+{
+    protected readonly TyphonBridge Bridge;
+    protected PheroDepSystemBase(TyphonBridge bridge) { Bridge = bridge; }
+
+    protected void ConfigureCommon(SystemBuilder b, string name, SimTier tier, int cellAmortize, string[] after) => b
+        .Name(name)
+        .Phase(AntPhases.Trail)
+        .Tier(tier)
+        .CellAmortize(cellAmortize)
+        .Parallel()
+        .ReadsSnapshot<WorldBounds>()
+        .ReadsSnapshot<AntState>()
+        .WritesResource("PheromoneGrid")
+        .Input(() => Bridge._antView)
+        .AfterAll(after);
+
+    protected override void Execute(TickContext ctx) => Bridge.PheromoneDepositTick(ctx);
+}
+
+internal sealed class PheroDepT0System : PheroDepSystemBase
+{
+    public PheroDepT0System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "PheroDep_T0", SimTier.Tier0, 1, ["Brain_T0", "Brain_T1", "Brain_T2", "Brain_T3"]);
+}
+
+internal sealed class PheroDepT1System : PheroDepSystemBase
+{
+    public PheroDepT1System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "PheroDep_T1", SimTier.Tier1, 2, ["PheroDep_T0"]);
+}
+
+internal sealed class PheroDepT2System : PheroDepSystemBase
+{
+    public PheroDepT2System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "PheroDep_T2", SimTier.Tier2, 4, ["PheroDep_T0", "PheroDep_T1"]);
+}
+
+internal sealed class PheroDepT3System : PheroDepSystemBase
+{
+    public PheroDepT3System(TyphonBridge bridge) : base(bridge) { }
+    protected override void Configure(SystemBuilder b) => ConfigureCommon(b, "PheroDep_T3", SimTier.Tier3, 8, ["PheroDep_T0", "PheroDep_T1", "PheroDep_T2"]);
+}
+
+/// <summary>
+/// Linear evaporate over the entire pheromone grid. Pure callback. Caps the deposit chain.
+/// </summary>
+internal sealed class PheroDecaySystem : CallbackSystem
+{
+    private readonly TyphonBridge _bridge;
+    public PheroDecaySystem(TyphonBridge bridge) { _bridge = bridge; }
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("PheroDecay")
+        .Phase(AntPhases.Trail)
+        .WritesResource("PheromoneGrid")
+        .AfterAll("PheroDep_T0", "PheroDep_T1", "PheroDep_T2", "PheroDep_T3");
+
+    protected override void Execute(TickContext ctx) => _bridge.PheromoneDecayTick(ctx);
+}

--- a/test/AntHill/Engine/ProfilerSetup.cs
+++ b/test/AntHill/Engine/ProfilerSetup.cs
@@ -32,6 +32,7 @@ public static class ProfilerSetup
     /// all subsequent events are measured against <c>startTimestamp</c>.
     /// </remarks>
     public static ProfilerSessionMetadata BuildSessionMetadata(SystemDefinition[] systems, int workerCount, float baseTickRate,
+        string[] phases = null,
         Func<long> currentEngineTickProvider = null)
     {
         // currentEngineTickProvider is accepted for forward-compat with callers but the current
@@ -40,7 +41,7 @@ public static class ProfilerSetup
         // has no public enumeration API yet, and the engine emits typed events with numeric IDs only,
         // so the viewer renders them un-resolved for the moment.
         _ = currentEngineTickProvider;
-        return new ProfilerSessionMetadata(SystemDefinitionRecordBuilder.BuildAll(systems), [], [], workerCount, baseTickRate, Stopwatch.GetTimestamp(), 
-            Stopwatch.Frequency, DateTime.UtcNow, phases: []);
+        return new ProfilerSessionMetadata(SystemDefinitionRecordBuilder.BuildAll(systems), [], [], workerCount, baseTickRate, Stopwatch.GetTimestamp(),
+            Stopwatch.Frequency, DateTime.UtcNow, phases: phases ?? []);
     }
 }

--- a/test/AntHill/Engine/ProfilerSetup.cs
+++ b/test/AntHill/Engine/ProfilerSetup.cs
@@ -40,52 +40,7 @@ public static class ProfilerSetup
         // has no public enumeration API yet, and the engine emits typed events with numeric IDs only,
         // so the viewer renders them un-resolved for the moment.
         _ = currentEngineTickProvider;
-        return new ProfilerSessionMetadata(BuildSystemRecords(systems), [], [], workerCount, baseTickRate,
-            Stopwatch.GetTimestamp(), Stopwatch.Frequency, DateTime.UtcNow);
-    }
-
-    // SystemDefinition stores successors but not predecessors — invert the edge list once so the
-    // record table is self-describing for the viewer (which renders both directions).
-    private static SystemDefinitionRecord[] BuildSystemRecords(SystemDefinition[] systems)
-    {
-        if (systems == null || systems.Length == 0) return [];
-
-        var predecessors = new System.Collections.Generic.List<ushort>[systems.Length];
-        for (int i = 0; i < systems.Length; i++)
-        {
-            predecessors[i] = new System.Collections.Generic.List<ushort>();
-        }
-        for (int i = 0; i < systems.Length; i++)
-        {
-            foreach (var succ in systems[i].Successors)
-            {
-                predecessors[succ].Add((ushort)i);
-            }
-        }
-
-        var records = new SystemDefinitionRecord[systems.Length];
-        for (int i = 0; i < systems.Length; i++)
-        {
-            var sys = systems[i];
-            var succIndices = sys.Successors;
-            var succUshort = new ushort[succIndices.Length];
-            for (int s = 0; s < succIndices.Length; s++)
-            {
-                succUshort[s] = (ushort)succIndices[s];
-            }
-
-            records[i] = new SystemDefinitionRecord
-            {
-                Index = (ushort)sys.Index,
-                Name = sys.Name,
-                Type = (byte)sys.Type,
-                Priority = (byte)sys.Priority,
-                IsParallel = sys.IsParallelQuery,
-                TierFilter = (byte)sys.TierFilter,
-                Predecessors = predecessors[i].ToArray(),
-                Successors = succUshort,
-            };
-        }
-        return records;
+        return new ProfilerSessionMetadata(SystemDefinitionRecordBuilder.BuildAll(systems), [], [], workerCount, baseTickRate, Stopwatch.GetTimestamp(), 
+            Stopwatch.Frequency, DateTime.UtcNow, phases: []);
     }
 }

--- a/test/AntHill/Engine/TyphonBridge.cs
+++ b/test/AntHill/Engine/TyphonBridge.cs
@@ -20,78 +20,88 @@ public sealed class TyphonBridge : IDisposable
 
     private ServiceProvider _serviceProvider;
     private IServiceScope _scope;
-    private DatabaseEngine _dbe;
+    internal DatabaseEngine _dbe;
     private TyphonRuntime _runtime;
-    private EcsView<Ant> _antView;
+    internal EcsView<Ant> _antView;
 
     private const int Stride = 12;
 
     // Per-worker render buffers — each worker writes to its own, no synchronization needed
-    private RenderWorkerBuffer[] _workerBuffers;
-    private RenderWorkerBuffer _overlayBuffer; // food + nests
+    internal RenderWorkerBuffer[] _workerBuffers;
+    internal RenderWorkerBuffer _overlayBuffer; // food + nests
 
     // Pheromone heatmap double-buffered RGBA (200×200×4)
-    private const int HeatmapPixels = RenderFrame.HeatmapSize * RenderFrame.HeatmapSize;
-    private byte[] _heatmapRGBA = new byte[HeatmapPixels * 4];
-    private byte[] _heatmapRGBARead = new byte[HeatmapPixels * 4];
-    private readonly float[] _heatMaxFood = new float[HeatmapPixels];
-    private readonly float[] _heatMaxHome = new float[HeatmapPixels];
-    private volatile bool _heatmapEnabled;
+    internal const int HeatmapPixels = RenderFrame.HeatmapSize * RenderFrame.HeatmapSize;
+    internal byte[] _heatmapRGBA = new byte[HeatmapPixels * 4];
+    internal byte[] _heatmapRGBARead = new byte[HeatmapPixels * 4];
+    internal readonly float[] _heatMaxFood = new float[HeatmapPixels];
+    internal readonly float[] _heatMaxHome = new float[HeatmapPixels];
+    internal volatile bool _heatmapEnabled;
 
     // Tier counts tracked during FillRenderBuffer
-    private readonly int[] _tierCounts = new int[4];
+    internal readonly int[] _tierCounts = new int[4];
     public ReadOnlySpan<int> TierCounts => _tierCounts;
 
     // Ant state counters
-    private readonly int[] _stateCounts = new int[2]; // [0]=Foraging, [1]=Carrying
+    internal readonly int[] _stateCounts = new int[2]; // [0]=Foraging, [1]=Carrying
     public ReadOnlySpan<int> StateCounts => _stateCounts;
 
     // Camera world-space AABB (updated from Godot render thread)
-    private volatile float _camMinX;
-    private volatile float _camMinY;
-    private volatile float _camMaxX = 20_000f;
-    private volatile float _camMaxY = 20_000f;
+    internal volatile float _camMinX;
+    internal volatile float _camMinY;
+    internal volatile float _camMaxX = 20_000f;
+    internal volatile float _camMaxY = 20_000f;
 
     // Time control
-    private volatile float _timeScale = 1f;
+    internal volatile float _timeScale = 1f;
     public float TimeScale { get => _timeScale; set => _timeScale = value; }
 
     // Tier radii
-    private float _tier0Radius = 2000f;
-    private const float Tier2Radius = 8000f;
+    internal float _tier0Radius = 2000f;
+    internal const float Tier2Radius = 8000f;
 
     // Tier mirror for rendering — linear indexed [cy * GridCells + cx]
-    private readonly byte[] _tierMirror = new byte[GridCells * GridCells];
+    internal readonly byte[] _tierMirror = new byte[GridCells * GridCells];
 
     // Nest data
-    private (float x, float y)[] _nestPositions;
-    private int[] _nestFoodStock;
-    private const int InitialNestFood = 10_000;
+    internal (float x, float y)[] _nestPositions;
+    internal int[] _nestFoodStock;
+    internal const int InitialNestFood = 10_000;
 
     // Food data
-    private (float x, float y, float remaining)[] _foodCache;
-    private int[] _foodRemainingInt;
-    private int _foodDelivered;
-    private int _deathCount;
+    internal (float x, float y, float remaining)[] _foodCache;
+    internal int[] _foodRemainingInt;
+    internal int _foodDelivered;
+    internal int _deathCount;
 
     // Food spatial grid: 40×40 cells (500-unit cells), per-cell list of food indices
-    private const int FoodGridCells = 40;
-    private const float FoodGridCellSize = WorldSize / FoodGridCells; // 500
-    private const float FoodGridInvCellSize = 1f / FoodGridCellSize;
-    private int[][] _foodGrid; // [cellIndex] → array of food source indices (null = empty)
+    internal const int FoodGridCells = 40;
+    internal const float FoodGridCellSize = WorldSize / FoodGridCells; // 500
+    internal const float FoodGridInvCellSize = 1f / FoodGridCellSize;
+    internal int[][] _foodGrid; // [cellIndex] → array of food source indices (null = empty)
 
     // Pheromone grid
-    private readonly PheromoneGrid _pheromones = new();
+    internal readonly PheromoneGrid _pheromones = new();
 
     // Render bridge
-    private readonly RenderBridge _renderBridge = new();
+    internal readonly RenderBridge _renderBridge = new();
     public RenderBridge RenderBridge => _renderBridge;
 
     // Migration tracking
-    private int _cellCrossingsThisTick;
-    private int _crossingsAccum;
-    private int _crossingsTickCount;
-    public int CrossingsPerSecond { get; private set; }
+    internal int _cellCrossingsThisTick;
+    internal int _crossingsAccum;
+    internal int _crossingsTickCount;
+    public int CrossingsPerSecond { get; internal set; }
+
+    // Event queues — wired in BuildSchedule, accessed by producer/consumer systems via the bridge.
+    // Replace the previous Interlocked.Increment counters with proper RFC 07 event flow so the
+    // System DAG view shows producer→consumer arrows.
+    internal EventQueue<AntDiedEvent> _antDiedQueue;
+    internal EventQueue<FoodPickedUpEvent> _foodPickedUpQueue;
+    internal EventQueue<FoodDeliveredEvent> _foodDeliveredQueue;
+
+    // Live runtime exposed to systems that need telemetry (PublishRender's periodic dump).
+    internal TyphonRuntime Runtime => _runtime;
 
     // Public stats
     public int VisibleAnts { get; private set; }
@@ -165,7 +175,8 @@ public sealed class TyphonBridge : IDisposable
         Archetype<Ant>.Touch();
         Archetype<Food>.Touch();
         Archetype<Nest>.Touch();
-        _dbe.RegisterComponentFromAccessor<Position>();
+        _dbe.RegisterComponentFromAccessor<WorldBounds>();
+        _dbe.RegisterComponentFromAccessor<Velocity>();
         _dbe.RegisterComponentFromAccessor<Genetics>();
         _dbe.RegisterComponentFromAccessor<AntState>();
         _dbe.RegisterComponentFromAccessor<FoodSource>();
@@ -187,10 +198,24 @@ public sealed class TyphonBridge : IDisposable
         _antView = txView.Query<Ant>().ToView();
 
         const int workerCount = 16;
-        _runtime = TyphonRuntime.Create(_dbe, BuildSystemDAG, new RuntimeOptions
+        _runtime = TyphonRuntime.Create(_dbe, BuildSchedule, new RuntimeOptions
         {
             BaseTickRate = 60,
             WorkerCount = workerCount,
+            // RFC 07 phase pipeline — declared as a total order. All systems in phase N complete
+            // before any system in phase N+1 starts. The Workbench's System DAG view uses this
+            // skeleton as the swim-lane structure.
+            Phases =
+            [
+                Phase.Input,
+                AntPhases.Movement,
+                AntPhases.Lifecycle,
+                AntPhases.Sense,
+                AntPhases.Brain,
+                AntPhases.Trail,
+                AntPhases.Render,
+            ],
+            DefaultPhase = AntPhases.Render,
         });
 
         // Per-worker render buffers: each parallel FillRender worker writes to its own buffer
@@ -206,67 +231,62 @@ public sealed class TyphonBridge : IDisposable
     // System DAG
     // ═══════════════════════════════════════════════════════════════════
 
-    private void BuildSystemDAG(RuntimeSchedule schedule)
+    /// <summary>
+    /// Build the schedule using class-based RFC 07 registrations. Phase-derived swim-lanes,
+    /// per-system access declarations (Reads/Writes for components, ReadsResource/WritesResource
+    /// for shared simulation state, ReadsEvents/WritesEvents for telemetry queues). The previous
+    /// lambda-overload form is gone — it didn't carry the access metadata the auto-DAG (and the
+    /// Workbench System DAG view) needs.
+    /// </summary>
+    private void BuildSchedule(RuntimeSchedule schedule)
     {
-        schedule.CallbackSystem("TierAssignment", TierAssignment, priority: SystemPriority.High);
+        // Event queues must exist before systems are registered (Configure captures them via
+        // WritesEvents / ReadsEvents). Capacities tuned for AntCount = 200 K — death events
+        // fire in bursts when energy crashes; food pickups are throttled by Interlocked checks.
+        _antDiedQueue        = schedule.CreateEventQueue<AntDiedEvent>("AntDied",        capacity: 4096);
+        _foodPickedUpQueue   = schedule.CreateEventQueue<FoodPickedUpEvent>("FoodPickedUp", capacity: 4096);
+        _foodDeliveredQueue  = schedule.CreateEventQueue<FoodDeliveredEvent>("FoodDelivered", capacity: 4096);
 
-        // MoveAll and Metabolism are INDEPENDENT — run in parallel across all workers
-        schedule.QuerySystem("MoveAll", MoveAllAnts,
-            input: () => _antView, parallel: true, after: "TierAssignment");
-        schedule.QuerySystem("Metabolism_T0", MetabolismTick,
-            input: () => _antView, tier: SimTier.Tier0, cellAmortize: 1, parallel: true, after: "TierAssignment");
-        schedule.QuerySystem("Metabolism_T1", MetabolismTick,
-            input: () => _antView, tier: SimTier.Tier1, cellAmortize: 8, parallel: true, after: "TierAssignment");
-        schedule.QuerySystem("Metabolism_T2", MetabolismTick,
-            input: () => _antView, tier: SimTier.Tier2, cellAmortize: 30, parallel: true, after: "TierAssignment");
-        schedule.QuerySystem("Metabolism_T3", MetabolismTick,
-            input: () => _antView, tier: SimTier.Tier3, cellAmortize: 60, parallel: true, after: "TierAssignment");
+        // Input phase
+        schedule.Add(new TierAssignmentSystem(this));
 
-        // FoodDetect: lightweight food proximity — every tick, all ants. Handles smell + pickup + nest drop.
-        schedule.QuerySystem("FoodDetect", FoodDetectTick,
-            input: () => _antView, parallel: true, after: "MoveAll");
+        // Movement phase
+        schedule.Add(new MoveAllSystem(this));
 
-        // AntBrain: pheromone sensing + steering + wander. After FoodDetect (state may have changed)
-        schedule.QuerySystem("Brain_T0", AntBrainTick,
-            input: () => _antView, tier: SimTier.Tier0, cellAmortize: 1, parallel: true,
-            afterAll: new[] { "FoodDetect", "Metabolism_T0" });
-        schedule.QuerySystem("Brain_T1", AntBrainTick,
-            input: () => _antView, tier: SimTier.Tier1, cellAmortize: 8, parallel: true,
-            afterAll: new[] { "FoodDetect", "Metabolism_T1" });
-        schedule.QuerySystem("Brain_T2", AntBrainTick,
-            input: () => _antView, tier: SimTier.Tier2, cellAmortize: 30, parallel: true,
-            afterAll: new[] { "FoodDetect", "Metabolism_T2" });
-        schedule.QuerySystem("Brain_T3", AntBrainTick,
-            input: () => _antView, tier: SimTier.Tier3, cellAmortize: 60, parallel: true,
-            afterAll: new[] { "FoodDetect", "Metabolism_T3" });
+        // Lifecycle phase — tier chain (W×W on AntState/WorldBounds/Velocity/NestInventory)
+        schedule.Add(new MetabolismT0System(this));
+        schedule.Add(new MetabolismT1System(this));
+        schedule.Add(new MetabolismT2System(this));
+        schedule.Add(new MetabolismT3System(this));
 
-        // PheromoneDeposit: after Brain (state transitions may have changed)
-        schedule.QuerySystem("PheroDep_T0", PheromoneDepositTick,
-            input: () => _antView, tier: SimTier.Tier0, cellAmortize: 1, parallel: true, after: "Brain_T0");
-        schedule.QuerySystem("PheroDep_T1", PheromoneDepositTick,
-            input: () => _antView, tier: SimTier.Tier1, cellAmortize: 2, parallel: true, after: "Brain_T1");
-        schedule.QuerySystem("PheroDep_T2", PheromoneDepositTick,
-            input: () => _antView, tier: SimTier.Tier2, cellAmortize: 4, parallel: true, after: "Brain_T2");
-        schedule.QuerySystem("PheroDep_T3", PheromoneDepositTick,
-            input: () => _antView, tier: SimTier.Tier3, cellAmortize: 8, parallel: true, after: "Brain_T3");
+        // Sense phase
+        schedule.Add(new FoodDetectSystem(this));
 
-        // PheromoneDecay: evaporate grid after deposits are done
-        schedule.CallbackSystem("PheroDecay", PheromoneDecayTick,
-            afterAll: new[] { "PheroDep_T0", "PheroDep_T1", "PheroDep_T2", "PheroDep_T3" });
+        // Brain phase — tier chain (W×W on Velocity)
+        schedule.Add(new BrainT0System(this));
+        schedule.Add(new BrainT1System(this));
+        schedule.Add(new BrainT2System(this));
+        schedule.Add(new BrainT3System(this));
 
-        // Render pipeline
-        schedule.CallbackSystem("PrepareRenderBuffer", PrepareRender,
-            afterAll: new[] { "Brain_T0", "Brain_T1", "Brain_T2", "Brain_T3", "PheroDecay" });
-        schedule.QuerySystem("FillRenderBuffer", FillRender,
-            input: () => _antView, parallel: true, after: "PrepareRenderBuffer");
-        schedule.CallbackSystem("PublishRenderFrame", PublishRender, after: "FillRenderBuffer");
+        // Trail phase — tier chain on PheromoneGrid + decay sweep
+        schedule.Add(new PheroDepT0System(this));
+        schedule.Add(new PheroDepT1System(this));
+        schedule.Add(new PheroDepT2System(this));
+        schedule.Add(new PheroDepT3System(this));
+        schedule.Add(new PheroDecaySystem(this));
+
+        // Render phase — stats sink consumes the three event queues, prepare/fill/publish chain
+        schedule.Add(new AntStatsAggregatorSystem(this));
+        schedule.Add(new PrepareRenderBufferSystem(this));
+        schedule.Add(new FillRenderBufferSystem(this));
+        schedule.Add(new PublishRenderFrameSystem(this));
     }
 
     // ═══════════════════════════════════════════════════════════════════
     // TierAssignment
     // ═══════════════════════════════════════════════════════════════════
 
-    private void TierAssignment(TickContext ctx)
+    internal void TierAssignment(TickContext ctx)
     {
         var camX = (_camMinX + _camMaxX) * 0.5f;
         var camY = (_camMinY + _camMaxY) * 0.5f;
@@ -310,7 +330,7 @@ public sealed class TyphonBridge : IDisposable
 
     private const int AntArchetypeId = 100;
 
-    private void MoveAllAnts(TickContext ctx)
+    internal void MoveAllAnts(TickContext ctx)
     {
         var dt = ctx.DeltaTime * _timeScale;
         using var clusters = ctx.ClusterIds != null
@@ -319,17 +339,19 @@ public sealed class TyphonBridge : IDisposable
         foreach (var cluster in clusters)
         {
             var bits = cluster.OccupancyBits;
-            var positions = cluster.GetSpan(Ant.Position);
+            var bounds = cluster.GetSpan(Ant.Bounds);
+            var velocities = cluster.GetSpan(Ant.Velocity);
             while (bits != 0)
             {
                 var idx = BitOperations.TrailingZeroCount(bits);
                 bits &= bits - 1;
-                ref var pos = ref positions[idx];
+                ref var pos = ref bounds[idx];
+                ref var vel = ref velocities[idx];
 
-                var x = pos.Bounds.MinX + pos.VelocityX * dt;
-                var y = pos.Bounds.MinY + pos.VelocityY * dt;
-                var vx = pos.VelocityX;
-                var vy = pos.VelocityY;
+                var x = pos.Bounds.MinX + vel.X * dt;
+                var y = pos.Bounds.MinY + vel.Y * dt;
+                var vx = vel.X;
+                var vy = vel.Y;
 
                 if (x < 0f) { x = -x; vx = -vx; }
                 else if (x > WorldSize) { x = 2f * WorldSize - x; vx = -vx; }
@@ -340,8 +362,8 @@ public sealed class TyphonBridge : IDisposable
                 pos.Bounds.MaxX = x;
                 pos.Bounds.MinY = y;
                 pos.Bounds.MaxY = y;
-                pos.VelocityX = vx;
-                pos.VelocityY = vy;
+                vel.X = vx;
+                vel.Y = vy;
             }
         }
     }
@@ -354,11 +376,12 @@ public sealed class TyphonBridge : IDisposable
     private const float BaseDt = 1f / 60f;
     private const float EnergyDrainRate = 0.15f;
 
-    private void MetabolismTick(TickContext ctx)
+    internal void MetabolismTick(TickContext ctx)
     {
         var dtScale = ctx.AmortizedDeltaTime / BaseDt * _timeScale;
         var nests = _nestPositions;
         var nestStock = _nestFoodStock;
+        var deathQueue = _antDiedQueue;
 
         using var clusters = ctx.ClusterIds != null
             ? ctx.Accessor.GetClusterEnumerator<Ant>(ctx.ClusterIds, ctx.StartClusterIndex, ctx.EndClusterIndex)
@@ -366,7 +389,8 @@ public sealed class TyphonBridge : IDisposable
         foreach (var cluster in clusters)
         {
             var bits = cluster.OccupancyBits;
-            var positions = cluster.GetSpan(Ant.Position);
+            var bounds = cluster.GetSpan(Ant.Bounds);
+            var velocities = cluster.GetSpan(Ant.Velocity);
             var states = cluster.GetSpan(Ant.State);
             var genetics = cluster.GetReadOnlySpan(Ant.Genetics);
             while (bits != 0)
@@ -380,8 +404,8 @@ public sealed class TyphonBridge : IDisposable
 
                 if (state.Energy <= 0f)
                 {
-                    Interlocked.Increment(ref _deathCount);
                     var ni = gen.HomeNestIndex;
+                    deathQueue?.Push(new AntDiedEvent((uint)((cluster.ChunkId << 8) | idx), ni));
 
                     var freeE = gen.BaseEnergy * 0.5f;
                     var bonusE = 0f;
@@ -398,15 +422,16 @@ public sealed class TyphonBridge : IDisposable
                     state.State = AntState.Foraging;
 
                     // Teleport to nest + random heading immediately (same pass, no heuristic)
-                    ref var pos = ref positions[idx];
+                    ref var pos = ref bounds[idx];
+                    ref var vel = ref velocities[idx];
                     pos.X = nests[ni].x;
                     pos.Y = nests[ni].y;
 
                     var h = (uint)(idx * 2654435761 + cluster.ChunkId * 40503 + ctx.TickNumber);
                     var angle = (h % 6283u) * 0.001f; // 0 to ~2π
                     var speed = gen.Speed * 40f;
-                    pos.VelocityX = MathF.Cos(angle) * speed;
-                    pos.VelocityY = MathF.Sin(angle) * speed;
+                    vel.X = MathF.Cos(angle) * speed;
+                    vel.Y = MathF.Sin(angle) * speed;
                     _dbe.MarkClusterSlotDirty(AntArchetypeId, cluster.ChunkId, idx);
                 }
             }
@@ -425,13 +450,15 @@ public sealed class TyphonBridge : IDisposable
     private const float FoodSmellRangeSq = FoodSmellRange * FoodSmellRange;
     private const float NestDropRangeSq = NestDropRange * NestDropRange;
 
-    private void FoodDetectTick(TickContext ctx)
+    internal void FoodDetectTick(TickContext ctx)
     {
         var food = _foodCache;
         var foodRemaining = _foodRemainingInt;
         var foodGrid = _foodGrid;
         var nests = _nestPositions;
         var nestStock = _nestFoodStock;
+        var pickedUpQueue = _foodPickedUpQueue;
+        var deliveredQueue = _foodDeliveredQueue;
 
         using var clusters = ctx.ClusterIds != null
             ? ctx.Accessor.GetClusterEnumerator<Ant>(ctx.ClusterIds, ctx.StartClusterIndex, ctx.EndClusterIndex)
@@ -439,14 +466,16 @@ public sealed class TyphonBridge : IDisposable
         foreach (var cluster in clusters)
         {
             var bits = cluster.OccupancyBits;
-            var positions = cluster.GetSpan(Ant.Position);
+            var bounds = cluster.GetReadOnlySpan(Ant.Bounds);
+            var velocities = cluster.GetSpan(Ant.Velocity);
             var states = cluster.GetSpan(Ant.State);
             var genetics = cluster.GetReadOnlySpan(Ant.Genetics);
             while (bits != 0)
             {
                 var idx = BitOperations.TrailingZeroCount(bits);
                 bits &= bits - 1;
-                ref var pos = ref positions[idx];
+                ref readonly var pos = ref bounds[idx];
+                ref var vel = ref velocities[idx];
                 ref var state = ref states[idx];
 
                 if (state.Energy <= 0f) continue;
@@ -475,8 +504,9 @@ public sealed class TyphonBridge : IDisposable
                             {
                                 state.State = AntState.ReturningFrom(fi);
                                 state.Energy = genetics[idx].BaseEnergy;
-                                pos.VelocityX = -pos.VelocityX;
-                                pos.VelocityY = -pos.VelocityY;
+                                vel.X = -vel.X;
+                                vel.Y = -vel.Y;
+                                pickedUpQueue?.Push(new FoodPickedUpEvent((uint)((cluster.ChunkId << 8) | idx), fi));
                             }
                             else
                             {
@@ -496,11 +526,11 @@ public sealed class TyphonBridge : IDisposable
                     if (bestIdx >= 0)
                     {
                         var heading = MathF.Atan2(food[bestIdx].y - pos.Y, food[bestIdx].x - pos.X);
-                        var speed = MathF.Sqrt(pos.VelocityX * pos.VelocityX + pos.VelocityY * pos.VelocityY);
+                        var speed = MathF.Sqrt(vel.X * vel.X + vel.Y * vel.Y);
                         ref readonly var gen = ref genetics[idx];
                         if (speed < 0.01f) speed = gen.Speed * 40f;
-                        pos.VelocityX = MathF.Cos(heading) * speed;
-                        pos.VelocityY = MathF.Sin(heading) * speed;
+                        vel.X = MathF.Cos(heading) * speed;
+                        vel.Y = MathF.Sin(heading) * speed;
                     }
                 }
                 else // Returning
@@ -512,7 +542,7 @@ public sealed class TyphonBridge : IDisposable
                     if (dx * dx + dy * dy < NestDropRangeSq)
                     {
                         Interlocked.Add(ref nestStock[ni], 3);
-                        Interlocked.Increment(ref _foodDelivered);
+                        deliveredQueue?.Push(new FoodDeliveredEvent((uint)((cluster.ChunkId << 8) | idx), ni, 3));
                         state.State = AntState.Foraging;
                     }
                 }
@@ -533,7 +563,7 @@ public sealed class TyphonBridge : IDisposable
     private const int WanderChangeTicks = 90;     // change direction every ~1.5s
     private const float WanderTurnMax = 0.8f;     // max turn on direction change (~45°)
 
-    private void AntBrainTick(TickContext ctx)
+    internal void AntBrainTick(TickContext ctx)
     {
         var phero = _pheromones;
         var nests = _nestPositions;
@@ -545,22 +575,24 @@ public sealed class TyphonBridge : IDisposable
         foreach (var cluster in clusters)
         {
             var bits = cluster.OccupancyBits;
-            var positions = cluster.GetSpan(Ant.Position);
+            var bounds = cluster.GetReadOnlySpan(Ant.Bounds);
+            var velocities = cluster.GetSpan(Ant.Velocity);
             var states = cluster.GetReadOnlySpan(Ant.State);
             var genetics = cluster.GetReadOnlySpan(Ant.Genetics);
             while (bits != 0)
             {
                 var idx = BitOperations.TrailingZeroCount(bits);
                 bits &= bits - 1;
-                ref var pos = ref positions[idx];
+                ref readonly var pos = ref bounds[idx];
+                ref var vel = ref velocities[idx];
                 ref readonly var state = ref states[idx];
                 ref readonly var gen = ref genetics[idx];
 
                 if (state.Energy <= 0f) continue;
 
-                var speed = MathF.Sqrt(pos.VelocityX * pos.VelocityX + pos.VelocityY * pos.VelocityY);
+                var speed = MathF.Sqrt(vel.X * vel.X + vel.Y * vel.Y);
                 if (speed < 0.01f) speed = gen.Speed * 40f;
-                var heading = MathF.Atan2(pos.VelocityY, pos.VelocityX);
+                var heading = MathF.Atan2(vel.Y, vel.X);
 
                 var steered = false;
 
@@ -625,8 +657,8 @@ public sealed class TyphonBridge : IDisposable
                     }
                 }
 
-                pos.VelocityX = MathF.Cos(heading) * speed;
-                pos.VelocityY = MathF.Sin(heading) * speed;
+                vel.X = MathF.Cos(heading) * speed;
+                vel.Y = MathF.Sin(heading) * speed;
             }
         }
     }
@@ -641,7 +673,7 @@ public sealed class TyphonBridge : IDisposable
     private const float DepositFalloffRange = 200f;
     private const float DepositFalloffRangeSq = DepositFalloffRange * DepositFalloffRange;
 
-    private void PheromoneDepositTick(TickContext ctx)
+    internal void PheromoneDepositTick(TickContext ctx)
     {
         var phero = _pheromones;
         var food = _foodCache;
@@ -656,13 +688,13 @@ public sealed class TyphonBridge : IDisposable
         foreach (var cluster in clusters)
         {
             var bits = cluster.OccupancyBits;
-            var positions = cluster.GetReadOnlySpan(Ant.Position);
+            var bounds = cluster.GetReadOnlySpan(Ant.Bounds);
             var states = cluster.GetReadOnlySpan(Ant.State);
             while (bits != 0)
             {
                 var idx = BitOperations.TrailingZeroCount(bits);
                 bits &= bits - 1;
-                ref readonly var pos = ref positions[idx];
+                ref readonly var pos = ref bounds[idx];
                 ref readonly var state = ref states[idx];
 
                 if (state.Energy <= 0f) continue;
@@ -701,7 +733,7 @@ public sealed class TyphonBridge : IDisposable
 
     private const float PheroDecayFactor = 0.995f;
 
-    private void PheromoneDecayTick(TickContext ctx)
+    internal void PheromoneDecayTick(TickContext ctx)
     {
         _pheromones.Evaporate(PheroDecayFactor);
     }
@@ -710,7 +742,7 @@ public sealed class TyphonBridge : IDisposable
     // Render Pipeline
     // ═══════════════════════════════════════════════════════════════════
 
-    private void PrepareRender(TickContext ctx)
+    internal void PrepareRender(TickContext ctx)
     {
         var crossings = Interlocked.Exchange(ref _cellCrossingsThisTick, 0);
         _crossingsAccum += crossings;
@@ -823,7 +855,7 @@ public sealed class TyphonBridge : IDisposable
         }
     }
 
-    private void FillRender(TickContext ctx)
+    internal void FillRender(TickContext ctx)
     {
         var wb = _workerBuffers[ctx.WorkerId];
         var tierMirror = _tierMirror;
@@ -858,7 +890,7 @@ public sealed class TyphonBridge : IDisposable
             }
 
             // Cluster overlaps camera — render visible ants
-            var positions = cluster.GetReadOnlySpan(Ant.Position);
+            var positions = cluster.GetReadOnlySpan(Ant.Bounds);
             var statesVis = cluster.GetReadOnlySpan(Ant.State);
             var genetics = cluster.GetReadOnlySpan(Ant.Genetics);
 
@@ -915,7 +947,7 @@ public sealed class TyphonBridge : IDisposable
         Interlocked.Add(ref _stateCounts[1], sCarrying);
     }
 
-    private void PublishRender(TickContext ctx)
+    internal void PublishRender(TickContext ctx)
     {
         // Snapshot current Data/Count into immutable frame — Godot reads only this
         var buffers = new BufferSnapshot[_workerBuffers.Length];
@@ -1007,11 +1039,14 @@ public sealed class TyphonBridge : IDisposable
                     var baseEnergy = 800f + (float)(rng.NextDouble() * 800f);
                     var eatAmount = 1 + rng.Next(3);
 
-                    var pos = new Position
+                    var bounds = new WorldBounds
                     {
-                        Bounds = new AABB2F { MinX = x, MinY = y, MaxX = x, MaxY = y },
-                        VelocityX = MathF.Cos(headAngle) * finalSpeed,
-                        VelocityY = MathF.Sin(headAngle) * finalSpeed
+                        Bounds = new AABB2F { MinX = x, MinY = y, MaxX = x, MaxY = y }
+                    };
+                    var vel = new Velocity
+                    {
+                        X = MathF.Cos(headAngle) * finalSpeed,
+                        Y = MathF.Sin(headAngle) * finalSpeed
                     };
                     var genetics = new Genetics
                     {
@@ -1029,7 +1064,8 @@ public sealed class TyphonBridge : IDisposable
                     };
 
                     tx.Spawn<Ant>(
-                        Ant.Position.Set(in pos),
+                        Ant.Bounds.Set(in bounds),
+                        Ant.Velocity.Set(in vel),
                         Ant.Genetics.Set(in genetics),
                         Ant.State.Set(in state));
                 }
@@ -1128,10 +1164,52 @@ public sealed class TyphonBridge : IDisposable
     // Public API
     // ═══════════════════════════════════════════════════════════════════
 
-    public void Start() => _runtime.Start();
+    public void Start()
+    {
+        _runtime.Start();
+        StartHangWatchdog();
+    }
+
+    /// <summary>
+    /// Polls <see cref="TyphonRuntime.CurrentTickNumber"/> from a background task. If the tick
+    /// counter doesn't advance for {HangThresholdSeconds}s the watchdog dumps the scheduler's
+    /// per-system state to stdout — predecessor count, ready flag, chunk progress, skip
+    /// reason — and stops. Designed for the 1st-tick-never-completes case where a CPU spin in
+    /// the worker pool prevents the engine from making progress; without this dump we'd have
+    /// no signal at all about which system is wedged.
+    /// </summary>
+    private void StartHangWatchdog()
+    {
+        const int hangThresholdSeconds = 5;
+        const int pollIntervalMs = 1_000;
+        System.Threading.Tasks.Task.Run(async () =>
+        {
+            var lastTick = -1L;
+            var stuckSince = DateTime.UtcNow;
+            while (true)
+            {
+                await System.Threading.Tasks.Task.Delay(pollIntervalMs).ConfigureAwait(false);
+                var rt = _runtime;
+                if (rt == null) return;
+                var current = rt.CurrentTickNumber;
+                if (current != lastTick)
+                {
+                    lastTick = current;
+                    stuckSince = DateTime.UtcNow;
+                    continue;
+                }
+                if ((DateTime.UtcNow - stuckSince).TotalSeconds < hangThresholdSeconds) continue;
+                Console.WriteLine($"[hang-watchdog] tick {current} stalled for >{hangThresholdSeconds}s — dumping scheduler state");
+                Console.WriteLine(rt.Scheduler.DumpHangDiagnostic());
+                return;
+            }
+        });
+    }
+
     public void SetHeatmapEnabled(bool enabled) => _heatmapEnabled = enabled;
     public TickTelemetryRing Telemetry => _runtime?.Telemetry;
     public SystemDefinition[] Systems => _runtime?.Systems;
+    public string[] PhaseNames => _runtime?.PhaseNames ?? [];
 
     // Parent resource under which profiler exporters (FileExporter / TcpExporter) must be created.
     // Available only after Initialize() has built the service provider.

--- a/test/AntHill/Scripts/Main.cs
+++ b/test/AntHill/Scripts/Main.cs
@@ -56,6 +56,7 @@ public partial class Main : Node2D
                 foreach (var exp in _exporters) TyphonProfiler.AttachExporter(exp);
                 var metadata = ProfilerSetup.BuildSessionMetadata(
                     _bridge.Systems, workerCount: 16, baseTickRate: 60f,
+                    phases: _bridge.PhaseNames,
                     currentEngineTickProvider: () => _bridge?.CurrentTick ?? 0);
 
                 if (_profilerConfig.LiveWaitMs > 0 && _profilerConfig.LivePort >= 0)

--- a/test/AntHill/profiling/Program.cs
+++ b/test/AntHill/profiling/Program.cs
@@ -63,6 +63,7 @@ public static class Program
                 foreach (var exp in exporters) TyphonProfiler.AttachExporter(exp);
                 var metadata = ProfilerSetup.BuildSessionMetadata(
                     bridge.Systems, workerCount: 16, baseTickRate: 60f,
+                    phases: bridge.PhaseNames,
                     currentEngineTickProvider: () => bridge.CurrentTick);
                 if (profilerConfig.LiveWaitMs > 0 && profilerConfig.LivePort >= 0)
                 {

--- a/test/Typhon.Engine.Tests/Profiler/FileExporterIntegrationTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/FileExporterIntegrationTests.cs
@@ -158,6 +158,7 @@ public class FileExporterIntegrationTests
         reader.ReadSystemDefinitions();
         reader.ReadArchetypes();
         reader.ReadComponentTypes();
+        reader.ReadPhases();
 
         // Walk all blocks + all records; tally what we saw.
         var kindCounts = new Dictionary<TraceEventKind, int>();

--- a/test/Typhon.Engine.Tests/Profiler/IncrementalCacheBuilderTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/IncrementalCacheBuilderTests.cs
@@ -49,6 +49,7 @@ public class IncrementalCacheBuilderTests
                 reader.ReadSystemDefinitions();
                 reader.ReadArchetypes();
                 reader.ReadComponentTypes();
+                reader.ReadPhases();
 
                 var sink = FileCacheSink.Create(cachePathB);
                 var profilerHeader = new ProfilerHeader { Version = fileHeader.Version, TimestampFrequency = fileHeader.TimestampFrequency };
@@ -123,6 +124,7 @@ public class IncrementalCacheBuilderTests
                 reader.ReadSystemDefinitions();
                 reader.ReadArchetypes();
                 reader.ReadComponentTypes();
+                reader.ReadPhases();
 
                 var sink = FileCacheSink.Create(cachePath);
                 var profilerHeader = new ProfilerHeader { Version = fileHeader.Version, TimestampFrequency = fileHeader.TimestampFrequency };
@@ -171,6 +173,7 @@ public class IncrementalCacheBuilderTests
                 reader.ReadSystemDefinitions();
                 reader.ReadArchetypes();
                 reader.ReadComponentTypes();
+                reader.ReadPhases();
 
                 var sink = FileCacheSink.Create(cachePath);
                 var profilerHeader = new ProfilerHeader { Version = fileHeader.Version, TimestampFrequency = fileHeader.TimestampFrequency };
@@ -235,6 +238,7 @@ public class IncrementalCacheBuilderTests
                 reader.ReadSystemDefinitions();
                 reader.ReadArchetypes();
                 reader.ReadComponentTypes();
+                reader.ReadPhases();
 
                 var sink = FileCacheSink.Create(cachePath);
                 var profilerHeader = new ProfilerHeader { Version = fileHeader.Version, TimestampFrequency = fileHeader.TimestampFrequency };
@@ -391,7 +395,9 @@ public class IncrementalCacheBuilderTests
             return (off, (uint)copy.Length, (uint)copy.Length);
         }
         public void WriteTrailer(IReadOnlyList<TickSummary> ts, in GlobalMetricsFixed gm, IReadOnlyList<SystemAggregateDuration> sa,
-            IReadOnlyList<ChunkManifestEntry> cm, IReadOnlyDictionary<int, string> sn, ReadOnlySpan<byte> sourceMetadataBytes, in CacheHeader h)
+            IReadOnlyList<ChunkManifestEntry> cm, IReadOnlyDictionary<int, string> sn, ReadOnlySpan<byte> sourceMetadataBytes, in CacheHeader h,
+            IReadOnlyList<SystemTickSummary> sts, IReadOnlyList<QueueTickSummary> qts, IReadOnlyList<PostTickSummary> pts,
+            IReadOnlyDictionary<ushort, string> qIdToName)
             => throw new NotSupportedException("MemorySink does not support trailer.");
         public void Dispose() { }
     }
@@ -450,6 +456,7 @@ public class IncrementalCacheBuilderTests
         writer.WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord>.Empty);
         writer.WriteArchetypes(ReadOnlySpan<ArchetypeRecord>.Empty);
         writer.WriteComponentTypes(ReadOnlySpan<ComponentTypeRecord>.Empty);
+        writer.WritePhases(ReadOnlySpan<string>.Empty);
 
         const int maxRecordsPerBlock = TraceFileWriter.MaxBlockBytes / CommonHeaderSize;
         var blockBuf = new byte[maxRecordsPerBlock * CommonHeaderSize];

--- a/test/Typhon.Engine.Tests/Profiler/SourceLocationManifestRoundTripTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/SourceLocationManifestRoundTripTests.cs
@@ -53,6 +53,7 @@ public class SourceLocationManifestRoundTripTests
         writer.WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord>.Empty);
         writer.WriteArchetypes(ReadOnlySpan<ArchetypeRecord>.Empty);
         writer.WriteComponentTypes(ReadOnlySpan<ComponentTypeRecord>.Empty);
+        writer.WritePhases(ReadOnlySpan<string>.Empty);
 
         var (fileTableOffset, manifestOffset) = writer.WriteSourceLocationManifest(files, entries);
 
@@ -113,6 +114,7 @@ public class SourceLocationManifestRoundTripTests
         writer.WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord>.Empty);
         writer.WriteArchetypes(ReadOnlySpan<ArchetypeRecord>.Empty);
         writer.WriteComponentTypes(ReadOnlySpan<ComponentTypeRecord>.Empty);
+        writer.WritePhases(ReadOnlySpan<string>.Empty);
         writer.Flush();
 
         stream.Position = 0;

--- a/test/Typhon.Engine.Tests/Profiler/SystemDefinitionRecordRoundTripTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/SystemDefinitionRecordRoundTripTests.cs
@@ -1,0 +1,177 @@
+using System.IO;
+using NUnit.Framework;
+using Typhon.Profiler;
+
+namespace Typhon.Engine.Tests.Profiler;
+
+/// <summary>
+/// Wire-format tests for the trace v6 SystemDefinitionTable + PhasesTable extension introduced for #310.
+///
+/// Goals:
+///   1. Round-trip every RFC 07 field declared on <see cref="SystemDefinitionRecord"/>.
+///   2. Backward-compat: a v5 trace (no RFC 07 fields, no Phases section) reads with empty defaults
+///      and does not throw.
+/// </summary>
+[TestFixture]
+public sealed class SystemDefinitionRecordRoundTripTests
+{
+    private static readonly TraceFileHeader DefaultHeaderV6 = new()
+    {
+        Magic = TraceFileHeader.MagicValue,
+        Version = TraceFileHeader.CurrentVersion,
+        Flags = 0,
+        TimestampFrequency = 10_000_000,
+        BaseTickRate = 60f,
+        WorkerCount = 1,
+        SystemCount = 1,
+        ArchetypeCount = 0,
+        ComponentTypeCount = 0,
+        CreatedUtcTicks = 0,
+        SamplingSessionStartQpc = 0,
+    };
+
+    [Test]
+    public void V6_RoundTrips_AllRfc07Fields()
+    {
+        var input = new SystemDefinitionRecord
+        {
+            Index = 7,
+            Name = "Movement",
+            Type = 0,
+            Priority = 1,
+            IsParallel = true,
+            TierFilter = 0x0F,
+            Predecessors = [3, 5],
+            Successors = [11],
+            PhaseName = "Simulation",
+            IsExclusivePhase = true,
+            Reads = ["A", "B"],
+            ReadsFresh = ["C"],
+            ReadsSnapshot = ["D", "E"],
+            AdditionalReads = ["F"],
+            Writes = ["G"],
+            SideWrites = ["H", "I"],
+            WritesEvents = ["q1"],
+            ReadsEvents = ["q2", "q3"],
+            WritesResources = ["r1"],
+            ReadsResources = ["r2"],
+            ExplicitAfter = ["X"],
+            ExplicitBefore = ["Y"],
+        };
+
+        byte[] bytes;
+        using (var writeStream = new MemoryStream())
+        {
+            using (var writer = new TraceFileWriter(writeStream))
+            {
+                var hdr = DefaultHeaderV6;
+                writer.WriteHeader(in hdr);
+                writer.WriteSystemDefinitions([input]);
+                writer.WriteArchetypes([]);
+                writer.WriteComponentTypes([]);
+                writer.WritePhases(["Input", "Simulation", "Output"]);
+                writer.Flush();
+                bytes = writeStream.ToArray();
+            }
+        }
+
+        using var ms = new MemoryStream(bytes, writable: false);
+        using var reader = new TraceFileReader(ms);
+        reader.ReadHeader();
+        reader.ReadSystemDefinitions();
+        reader.ReadArchetypes();
+        reader.ReadComponentTypes();
+        reader.ReadPhases();
+
+        Assert.That(reader.Systems, Has.Count.EqualTo(1));
+        var output = reader.Systems[0];
+        Assert.That(output.Index, Is.EqualTo(7));
+        Assert.That(output.Name, Is.EqualTo("Movement"));
+        Assert.That(output.IsParallel, Is.True);
+        Assert.That(output.Predecessors, Is.EqualTo(new ushort[] { 3, 5 }));
+        Assert.That(output.Successors, Is.EqualTo(new ushort[] { 11 }));
+        Assert.That(output.PhaseName, Is.EqualTo("Simulation"));
+        Assert.That(output.IsExclusivePhase, Is.True);
+        Assert.That(output.Reads, Is.EqualTo(new[] { "A", "B" }));
+        Assert.That(output.ReadsFresh, Is.EqualTo(new[] { "C" }));
+        Assert.That(output.ReadsSnapshot, Is.EqualTo(new[] { "D", "E" }));
+        Assert.That(output.AdditionalReads, Is.EqualTo(new[] { "F" }));
+        Assert.That(output.Writes, Is.EqualTo(new[] { "G" }));
+        Assert.That(output.SideWrites, Is.EqualTo(new[] { "H", "I" }));
+        Assert.That(output.WritesEvents, Is.EqualTo(new[] { "q1" }));
+        Assert.That(output.ReadsEvents, Is.EqualTo(new[] { "q2", "q3" }));
+        Assert.That(output.WritesResources, Is.EqualTo(new[] { "r1" }));
+        Assert.That(output.ReadsResources, Is.EqualTo(new[] { "r2" }));
+        Assert.That(output.ExplicitAfter, Is.EqualTo(new[] { "X" }));
+        Assert.That(output.ExplicitBefore, Is.EqualTo(new[] { "Y" }));
+
+        Assert.That(reader.Phases, Is.EqualTo(new[] { "Input", "Simulation", "Output" }));
+    }
+
+    [Test]
+    public void V5_BackwardCompat_RfcFieldsDefaultToEmpty()
+    {
+        // Craft a v5 system-definition table — same byte layout as v6 minus the RFC 07 trailer and
+        // minus the PhasesTable section. The reader must populate empty defaults and not consume bytes
+        // for the missing trailer / phases. We serialize the header through MemoryMarshal so the on-disk
+        // struct shape is whatever the runtime would produce, regardless of packing nuances.
+        var v5Header = DefaultHeaderV6;
+        v5Header.Version = 5;
+
+        byte[] bytes;
+        using (var ms = new MemoryStream())
+        using (var bw = new System.IO.BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: false))
+        {
+            var headerBytes = System.Runtime.InteropServices.MemoryMarshal.AsBytes(
+                System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpan(ref v5Header, 1));
+            ms.Write(headerBytes);
+
+            // SystemDefinitionTable — v5 layout (no RFC 07 trailer).
+            bw.Write((ushort)1);                          // count
+            bw.Write((ushort)0);                          // index
+            WriteShortString(bw, "Legacy");                // name
+            bw.Write((byte)0);                             // type
+            bw.Write((byte)0);                             // priority
+            bw.Write(false);                               // isParallel
+            bw.Write((byte)0x0F);                          // tierFilter
+            bw.Write((byte)0);                             // predCount
+            bw.Write((byte)0);                             // succCount
+
+            // Archetypes + ComponentTypes — empty. (No PhasesTable in v5.)
+            bw.Write((ushort)0);
+            bw.Write((ushort)0);
+            bw.Flush();
+            bytes = ms.ToArray();
+        }
+
+        using var readStream = new MemoryStream(bytes, writable: false);
+        using var reader = new TraceFileReader(readStream);
+        reader.ReadHeader();
+        reader.ReadSystemDefinitions();
+        reader.ReadArchetypes();
+        reader.ReadComponentTypes();
+        reader.ReadPhases();
+
+        Assert.That(reader.Header.Version, Is.EqualTo(5));
+        Assert.That(reader.Systems, Has.Count.EqualTo(1));
+        var s = reader.Systems[0];
+        Assert.That(s.Name, Is.EqualTo("Legacy"));
+        Assert.That(s.PhaseName, Is.EqualTo(string.Empty));
+        Assert.That(s.IsExclusivePhase, Is.False);
+        Assert.That(s.Reads, Is.Empty);
+        Assert.That(s.Writes, Is.Empty);
+        Assert.That(s.WritesEvents, Is.Empty);
+        Assert.That(s.ReadsEvents, Is.Empty);
+        Assert.That(s.ExplicitAfter, Is.Empty);
+        Assert.That(s.ExplicitBefore, Is.Empty);
+        Assert.That(reader.Phases, Is.Empty);
+    }
+
+    private static void WriteShortString(System.IO.BinaryWriter bw, string value)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(value ?? string.Empty);
+        var len = (byte)System.Math.Min(bytes.Length, 255);
+        bw.Write(len);
+        bw.Write(bytes, 0, len);
+    }
+}

--- a/test/Typhon.Engine.Tests/Profiler/TcpExporterIntegrationTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/TcpExporterIntegrationTests.cs
@@ -83,6 +83,7 @@ public class TcpExporterIntegrationTests
                 reader.ReadSystemDefinitions();
                 reader.ReadArchetypes();
                 reader.ReadComponentTypes();
+                reader.ReadPhases();
             }
 
             // ── Emit records on a dedicated fresh thread so the slot buffer starts clean. NUnit reuses the test thread across tests

--- a/test/Typhon.Engine.Tests/Profiler/TraceFileCacheBuilderSplitTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/TraceFileCacheBuilderSplitTests.cs
@@ -138,6 +138,7 @@ public class TraceFileCacheBuilderSplitTests
         writer.WriteSystemDefinitions(ReadOnlySpan<SystemDefinitionRecord>.Empty);
         writer.WriteArchetypes(ReadOnlySpan<ArchetypeRecord>.Empty);
         writer.WriteComponentTypes(ReadOnlySpan<ComponentTypeRecord>.Empty);
+        writer.WritePhases(ReadOnlySpan<string>.Empty);
 
         // Build record bytes in blocks no larger than TraceFileWriter.MaxBlockBytes (256 KiB). At 12 B per record that's up to
         // ~21K records per block — chunk the emission into pages.

--- a/test/Typhon.Engine.Tests/Profiler/V12CacheRoundTripTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/V12CacheRoundTripTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using Typhon.Profiler;
+
+namespace Typhon.Engine.Tests.Profiler;
+
+/// <summary>
+/// Round-trip tests for the v12 cache sections introduced for #311 — <see cref="CacheSectionId.SystemTickSummaries"/>,
+/// <see cref="CacheSectionId.QueueTickSummaries"/>, <see cref="CacheSectionId.PostTickSummaries"/>, and
+/// <see cref="CacheSectionId.QueueNameTable"/>. Each test writes a small set of records, closes the writer, opens a
+/// reader, and asserts the round-tripped values match.
+/// </summary>
+[TestFixture]
+public sealed class V12CacheRoundTripTests
+{
+    [Test]
+    public void SystemTickSummary_RoundTrip()
+    {
+        var rows = new[]
+        {
+            new SystemTickSummary
+            {
+                TickNumber = 1, SystemIndex = 0, SkipReasonCode = 0, Flags = 0,
+                StartUs = 100, EndUs = 250, ReadyUs = 95, DurationUs = 150f,
+                EntitiesProcessed = 42, WorkersTouched = 4, ChunksProcessed = 8, _reserved = 0,
+            },
+            new SystemTickSummary
+            {
+                TickNumber = 1, SystemIndex = 1, SkipReasonCode = 3, Flags = 0,
+                StartUs = 0, EndUs = 0, ReadyUs = 0, DurationUs = 0f,
+                EntitiesProcessed = 0, WorkersTouched = 0, ChunksProcessed = 0, _reserved = 0,
+            },
+        };
+
+        var path = Path.Combine(Path.GetTempPath(), $"v12-sys-{System.Guid.NewGuid():N}.cache");
+        try
+        {
+            WriteCache(path, systemRows: rows);
+            using var reader = new TraceFileCacheReader(File.OpenRead(path));
+            Assert.That(reader.SystemTickSummaries, Has.Count.EqualTo(2));
+            Assert.That(reader.SystemTickSummaries[0].DurationUs, Is.EqualTo(150f));
+            Assert.That(reader.SystemTickSummaries[0].EntitiesProcessed, Is.EqualTo(42));
+            Assert.That(reader.SystemTickSummaries[0].WorkersTouched, Is.EqualTo(4));
+            Assert.That(reader.SystemTickSummaries[1].SkipReasonCode, Is.EqualTo(3));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void QueueTickSummary_AndQueueNameTable_RoundTrip()
+    {
+        var rows = new[]
+        {
+            new QueueTickSummary { TickNumber = 5, QueueId = 0, _reserved = 0, PeakDepth = 100, EndOfTickDepth = 12, OverflowCount = 0, Produced = 50, Consumed = 38 },
+            new QueueTickSummary { TickNumber = 5, QueueId = 1, _reserved = 0, PeakDepth = 1024, EndOfTickDepth = 0, OverflowCount = 3, Produced = 1027, Consumed = 1027 },
+        };
+        var names = new Dictionary<ushort, string> { [0] = "DamageQueue", [1] = "DeathQueue" };
+
+        var path = Path.Combine(Path.GetTempPath(), $"v12-queue-{System.Guid.NewGuid():N}.cache");
+        try
+        {
+            WriteCache(path, queueRows: rows, queueNames: names);
+            using var reader = new TraceFileCacheReader(File.OpenRead(path));
+            Assert.That(reader.QueueTickSummaries, Has.Count.EqualTo(2));
+            Assert.That(reader.QueueTickSummaries[0].PeakDepth, Is.EqualTo(100));
+            Assert.That(reader.QueueTickSummaries[1].OverflowCount, Is.EqualTo(3));
+            Assert.That(reader.QueueIdToName, Has.Count.EqualTo(2));
+            Assert.That(reader.QueueIdToName[0], Is.EqualTo("DamageQueue"));
+            Assert.That(reader.QueueIdToName[1], Is.EqualTo("DeathQueue"));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void PostTickSummary_RoundTrip()
+    {
+        var rows = new[]
+        {
+            new PostTickSummary
+            {
+                TickNumber = 10, _reserved = 0,
+                WriteTickFenceUs = 12.5f, WalFlushUs = 100f, SubscriptionOutputUs = 5.2f,
+                TierIndexRebuildUs = 0f, DormancySweepUs = 1.1f, TierBudgetUs = 0f,
+            },
+        };
+
+        var path = Path.Combine(Path.GetTempPath(), $"v12-post-{System.Guid.NewGuid():N}.cache");
+        try
+        {
+            WriteCache(path, postRows: rows);
+            using var reader = new TraceFileCacheReader(File.OpenRead(path));
+            Assert.That(reader.PostTickSummaries, Has.Count.EqualTo(1));
+            Assert.That(reader.PostTickSummaries[0].WalFlushUs, Is.EqualTo(100f));
+            Assert.That(reader.PostTickSummaries[0].WriteTickFenceUs, Is.EqualTo(12.5f));
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void EmptyV12Sections_PresentInTrailer_DoNotBreakReader()
+    {
+        // Smoke test: explicitly write empty v12 sections + verify reader sees zero rows.
+        var path = Path.Combine(Path.GetTempPath(), $"v12-empty-{System.Guid.NewGuid():N}.cache");
+        try
+        {
+            WriteCache(path);
+            using var reader = new TraceFileCacheReader(File.OpenRead(path));
+            Assert.That(reader.SystemTickSummaries, Is.Empty);
+            Assert.That(reader.QueueTickSummaries, Is.Empty);
+            Assert.That(reader.PostTickSummaries, Is.Empty);
+            Assert.That(reader.QueueIdToName, Is.Empty);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+
+    private static void WriteCache(
+        string path,
+        SystemTickSummary[] systemRows = null,
+        QueueTickSummary[] queueRows = null,
+        PostTickSummary[] postRows = null,
+        Dictionary<ushort, string> queueNames = null)
+    {
+        using var sink = FileCacheSink.Create(path);
+        // FileCacheSink.WriteTrailer auto-opens the FoldedChunkData section when no chunks were appended; no AppendChunk needed here.
+        var headerTemplate = new CacheHeader
+        {
+            Magic = CacheHeader.MagicValue,
+            Version = CacheHeader.CurrentVersion,
+            ChunkerVersion = TraceFileCacheConstants.CurrentChunkerVersion,
+        };
+        // Identifier doesn't matter for these tests.
+        var ident = new byte[32];
+        CacheHeader.SetIdentifier(ref headerTemplate, ident);
+
+        sink.WriteTrailer(
+            tickSummaries: System.Array.Empty<TickSummary>(),
+            globalMetrics: new GlobalMetricsFixed(),
+            systemAggregates: System.Array.Empty<SystemAggregateDuration>(),
+            chunkManifest: System.Array.Empty<ChunkManifestEntry>(),
+            spanNames: new Dictionary<int, string>(),
+            sourceMetadataBytes: default,
+            headerTemplate: headerTemplate,
+            systemTickSummaries: systemRows ?? System.Array.Empty<SystemTickSummary>(),
+            queueTickSummaries: queueRows ?? System.Array.Empty<QueueTickSummary>(),
+            postTickSummaries: postRows ?? System.Array.Empty<PostTickSummary>(),
+            queueIdToName: queueNames ?? new Dictionary<ushort, string>());
+    }
+}

--- a/test/Typhon.Engine.Tests/Runtime/EventQueueTelemetryTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/EventQueueTelemetryTests.cs
@@ -1,0 +1,90 @@
+using NUnit.Framework;
+using Typhon.Engine;
+
+namespace Typhon.Engine.Tests.Runtime;
+
+/// <summary>
+/// Per-tick telemetry accumulators on <see cref="EventQueueBase"/> (#311). Push/Drain update PeakDepth, Produced,
+/// Consumed, OverflowCount; Reset clears them at tick start.
+/// </summary>
+[TestFixture]
+public sealed class EventQueueTelemetryTests
+{
+    private struct DamageEvent { public int Amount; }
+
+    [Test]
+    public void StartsZero_OnFreshQueue()
+    {
+        var q = new EventQueue<DamageEvent>("Damage", capacity: 64);
+        Assert.That(q.PeakDepth, Is.EqualTo(0u));
+        Assert.That(q.Produced, Is.EqualTo(0u));
+        Assert.That(q.Consumed, Is.EqualTo(0u));
+        Assert.That(q.OverflowCount, Is.EqualTo(0u));
+    }
+
+    [Test]
+    public void Push_BumpsProduced_AndPeakDepth()
+    {
+        var q = new EventQueue<DamageEvent>("Damage", capacity: 64);
+        q.Push(new DamageEvent { Amount = 1 });
+        q.Push(new DamageEvent { Amount = 2 });
+        q.Push(new DamageEvent { Amount = 3 });
+        Assert.That(q.Produced, Is.EqualTo(3u));
+        Assert.That(q.PeakDepth, Is.EqualTo(3u));
+    }
+
+    [Test]
+    public void Drain_BumpsConsumed_DoesNotResetPeak()
+    {
+        var q = new EventQueue<DamageEvent>("Damage", capacity: 64);
+        for (var i = 0; i < 5; i++) q.Push(new DamageEvent { Amount = i });
+        var buf = new DamageEvent[5];
+        var drained = q.Drain(buf);
+        Assert.That(drained, Is.EqualTo(5));
+        Assert.That(q.Consumed, Is.EqualTo(5u));
+        Assert.That(q.PeakDepth, Is.EqualTo(5u), "peak persists for the whole tick — only Reset clears it");
+        Assert.That(q.Produced, Is.EqualTo(5u));
+    }
+
+    [Test]
+    public void Push_AfterDrainInSameTick_ContinuesToTrackPeak()
+    {
+        var q = new EventQueue<DamageEvent>("Damage", capacity: 64);
+        for (var i = 0; i < 3; i++) q.Push(new DamageEvent { Amount = i });
+        var buf = new DamageEvent[3];
+        q.Drain(buf);
+        // After drain, push more — peak should NOT regress to current count.
+        q.Push(new DamageEvent { Amount = 100 });
+        Assert.That(q.PeakDepth, Is.EqualTo(3u), "peak is high-water-mark across the tick, not a snapshot of current depth");
+    }
+
+    [Test]
+    public void Push_OnFullQueue_BumpsOverflowCount_AndThrows()
+    {
+        var q = new EventQueue<DamageEvent>("Tiny", capacity: 2);
+        q.Push(new DamageEvent { Amount = 1 });
+        q.Push(new DamageEvent { Amount = 2 });
+        Assert.Throws<System.InvalidOperationException>(() => q.Push(new DamageEvent { Amount = 3 }));
+        Assert.That(q.OverflowCount, Is.EqualTo(1u));
+        Assert.That(q.Produced, Is.EqualTo(2u), "overflowed push does not count toward Produced");
+    }
+
+    [Test]
+    public void Reset_ClearsAllAccumulators()
+    {
+        var q = new EventQueue<DamageEvent>("Damage", capacity: 4);
+        q.Push(new DamageEvent());
+        q.Push(new DamageEvent());
+        q.Push(new DamageEvent());
+        q.Push(new DamageEvent());
+        try { q.Push(new DamageEvent()); } catch (System.InvalidOperationException) { /* expected: full */ }
+        var buf = new DamageEvent[4];
+        q.Drain(buf);
+
+        q.Reset();
+        Assert.That(q.PeakDepth, Is.EqualTo(0u));
+        Assert.That(q.Produced, Is.EqualTo(0u));
+        Assert.That(q.Consumed, Is.EqualTo(0u));
+        Assert.That(q.OverflowCount, Is.EqualTo(0u));
+    }
+}

--- a/test/Typhon.Engine.Tests/Runtime/ExceptionHandlingTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/ExceptionHandlingTests.cs
@@ -86,6 +86,49 @@ class ExceptionHandlingTests
     }
 
     [Test]
+    public void ParallelQueryException_TickCompletes_NoFullCpuWedge()
+    {
+        // Repro for the chunk-exception wedge: a parallel QuerySystem where one chunk throws
+        // would never reach `OnSystemComplete` because the failing worker bailed at the top of
+        // `ProcessPipeline` / `ProcessParallelQuery` without claiming + decrementing remaining
+        // chunks. `FindReadySystem` then keeps returning the system (chunks still unclaimed) and
+        // workers loop into `ProcessSystem` → break → repeat — a full-CPU spin that never
+        // advances the tick. Fix: drain remaining chunks on failure (`DrainFailedSystemChunks`).
+        // This test fails (timeout) without the fix; passes within ~1 s with it.
+        var afterCount = 0;
+        var schedule = RuntimeSchedule.Create(new RuntimeOptions
+        {
+            WorkerCount = 4, BaseTickRate = 1000, ParallelQueryMinChunkSize = 64,
+        });
+        schedule
+            .QuerySystem("ThrowingParallel", _ => { }, input: () => null, parallel: true)
+            .CallbackSystem("After", _ => Interlocked.Increment(ref afterCount));
+
+        using var scheduler = schedule.Build(_registry.Runtime);
+        scheduler.ParallelQueryPrepareCallback = _ => 4;
+        scheduler.ParallelQueryChunkCallback = (_, chunk, _, _) =>
+        {
+            if (chunk == 0)
+            {
+                throw new InvalidOperationException("chunk 0 fails");
+            }
+            // Other chunks may run if a worker grabs them BEFORE the failure flag is set —
+            // that's fine, the test only cares that the tick advances.
+        };
+        scheduler.ParallelQueryCleanupCallback = _ => false;
+
+        scheduler.Start();
+        // 2 s budget — without the fix the scheduler wedges and CurrentTickNumber stays at 0,
+        // SpinUntil times out, Assert below fails. With the fix the tick completes in <100 ms.
+        var advanced = SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 3, TimeSpan.FromSeconds(2));
+        scheduler.Shutdown();
+
+        Assert.That(advanced, Is.True, "Tick should advance even when a parallel-query chunk throws");
+        Assert.That(afterCount, Is.GreaterThanOrEqualTo(3),
+            "Independent successor should run on every tick after the throwing system");
+    }
+
+    [Test]
     public void SystemException_IndependentBranchContinues()
     {
         var branch1Count = 0;

--- a/test/Typhon.IOProfileRunner/Program.cs
+++ b/test/Typhon.IOProfileRunner/Program.cs
@@ -831,6 +831,7 @@ public static class Program
             reader.ReadSystemDefinitions();
             reader.ReadArchetypes();
             reader.ReadComponentTypes();
+            reader.ReadPhases();
 
             var kindCounts = new SortedDictionary<TraceEventKind, int>();
             var threadSlotCounts = new SortedDictionary<int, int>();

--- a/test/Typhon.Workbench.Tests/Data/AggregationServiceTests.cs
+++ b/test/Typhon.Workbench.Tests/Data/AggregationServiceTests.cs
@@ -1,0 +1,573 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Typhon.Profiler;
+using Typhon.Workbench.Dtos.Data;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Services;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Tests.Data;
+
+/// <summary>
+/// Pure unit tests for <see cref="AggregationService.Compute"/>. No HTTP layer — exercises all
+/// 13 Tier 1 operators, multi-query ordering, range clamping, and validation errors.
+/// </summary>
+[TestFixture]
+public sealed class AggregationServiceTests
+{
+    private static TickSummaryDto Tick(uint n, float dur, ushort waitUs = 0, byte intentClass = 0)
+        => new(n, 0.0, dur, 0, 0f, "0", 0, 0, waitUs, intentClass, 0, 0);
+
+    // Five ticks (1–5), DurationUs = 10, 20, 30, 40, 50 µs.
+    private static readonly TickSummaryDto[] Ticks5 =
+    [
+        Tick(1, 10f), Tick(2, 20f), Tick(3, 30f), Tick(4, 40f), Tick(5, 50f),
+    ];
+
+    private static AggregationQueryDto Q(string op, string trackId = "tick/summary", string field = "durationUs",
+        uint t0 = 1, uint t1 = 5)
+        => new(trackId, field, op, [t0, t1]);
+
+    private static double? Run(string op) =>
+        AggregationService.Compute(Ticks5, [Q(op)])[0].Value;
+
+    // ── All 13 Tier-1 operators on a 5-element full-range dataset ──
+
+    [Test] public void Mean_FullRange() => Assert.That(Run("mean"), Is.EqualTo(30.0).Within(1e-9));
+    [Test] public void Sum_FullRange() => Assert.That(Run("sum"), Is.EqualTo(150.0).Within(1e-9));
+    [Test] public void Count_FullRange() => Assert.That(Run("count"), Is.EqualTo(5.0).Within(1e-9));
+    [Test] public void Min_FullRange() => Assert.That(Run("min"), Is.EqualTo(10.0).Within(1e-9));
+    [Test] public void Max_FullRange() => Assert.That(Run("max"), Is.EqualTo(50.0).Within(1e-9));
+
+    [Test]
+    public void Variance_FullRange()
+    {
+        // Population variance: mean=30, deviations²=400+100+0+100+400 → m2=1000, var=1000/5=200
+        Assert.That(Run("variance"), Is.EqualTo(200.0).Within(1e-9));
+    }
+
+    [Test]
+    public void Stddev_FullRange()
+    {
+        Assert.That(Run("stddev"), Is.EqualTo(Math.Sqrt(200.0)).Within(1e-9));
+    }
+
+    [Test] public void P50_FullRange() => Assert.That(Run("p50"), Is.EqualTo(30.0).Within(1e-9)); // floor(0.5*4)=2
+    [Test] public void Median_EqualsP50() => Assert.That(Run("median"), Is.EqualTo(Run("p50")).Within(1e-9));
+    [Test] public void P75_FullRange() => Assert.That(Run("p75"), Is.EqualTo(40.0).Within(1e-9)); // floor(0.75*4)=3
+    [Test] public void P90_FullRange() => Assert.That(Run("p90"), Is.EqualTo(40.0).Within(1e-9)); // floor(0.9*4)=3
+    [Test] public void P95_FullRange() => Assert.That(Run("p95"), Is.EqualTo(40.0).Within(1e-9)); // floor(0.95*4)=3
+    [Test] public void P99_FullRange() => Assert.That(Run("p99"), Is.EqualTo(40.0).Within(1e-9)); // floor(0.99*4)=3
+
+    // ── Edge cases ──
+
+    [Test]
+    public void EmptyRange_ReturnsNull()
+    {
+        var result = AggregationService.Compute(Ticks5, [Q("mean", t0: 100, t1: 200)]);
+        Assert.That(result[0].Value, Is.Null, "range beyond max tick should return null, not throw");
+    }
+
+    [Test]
+    public void RangeBelowMin_ReturnsNull()
+    {
+        var result = AggregationService.Compute(Ticks5, [Q("sum", t0: 0, t1: 0)]);
+        Assert.That(result[0].Value, Is.Null, "range [0,0] has no matching ticks (first is tick 1)");
+    }
+
+    [Test]
+    public void SingleElement_Count_IsOne()
+    {
+        var result = AggregationService.Compute(Ticks5, [Q("count", t0: 3, t1: 3)]);
+        Assert.That(result[0].Value, Is.EqualTo(1.0).Within(1e-9));
+    }
+
+    [Test]
+    public void SingleElement_Mean_EqualsSingleValue()
+    {
+        var result = AggregationService.Compute(Ticks5, [Q("mean", t0: 3, t1: 3)]);
+        Assert.That(result[0].Value, Is.EqualTo(30.0).Within(1e-9));
+    }
+
+    [Test]
+    public void SingleElement_Stddev_IsZero()
+    {
+        // Welford: n=1 → m2=0 → variance=0/1=0 → stddev=0
+        var result = AggregationService.Compute(Ticks5, [Q("stddev", t0: 3, t1: 3)]);
+        Assert.That(result[0].Value, Is.EqualTo(0.0).Within(1e-9));
+    }
+
+    [Test]
+    public void SubRange_Correctly_Sliced()
+    {
+        // Ticks 2–4 → DurationUs 20,30,40 → sum=90, mean=30, min=20, max=40
+        var queries = new[]
+        {
+            Q("sum",  t0: 2, t1: 4),
+            Q("mean", t0: 2, t1: 4),
+            Q("min",  t0: 2, t1: 4),
+            Q("max",  t0: 2, t1: 4),
+        };
+        var results = AggregationService.Compute(Ticks5, queries);
+        Assert.That(results[0].Value, Is.EqualTo(90.0).Within(1e-9));
+        Assert.That(results[1].Value, Is.EqualTo(30.0).Within(1e-9));
+        Assert.That(results[2].Value, Is.EqualTo(20.0).Within(1e-9));
+        Assert.That(results[3].Value, Is.EqualTo(40.0).Within(1e-9));
+    }
+
+    [Test]
+    public void MultipleQueries_ReturnedInOrder()
+    {
+        var queries = new[]
+        {
+            Q("min"),
+            Q("max"),
+            Q("count"),
+        };
+        var results = AggregationService.Compute(Ticks5, queries);
+        Assert.That(results[0].Value, Is.EqualTo(10.0).Within(1e-9));
+        Assert.That(results[1].Value, Is.EqualTo(50.0).Within(1e-9));
+        Assert.That(results[2].Value, Is.EqualTo(5.0).Within(1e-9));
+    }
+
+    // ── metronome/wait track ──
+
+    [Test]
+    public void MetronomeWait_WaitUs_Mean()
+    {
+        var ticks = new[]
+        {
+            Tick(1, 0f, waitUs: 100),
+            Tick(2, 0f, waitUs: 200),
+            Tick(3, 0f, waitUs: 300),
+        };
+        var result = AggregationService.Compute(ticks, [Q("mean", trackId: "metronome/wait", field: "waitUs", t0: 1, t1: 3)]);
+        Assert.That(result[0].Value, Is.EqualTo(200.0).Within(1e-9));
+    }
+
+    [Test]
+    public void MetronomeWait_IntentClass_Max()
+    {
+        var ticks = new[]
+        {
+            Tick(1, 0f, intentClass: 0),
+            Tick(2, 0f, intentClass: 2),
+            Tick(3, 0f, intentClass: 1),
+        };
+        var result = AggregationService.Compute(ticks,
+            [Q("max", trackId: "metronome/wait", field: "intentClass", t0: 1, t1: 3)]);
+        Assert.That(result[0].Value, Is.EqualTo(2.0).Within(1e-9));
+    }
+
+    // ── Validation errors ──
+
+    [Test]
+    public void UnknownTrackId_ThrowsWorkbenchException()
+    {
+        var q = Q("mean", trackId: "bad/track");
+        Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+    }
+
+    [Test]
+    public void UnknownField_ThrowsWorkbenchException()
+    {
+        var q = Q("mean", field: "notAField");
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("unknown-field"));
+    }
+
+    [Test]
+    public void UnknownOp_ThrowsWorkbenchException_EvenOnEmptyRange()
+    {
+        // Op validation must fire before range evaluation so an invalid op is never silently null.
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "garbage", [100, 200]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("unknown-op"));
+    }
+
+    [Test]
+    public void BadRange_t0GreaterThan_t1_ThrowsWorkbenchException()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "mean", [5, 1]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("bad-range"));
+    }
+
+    [Test]
+    public void NullRange_ThrowsWorkbenchException()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "mean", null);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("bad-range"));
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Tier 2 (#312) — histogram / topk / cdf
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void Histogram_FullRange_5BucketsOver_10_50()
+    {
+        // Values 10,20,30,40,50; range [10,50], 5 equal-width buckets of width 8.
+        // Boundaries: 10–18, 18–26, 26–34, 34–42, 42–50. Last bucket inclusive of 50.
+        // 10→[0]; 20→[1]; 30→[2]; 40→[3]; 50→[4].
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "histogram", [1, 5], Buckets: 5);
+        var result = AggregationService.Compute(Ticks5, [q])[0];
+        Assert.That(result.Histogram, Is.Not.Null);
+        Assert.That(result.Histogram, Has.Length.EqualTo(5));
+        Assert.That(result.Histogram[0].Count, Is.EqualTo(1));
+        Assert.That(result.Histogram[1].Count, Is.EqualTo(1));
+        Assert.That(result.Histogram[2].Count, Is.EqualTo(1));
+        Assert.That(result.Histogram[3].Count, Is.EqualTo(1));
+        Assert.That(result.Histogram[4].Count, Is.EqualTo(1), "last bucket must include max value");
+        // Total preserved.
+        var total = 0;
+        for (var i = 0; i < result.Histogram.Length; i++) total += result.Histogram[i].Count;
+        Assert.That(total, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Histogram_AllSameValue_DegenerateRange()
+    {
+        var ticks = new[] { Tick(1, 100f), Tick(2, 100f), Tick(3, 100f) };
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "histogram", [1, 3], Buckets: 4);
+        var result = AggregationService.Compute(ticks, [q])[0];
+        Assert.That(result.Histogram, Has.Length.EqualTo(4));
+        Assert.That(result.Histogram[0].Count, Is.EqualTo(3));
+        Assert.That(result.Histogram[1].Count, Is.EqualTo(0));
+        Assert.That(result.Histogram[2].Count, Is.EqualTo(0));
+        Assert.That(result.Histogram[3].Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Histogram_MissingBuckets_ThrowsMissingParam()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "histogram", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("missing-param"));
+    }
+
+    [Test]
+    public void TopK_ReturnsTopByValueDescending_WithTickNumbers()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "topk", [1, 5], N: 3);
+        var result = AggregationService.Compute(Ticks5, [q])[0];
+        Assert.That(result.TopK, Is.Not.Null);
+        Assert.That(result.TopK, Has.Length.EqualTo(3));
+        Assert.That(result.TopK[0].Value, Is.EqualTo(50.0).Within(1e-9));
+        Assert.That(result.TopK[0].TickNumber, Is.EqualTo(5u));
+        Assert.That(result.TopK[1].Value, Is.EqualTo(40.0).Within(1e-9));
+        Assert.That(result.TopK[1].TickNumber, Is.EqualTo(4u));
+        Assert.That(result.TopK[2].Value, Is.EqualTo(30.0).Within(1e-9));
+        Assert.That(result.TopK[2].TickNumber, Is.EqualTo(3u));
+    }
+
+    [Test]
+    public void TopK_NLargerThanCount_ReturnsAll()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "topk", [1, 5], N: 100);
+        var result = AggregationService.Compute(Ticks5, [q])[0];
+        Assert.That(result.TopK, Has.Length.EqualTo(5));
+    }
+
+    [Test]
+    public void TopK_EmptyRange_ReturnsEmptyArray()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "topk", [100, 200], N: 5);
+        var result = AggregationService.Compute(Ticks5, [q])[0];
+        Assert.That(result.TopK, Is.Not.Null);
+        Assert.That(result.TopK, Is.Empty);
+    }
+
+    [Test]
+    public void TopK_MissingN_ThrowsMissingParam()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "topk", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("missing-param"));
+    }
+
+    [Test]
+    public void Cdf_5Samples_QuantilesMonotonic()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "cdf", [1, 5], Samples: 5);
+        var result = AggregationService.Compute(Ticks5, [q])[0];
+        Assert.That(result.Cdf, Is.Not.Null);
+        Assert.That(result.Cdf, Has.Length.EqualTo(5));
+        // Quantiles: 0, 0.25, 0.5, 0.75, 1.0 over [10,20,30,40,50] indices 0..4
+        // round(q*4) → indices 0,1,2,3,4 → values 10,20,30,40,50.
+        Assert.That(result.Cdf[0].Quantile, Is.EqualTo(0.0).Within(1e-9));
+        Assert.That(result.Cdf[0].Value, Is.EqualTo(10.0).Within(1e-9));
+        Assert.That(result.Cdf[2].Quantile, Is.EqualTo(0.5).Within(1e-9));
+        Assert.That(result.Cdf[2].Value, Is.EqualTo(30.0).Within(1e-9));
+        Assert.That(result.Cdf[4].Quantile, Is.EqualTo(1.0).Within(1e-9));
+        Assert.That(result.Cdf[4].Value, Is.EqualTo(50.0).Within(1e-9));
+        // Values are non-decreasing (sorted set).
+        for (var i = 1; i < result.Cdf.Length; i++)
+        {
+            Assert.That(result.Cdf[i].Value, Is.GreaterThanOrEqualTo(result.Cdf[i - 1].Value));
+        }
+    }
+
+    [Test]
+    public void Cdf_MissingSamples_ThrowsMissingParam()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "cdf", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("missing-param"));
+    }
+
+    [Test]
+    public void Cdf_SamplesLessThan2_ThrowsMissingParam()
+    {
+        var q = new AggregationQueryDto("tick/summary", "durationUs", "cdf", [1, 5], Samples: 1);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("missing-param"));
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // v2 track families — system/<name>, queue/<name>, posttick/<phase>
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void SystemTrack_DurationUs_Mean()
+    {
+        var meta = TestMetadata.WithSystemRows("Physics", sysIdx: 7,
+            (tick: 1u, duration: 100f),
+            (tick: 2u, duration: 200f),
+            (tick: 3u, duration: 300f));
+        var q = new AggregationQueryDto("system/Physics", "durationUs", "mean", [1, 3]);
+        var result = AggregationService.Compute(meta, [q])[0];
+        Assert.That(result.Value, Is.EqualTo(200.0).Within(1e-9));
+    }
+
+    [Test]
+    public void SystemTrack_FiltersBySystemIndex_IgnoresOtherSystems()
+    {
+        // Two systems share the metadata; query for "Physics" must skip "AI" rows.
+        var systems = new[]
+        {
+            MakeSystem("Physics", 7),
+            MakeSystem("AI", 8),
+        };
+        var rows = new[]
+        {
+            MakeSystemRow(tick: 1, sysIdx: 7, duration: 100f),
+            MakeSystemRow(tick: 1, sysIdx: 8, duration: 9999f), // AI tick 1 — must NOT be aggregated.
+            MakeSystemRow(tick: 2, sysIdx: 7, duration: 200f),
+            MakeSystemRow(tick: 2, sysIdx: 8, duration: 9999f),
+        };
+        var meta = TestMetadata.Build(systems: systems, systemRows: rows);
+
+        var q = new AggregationQueryDto("system/Physics", "durationUs", "sum", [1, 2]);
+        var result = AggregationService.Compute(meta, [q])[0];
+        Assert.That(result.Value, Is.EqualTo(300.0).Within(1e-9), "sum must include only Physics rows");
+    }
+
+    [Test]
+    public void SystemTrack_UnknownSystem_ThrowsUnknownSystem()
+    {
+        var meta = TestMetadata.WithSystemRows("Physics", 0);
+        var q = new AggregationQueryDto("system/Bogus", "durationUs", "mean", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(meta, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("unknown-system"));
+    }
+
+    [Test]
+    public void SystemTrack_UnknownField_ThrowsUnknownField()
+    {
+        var meta = TestMetadata.WithSystemRows("Physics", 0);
+        var q = new AggregationQueryDto("system/Physics", "garbage", "mean", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(meta, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("unknown-field"));
+    }
+
+    [Test]
+    public void QueueTrack_PeakDepth_Max()
+    {
+        var meta = TestMetadata.WithQueueRows("Damage", qid: 3,
+            (tick: 1u, peak: 10u),
+            (tick: 2u, peak: 50u),
+            (tick: 3u, peak: 30u));
+        var q = new AggregationQueryDto("queue/Damage", "peakDepth", "max", [1, 3]);
+        var result = AggregationService.Compute(meta, [q])[0];
+        Assert.That(result.Value, Is.EqualTo(50.0).Within(1e-9));
+    }
+
+    [Test]
+    public void QueueTrack_UnknownQueue_ThrowsUnknownQueue()
+    {
+        var meta = TestMetadata.WithQueueRows("Damage", 0);
+        var q = new AggregationQueryDto("queue/Bogus", "peakDepth", "mean", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(meta, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("unknown-queue"));
+    }
+
+    [Test]
+    public void PostTickTrack_WalFlush_DurationUs_Mean()
+    {
+        var meta = TestMetadata.WithPostTickRows(
+            (tick: 1u, walFlushUs: 10f),
+            (tick: 2u, walFlushUs: 20f),
+            (tick: 3u, walFlushUs: 30f));
+        var q = new AggregationQueryDto("posttick/walFlush", "durationUs", "mean", [1, 3]);
+        var result = AggregationService.Compute(meta, [q])[0];
+        Assert.That(result.Value, Is.EqualTo(20.0).Within(1e-9));
+    }
+
+    [Test]
+    public void PostTickTrack_UnknownPhase_ThrowsUnknownPhase()
+    {
+        var meta = TestMetadata.WithPostTickRows();
+        var q = new AggregationQueryDto("posttick/garbage", "durationUs", "mean", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(meta, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("unknown-posttick-phase"));
+    }
+
+    [Test]
+    public void PostTickTrack_AllPhases_Resolve()
+    {
+        var meta = TestMetadata.Build(postRows: new[]
+        {
+            new PostTickSummary
+            {
+                TickNumber = 1, _reserved = 0,
+                WriteTickFenceUs = 1f, WalFlushUs = 2f, SubscriptionOutputUs = 3f,
+                TierIndexRebuildUs = 4f, DormancySweepUs = 5f, TierBudgetUs = 6f,
+            },
+        });
+        var queries = new[]
+        {
+            new AggregationQueryDto("posttick/writeTickFence",     "durationUs", "sum", [1, 1]),
+            new AggregationQueryDto("posttick/walFlush",           "durationUs", "sum", [1, 1]),
+            new AggregationQueryDto("posttick/subscriptionOutput", "durationUs", "sum", [1, 1]),
+            new AggregationQueryDto("posttick/tierIndexRebuild",   "durationUs", "sum", [1, 1]),
+            new AggregationQueryDto("posttick/dormancySweep",      "durationUs", "sum", [1, 1]),
+            new AggregationQueryDto("posttick/tierBudget",         "durationUs", "sum", [1, 1]),
+        };
+        var results = AggregationService.Compute(meta, queries);
+        Assert.That(results[0].Value, Is.EqualTo(1.0).Within(1e-9));
+        Assert.That(results[1].Value, Is.EqualTo(2.0).Within(1e-9));
+        Assert.That(results[2].Value, Is.EqualTo(3.0).Within(1e-9));
+        Assert.That(results[3].Value, Is.EqualTo(4.0).Within(1e-9));
+        Assert.That(results[4].Value, Is.EqualTo(5.0).Within(1e-9));
+        Assert.That(results[5].Value, Is.EqualTo(6.0).Within(1e-9));
+    }
+
+    [Test]
+    public void V2Track_OnLegacyOverload_ThrowsUnknownTrack()
+    {
+        // Legacy Compute(TickSummaryDto[], …) has no metadata to resolve v2 tracks.
+        var q = new AggregationQueryDto("system/Physics", "durationUs", "mean", [1, 5]);
+        var ex = Assert.Throws<WorkbenchException>(() => AggregationService.Compute(Ticks5, [q]));
+        Assert.That(ex.ErrorCode, Is.EqualTo("unknown-track"));
+    }
+
+    [Test]
+    public void V2Track_TopK_ReturnsTickNumbersFromV2Rows()
+    {
+        // Cross-feature: topk over a per-system track must report the correct system-row tick numbers.
+        var meta = TestMetadata.WithSystemRows("Physics", sysIdx: 7,
+            (tick: 10u, duration: 100f),
+            (tick: 11u, duration: 50f),
+            (tick: 12u, duration: 200f),
+            (tick: 13u, duration: 75f));
+        var q = new AggregationQueryDto("system/Physics", "durationUs", "topk", [10, 13], N: 2);
+        var result = AggregationService.Compute(meta, [q])[0];
+        Assert.That(result.TopK, Has.Length.EqualTo(2));
+        Assert.That(result.TopK[0].TickNumber, Is.EqualTo(12u));
+        Assert.That(result.TopK[0].Value, Is.EqualTo(200.0).Within(1e-9));
+        Assert.That(result.TopK[1].TickNumber, Is.EqualTo(10u));
+        Assert.That(result.TopK[1].Value, Is.EqualTo(100.0).Within(1e-9));
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Test fixtures — construct minimal ProfilerMetadataDto instances.
+    // ────────────────────────────────────────────────────────────────────────
+
+    private static SystemDefinitionDto MakeSystem(string name, ushort idx) => new(
+        idx, name, 0, 0, false, 0,
+        System.Array.Empty<ushort>(), System.Array.Empty<ushort>(),
+        "", false,
+        System.Array.Empty<string>(), System.Array.Empty<string>(),
+        System.Array.Empty<string>(), System.Array.Empty<string>(),
+        System.Array.Empty<string>(), System.Array.Empty<string>(),
+        System.Array.Empty<string>(), System.Array.Empty<string>(),
+        System.Array.Empty<string>(), System.Array.Empty<string>(),
+        System.Array.Empty<string>(), System.Array.Empty<string>());
+
+    private static SystemTickSummary MakeSystemRow(uint tick, ushort sysIdx, float duration) => new()
+    {
+        TickNumber = tick, SystemIndex = sysIdx, SkipReasonCode = 0, Flags = 0,
+        StartUs = 0, EndUs = 0, ReadyUs = 0, DurationUs = duration,
+        EntitiesProcessed = 0, WorkersTouched = 0, ChunksProcessed = 0, _reserved = 0,
+    };
+
+    private static class TestMetadata
+    {
+        public static ProfilerMetadataDto WithSystemRows(string name, ushort sysIdx, params (uint tick, float duration)[] rows)
+        {
+            var sysRows = new SystemTickSummary[rows.Length];
+            for (var i = 0; i < rows.Length; i++)
+            {
+                sysRows[i] = MakeSystemRow(rows[i].tick, sysIdx, rows[i].duration);
+            }
+            return Build(systems: [MakeSystem(name, sysIdx)], systemRows: sysRows);
+        }
+
+        public static ProfilerMetadataDto WithQueueRows(string name, ushort qid, params (uint tick, uint peak)[] rows)
+        {
+            var qRows = new QueueTickSummary[rows.Length];
+            for (var i = 0; i < rows.Length; i++)
+            {
+                qRows[i] = new QueueTickSummary
+                {
+                    TickNumber = rows[i].tick, QueueId = qid, _reserved = 0,
+                    PeakDepth = rows[i].peak, EndOfTickDepth = 0, OverflowCount = 0,
+                    Produced = 0, Consumed = 0,
+                };
+            }
+            return Build(queueRows: qRows, queueIdToName: new Dictionary<ushort, string> { [qid] = name });
+        }
+
+        public static ProfilerMetadataDto WithPostTickRows(params (uint tick, float walFlushUs)[] rows)
+        {
+            var pRows = new PostTickSummary[rows.Length];
+            for (var i = 0; i < rows.Length; i++)
+            {
+                pRows[i] = new PostTickSummary
+                {
+                    TickNumber = rows[i].tick, _reserved = 0,
+                    WriteTickFenceUs = 0, WalFlushUs = rows[i].walFlushUs, SubscriptionOutputUs = 0,
+                    TierIndexRebuildUs = 0, DormancySweepUs = 0, TierBudgetUs = 0,
+                };
+            }
+            return Build(postRows: pRows);
+        }
+
+        public static ProfilerMetadataDto Build(
+            SystemDefinitionDto[] systems = null,
+            SystemTickSummary[] systemRows = null,
+            QueueTickSummary[] queueRows = null,
+            PostTickSummary[] postRows = null,
+            Dictionary<ushort, string> queueIdToName = null)
+        {
+            return new ProfilerMetadataDto(
+                Fingerprint: "TEST",
+                Header: new ProfilerHeaderDto(0, 1, 0f, 0, 0, 0, 0, 0, 0),
+                Systems: systems ?? System.Array.Empty<SystemDefinitionDto>(),
+                Archetypes: System.Array.Empty<ArchetypeDto>(),
+                ComponentTypes: System.Array.Empty<ComponentTypeDto>(),
+                SpanNames: new Dictionary<int, string>(),
+                GlobalMetrics: new GlobalMetricsDto(0, 0, 0, 0, 0, 0, 0, System.Array.Empty<SystemAggregateDto>()),
+                TickSummaries: System.Array.Empty<TickSummaryDto>(),
+                ChunkManifest: System.Array.Empty<ChunkManifestEntryDto>(),
+                GcSuspensions: System.Array.Empty<GcSuspensionDto>(),
+                Phases: System.Array.Empty<string>(),
+                SystemTickSummaries: systemRows ?? System.Array.Empty<SystemTickSummary>(),
+                QueueTickSummaries: queueRows ?? System.Array.Empty<QueueTickSummary>(),
+                PostTickSummaries: postRows ?? System.Array.Empty<PostTickSummary>(),
+                QueueIdToName: queueIdToName ?? new Dictionary<ushort, string>());
+        }
+    }
+}

--- a/test/Typhon.Workbench.Tests/Data/DataControllerTests.cs
+++ b/test/Typhon.Workbench.Tests/Data/DataControllerTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Workbench.Dtos.Sessions;
+using Typhon.Workbench.Fixtures;
+
+namespace Typhon.Workbench.Tests.Data;
+
+/// <summary>
+/// Integration tests for <see cref="Typhon.Workbench.Controllers.DataController"/>.
+/// Covers the <c>X-Workbench-Api</c> version negotiation filter, track schema round-trip,
+/// and input validation (unknown trackId, bad range, empty aggregate body).
+/// </summary>
+[TestFixture]
+public sealed class DataControllerTests
+{
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateAuthenticatedClient();
+    }
+
+    [TearDown]
+    public void TearDown() => _factory.Dispose();
+
+    private async Task<SessionDto> CreateTraceSessionAsync(int tickCount = 3, int instantsPerTick = 2)
+    {
+        var path = TraceFixtureBuilder.BuildMinimalTrace(_factory.DemoDirectory, tickCount, instantsPerTick);
+        var resp = await _client.PostAsJsonAsync("/api/sessions/trace", new CreateTraceSessionRequest(path));
+        resp.EnsureSuccessStatusCode();
+        return JsonSerializer.Deserialize<SessionDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+    }
+
+    private async Task WaitForBuildAsync(Guid sessionId, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, $"/api/sessions/{sessionId}/profiler/metadata");
+            req.Headers.Add("X-Session-Token", sessionId.ToString());
+            var resp = await _client.SendAsync(req);
+            if (resp.StatusCode == HttpStatusCode.OK) return;
+            if (resp.StatusCode != HttpStatusCode.Accepted)
+                Assert.Fail($"Unexpected status waiting for build: {resp.StatusCode}");
+            await Task.Delay(25);
+        }
+        Assert.Fail("Trace cache build did not complete within the allotted timeout.");
+    }
+
+    private HttpRequestMessage DataReq(HttpMethod method, Guid sessionId, string path, string apiVersion = null)
+    {
+        var req = new HttpRequestMessage(method, $"/api/sessions/{sessionId}/{path}");
+        req.Headers.Add("X-Session-Token", sessionId.ToString());
+        if (apiVersion != null)
+            req.Headers.Add("X-Workbench-Api", apiVersion);
+        return req;
+    }
+
+    // ── X-Workbench-Api version negotiation ──
+
+    [Test]
+    public async Task Topology_MissingVersionHeader_SoftLaunchPassesThrough()
+    {
+        var session = await CreateTraceSessionAsync();
+
+        // No X-Workbench-Api header: soft-launch defaults to v1. Expect 200 or 202 (build may be in flight),
+        // but never 400 or 426 (those come from the version filter).
+        var req = DataReq(HttpMethod.Get, session.SessionId, "topology"); // no version header
+        var resp = await _client.SendAsync(req);
+        Assert.That((int)resp.StatusCode, Is.AnyOf(200, 202),
+            "missing X-Workbench-Api should soft-launch as v1, not reject");
+    }
+
+    [Test]
+    public async Task Topology_VersionHeader1_PassesThrough()
+    {
+        var session = await CreateTraceSessionAsync();
+
+        var req = DataReq(HttpMethod.Get, session.SessionId, "topology", apiVersion: "1");
+        var resp = await _client.SendAsync(req);
+        Assert.That((int)resp.StatusCode, Is.AnyOf(200, 202),
+            "X-Workbench-Api: 1 is the supported version and should pass through");
+    }
+
+    [Test]
+    public async Task Topology_VersionHeader2_Returns426()
+    {
+        var session = await CreateTraceSessionAsync();
+
+        var req = DataReq(HttpMethod.Get, session.SessionId, "topology", apiVersion: "2");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.UpgradeRequired));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var type = doc.RootElement.GetProperty("type").GetString();
+        Assert.That(type, Is.EqualTo("api-version-mismatch"));
+    }
+
+    [Test]
+    public async Task Topology_VersionHeaderNonInteger_Returns400()
+    {
+        var session = await CreateTraceSessionAsync();
+
+        var req = DataReq(HttpMethod.Get, session.SessionId, "topology", apiVersion: "not-a-number");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var type = doc.RootElement.GetProperty("type").GetString();
+        Assert.That(type, Is.EqualTo("invalid-api-version"));
+    }
+
+    // ── /tracks schema round-trip ──
+
+    [Test]
+    public async Task Tracks_ReturnsExpectedSchema_AfterBuildCompletes()
+    {
+        var session = await CreateTraceSessionAsync(tickCount: 4, instantsPerTick: 2);
+        await WaitForBuildAsync(session.SessionId, TimeSpan.FromSeconds(5));
+
+        var req = DataReq(HttpMethod.Get, session.SessionId, "tracks", apiVersion: "1");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var tracks = doc.RootElement.GetProperty("tracks");
+        // v1 had 2 tracks; v2 (#311) added 3 track families: system/<name>, queue/<name>, posttick/<phase>.
+        Assert.That(tracks.GetArrayLength(), Is.EqualTo(5), "v2 exposes 5 tracks (2 v1 + 3 v2 family descriptors)");
+
+        var ids = Enumerable.Range(0, tracks.GetArrayLength())
+            .Select(i => tracks[i].GetProperty("id").GetString())
+            .ToArray();
+        Assert.That(ids, Is.EquivalentTo(new[]
+        {
+            "tick/summary", "metronome/wait",
+            "system/<name>", "queue/<name>", "posttick/<phase>",
+        }));
+
+        var tickSummary = tracks[0];
+        Assert.That(tickSummary.GetProperty("id").GetString(), Is.EqualTo("tick/summary"));
+        Assert.That(tickSummary.GetProperty("kind").GetString(), Is.EqualTo("perTick"));
+
+        var fields = tickSummary.GetProperty("fields");
+        var fieldNames = Enumerable.Range(0, fields.GetArrayLength())
+            .Select(i => fields[i].GetProperty("name").GetString())
+            .ToArray();
+
+        Assert.That(fieldNames, Is.EquivalentTo(new[]
+        {
+            "tickNumber", "startUs", "durationUs", "eventCount",
+            "maxSystemDurationUs", "overloadLevel", "tickMultiplier",
+            "consecutiveOverrun", "consecutiveUnderrun",
+        }), "tick/summary must expose all 9 spec-defined fields");
+
+        var metronome = tracks[1];
+        Assert.That(metronome.GetProperty("id").GetString(), Is.EqualTo("metronome/wait"));
+        var mFields = metronome.GetProperty("fields");
+        var mFieldNames = Enumerable.Range(0, mFields.GetArrayLength())
+            .Select(i => mFields[i].GetProperty("name").GetString())
+            .ToArray();
+        Assert.That(mFieldNames, Is.EquivalentTo(new[] { "tickNumber", "waitUs", "intentClass" }),
+            "metronome/wait must expose exactly 3 spec-defined fields");
+
+        // ── v2 family descriptors (#311) ───────────────────────────────────
+        var systemTrack = tracks[2];
+        Assert.That(systemTrack.GetProperty("kind").GetString(), Is.EqualTo("perTickPerSystem"));
+        Assert.That(EnumerateNames(systemTrack), Does.Contain("readyUs").And.Contain("workersTouched").And.Contain("skipReason"));
+
+        var queueTrack = tracks[3];
+        Assert.That(queueTrack.GetProperty("kind").GetString(), Is.EqualTo("perTickPerQueue"));
+        Assert.That(EnumerateNames(queueTrack), Does.Contain("peakDepth").And.Contain("overflowCount"));
+
+        var postTrack = tracks[4];
+        Assert.That(postTrack.GetProperty("kind").GetString(), Is.EqualTo("perTick"));
+        Assert.That(EnumerateNames(postTrack), Is.EquivalentTo(new[] { "tickNumber", "durationUs" }));
+
+        static string[] EnumerateNames(JsonElement track)
+        {
+            var f = track.GetProperty("fields");
+            var names = new string[f.GetArrayLength()];
+            for (var i = 0; i < names.Length; i++) names[i] = f[i].GetProperty("name").GetString();
+            return names;
+        }
+    }
+
+    // ── /track/{trackId} input validation ──
+
+    [Test]
+    public async Task Track_UnknownTrackId_Returns400()
+    {
+        var session = await CreateTraceSessionAsync();
+
+        var req = DataReq(HttpMethod.Get, session.SessionId, "track/bad/trackid", apiVersion: "1");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.That(doc.RootElement.GetProperty("title").GetString(), Is.EqualTo("unknown-track"));
+    }
+
+    [Test]
+    public async Task Track_BadRange_Returns400()
+    {
+        var session = await CreateTraceSessionAsync();
+
+        // from=10 > to=5 is invalid; the check fires before metadata resolution.
+        var req = DataReq(HttpMethod.Get, session.SessionId, "track/tick/summary?from=10&to=5", apiVersion: "1");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.That(doc.RootElement.GetProperty("title").GetString(), Is.EqualTo("bad-range"));
+    }
+
+    [Test]
+    public async Task Track_TickSummary_ReturnsRecordsAfterBuild()
+    {
+        var session = await CreateTraceSessionAsync(tickCount: 4, instantsPerTick: 2);
+        await WaitForBuildAsync(session.SessionId, TimeSpan.FromSeconds(5));
+
+        var req = DataReq(HttpMethod.Get, session.SessionId, "track/tick/summary", apiVersion: "1");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        Assert.That(doc.RootElement.GetProperty("trackId").GetString(), Is.EqualTo("tick/summary"));
+        var records = doc.RootElement.GetProperty("records");
+        Assert.That(records.GetArrayLength(), Is.EqualTo(4), "fixture has 4 ticks");
+
+        // Each record must carry tickNumber.
+        for (var i = 0; i < records.GetArrayLength(); i++)
+        {
+            Assert.That(records[i].TryGetProperty("tickNumber", out _), Is.True, $"record[{i}] missing tickNumber");
+        }
+    }
+
+    // ── /aggregate input validation ──
+
+    [Test]
+    public async Task Aggregate_EmptyBody_Returns400()
+    {
+        var session = await CreateTraceSessionAsync();
+
+        var req = DataReq(HttpMethod.Post, session.SessionId, "aggregate", apiVersion: "1");
+        req.Content = new StringContent("{\"queries\":[]}", System.Text.Encoding.UTF8, "application/json");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task Aggregate_ValidQuery_ReturnsResultsAfterBuild()
+    {
+        var session = await CreateTraceSessionAsync(tickCount: 4, instantsPerTick: 2);
+        await WaitForBuildAsync(session.SessionId, TimeSpan.FromSeconds(5));
+
+        var body = """
+            {"queries":[{"trackId":"tick/summary","field":"durationUs","op":"count","range":[1,999]}]}
+            """;
+        var req = DataReq(HttpMethod.Post, session.SessionId, "aggregate", apiVersion: "1");
+        req.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var results = doc.RootElement.GetProperty("results");
+        Assert.That(results.GetArrayLength(), Is.EqualTo(1));
+        var value = results[0].GetProperty("value").GetDouble();
+        Assert.That(value, Is.EqualTo(4.0).Within(1e-9), "fixture has 4 ticks in range [1,999]");
+    }
+}

--- a/test/Typhon.Workbench.Tests/Data/TopologyAccessDeclarationsTests.cs
+++ b/test/Typhon.Workbench.Tests/Data/TopologyAccessDeclarationsTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Typhon.Workbench.Dtos.Data;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Dtos.Sessions;
+using Typhon.Workbench.Fixtures;
+
+namespace Typhon.Workbench.Tests.Data;
+
+/// <summary>
+/// Integration tests for RFC 07 surfacing through the Data API (#310): the topology endpoint must
+/// return access declarations + phase order, and the new <c>/queries/who-writes/{component}</c> /
+/// <c>/queries/who-reads/{component}</c> endpoints must filter the system list correctly.
+/// </summary>
+[TestFixture]
+public sealed class TopologyAccessDeclarationsTests
+{
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateAuthenticatedClient();
+    }
+
+    [TearDown]
+    public void TearDown() => _factory.Dispose();
+
+    private async Task<SessionDto> CreateRfc07TraceAsync()
+    {
+        var path = TraceFixtureBuilder.BuildTraceWithAccessDeclarations(_factory.DemoDirectory);
+        var resp = await _client.PostAsJsonAsync("/api/sessions/trace", new CreateTraceSessionRequest(path));
+        resp.EnsureSuccessStatusCode();
+        return JsonSerializer.Deserialize<SessionDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+    }
+
+    private async Task<TopologyDto> WaitForTopologyAsync(Guid sessionId)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, $"/api/sessions/{sessionId}/topology");
+            req.Headers.Add("X-Session-Token", sessionId.ToString());
+            req.Headers.Add("X-Workbench-Api", "1");
+            var resp = await _client.SendAsync(req);
+            if (resp.StatusCode == HttpStatusCode.OK)
+            {
+                return JsonSerializer.Deserialize<TopologyDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+            }
+            if (resp.StatusCode != HttpStatusCode.Accepted)
+            {
+                Assert.Fail($"Unexpected status: {resp.StatusCode}");
+            }
+            await Task.Delay(20);
+        }
+        Assert.Fail("topology did not become available in time");
+        return null!;
+    }
+
+    [Test]
+    public async Task Topology_PopulatesRfc07Fields()
+    {
+        var session = await CreateRfc07TraceAsync();
+        var topo = await WaitForTopologyAsync(session.SessionId);
+
+        Assert.That(topo.Phases, Is.EqualTo(new[] { "Input", "Simulation", "Output" }));
+        Assert.That(topo.Systems.Length, Is.EqualTo(2));
+
+        var movement = FindByName(topo.Systems, "Movement");
+        Assert.That(movement.PhaseName, Is.EqualTo("Simulation"));
+        Assert.That(movement.IsExclusivePhase, Is.False);
+        Assert.That(movement.Reads, Is.EqualTo(new[] { "Game.Velocity" }));
+        Assert.That(movement.Writes, Is.EqualTo(new[] { "Game.Position" }));
+        Assert.That(movement.ReadsEvents, Is.EqualTo(new[] { "Damage" }));
+        Assert.That(movement.WritesResources, Is.EqualTo(new[] { "world.physics" }));
+
+        var damage = FindByName(topo.Systems, "Damage");
+        Assert.That(damage.IsExclusivePhase, Is.True);
+        Assert.That(damage.ReadsSnapshot, Is.EqualTo(new[] { "Game.Position" }));
+        Assert.That(damage.Writes, Is.EqualTo(new[] { "Game.Health" }));
+        Assert.That(damage.WritesEvents, Is.EqualTo(new[] { "Death" }));
+    }
+
+    [Test]
+    public async Task WhoWrites_ReturnsMatchingSystems()
+    {
+        var session = await CreateRfc07TraceAsync();
+        await WaitForTopologyAsync(session.SessionId); // Make sure metadata is ready
+
+        var result = await GetSystemListAsync(session.SessionId, "queries/who-writes/Game.Position");
+        Assert.That(result.Query, Is.EqualTo("Game.Position"));
+        Assert.That(result.Systems.Length, Is.EqualTo(1));
+        Assert.That(result.Systems[0].Name, Is.EqualTo("Movement"));
+    }
+
+    [Test]
+    public async Task WhoReads_IncludesAllReadKinds()
+    {
+        var session = await CreateRfc07TraceAsync();
+        await WaitForTopologyAsync(session.SessionId);
+
+        // Game.Position is read snapshot-style by Damage; Movement reads Velocity, not Position.
+        var result = await GetSystemListAsync(session.SessionId, "queries/who-reads/Game.Position");
+        Assert.That(result.Query, Is.EqualTo("Game.Position"));
+        Assert.That(result.Systems.Length, Is.EqualTo(1));
+        Assert.That(result.Systems[0].Name, Is.EqualTo("Damage"));
+    }
+
+    [Test]
+    public async Task WhoReads_NoMatch_ReturnsEmptyArray()
+    {
+        var session = await CreateRfc07TraceAsync();
+        await WaitForTopologyAsync(session.SessionId);
+
+        var result = await GetSystemListAsync(session.SessionId, "queries/who-reads/Game.NonExistent");
+        Assert.That(result.Systems, Is.Empty);
+    }
+
+    private async Task<SystemListDto> GetSystemListAsync(Guid sessionId, string path)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/sessions/{sessionId}/{path}");
+        req.Headers.Add("X-Session-Token", sessionId.ToString());
+        req.Headers.Add("X-Workbench-Api", "1");
+        var resp = await _client.SendAsync(req);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"GET {path} → {resp.StatusCode}");
+        return JsonSerializer.Deserialize<SystemListDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+    }
+
+    private static SystemDefinitionDto FindByName(SystemDefinitionDto[] systems, string name)
+    {
+        foreach (var s in systems)
+        {
+            if (s.Name == name) return s;
+        }
+        Assert.Fail($"system '{name}' not found in topology");
+        return null!;
+    }
+}

--- a/test/Typhon.Workbench.Tests/Fixtures/SseFrameReader.cs
+++ b/test/Typhon.Workbench.Tests/Fixtures/SseFrameReader.cs
@@ -1,0 +1,64 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Typhon.Workbench.Tests.Fixtures;
+
+/// <summary>
+/// Tiny SSE frame parser — reads <c>event: &lt;type&gt;\ndata: &lt;json&gt;\n\n</c> tuples from a
+/// <see cref="StreamReader"/>. Tests use this to verify the typed-event wire format added in #308.
+/// Default <c>message</c> events (no <c>event:</c> line) surface with <see cref="SseFrame.EventType"/>
+/// equal to <c>"message"</c> so legacy untyped streams work the same way.
+/// </summary>
+internal readonly record struct SseFrame(string EventType, string Data);
+
+internal static class SseFrameReader
+{
+    /// <summary>
+    /// Reads frames from <paramref name="reader"/> one at a time. Yields the next complete frame
+    /// or <see langword="null"/> when the stream ends. Comment lines (<c>: ...</c>) and field lines
+    /// other than <c>event:</c> / <c>data:</c> (e.g., <c>id:</c>, <c>retry:</c>) are ignored.
+    /// </summary>
+    public static async Task<SseFrame?> ReadFrameAsync(StreamReader reader, CancellationToken ct)
+    {
+        string eventType = "message";
+        string data = null;
+        while (true)
+        {
+            var line = await reader.ReadLineAsync(ct);
+            if (line == null)
+            {
+                return data == null ? null : new SseFrame(eventType, data);
+            }
+
+            if (line.Length == 0)
+            {
+                // Empty line terminates the current frame. Only return if we accumulated a payload —
+                // a stream that opens with a comment + blank line shouldn't surface as an empty frame.
+                if (data != null)
+                {
+                    return new SseFrame(eventType, data);
+                }
+                continue;
+            }
+
+            if (line.StartsWith(":", System.StringComparison.Ordinal))
+            {
+                continue; // comment / keepalive
+            }
+
+            const string EventPrefix = "event:";
+            const string DataPrefix = "data:";
+            if (line.StartsWith(EventPrefix, System.StringComparison.Ordinal))
+            {
+                eventType = line[EventPrefix.Length..].Trim();
+            }
+            else if (line.StartsWith(DataPrefix, System.StringComparison.Ordinal))
+            {
+                var chunk = line[DataPrefix.Length..].TrimStart();
+                data = data == null ? chunk : data + "\n" + chunk;
+            }
+            // Other field types (id:, retry:) are silently skipped — not used by Workbench streams.
+        }
+    }
+}

--- a/test/Typhon.Workbench.Tests/HeartbeatStreamTests.cs
+++ b/test/Typhon.Workbench.Tests/HeartbeatStreamTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using NUnit.Framework;
 using Typhon.Workbench.Dtos.Sessions;
+using Typhon.Workbench.Tests.Fixtures;
 
 namespace Typhon.Workbench.Tests;
 
@@ -50,10 +51,11 @@ public sealed class HeartbeatStreamTests
         await using var stream = await response.Content.ReadAsStreamAsync(testCt);
         using var reader = new StreamReader(stream);
 
-        var line = await reader.ReadLineAsync(testCt);
-        Assert.That(line, Does.StartWith("data:"));
-        var json = line!["data:".Length..].Trim();
-        using var doc = JsonDocument.Parse(json);
+        var frame = await SseFrameReader.ReadFrameAsync(reader, testCt);
+        Assert.That(frame, Is.Not.Null, "expected at least one SSE frame");
+        Assert.That(frame.Value.EventType, Is.EqualTo("heartbeat"),
+            "post-#308 wire format: heartbeat frames carry event type on the SSE event: line");
+        using var doc = JsonDocument.Parse(frame.Value.Data);
         Assert.That(doc.RootElement.TryGetProperty("revision", out _), Is.True, "payload missing 'revision'");
         Assert.That(doc.RootElement.TryGetProperty("memoryMb", out _), Is.True, "payload missing 'memoryMb'");
     }

--- a/test/Typhon.Workbench.Tests/ProfilerBuildProgressStreamTests.cs
+++ b/test/Typhon.Workbench.Tests/ProfilerBuildProgressStreamTests.cs
@@ -114,9 +114,11 @@ public sealed class ProfilerBuildProgressStreamTests
     }
 
     /// <summary>
-    /// Reads SSE <c>data:</c> frames from <paramref name="resp"/> until one whose JSON body has a
-    /// <c>phase</c> of <c>done</c> or <c>error</c>. Returns that phase string. Throws if the stream
-    /// ends without a terminal frame.
+    /// Reads typed SSE frames from <paramref name="resp"/> until one whose <c>event:</c> line is
+    /// <c>done</c> or <c>error</c>. Returns the event type. Throws if the stream ends without a
+    /// terminal frame. Post-#308 the build-progress stream emits typed events
+    /// (<c>progress</c> / <c>done</c> / <c>error</c>) instead of putting the phase inside the JSON
+    /// payload.
     /// </summary>
     private static async Task<string> ReadFirstTerminalPhaseAsync(HttpResponseMessage resp, CancellationToken ct)
     {
@@ -124,17 +126,13 @@ public sealed class ProfilerBuildProgressStreamTests
         using var reader = new StreamReader(stream);
         while (true)
         {
-            var line = await reader.ReadLineAsync(ct);
-            if (line == null) break; // stream ended
-            if (string.IsNullOrEmpty(line) || !line.StartsWith("data:", StringComparison.Ordinal)) continue;
-            var payload = line[5..].TrimStart();
-            using var doc = JsonDocument.Parse(payload);
-            var phase = doc.RootElement.GetProperty("phase").GetString();
-            if (phase is "done" or "error")
+            var frame = await Fixtures.SseFrameReader.ReadFrameAsync(reader, ct);
+            if (frame is null) break;
+            if (frame.Value.EventType is "done" or "error")
             {
-                return phase;
+                return frame.Value.EventType;
             }
-            // otherwise it's a progress frame; keep reading.
+            // otherwise it's a `progress` frame; keep reading.
         }
         throw new InvalidOperationException("SSE stream ended without a terminal frame.");
     }

--- a/test/Typhon.Workbench.Tests/ProfilerLiveStreamTests.cs
+++ b/test/Typhon.Workbench.Tests/ProfilerLiveStreamTests.cs
@@ -13,10 +13,12 @@ using Typhon.Workbench.Fixtures;
 namespace Typhon.Workbench.Tests;
 
 /// <summary>
-/// End-to-end coverage for the profiler live-stream SSE endpoint. The client's useEventSource
-/// hook branches on the <c>kind</c> discriminant — <c>"metadata"</c> / <c>"tick"</c> /
-/// <c>"heartbeat"</c> — so a regression that drops a field or renames the kind would silently
-/// break the attach-mode panel. These tests pin the exact frame shape emitted for each kind.
+/// End-to-end coverage for the profiler live-stream SSE endpoint. Post-#308 the wire format uses
+/// typed SSE events (<c>event: metadata</c>, <c>event: tickSummaryAdded</c>, etc.) instead of
+/// putting the discriminant inside the payload. Clients install one <c>addEventListener</c> per
+/// kind for clean TypeScript narrowing — a regression that drops a field or renames the event type
+/// would silently break the attach-mode panel. These tests pin the exact event type and per-event
+/// payload shape.
 /// </summary>
 [TestFixture]
 public sealed class ProfilerLiveStreamTests
@@ -74,26 +76,21 @@ public sealed class ProfilerLiveStreamTests
         using var reader = new StreamReader(stream);
         while (!(seenMetadata && seenHeartbeat && seenTickSummaryAdded))
         {
-            var line = await reader.ReadLineAsync(cts.Token);
-            if (line == null) break;
-            if (!line.StartsWith("data:", StringComparison.Ordinal)) continue;
+            var frame = await Fixtures.SseFrameReader.ReadFrameAsync(reader, cts.Token);
+            if (frame is null) break;
 
-            var payload = line[5..].TrimStart();
-            using var doc = JsonDocument.Parse(payload);
-            var kind = doc.RootElement.GetProperty("kind").GetString();
-
-            switch (kind)
+            switch (frame.Value.EventType)
             {
                 case "metadata":
                     seenMetadata = true;
-                    metadataJson = payload;
+                    metadataJson = frame.Value.Data;
                     break;
                 case "heartbeat":
                     seenHeartbeat = true;
                     break;
                 case "tickSummaryAdded":
                     seenTickSummaryAdded = true;
-                    tickJson = payload;
+                    tickJson = frame.Value.Data;
                     break;
             }
         }
@@ -102,9 +99,10 @@ public sealed class ProfilerLiveStreamTests
         Assert.That(seenHeartbeat, Is.True, "client expects a heartbeat frame with the initial connection status");
         Assert.That(seenTickSummaryAdded, Is.True, "client expects at least one tickSummaryAdded delta from block-frame ingest");
 
+        // Post-#308 the kind no longer ships in payload; the SSE event: line above already discriminates. The payload
+        // carries only the per-kind sub-object.
         using (var metaDoc = JsonDocument.Parse(metadataJson!))
         {
-            Assert.That(metaDoc.RootElement.GetProperty("kind").GetString(), Is.EqualTo("metadata"));
             Assert.That(metaDoc.RootElement.TryGetProperty("metadata", out var metaProp), Is.True,
                 "metadata frame must carry a non-null metadata sub-object");
             Assert.That(metaProp.GetProperty("header").GetProperty("timestampFrequency").GetInt64(),
@@ -114,7 +112,6 @@ public sealed class ProfilerLiveStreamTests
 
         using (var tickDoc = JsonDocument.Parse(tickJson!))
         {
-            Assert.That(tickDoc.RootElement.GetProperty("kind").GetString(), Is.EqualTo("tickSummaryAdded"));
             Assert.That(tickDoc.RootElement.TryGetProperty("tickSummary", out var summaryProp), Is.True,
                 "tickSummaryAdded frame must carry a non-null tickSummary sub-object");
             Assert.That(summaryProp.GetProperty("tickNumber").GetUInt32(), Is.GreaterThan(0u));

--- a/test/Typhon.Workbench.Tests/SseExtensionsTests.cs
+++ b/test/Typhon.Workbench.Tests/SseExtensionsTests.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using Typhon.Workbench.Streams;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// Wire-format pin for the shared SSE writer (#308). Every Workbench stream goes through these
+/// helpers — a regression in framing (missing <c>event:</c>, missing trailing blank line, wrong
+/// camelCase casing) breaks every consumer.
+/// </summary>
+[TestFixture]
+public sealed class SseExtensionsTests
+{
+    [Test]
+    public async Task WriteEventAsync_EmitsTypedEventLine_ThenDataLine_ThenBlank()
+    {
+        var (ctx, body) = MakeContext();
+
+        await SseExtensions.WriteEventAsync(ctx, "tick", new { tickNumber = 42 }, default);
+
+        var wire = ReadAll(body);
+        Assert.That(wire, Is.EqualTo("event: tick\ndata: {\"tickNumber\":42}\n\n"),
+            "wire format must be event:\\ndata:\\n\\n with no extra whitespace; clients depend on the exact layout");
+    }
+
+    [Test]
+    public async Task WriteEventAsync_PayloadSerialisedWithCamelCase_AndIgnoresNulls()
+    {
+        var (ctx, body) = MakeContext();
+
+        await SseExtensions.WriteEventAsync(
+            ctx,
+            "demo",
+            new SamplePayload(BytesRead: 100, Message: null),
+            default);
+
+        var wire = ReadAll(body);
+        // bytesRead camelCase, message dropped (null + WhenWritingNull policy from SseJsonOptions.Web).
+        Assert.That(wire, Does.Contain("\"bytesRead\":100"));
+        Assert.That(wire, Does.Not.Contain("message"),
+            "null fields must be omitted from the wire — keeps payloads tight under heavy ingest");
+    }
+
+    [Test]
+    public async Task WriteCommentAsync_EmitsCommentLine_ThenBlank()
+    {
+        var (ctx, body) = MakeContext();
+
+        await SseExtensions.WriteCommentAsync(ctx, "keepalive", default);
+
+        var wire = ReadAll(body);
+        Assert.That(wire, Is.EqualTo(": keepalive\n\n"),
+            "comment frames are colon-prefixed, ignored by EventSource consumers but visible to NAT idle timers");
+    }
+
+    [Test]
+    public async Task WriteSseHeadersAsync_SetsContentType_CacheControl_Connection()
+    {
+        var (ctx, _) = MakeContext();
+
+        await SseExtensions.WriteSseHeadersAsync(ctx, default);
+
+        Assert.That(ctx.Response.Headers.ContentType.ToString(), Is.EqualTo("text/event-stream"));
+        Assert.That(ctx.Response.Headers.CacheControl.ToString(), Is.EqualTo("no-cache"));
+        Assert.That(ctx.Response.Headers.Connection.ToString(), Is.EqualTo("keep-alive"));
+    }
+
+    private static (HttpContext ctx, MemoryStream body) MakeContext()
+    {
+        var body = new MemoryStream();
+        var ctx = new DefaultHttpContext { Response = { Body = body } };
+        return (ctx, body);
+    }
+
+    private static string ReadAll(MemoryStream body)
+    {
+        body.Position = 0;
+        return Encoding.UTF8.GetString(body.ToArray());
+    }
+
+    private record SamplePayload(long? BytesRead = null, string Message = null);
+}

--- a/test/Typhon.Workbench.Tests/StreamSubscriptionRegistryTests.cs
+++ b/test/Typhon.Workbench.Tests/StreamSubscriptionRegistryTests.cs
@@ -1,0 +1,131 @@
+using NUnit.Framework;
+using Typhon.Workbench.Services;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="StreamSubscriptionRegistry"/> (#308 Phase C). Pin the membership
+/// semantics that the unified-stream multiplexer depends on — a regression that returns
+/// <c>true</c> from <see cref="StreamSubscriptionRegistry.IsSubscribed"/> for an unregistered
+/// streamId would silently fan out events to disconnected clients.
+/// </summary>
+[TestFixture]
+public sealed class StreamSubscriptionRegistryTests
+{
+    [Test]
+    public void IsSubscribed_UnknownStreamId_ReturnsFalse()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        Assert.That(reg.IsSubscribed(Guid.NewGuid(), "tick"), Is.False);
+    }
+
+    [Test]
+    public void IsSubscribed_RegisteredButEmpty_ReturnsFalse()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+        Assert.That(reg.IsSubscribed(id, "tick"), Is.False,
+            "default subscription set is empty — bootstrap events bypass the filter elsewhere");
+    }
+
+    [Test]
+    public void Subscribe_AddsEvents_IsSubscribedReturnsTrue()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+
+        Assert.That(reg.Subscribe(id, ["tick", "log"]), Is.True);
+        Assert.That(reg.IsSubscribed(id, "tick"), Is.True);
+        Assert.That(reg.IsSubscribed(id, "log"), Is.True);
+        Assert.That(reg.IsSubscribed(id, "error"), Is.False, "untouched events remain unsubscribed");
+    }
+
+    [Test]
+    public void Subscribe_UnknownStreamId_ReturnsFalse()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        Assert.That(reg.Subscribe(Guid.NewGuid(), ["tick"]), Is.False,
+            "client racing the connection close gets a `false` rather than a thrown exception");
+    }
+
+    [Test]
+    public void Subscribe_Idempotent()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+
+        reg.Subscribe(id, ["tick"]);
+        reg.Subscribe(id, ["tick"]);
+
+        Assert.That(reg.IsSubscribed(id, "tick"), Is.True);
+        Assert.That(reg.Snapshot(id), Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void Unsubscribe_RemovesEvent()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+        reg.Subscribe(id, ["tick", "log"]);
+
+        Assert.That(reg.Unsubscribe(id, ["tick"]), Is.True);
+        Assert.That(reg.IsSubscribed(id, "tick"), Is.False);
+        Assert.That(reg.IsSubscribed(id, "log"), Is.True, "untouched events remain subscribed");
+    }
+
+    [Test]
+    public void Unsubscribe_UnknownEvent_NoOp()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+
+        Assert.That(reg.Unsubscribe(id, ["never-subscribed"]), Is.True,
+            "method returns whether the streamId is known, not whether the event was previously subscribed");
+    }
+
+    [Test]
+    public void Unregister_DropsAllSubscriptions()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+        reg.Subscribe(id, ["tick"]);
+
+        reg.Unregister(id);
+
+        Assert.That(reg.IsSubscribed(id, "tick"), Is.False);
+        Assert.That(reg.Subscribe(id, ["log"]), Is.False, "unregistered streamId no longer accepts subscriptions");
+    }
+
+    [Test]
+    public void Register_Idempotent_DoesNotResetSubscriptions()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+        reg.Subscribe(id, ["tick"]);
+
+        reg.Register(id);
+
+        Assert.That(reg.IsSubscribed(id, "tick"), Is.True,
+            "double-register must NOT clear an already-built subscription set");
+    }
+
+    [Test]
+    public void Snapshot_ReturnsCurrentEvents()
+    {
+        var reg = new StreamSubscriptionRegistry();
+        var id = Guid.NewGuid();
+        reg.Register(id);
+        reg.Subscribe(id, ["tick", "log"]);
+
+        var snap = reg.Snapshot(id);
+
+        Assert.That(snap, Is.EquivalentTo(new[] { "tick", "log" }));
+    }
+}

--- a/test/Typhon.Workbench.Tests/UnifiedDataStreamTests.cs
+++ b/test/Typhon.Workbench.Tests/UnifiedDataStreamTests.cs
@@ -1,0 +1,259 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Typhon.Workbench.Dtos.Sessions;
+using Typhon.Workbench.Fixtures;
+using Typhon.Workbench.Services;
+using Typhon.Workbench.Tests.Fixtures;
+
+namespace Typhon.Workbench.Tests;
+
+/// <summary>
+/// End-to-end coverage for the unified data stream (#308 Phase B/C). Pins:
+/// <list type="bullet">
+///   <item>Bootstrap event order on connect: <c>stream-id</c> → <c>metadata</c> →
+///         <c>session-state</c>.</item>
+///   <item>Auth boundary: 401 for missing session, 409 for unsupported session kind (Open).</item>
+///   <item>Subscribe / unsubscribe round-trip: events not in the set are dropped before
+///         serialisation; events added later flow through.</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public sealed class UnifiedDataStreamTests
+{
+    private WorkbenchFactory _factory;
+    private HttpClient _client;
+
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new WorkbenchFactory();
+        _client = _factory.CreateAuthenticatedClient();
+    }
+
+    [TearDown]
+    public void TearDown() => _factory.Dispose();
+
+    [Test]
+    public async Task Stream_NoSession_Returns401()
+    {
+        var resp = await _client.GetAsync($"/api/sessions/{Guid.NewGuid()}/stream");
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+    }
+
+    [Test]
+    public async Task Stream_OpenSession_Returns409()
+    {
+        // The unified data stream is a profiler-data surface — a database-open session has no
+        // tick / metadata / topology to push, so we 409 early. Same boundary as DataController.
+        var createResp = await _client.PostAsJsonAsync("/api/sessions/file", new CreateFileSessionRequest("demo.typhon"));
+        createResp.EnsureSuccessStatusCode();
+        var session = JsonSerializer.Deserialize<SessionDto>(await createResp.Content.ReadAsStringAsync(), Json)!;
+
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/sessions/{session.SessionId}/stream");
+        req.Headers.Add("X-Session-Token", session.SessionId.ToString());
+        var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
+
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+    }
+
+    [Test]
+    [CancelAfter(20000)]
+    public async Task Stream_AttachSession_EmitsBootstrapEventsInOrder(CancellationToken testCt)
+    {
+        await using var server = new MockTcpProfilerServer
+        {
+            BlockInterval = TimeSpan.FromMilliseconds(40),
+            MaxBlocks = 50,
+        };
+        server.Start();
+
+        var attachResp = await _client.PostAsJsonAsync(
+            "/api/sessions/attach",
+            new CreateAttachSessionRequest($"127.0.0.1:{server.Port}"));
+        attachResp.EnsureSuccessStatusCode();
+        var session = JsonSerializer.Deserialize<SessionDto>(await attachResp.Content.ReadAsStringAsync(), Json)!;
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(testCt);
+        cts.CancelAfter(TimeSpan.FromSeconds(8));
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/sessions/{session.SessionId}/stream");
+        req.Headers.Add("X-Session-Token", session.SessionId.ToString());
+
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(resp.Content.Headers.ContentType!.MediaType, Is.EqualTo("text/event-stream"));
+
+        using var stream = await resp.Content.ReadAsStreamAsync(cts.Token);
+        using var reader = new StreamReader(stream);
+
+        var streamIdFrame = await SseFrameReader.ReadFrameAsync(reader, cts.Token);
+        Assert.That(streamIdFrame, Is.Not.Null);
+        Assert.That(streamIdFrame.Value.EventType, Is.EqualTo("stream-id"),
+            "first frame on the unified stream must be stream-id so clients can target /subscribe at this connection");
+
+        using (var doc = JsonDocument.Parse(streamIdFrame.Value.Data))
+        {
+            Assert.That(doc.RootElement.TryGetProperty("streamId", out _), Is.True,
+                "stream-id frame must carry a non-null streamId");
+        }
+
+        // Read until we see session-state — metadata may or may not be present yet (depending on
+        // how fast the mock server's first Init lands), but session-state is always emitted.
+        var sawSessionState = false;
+        SseFrame? frame;
+        while ((frame = await SseFrameReader.ReadFrameAsync(reader, cts.Token)) is not null)
+        {
+            if (frame.Value.EventType == "session-state")
+            {
+                sawSessionState = true;
+                break;
+            }
+            // metadata / heartbeat frames in between are fine.
+        }
+        Assert.That(sawSessionState, Is.True, "stream must emit a session-state event after stream-id");
+    }
+
+    [Test]
+    [CancelAfter(20000)]
+    public async Task Stream_TickEventsRequireSubscription(CancellationToken testCt)
+    {
+        // Without a /subscribe call for `tick`, the multiplexer should drop tick frames before the
+        // wire. We connect, capture the streamId, then read for a short window and assert no tick
+        // frames arrive — even though the mock server is producing block frames at 40 ms.
+        await using var server = new MockTcpProfilerServer
+        {
+            BlockInterval = TimeSpan.FromMilliseconds(40),
+            MaxBlocks = 50,
+        };
+        server.Start();
+
+        var attachResp = await _client.PostAsJsonAsync(
+            "/api/sessions/attach",
+            new CreateAttachSessionRequest($"127.0.0.1:{server.Port}"));
+        attachResp.EnsureSuccessStatusCode();
+        var session = JsonSerializer.Deserialize<SessionDto>(await attachResp.Content.ReadAsStringAsync(), Json)!;
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(testCt);
+        cts.CancelAfter(TimeSpan.FromSeconds(4));
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/sessions/{session.SessionId}/stream");
+        req.Headers.Add("X-Session-Token", session.SessionId.ToString());
+
+        using var resp = await _client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        using var stream = await resp.Content.ReadAsStreamAsync(cts.Token);
+        using var reader = new StreamReader(stream);
+
+        // Read for ~1.5 s to give the mock plenty of opportunity to produce ticks.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(1.5);
+        var sawTick = false;
+        try
+        {
+            while (DateTime.UtcNow < deadline)
+            {
+                using var inner = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+                inner.CancelAfter(deadline - DateTime.UtcNow);
+                var frame = await SseFrameReader.ReadFrameAsync(reader, inner.Token);
+                if (frame is null) break;
+                if (frame.Value.EventType == "tick") { sawTick = true; break; }
+            }
+        }
+        catch (OperationCanceledException) { /* timeout reached — expected */ }
+
+        Assert.That(sawTick, Is.False,
+            "tick events must not flow without a /subscribe call — server-side filter dropped them");
+    }
+
+    [Test]
+    public async Task Subscribe_UnknownStreamId_Returns404()
+    {
+        var session = await CreateOpenForSubscribeAsync();
+
+        var resp = await PostWithSessionTokenAsync(session, "/subscribe",
+            new { streamId = Guid.NewGuid(), events = new[] { "tick" } });
+
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task Subscribe_MissingStreamId_Returns400()
+    {
+        var session = await CreateOpenForSubscribeAsync();
+
+        var resp = await PostWithSessionTokenAsync(session, "/subscribe",
+            new { streamId = Guid.Empty, events = new[] { "tick" } });
+
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task Unsubscribe_UnknownStreamId_Returns404()
+    {
+        var session = await CreateOpenForSubscribeAsync();
+
+        var resp = await PostWithSessionTokenAsync(session, "/unsubscribe",
+            new { streamId = Guid.NewGuid(), events = new[] { "tick" } });
+
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task Subscribe_RegisteredStream_MutatesRegistry()
+    {
+        // Drives subscribe by registering the streamId directly on the singleton registry rather
+        // than waiting for the SSE handshake — keeps the assertion synchronous on the registry's
+        // observable state.
+        var session = await CreateOpenForSubscribeAsync();
+        var registry = _factory.Services.GetRequiredService<StreamSubscriptionRegistry>();
+        var streamId = Guid.NewGuid();
+        registry.Register(streamId);
+
+        var subscribeResp = await PostWithSessionTokenAsync(session, "/subscribe",
+            new { streamId, events = new[] { "tick", "log" } });
+        Assert.That(subscribeResp.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+        Assert.That(registry.IsSubscribed(streamId, "tick"), Is.True);
+        Assert.That(registry.IsSubscribed(streamId, "log"), Is.True);
+
+        var unsubscribeResp = await PostWithSessionTokenAsync(session, "/unsubscribe",
+            new { streamId, events = new[] { "tick" } });
+        Assert.That(unsubscribeResp.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+        Assert.That(registry.IsSubscribed(streamId, "tick"), Is.False);
+        Assert.That(registry.IsSubscribed(streamId, "log"), Is.True);
+
+        registry.Unregister(streamId);
+    }
+
+    [Test]
+    public void Registry_DI_RegistersAsSingleton()
+    {
+        // Pin DI registration so adding a new SessionsController-style scope doesn't break the
+        // multiplexer's reliance on a process-wide singleton.
+        var registry = _factory.Services.GetRequiredService<StreamSubscriptionRegistry>();
+        var registry2 = _factory.Services.GetRequiredService<StreamSubscriptionRegistry>();
+        Assert.That(registry, Is.SameAs(registry2));
+    }
+
+    private async Task<SessionDto> CreateOpenForSubscribeAsync()
+    {
+        // We just need a valid sessionId for the controller's RequireSession middleware to let the
+        // body validation run. Use an open session — controller doesn't reject by kind.
+        var resp = await _client.PostAsJsonAsync("/api/sessions/file", new CreateFileSessionRequest("demo.typhon"));
+        resp.EnsureSuccessStatusCode();
+        var session = JsonSerializer.Deserialize<SessionDto>(await resp.Content.ReadAsStringAsync(), Json)!;
+        return session;
+    }
+
+    private Task<HttpResponseMessage> PostWithSessionTokenAsync(SessionDto session, string path, object body)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/api/sessions/{session.SessionId}{path}")
+        {
+            Content = JsonContent.Create(body),
+        };
+        req.Headers.Add("X-Session-Token", session.SessionId.ToString());
+        return _client.SendAsync(req);
+    }
+}

--- a/tools/Typhon.Workbench.Fixtures/MockTcpProfilerServer.cs
+++ b/tools/Typhon.Workbench.Fixtures/MockTcpProfilerServer.cs
@@ -129,6 +129,7 @@ public sealed class MockTcpProfilerServer : IAsyncDisposable
         bw.Write((ushort)0); // system count = 0
         bw.Write((ushort)0); // archetype count = 0
         bw.Write((ushort)0); // component-type count = 0
+        bw.Write((ushort)0); // phase count = 0 (v6+ Phases section)
         bw.Flush();
         return ms.ToArray();
     }

--- a/tools/Typhon.Workbench.Fixtures/TraceFixtureBuilder.cs
+++ b/tools/Typhon.Workbench.Fixtures/TraceFixtureBuilder.cs
@@ -41,6 +41,7 @@ public static class TraceFixtureBuilder
         writer.WriteSystemDefinitions([]);
         writer.WriteArchetypes([]);
         writer.WriteComponentTypes([]);
+        writer.WritePhases([]);
 
         // One block containing every record. Record sizes follow the production codec:
         //   TickStart = 12 B (header only)
@@ -84,6 +85,102 @@ public static class TraceFixtureBuilder
     }
 
     /// <summary>
+    /// Build a minimal trace whose system table carries RFC 07 access declarations and a Phases section.
+    /// Exercises the v6 wire path end-to-end — used by topology / who-writes / who-reads endpoint tests.
+    /// </summary>
+    public static string BuildTraceWithAccessDeclarations(string directory)
+    {
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, $"fixture-rfc07-{Guid.NewGuid():N}.typhon-trace");
+
+        var systems = new[]
+        {
+            new SystemDefinitionRecord
+            {
+                Index = 0,
+                Name = "Movement",
+                Type = 0,
+                Priority = 0,
+                IsParallel = false,
+                TierFilter = 0x0F,
+                Predecessors = [],
+                Successors = [1],
+                PhaseName = "Simulation",
+                IsExclusivePhase = false,
+                Reads = ["Game.Velocity"],
+                Writes = ["Game.Position"],
+                ReadsEvents = ["Damage"],
+                WritesResources = ["world.physics"],
+            },
+            new SystemDefinitionRecord
+            {
+                Index = 1,
+                Name = "Damage",
+                Type = 0,
+                Priority = 0,
+                IsParallel = false,
+                TierFilter = 0x0F,
+                Predecessors = [0],
+                Successors = [],
+                PhaseName = "Simulation",
+                IsExclusivePhase = true,
+                ReadsSnapshot = ["Game.Position"],
+                Writes = ["Game.Health"],
+                WritesEvents = ["Death"],
+            },
+        };
+
+        var components = new[]
+        {
+            new ComponentTypeRecord { ComponentTypeId = 1, Name = "Game.Position" },
+            new ComponentTypeRecord { ComponentTypeId = 2, Name = "Game.Velocity" },
+            new ComponentTypeRecord { ComponentTypeId = 3, Name = "Game.Health" },
+        };
+
+        using var fs = File.Create(path);
+        using var writer = new TraceFileWriter(fs);
+        writer.WriteHeader(in DefaultHeader);
+        writer.WriteSystemDefinitions(systems);
+        writer.WriteArchetypes([]);
+        writer.WriteComponentTypes(components);
+        writer.WritePhases(["Input", "Simulation", "Output"]);
+
+        // Same record body as BuildMinimalTrace — 3 ticks of TickStart + Instant + TickEnd. Anything thinner
+        // can prevent the cache builder from producing a non-empty manifest, which leaves /topology stuck at 202.
+        const int tickStartSize = CommonHeaderSize;
+        const int instantSize = CommonHeaderSize + 8;
+        const int tickEndSize = CommonHeaderSize + 2;
+        const int tickCount = 3;
+        const int instantsPerTick = 2;
+        var totalRecords = tickCount * (2 + instantsPerTick);
+        var blockSize = tickCount * (tickStartSize + instantsPerTick * instantSize + tickEndSize);
+        var block = new byte[blockSize];
+        long ts = 100;
+        var offset = 0;
+        for (var t = 0; t < tickCount; t++)
+        {
+            WriteRecordHeader(block.AsSpan(offset), tickStartSize, TraceEventKind.TickStart, ts);
+            offset += tickStartSize;
+            ts++;
+            for (var i = 0; i < instantsPerTick; i++)
+            {
+                WriteRecordHeader(block.AsSpan(offset), instantSize, TraceEventKind.Instant, ts);
+                offset += instantSize;
+                ts++;
+            }
+            WriteRecordHeader(block.AsSpan(offset), tickEndSize, TraceEventKind.TickEnd, ts);
+            block[offset + CommonHeaderSize] = 0;
+            block[offset + CommonHeaderSize + 1] = 1;
+            offset += tickEndSize;
+            ts++;
+        }
+        writer.WriteRecords(block, totalRecords);
+        writer.WriteSpanNames(new Dictionary<int, string>());
+        writer.Flush();
+        return path;
+    }
+
+    /// <summary>
     /// Build a trace with a deliberately wrong magic number. Used for the "malformed file" path in
     /// <c>TraceSessionRuntime</c> tests — the runtime should reject it before reading further.
     /// </summary>
@@ -111,6 +208,7 @@ public static class TraceFixtureBuilder
         writer.WriteSystemDefinitions([]);
         writer.WriteArchetypes([]);
         writer.WriteComponentTypes([]);
+        writer.WritePhases([]);
         // No records, no span-name table → reader sees EOF mid-way through block scan.
         writer.Flush();
         return path;

--- a/tools/Typhon.Workbench/ClientApp/package-lock.json
+++ b/tools/Typhon.Workbench/ClientApp/package-lock.json
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.4",
+        "@testing-library/react": "^16.3.2",
         "@types/dagre": "^0.7.54",
         "@types/node": "^22.10.0",
         "@types/react": "^19.0.0",
@@ -3827,6 +3828,63 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4630,6 +4688,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5325,6 +5394,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5400,6 +5480,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",
@@ -7452,6 +7540,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8064,6 +8163,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",

--- a/tools/Typhon.Workbench/ClientApp/package.json
+++ b/tools/Typhon.Workbench/ClientApp/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.4",
+    "@testing-library/react": "^16.3.2",
     "@types/dagre": "^0.7.54",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",

--- a/tools/Typhon.Workbench/ClientApp/schema/openapi.json
+++ b/tools/Typhon.Workbench/ClientApp/schema/openapi.json
@@ -102,6 +102,377 @@
         }
       }
     },
+    "/api/sessions/{sessionId}/stream": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/options/stream": {
+      "get": {
+        "tags": [
+          "Options"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/topology": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopologyDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/queries/who-writes/{component}": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "component",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemListDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/queries/who-reads/{component}": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "component",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemListDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/tracks": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TracksResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/track/{trackId}": {
+      "get": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "trackId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "uint32",
+              "default": 0
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "uint32",
+              "default": 4294967295
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackDataResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/aggregate": {
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AggregationRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AggregationRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AggregationRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AggregationResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/subscribe": {
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamSubscriptionRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamSubscriptionRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamSubscriptionRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/unsubscribe": {
+      "post": {
+        "tags": [
+          "Data"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamSubscriptionRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamSubscriptionRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/StreamSubscriptionRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/fs/home": {
       "get": {
         "tags": [
@@ -349,6 +720,140 @@
         }
       }
     },
+    "/api/options": {
+      "get": {
+        "tags": [
+          "Options"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkbenchOptions"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Options"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkbenchOptions"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkbenchOptions"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkbenchOptions"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkbenchOptions"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/options/editor": {
+      "patch": {
+        "tags": [
+          "Options"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditorOptions"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditorOptions"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditorOptions"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkbenchOptions"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/options/profiler": {
+      "patch": {
+        "tags": [
+          "Options"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfilerOptions"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfilerOptions"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfilerOptions"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkbenchOptions"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/sessions/{sessionId}/profiler/metadata": {
       "get": {
         "tags": [
@@ -372,6 +877,36 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProfilerMetadataDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{sessionId}/profiler/source-locations": {
+      "get": {
+        "tags": [
+          "Profiler"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourceLocationManifestDto"
                 }
               }
             }
@@ -481,6 +1016,116 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/profiler/workspace-root": {
+      "get": {
+        "tags": [
+          "Profiler"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceRootDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profiler/open-in-editor": {
+      "post": {
+        "tags": [
+          "Profiler"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenInEditorRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenInEditorRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenInEditorRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenInEditorResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profiler/source": {
+      "get": {
+        "tags": [
+          "Profiler"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "line",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "context",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourceWindowDto"
+                }
+              }
+            }
           }
         }
       }
@@ -954,10 +1599,204 @@
           }
         }
       }
+    },
+    "/api/sessions/{id}/state": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionStateDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/system/os": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OsInfo"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "AggregationQueryDto": {
+        "required": [
+          "trackId",
+          "field",
+          "op",
+          "range"
+        ],
+        "type": "object",
+        "properties": {
+          "trackId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "field": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "op": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "range": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "uint32"
+            }
+          },
+          "buckets": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "n": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "samples": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          }
+        }
+      },
+      "AggregationRequestDto": {
+        "required": [
+          "queries"
+        ],
+        "type": "object",
+        "properties": {
+          "queries": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AggregationQueryDto"
+            }
+          }
+        }
+      },
+      "AggregationResponseDto": {
+        "required": [
+          "results"
+        ],
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AggregationResultDto"
+            }
+          }
+        }
+      },
+      "AggregationResultDto": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "histogram": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/HistogramBucketDto"
+            }
+          },
+          "topK": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/TopKEntryDto"
+            }
+          },
+          "cdf": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CdfSampleDto"
+            }
+          }
+        }
+      },
       "ArchetypeDto": {
         "required": [
           "archetypeId",
@@ -1048,6 +1887,31 @@
             "format": "int32"
           },
           "occupancyPct": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "CdfSampleDto": {
+        "required": [
+          "quantile",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "quantile": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "value": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
             "type": [
               "number",
@@ -1435,6 +2299,23 @@
           }
         }
       },
+      "EditorKind": {
+        "type": "integer"
+      },
+      "EditorOptions": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/EditorKind"
+          },
+          "customCommand": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "FieldDto": {
         "required": [
           "name",
@@ -1680,6 +2561,40 @@
           }
         }
       },
+      "HistogramBucketDto": {
+        "required": [
+          "bucketStart",
+          "bucketEnd",
+          "count"
+        ],
+        "type": "object",
+        "properties": {
+          "bucketStart": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "bucketEnd": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "count": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          }
+        }
+      },
       "IndexInfoDto": {
         "required": [
           "fieldName",
@@ -1722,6 +2637,81 @@
             ]
           }
         }
+      },
+      "OpenInEditorRequest": {
+        "required": [
+          "file",
+          "line",
+          "column"
+        ],
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "line": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "column": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          }
+        }
+      },
+      "OpenInEditorResult": {
+        "required": [
+          "ok",
+          "error",
+          "hint"
+        ],
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "error": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "hint": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "OsInfo": {
+        "required": [
+          "os"
+        ],
+        "type": "object",
+        "properties": {
+          "os": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "PostTickSummary": {
+        "type": "object"
       },
       "ProfilerHeaderDto": {
         "required": [
@@ -1822,7 +2812,12 @@
           "globalMetrics",
           "tickSummaries",
           "chunkManifest",
-          "gcSuspensions"
+          "gcSuspensions",
+          "phases",
+          "systemTickSummaries",
+          "queueTickSummaries",
+          "postTickSummaries",
+          "queueIdToName"
         ],
         "type": "object",
         "properties": {
@@ -1900,8 +2895,67 @@
             "items": {
               "$ref": "#/components/schemas/GcSuspensionDto"
             }
+          },
+          "phases": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "systemTickSummaries": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SystemTickSummary"
+            }
+          },
+          "queueTickSummaries": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/QueueTickSummary"
+            }
+          },
+          "postTickSummaries": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/PostTickSummary"
+            }
+          },
+          "queueIdToName": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
+      },
+      "ProfilerOptions": {
+        "type": "object",
+        "properties": {
+          "workspaceRoot": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "QueueTickSummary": {
+        "type": "object"
       },
       "ResourceGraphDto": {
         "required": [
@@ -2090,6 +3144,234 @@
             "items": {
               "$ref": "#/components/schemas/SessionDiagnosticDto"
             }
+          },
+          "lifecycle": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "isStreaming": {
+            "type": "boolean",
+            "default": false
+          },
+          "isPaused": {
+            "type": "boolean",
+            "default": false
+          },
+          "isReattaching": {
+            "type": "boolean",
+            "default": false
+          },
+          "schemaCompatibility": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "reason": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "SessionStateDto": {
+        "required": [
+          "kind",
+          "lifecycle",
+          "isStreaming",
+          "isPaused",
+          "isReattaching",
+          "schemaCompatibility",
+          "reason"
+        ],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "lifecycle": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "isStreaming": {
+            "type": "boolean"
+          },
+          "isPaused": {
+            "type": "boolean"
+          },
+          "isReattaching": {
+            "type": "boolean"
+          },
+          "schemaCompatibility": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "reason": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "SourceLocationEntryDto": {
+        "required": [
+          "id",
+          "fileId",
+          "line",
+          "kind",
+          "method"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "uint16"
+          },
+          "fileId": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "uint16"
+          },
+          "line": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "uint32"
+          },
+          "kind": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "uint8"
+          },
+          "method": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "SourceLocationFileDto": {
+        "required": [
+          "fileId",
+          "path"
+        ],
+        "type": "object",
+        "properties": {
+          "fileId": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "uint16"
+          },
+          "path": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "SourceLocationManifestDto": {
+        "required": [
+          "files",
+          "entries"
+        ],
+        "type": "object",
+        "properties": {
+          "files": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SourceLocationFileDto"
+            }
+          },
+          "entries": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SourceLocationEntryDto"
+            }
+          }
+        }
+      },
+      "SourceWindowDto": {
+        "required": [
+          "file",
+          "line",
+          "startLine",
+          "endLine",
+          "lines"
+        ],
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "line": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "startLine": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "endLine": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "lines": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -2136,6 +3418,28 @@
           }
         }
       },
+      "StreamSubscriptionRequestDto": {
+        "required": [
+          "streamId",
+          "events"
+        ],
+        "type": "object",
+        "properties": {
+          "streamId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "events": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "SystemAggregateDto": {
         "required": [
           "systemIndex",
@@ -2179,7 +3483,21 @@
           "isParallel",
           "tierFilter",
           "predecessors",
-          "successors"
+          "successors",
+          "phaseName",
+          "isExclusivePhase",
+          "reads",
+          "readsFresh",
+          "readsSnapshot",
+          "additionalReads",
+          "writes",
+          "sideWrites",
+          "writesEvents",
+          "readsEvents",
+          "writesResources",
+          "readsResources",
+          "explicitAfter",
+          "explicitBefore"
         ],
         "type": "object",
         "properties": {
@@ -2250,6 +3568,147 @@
                 "string"
               ],
               "format": "uint16"
+            }
+          },
+          "phaseName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "isExclusivePhase": {
+            "type": "boolean"
+          },
+          "reads": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "readsFresh": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "readsSnapshot": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "additionalReads": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "writes": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "sideWrites": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "writesEvents": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "readsEvents": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "writesResources": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "readsResources": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "explicitAfter": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "explicitBefore": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "SystemListDto": {
+        "required": [
+          "query",
+          "systems"
+        ],
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "systems": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SystemDefinitionDto"
             }
           }
         }
@@ -2322,6 +3781,9 @@
             }
           }
         }
+      },
+      "SystemTickSummary": {
+        "type": "object"
       },
       "TickSummaryDto": {
         "required": [
@@ -2435,6 +3897,200 @@
             "format": "uint16"
           }
         }
+      },
+      "TopKEntryDto": {
+        "required": [
+          "tickNumber",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "tickNumber": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "uint32"
+          },
+          "value": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "TopologyDto": {
+        "required": [
+          "systems",
+          "archetypes",
+          "componentTypes",
+          "phases"
+        ],
+        "type": "object",
+        "properties": {
+          "systems": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SystemDefinitionDto"
+            }
+          },
+          "archetypes": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ArchetypeDto"
+            }
+          },
+          "componentTypes": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ComponentTypeDto"
+            }
+          },
+          "phases": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TrackDataResponseDto": {
+        "required": [
+          "trackId",
+          "records"
+        ],
+        "type": "object",
+        "properties": {
+          "trackId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "records": {
+            "type": [
+              "null",
+              "array"
+            ]
+          }
+        }
+      },
+      "TrackFieldDescriptorDto": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "TrackSchemaDto": {
+        "required": [
+          "id",
+          "kind",
+          "fields"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "kind": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "fields": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/TrackFieldDescriptorDto"
+            }
+          }
+        }
+      },
+      "TracksResponseDto": {
+        "required": [
+          "tracks"
+        ],
+        "type": "object",
+        "properties": {
+          "tracks": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/TrackSchemaDto"
+            }
+          }
+        }
+      },
+      "WorkbenchOptions": {
+        "type": "object",
+        "properties": {
+          "editor": {
+            "$ref": "#/components/schemas/EditorOptions"
+          },
+          "profiler": {
+            "$ref": "#/components/schemas/ProfilerOptions"
+          }
+        }
+      },
+      "WorkspaceRootDto": {
+        "required": [
+          "effective",
+          "source"
+        ],
+        "type": "object",
+        "properties": {
+          "effective": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "source": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
       }
     }
   },
@@ -2449,6 +4105,12 @@
       "name": "Profiler"
     },
     {
+      "name": "Data"
+    },
+    {
+      "name": "Options"
+    },
+    {
       "name": "Files"
     },
     {
@@ -2459,6 +4121,9 @@
     },
     {
       "name": "Schema"
+    },
+    {
+      "name": "System"
     }
   ]
 }

--- a/tools/Typhon.Workbench/ClientApp/src/api/client.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/api/client.ts
@@ -14,6 +14,7 @@ export const customFetch = async <T>(url: string, init?: RequestInit): Promise<T
   if (token && !headers.has('X-Session-Token')) {
     headers.set('X-Session-Token', token);
   }
+  headers.set('X-Workbench-Api', '1');
 
   const response = await fetch(url, { ...init, headers });
 

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/__tests__/useSelectionBootstrap.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/__tests__/useSelectionBootstrap.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { renderHook, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useProfilerViewStore } from '@/stores/useProfilerViewStore';
+import { useSchemaInspectorStore } from '@/stores/useSchemaInspectorStore';
+import { useSelectionStore } from '@/stores/useSelectionStore';
+import { useSelectionBootstrap } from '../useSelectionBootstrap';
+
+function setUrl(search: string): void {
+  window.history.replaceState(null, '', `/${search}`);
+}
+
+beforeEach(() => {
+  setUrl('');
+  useSelectionStore.getState().clear();
+  useSchemaInspectorStore.getState().reset();
+  useProfilerViewStore.getState().setViewRange({ startUs: 0, endUs: 0 });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useSelectionBootstrap', () => {
+  it('cold-load: URL → unified store on mount', () => {
+    setUrl('?session=abc&time=120000-134000&system=AI&component=Position&queue=Damage');
+
+    renderHook(() => useSelectionBootstrap());
+
+    const s = useSelectionStore.getState();
+    expect(s.time).toEqual({ start: 120_000, end: 134_000 });
+    expect(s.system).toBe('AI');
+    expect(s.component).toBe('Position');
+    expect(s.queue).toBe('Damage');
+  });
+
+  it('cold-load: URL values propagate through bridges to legacy stores', () => {
+    setUrl('?time=200000-300000&component=Velocity');
+
+    renderHook(() => useSelectionBootstrap());
+
+    // The bridge installed before applySelectionToStore picks up the URL writes and forwards
+    // them out to legacy stores.
+    expect(useProfilerViewStore.getState().viewRange).toEqual({ startUs: 200_000, endUs: 300_000 });
+    expect(useSchemaInspectorStore.getState().selectedComponentType).toBe('Velocity');
+  });
+
+  it('steady-state: store changes mirror to URL', () => {
+    setUrl('?session=abc');
+    renderHook(() => useSelectionBootstrap());
+
+    useSelectionStore.getState().setSystem('AI');
+    expect(window.location.search).toContain('system=AI');
+    expect(window.location.search).toContain('session=abc');
+
+    useSelectionStore.getState().setQueue('Damage');
+    expect(window.location.search).toContain('queue=Damage');
+  });
+
+  it('volatile slots stay out of the URL', () => {
+    setUrl('');
+    renderHook(() => useSelectionBootstrap());
+
+    useSelectionStore.getState().setFocusTick(7);
+    useSelectionStore.getState().setWorker(3);
+
+    expect(window.location.search).toBe('');
+  });
+
+  it('teardown unsubscribes both URL sync and bridges', () => {
+    setUrl('');
+    const { unmount } = renderHook(() => useSelectionBootstrap());
+
+    unmount();
+
+    // After unmount, store changes must NOT reach the URL.
+    useSelectionStore.getState().setSystem('AI');
+    expect(window.location.search).toBe('');
+    // ...nor reach the legacy stores via the bridges.
+    useSelectionStore.getState().setComponent('Position');
+    expect(useSchemaInspectorStore.getState().selectedComponentType).toBeNull();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/data/__tests__/useDataStream.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/data/__tests__/useDataStream.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDataStream } from '../useDataStream';
+
+class StubEventSource {
+  static OPEN = 1;
+  static CLOSED = 2;
+  /** Tracks all currently-live instances so a test can address them by URL. */
+  static instances: StubEventSource[] = [];
+
+  url: string;
+  readyState = 0;
+  onopen: ((this: EventSource) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+  closed = false;
+  private listeners: Map<string, Set<(ev: MessageEvent) => void>> = new Map();
+
+  constructor(url: string) {
+    this.url = url;
+    StubEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(fn);
+  }
+
+  removeEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    this.listeners.get(type)?.delete(fn);
+  }
+
+  dispatch(type: string, data: unknown): void {
+    const evt = new MessageEvent(type, { data: JSON.stringify(data) });
+    this.listeners.get(type)?.forEach((fn) => fn(evt));
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = StubEventSource.CLOSED;
+  }
+}
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: { streamId: string; events: string[] };
+}
+
+function setupFetchSpy(): { calls: FetchCall[]; restore: () => void } {
+  const calls: FetchCall[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: typeof input === 'string' ? input : input.toString(),
+      method: init?.method ?? 'GET',
+      body: init?.body ? JSON.parse(init.body as string) : { streamId: '', events: [] },
+    });
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+describe('useDataStream (#308 Phase C)', () => {
+  let fetchSpy: { calls: FetchCall[]; restore: () => void };
+
+  beforeEach(() => {
+    StubEventSource.instances = [];
+    (globalThis as unknown as { EventSource: typeof StubEventSource }).EventSource = StubEventSource;
+    fetchSpy = setupFetchSpy();
+  });
+
+  afterEach(() => {
+    fetchSpy.restore();
+  });
+
+  it('opens one EventSource per session and fans out typed events to mounted handlers', async () => {
+    const tickHandler = vi.fn();
+    renderHook(() => useDataStream('session-A', { tick: tickHandler }));
+
+    expect(StubEventSource.instances).toHaveLength(1);
+    const es = StubEventSource.instances[0];
+    expect(es.url).toBe('/api/sessions/session-A/stream');
+
+    act(() => {
+      es.dispatch('stream-id', { streamId: '00000000-0000-0000-0000-000000000001' });
+    });
+
+    // After streamId arrives, /subscribe should be POSTed for `tick`.
+    await waitFor(() => {
+      expect(fetchSpy.calls.some((c) => c.url.endsWith('/subscribe'))).toBe(true);
+    });
+
+    const subscribeCall = fetchSpy.calls.find((c) => c.url.endsWith('/subscribe'))!;
+    expect(subscribeCall.body.streamId).toBe('00000000-0000-0000-0000-000000000001');
+    expect(subscribeCall.body.events).toEqual(['tick']);
+
+    act(() => {
+      es.dispatch('tick', { tickSummary: { tickNumber: 1 } });
+    });
+    expect(tickHandler).toHaveBeenCalledWith({ tickSummary: { tickNumber: 1 } });
+  });
+
+  it('shares the connection across two consumers and unions their subscriptions', async () => {
+    const tickHandler = vi.fn();
+    const logHandler = vi.fn();
+
+    const consumerA = renderHook(() => useDataStream('session-X', { tick: tickHandler }));
+    renderHook(() => useDataStream('session-X', { log: logHandler }));
+
+    // Only one underlying EventSource — both hooks share it.
+    expect(StubEventSource.instances).toHaveLength(1);
+    const es = StubEventSource.instances[0];
+
+    act(() => {
+      es.dispatch('stream-id', { streamId: 'shared-stream' });
+    });
+
+    await waitFor(() => {
+      const subscribed = new Set<string>();
+      for (const c of fetchSpy.calls.filter((c) => c.url.endsWith('/subscribe'))) {
+        for (const e of c.body.events) subscribed.add(e);
+      }
+      expect(subscribed.has('tick')).toBe(true);
+      expect(subscribed.has('log')).toBe(true);
+    });
+
+    act(() => {
+      es.dispatch('log', { message: 'hi' });
+    });
+    expect(logHandler).toHaveBeenCalledWith({ message: 'hi' });
+    expect(tickHandler).not.toHaveBeenCalled();
+
+    // Unmount consumer A — log handler should still receive events; tick should be unsubscribed
+    // since no one wants it any more.
+    consumerA.unmount();
+
+    await waitFor(() => {
+      const unsubs = fetchSpy.calls.filter((c) => c.url.endsWith('/unsubscribe'));
+      expect(unsubs.some((c) => c.body.events.includes('tick'))).toBe(true);
+    });
+
+    // Connection still open because consumer B is still mounted.
+    expect(es.closed).toBe(false);
+  });
+
+  it('closes the connection when the last consumer unmounts', async () => {
+    const { unmount } = renderHook(() => useDataStream('session-Y', { tick: vi.fn() }));
+    const es = StubEventSource.instances[0];
+
+    act(() => {
+      es.dispatch('stream-id', { streamId: 'lone-stream' });
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(es.closed).toBe(true);
+    });
+  });
+
+  it('null sessionId opens no connection and surfaces idle state', () => {
+    const { result } = renderHook(() => useDataStream(null, { tick: vi.fn() }));
+    expect(StubEventSource.instances).toHaveLength(0);
+    expect(result.current.state).toBe('idle');
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/data/useAccessQueries.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/data/useAccessQueries.ts
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { SystemDefinitionDto } from '@/api/generated/model/systemDefinitionDto';
+import type { SystemListDto } from '@/api/generated/model/systemListDto';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { useTopology } from './useTopology';
+
+/**
+ * Helpers around the RFC 07 access declarations carried on {@link TopologyDto.systems}. The data
+ * is small (≤ a few hundred systems × small string arrays) and static after `Build()`, so the
+ * single-component lookups derive locally from the cached topology — no extra round-trip. The
+ * server-side `/queries/who-writes/{T}` + `/queries/who-reads/{T}` endpoints exist for clients
+ * that don't already have the topology loaded; expose them too via {@link useWhoWritesRemote} /
+ * {@link useWhoReadsRemote} for parity, but prefer the local versions inside this app.
+ */
+
+function arrayHas(a: string[] | null | undefined, value: string): boolean {
+  if (!a) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === value) return true;
+  }
+  return false;
+}
+
+/**
+ * Local resolution: scan {@link TopologyDto.systems} for systems whose declarations include the
+ * named component as any kind of write (Writes ∪ SideWrites).
+ */
+export function useWhoWrites(component: string | null): SystemDefinitionDto[] {
+  const { data: topology } = useTopology(useSessionStore((s) => s.sessionId));
+  return useMemo(() => {
+    if (!topology?.systems || !component) return [];
+    return topology.systems.filter((s) => arrayHas(s.writes, component) || arrayHas(s.sideWrites, component));
+  }, [topology, component]);
+}
+
+/**
+ * Local resolution: scan {@link TopologyDto.systems} for systems whose declarations include the
+ * named component as any kind of read (Reads ∪ ReadsFresh ∪ ReadsSnapshot ∪ AdditionalReads).
+ */
+export function useWhoReads(component: string | null): SystemDefinitionDto[] {
+  const { data: topology } = useTopology(useSessionStore((s) => s.sessionId));
+  return useMemo(() => {
+    if (!topology?.systems || !component) return [];
+    return topology.systems.filter(
+      (s) =>
+        arrayHas(s.reads, component) ||
+        arrayHas(s.readsFresh, component) ||
+        arrayHas(s.readsSnapshot, component) ||
+        arrayHas(s.additionalReads, component),
+    );
+  }, [topology, component]);
+}
+
+/**
+ * Local resolution: snapshot readers (read the previous-tick value, ordered before writers).
+ * Useful for the DAG view's snapshot-edge lens.
+ */
+export function useSnapshotReadersOf(component: string | null): SystemDefinitionDto[] {
+  const { data: topology } = useTopology(useSessionStore((s) => s.sessionId));
+  return useMemo(() => {
+    if (!topology?.systems || !component) return [];
+    return topology.systems.filter((s) => arrayHas(s.readsSnapshot, component));
+  }, [topology, component]);
+}
+
+/**
+ * Server round-trip variant of {@link useWhoWrites}. Hits `/queries/who-writes/{component}`. Use
+ * this when the topology hasn't been (or shouldn't be) cached locally — otherwise prefer the
+ * local hook above.
+ */
+export function useWhoWritesRemote(component: string | null) {
+  return useSystemListQuery('who-writes', component);
+}
+
+/** Server round-trip variant of {@link useWhoReads}. */
+export function useWhoReadsRemote(component: string | null) {
+  return useSystemListQuery('who-reads', component);
+}
+
+function useSystemListQuery(kind: 'who-writes' | 'who-reads', component: string | null) {
+  const sessionId = useSessionStore((s) => s.sessionId);
+  const token = useSessionStore((s) => s.token);
+
+  return useQuery<SystemListDto | null, Error>({
+    queryKey: ['data', 'queries', kind, sessionId, component],
+    enabled: !!sessionId && !!component,
+    staleTime: Infinity,
+    queryFn: async ({ signal }) => {
+      if (!sessionId || !component) return null;
+      const headers = new Headers();
+      if (token) headers.set('X-Session-Token', token);
+      headers.set('X-Workbench-Api', '1');
+      const res = await fetch(
+        `/api/sessions/${sessionId}/queries/${kind}/${encodeURIComponent(component)}`,
+        { signal, headers },
+      );
+      if (res.status === 202) return null;
+      if (!res.ok) {
+        let detail = `${res.status} ${res.statusText}`;
+        try {
+          const problem = (await res.json()) as { detail?: string; title?: string };
+          if (problem?.detail) detail = problem.detail;
+          else if (problem?.title) detail = problem.title;
+        } catch {
+          // Non-JSON body — fall back to status text.
+        }
+        throw new Error(detail);
+      }
+      return (await res.json()) as SystemListDto;
+    },
+  });
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/data/useAggregations.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/data/useAggregations.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSessionStore } from '@/stores/useSessionStore';
+import type { AggregationQueryDto } from '@/api/generated/model/aggregationQueryDto';
+import type { AggregationResponseDto } from '@/api/generated/model/aggregationResponseDto';
+
+export function useAggregations(sessionId: string | null, queries: AggregationQueryDto[]) {
+  const token = useSessionStore((s) => s.token);
+
+  return useQuery<AggregationResponseDto | null, Error>({
+    queryKey: ['data', 'aggregate', sessionId, queries],
+    enabled: !!sessionId && queries.length > 0,
+    staleTime: 30_000,
+    queryFn: async ({ signal }) => {
+      if (!sessionId || queries.length === 0) return null;
+      const headers = new Headers({ 'Content-Type': 'application/json' });
+      if (token) headers.set('X-Session-Token', token);
+      headers.set('X-Workbench-Api', '1');
+      const res = await fetch(`/api/sessions/${sessionId}/aggregate`, {
+        method: 'POST',
+        body: JSON.stringify({ queries }),
+        signal,
+        headers,
+      });
+      if (res.status === 202) return null;
+      if (!res.ok) {
+        let detail = `${res.status} ${res.statusText}`;
+        try {
+          const problem = (await res.json()) as { detail?: string; title?: string };
+          if (problem?.detail) detail = problem.detail;
+          else if (problem?.title) detail = problem.title;
+        } catch {
+          // Non-JSON body — fall back to status text.
+        }
+        throw new Error(detail);
+      }
+      return (await res.json()) as AggregationResponseDto;
+    },
+  });
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/data/useDataStream.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/data/useDataStream.ts
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * Per-session shared state for the unified data stream (#308 Phase B/C). One open EventSource per
+ * sessionId, multiplexed across N panel-level consumers. The wrapper layered around it
+ * (`useDataStream`) reference-counts subscriptions so a consumer mounting / unmounting on a
+ * subset of events only affects the union of what the server should send — peers stay
+ * unaffected.
+ *
+ * Module-level singletons (one entry per sessionId) keep the connection alive across React
+ * re-mounts of individual panels. The connection only closes when the last consumer unmounts.
+ */
+interface SharedConnection {
+  sessionId: string;
+  source: EventSource;
+  /** streamId emitted by the server on first frame; targeted by /subscribe & /unsubscribe. */
+  streamId: string | null;
+  /** Per-event-type subscriber lists (handler array). Multiple consumers can listen to the same type. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handlers: Map<string, Set<(data: any) => void>>;
+  /** Per-event-type ref count — total panels currently asking for this type. */
+  refCounts: Map<string, number>;
+  /** Set last sent to /subscribe. Used to compute add/remove deltas vs the live ref-count map. */
+  serverWantedSet: Set<string>;
+  /** Pending sync pass — one in-flight at a time. */
+  syncing: boolean;
+  /** Number of consumers currently mounted on this connection — when it hits zero we close. */
+  mountCount: number;
+  /** Pending bootstrap-event handlers fired before streamId was known — replayed after register. */
+  pendingBootstrapHandlers: ((id: string) => void)[];
+}
+
+const _connections = new Map<string, SharedConnection>();
+
+function getOrCreateConnection(sessionId: string): SharedConnection {
+  let conn = _connections.get(sessionId);
+  if (conn) return conn;
+
+  // EventSource is browser-only — bail safely in test envs (the surrounding hook will simply not
+  // dispatch any events; the test passes a `null` sessionId or stubs EventSource itself).
+  if (typeof EventSource === 'undefined') {
+    throw new Error('EventSource is not available in this environment');
+  }
+
+  const source = new EventSource(`/api/sessions/${sessionId}/stream`);
+  conn = {
+    sessionId,
+    source,
+    streamId: null,
+    handlers: new Map(),
+    refCounts: new Map(),
+    serverWantedSet: new Set(),
+    syncing: false,
+    mountCount: 0,
+    pendingBootstrapHandlers: [],
+  };
+
+  // Capture streamId on the first `stream-id` event — every subsequent /subscribe call needs it.
+  source.addEventListener('stream-id', (event: MessageEvent) => {
+    try {
+      const payload = JSON.parse(event.data) as { streamId: string };
+      conn!.streamId = payload.streamId;
+      // Replay any handlers queued before streamId arrived. Cleared once flushed.
+      for (const cb of conn!.pendingBootstrapHandlers) {
+        try {
+          cb(payload.streamId);
+        } catch {
+          /* swallow */
+        }
+      }
+      conn!.pendingBootstrapHandlers = [];
+      // Also sync any subscriptions that landed before we had a streamId.
+      void syncSubscriptions(conn!);
+    } catch {
+      /* malformed — ignore */
+    }
+  });
+
+  _connections.set(sessionId, conn);
+  return conn;
+}
+
+function teardownConnection(sessionId: string): void {
+  const conn = _connections.get(sessionId);
+  if (!conn) return;
+  conn.source.close();
+  _connections.delete(sessionId);
+}
+
+/**
+ * Reconciles the server's known subscription set with the live ref-counted set. Adds events that
+ * have ref-count > 0 and aren't on the server; removes events that have ref-count == 0 but are
+ * still on the server. POST batched in one call each (no per-event fetches).
+ */
+async function syncSubscriptions(conn: SharedConnection): Promise<void> {
+  if (!conn.streamId) return;
+  if (conn.syncing) return;
+  conn.syncing = true;
+  try {
+    // Converge to a fixed point — refCounts can mutate during awaits as panels mount/unmount.
+    let converged = false;
+    while (!converged) {
+      const wanted = new Set<string>();
+      for (const [type, count] of conn.refCounts) {
+        if (count > 0) wanted.add(type);
+      }
+      const toAdd: string[] = [];
+      const toRemove: string[] = [];
+      for (const t of wanted) {
+        if (!conn.serverWantedSet.has(t)) toAdd.push(t);
+      }
+      for (const t of conn.serverWantedSet) {
+        if (!wanted.has(t)) toRemove.push(t);
+      }
+      if (toAdd.length === 0 && toRemove.length === 0) {
+        converged = true;
+        continue;
+      }
+      if (toAdd.length > 0) {
+        const ok = await postSubscription(conn.sessionId, '/subscribe', conn.streamId, toAdd);
+        if (ok) {
+          for (const t of toAdd) conn.serverWantedSet.add(t);
+        }
+      }
+      if (toRemove.length > 0) {
+        const ok = await postSubscription(conn.sessionId, '/unsubscribe', conn.streamId, toRemove);
+        if (ok) {
+          for (const t of toRemove) conn.serverWantedSet.delete(t);
+        }
+      }
+    }
+  } finally {
+    conn.syncing = false;
+  }
+}
+
+async function postSubscription(
+  sessionId: string,
+  path: '/subscribe' | '/unsubscribe',
+  streamId: string,
+  events: string[],
+): Promise<boolean> {
+  try {
+    const resp = await fetch(`/api/sessions/${sessionId}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ streamId, events }),
+    });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Subscribe to events on the unified data stream. Each consumer declares the set of event types it
+ * cares about and a handler map; the hook ensures (a) one EventSource per session, shared across
+ * consumers, and (b) the server-side subscription set is the union of what mounted consumers want.
+ *
+ * ```ts
+ * useDataStream(sessionId, {
+ *   tick: (data) => store.applyTick(data),
+ *   'topology-changed': () => queryClient.invalidateQueries(['topology']),
+ * });
+ * ```
+ *
+ * Bootstrap events (`stream-id`, `metadata`, `session-state`, `heartbeat`, `shutdown`) are
+ * delivered to handlers without needing explicit subscription — those are always sent by the
+ * server. Domain events (`tick`, `log`, `topology-changed`, `error`) require a subscribed handler.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type EventHandlers = Record<string, (data: any) => void>;
+
+export type DataStreamConnectionState = 'idle' | 'connecting' | 'open' | 'closed';
+
+export function useDataStream(
+  sessionId: string | null,
+  handlers: EventHandlers,
+): { state: DataStreamConnectionState; streamId: string | null } {
+  const [state, setState] = useState<DataStreamConnectionState>(sessionId ? 'connecting' : 'idle');
+  const [streamId, setStreamId] = useState<string | null>(null);
+
+  // Stabilise the handler map across renders without forcing consumers to memoize. Each render's
+  // latest handler is captured in a ref; the actual addEventListener closures resolve from the
+  // ref at dispatch time so re-renders don't tear down the SSE connection.
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  // Stable list of event types this consumer wants. Memoised over the *keys* of the handler map —
+  // adding / removing event types between renders is rare, but supported.
+  const wantedTypes = useMemo(() => Object.keys(handlers).sort().join(','), [handlers]);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setState('idle');
+      setStreamId(null);
+      return;
+    }
+
+    let conn: SharedConnection;
+    try {
+      conn = getOrCreateConnection(sessionId);
+    } catch {
+      // EventSource unavailable (e.g., SSR) — render the hook idle.
+      setState('idle');
+      return;
+    }
+    setState(conn.source.readyState === EventSource.OPEN ? 'open' : 'connecting');
+    if (conn.streamId) setStreamId(conn.streamId);
+
+    const types = wantedTypes.split(',').filter((s) => s.length > 0);
+
+    // ── Per-event-type listener installation ──────────────────────────────────────────────────
+    // For each event type the consumer cares about, add to the shared handler set and bump the
+    // ref count. The dispatcher (a single per-type listener on the underlying EventSource)
+    // forwards into all currently-registered consumer handlers.
+    const installedTypes: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const registeredHandlers = new Map<string, (data: any) => void>();
+    for (const type of types) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const userHandler = (data: any) => {
+        const live = handlersRef.current[type];
+        if (live) live(data);
+      };
+      registeredHandlers.set(type, userHandler);
+
+      let set = conn.handlers.get(type);
+      if (!set) {
+        set = new Set();
+        conn.handlers.set(type, set);
+        // First mount of this event type — install the EventSource listener that fans out to
+        // all consumers. There's only ever one per type per connection.
+        conn.source.addEventListener(type, (event: MessageEvent) => {
+          try {
+            const data = JSON.parse(event.data);
+            const subs = conn.handlers.get(type);
+            if (subs) {
+              for (const fn of subs) {
+                try {
+                  fn(data);
+                } catch {
+                  /* swallow consumer-side errors */
+                }
+              }
+            }
+          } catch {
+            /* malformed payload — ignore */
+          }
+        });
+      }
+      set.add(userHandler);
+      conn.refCounts.set(type, (conn.refCounts.get(type) ?? 0) + 1);
+      installedTypes.push(type);
+    }
+
+    conn.mountCount += 1;
+
+    const onOpen = () => setState('open');
+    const onError = () => setState('closed');
+    conn.source.addEventListener('open', onOpen);
+    conn.source.addEventListener('error', onError);
+
+    // Hand off the streamId once it lands (or immediately if already known).
+    const onStreamId = (id: string) => setStreamId(id);
+    if (conn.streamId) {
+      onStreamId(conn.streamId);
+    } else {
+      conn.pendingBootstrapHandlers.push(onStreamId);
+    }
+
+    void syncSubscriptions(conn);
+
+    return () => {
+      conn.source.removeEventListener('open', onOpen);
+      conn.source.removeEventListener('error', onError);
+
+      for (const type of installedTypes) {
+        const set = conn.handlers.get(type);
+        const userHandler = registeredHandlers.get(type);
+        if (set && userHandler) {
+          set.delete(userHandler);
+        }
+        const next = (conn.refCounts.get(type) ?? 1) - 1;
+        if (next <= 0) {
+          conn.refCounts.delete(type);
+        } else {
+          conn.refCounts.set(type, next);
+        }
+      }
+
+      conn.mountCount -= 1;
+      if (conn.mountCount <= 0) {
+        teardownConnection(sessionId);
+      } else {
+        void syncSubscriptions(conn);
+      }
+    };
+  }, [sessionId, wantedTypes]);
+
+  return { state, streamId };
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/data/useTopology.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/data/useTopology.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSessionStore } from '@/stores/useSessionStore';
+import type { TopologyDto } from '@/api/generated/model/topologyDto';
+
+export function useTopology(sessionId: string | null) {
+  const token = useSessionStore((s) => s.token);
+
+  return useQuery<TopologyDto | null, Error>({
+    queryKey: ['data', 'topology', sessionId],
+    enabled: !!sessionId,
+    // Topology is static after Build(), so we don't refetch successful loads. But the server returns 202
+    // while the cache is still building; in that case `queryFn` returns null. Without a poll, the query
+    // sticks at "loading" forever. Match `useProfilerMetadata`'s pattern: poll every 2 s until data lands
+    // or an error fires; stop afterwards (data is then cached at staleTime: Infinity).
+    staleTime: Infinity,
+    refetchInterval: (q) => (q.state.data || q.state.error ? false : 2000),
+    queryFn: async ({ signal }) => {
+      if (!sessionId) return null;
+      const headers = new Headers();
+      if (token) headers.set('X-Session-Token', token);
+      headers.set('X-Workbench-Api', '1');
+      const res = await fetch(`/api/sessions/${sessionId}/topology`, { signal, headers });
+      if (res.status === 202) return null;
+      if (!res.ok) {
+        let detail = `${res.status} ${res.statusText}`;
+        try {
+          const problem = (await res.json()) as { detail?: string; title?: string };
+          if (problem?.detail) detail = problem.detail;
+          else if (problem?.title) detail = problem.title;
+        } catch {
+          // Non-JSON body — fall back to status text.
+        }
+        throw new Error(detail);
+      }
+      return (await res.json()) as TopologyDto;
+    },
+  });
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/data/useTrack.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/data/useTrack.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSessionStore } from '@/stores/useSessionStore';
+import type { TrackDataResponseDto } from '@/api/generated/model/trackDataResponseDto';
+
+export function useTrack(
+  sessionId: string | null,
+  trackId: string,
+  from?: number,
+  to?: number,
+) {
+  const token = useSessionStore((s) => s.token);
+
+  return useQuery<TrackDataResponseDto | null, Error>({
+    queryKey: ['data', 'track', sessionId, trackId, from, to],
+    enabled: !!sessionId && !!trackId,
+    staleTime: 30_000,
+    queryFn: async ({ signal }) => {
+      if (!sessionId) return null;
+      const params = new URLSearchParams();
+      if (from != null) params.set('from', String(from));
+      if (to != null) params.set('to', String(to));
+      const qs = params.toString() ? `?${params.toString()}` : '';
+      const headers = new Headers();
+      if (token) headers.set('X-Session-Token', token);
+      headers.set('X-Workbench-Api', '1');
+      // trackId may contain '/' (e.g. "tick/summary") — the server uses a catch-all route {**trackId}.
+      const res = await fetch(`/api/sessions/${sessionId}/track/${trackId}${qs}`, { signal, headers });
+      if (res.status === 202) return null;
+      if (!res.ok) {
+        let detail = `${res.status} ${res.statusText}`;
+        try {
+          const problem = (await res.json()) as { detail?: string; title?: string };
+          if (problem?.detail) detail = problem.detail;
+          else if (problem?.title) detail = problem.title;
+        } catch {
+          // Non-JSON body — fall back to status text.
+        }
+        throw new Error(detail);
+      }
+      return (await res.json()) as TrackDataResponseDto;
+    },
+  });
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerBuildProgress.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerBuildProgress.ts
@@ -1,17 +1,29 @@
-import { useCallback, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEventSource } from '@/hooks/streams/useEventSource';
-import { useProfilerSessionStore, type BuildProgressPayload } from '@/stores/useProfilerSessionStore';
+import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
+
+interface ProgressPayload {
+  bytesRead?: number;
+  totalBytes?: number;
+  tickCount?: number;
+  eventCount?: number;
+}
+
+interface ErrorPayload {
+  message?: string;
+}
 
 /**
  * SSE subscription for the profiler build-progress stream. Wraps the generic {@link useEventSource} hook to
  * dispatch payload frames into {@link useProfilerSessionStore}.
  *
- * Server emits frames as default `message` events (no `event:` prefix) with phase ∈ {building, done, error}
- * inside the JSON. After a terminal phase the server cleanly closes the SSE connection; the browser's
- * `EventSource` surfaces *every* close (clean or otherwise) as an `error`, which is why the hook tracks
- * `terminated` here and passes `null` for the URL once we're done — without that the underlying
- * {@link useEventSource} would auto-reconnect every 3 s and spam the server log forever.
+ * Server emits typed `progress` / `done` / `error` events (#308); the hook synthesises the
+ * client-side `BuildProgressPayload.phase` discriminant from the event type so the store API stays
+ * unchanged. After a terminal phase the server cleanly closes the SSE connection; the browser's
+ * `EventSource` surfaces *every* close (clean or otherwise) as an `error`, which is why the hook
+ * tracks `terminated` here and passes `null` for the URL once we're done — without that the
+ * underlying {@link useEventSource} would auto-reconnect every 3 s and spam the server log forever.
  */
 export function useProfilerBuildProgress(sessionId: string | null) {
   const setBuildProgress = useProfilerSessionStore((s) => s.setBuildProgress);
@@ -19,15 +31,13 @@ export function useProfilerBuildProgress(sessionId: string | null) {
   const [terminated, setTerminated] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
-  const onMessage = useCallback(
-    (payload: BuildProgressPayload) => {
-      if (payload.phase === 'error') {
-        setBuildError(payload.message ?? 'Build failed.');
-        setTerminated(sessionId);
-        return;
-      }
-      setBuildProgress(payload);
-      if (payload.phase === 'done') {
+  const listeners = useMemo(
+    () => ({
+      progress: (data: ProgressPayload) => {
+        setBuildProgress({ phase: 'building', ...data });
+      },
+      done: (_data: Record<string, never>) => {
+        setBuildProgress({ phase: 'done' });
         setTerminated(sessionId);
         // The SSE signals build completion faster than the 2s polling interval in useProfilerMetadata.
         // Invalidate immediately so the overlay clears as soon as the cache is ready instead of
@@ -36,8 +46,12 @@ export function useProfilerBuildProgress(sessionId: string | null) {
         if (sessionId) {
           void queryClient.invalidateQueries({ queryKey: ['profiler', 'metadata', sessionId] });
         }
-      }
-    },
+      },
+      error: (data: ErrorPayload) => {
+        setBuildError(data.message ?? 'Build failed.');
+        setTerminated(sessionId);
+      },
+    }),
     [setBuildProgress, setBuildError, sessionId, queryClient],
   );
 
@@ -46,5 +60,5 @@ export function useProfilerBuildProgress(sessionId: string | null) {
   // a second trace re-subscribes its own build-progress stream.
   const isTerminated = terminated !== null && terminated === sessionId;
   const url = sessionId && !isTerminated ? `/api/sessions/${sessionId}/profiler/build-progress` : null;
-  return useEventSource<BuildProgressPayload>(url, onMessage);
+  return useEventSource(url, listeners);
 }

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerLiveStream.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/profiler/useProfilerLiveStream.ts
@@ -1,16 +1,27 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useEventSource } from '@/hooks/streams/useEventSource';
 import {
   useProfilerSessionStore,
+  type ConnectionStatus,
   type LiveStreamPayload,
+  type LiveThreadInfo,
 } from '@/stores/useProfilerSessionStore';
+import type {
+  ChunkManifestEntryDto,
+  GlobalMetricsDto,
+  ProfilerMetadataDto,
+  TickSummaryDto,
+} from '@/api/generated/model';
 
 /**
- * SSE subscription for the profiler live delta stream (#289 unified pipeline).
+ * SSE subscription for the profiler live delta stream (#289 unified pipeline; retyped for #308).
  *
- * Wraps {@link useEventSource} and dispatches the server's growth deltas into {@link useProfilerSessionStore}:
- * `metadata` (full snapshot on connect), `tickSummaryAdded`, `chunkAdded`, `globalMetricsUpdated`,
- * `heartbeat`, and `shutdown`.
+ * Wraps {@link useEventSource} with typed event listeners — each delta arrives on its own SSE
+ * event channel (`metadata`, `tickSummaryAdded`, `chunkAdded`, `globalMetricsUpdated`,
+ * `threadInfoAdded`, `heartbeat`, `shutdown`) instead of switching on a discriminator inside the
+ * payload. The hook reconstructs the in-store `LiveStreamPayload` union shape (which still carries
+ * `kind`) before pushing into the rAF-batched buffer, so {@link useProfilerSessionStore.applyLiveBatch}
+ * sees the same union it always has.
  *
  * **rAF-coalesced batching.** Each SSE message handler runs synchronously on the main thread; under heavy ingest
  * (many chunkAdded + tickSummaryAdded per second from a busy engine), one-mutation-per-event meant N×O(N)
@@ -18,10 +29,6 @@ import {
  * incoming events in a ref and flush them via `requestAnimationFrame` so each native paint cycle applies AT MOST
  * one batched mutation. The `applyLiveBatch` store action collapses the N appends into a single O(N+batchSize)
  * spread + a single subscriber notification, regardless of how many events landed in the frame.
- *
- * Trade-off: deltas are visible to the UI ≤ one frame (~16 ms) later than they used to be. That's smaller than
- * any human-perceptible cadence and well under the engine's chunk-flush period (200 ms), so user-facing UX is
- * indistinguishable except smoother.
  */
 export function useProfilerLiveStream(sessionId: string | null) {
   const applyLiveBatch = useProfilerSessionStore((s) => s.applyLiveBatch);
@@ -40,14 +47,31 @@ export function useProfilerLiveStream(sessionId: string | null) {
     applyLiveBatch(batch);
   }, [applyLiveBatch]);
 
-  const onMessage = useCallback(
-    (payload: LiveStreamPayload) => {
-      bufferRef.current.push(payload);
+  const enqueue = useCallback(
+    (event: LiveStreamPayload) => {
+      bufferRef.current.push(event);
       if (rafIdRef.current === 0) {
         rafIdRef.current = requestAnimationFrame(flush);
       }
     },
     [flush],
+  );
+
+  const listeners = useMemo(
+    () => ({
+      metadata: (data: { metadata: ProfilerMetadataDto }) => enqueue({ kind: 'metadata', metadata: data.metadata }),
+      tickSummaryAdded: (data: { tickSummary: TickSummaryDto }) =>
+        enqueue({ kind: 'tickSummaryAdded', tickSummary: data.tickSummary }),
+      chunkAdded: (data: { chunkEntry: ChunkManifestEntryDto }) =>
+        enqueue({ kind: 'chunkAdded', chunkEntry: data.chunkEntry }),
+      threadInfoAdded: (data: { threadInfo: LiveThreadInfo }) =>
+        enqueue({ kind: 'threadInfoAdded', threadInfo: data.threadInfo }),
+      globalMetricsUpdated: (data: { globalMetrics: GlobalMetricsDto }) =>
+        enqueue({ kind: 'globalMetricsUpdated', globalMetrics: data.globalMetrics }),
+      heartbeat: (data: { status: ConnectionStatus }) => enqueue({ kind: 'heartbeat', status: data.status }),
+      shutdown: (data: { status: string }) => enqueue({ kind: 'shutdown', status: data.status ?? 'disconnected' }),
+    }),
+    [enqueue],
   );
 
   // Cancel any pending flush on unmount / session change so a late-firing rAF can't hit a stale store.
@@ -62,5 +86,5 @@ export function useProfilerLiveStream(sessionId: string | null) {
   }, [sessionId]);
 
   const url = sessionId ? `/api/sessions/${sessionId}/profiler/stream` : null;
-  return useEventSource<LiveStreamPayload>(url, onMessage);
+  return useEventSource(url, listeners);
 }

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/streams/__tests__/useEventSource.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/streams/__tests__/useEventSource.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEventSource } from '../useEventSource';
+
+/**
+ * Minimal EventSource stub that captures registered listeners and exposes a `dispatch` method to
+ * simulate server-sent events. Mirrors only the surface useEventSource depends on
+ * (addEventListener, onmessage, onopen, onerror, close, readyState).
+ */
+class StubEventSource {
+  static OPEN = 1;
+  static CLOSED = 2;
+  static lastInstance: StubEventSource | null = null;
+
+  url: string;
+  readyState = 0;
+  onopen: ((this: EventSource) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+  private listeners: Map<string, Set<(ev: MessageEvent) => void>> = new Map();
+
+  constructor(url: string) {
+    this.url = url;
+    StubEventSource.lastInstance = this;
+  }
+
+  addEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(fn);
+  }
+
+  removeEventListener(type: string, fn: (ev: MessageEvent) => void): void {
+    this.listeners.get(type)?.delete(fn);
+  }
+
+  /** Fires the named event with a JSON-stringified payload. */
+  dispatch(type: string, data: unknown): void {
+    const evt = new MessageEvent(type, { data: JSON.stringify(data) });
+    this.listeners.get(type)?.forEach((fn) => fn(evt));
+    if (type === 'message' && this.onmessage) this.onmessage.call(this as unknown as EventSource, evt);
+  }
+
+  open(): void {
+    this.readyState = StubEventSource.OPEN;
+    this.onopen?.call(this as unknown as EventSource);
+  }
+
+  close(): void {
+    this.readyState = StubEventSource.CLOSED;
+  }
+}
+
+describe('useEventSource — typed-listener overload (#308)', () => {
+  beforeEach(() => {
+    StubEventSource.lastInstance = null;
+    (globalThis as unknown as { EventSource: typeof StubEventSource }).EventSource = StubEventSource;
+  });
+  afterEach(() => {
+    StubEventSource.lastInstance?.close();
+    StubEventSource.lastInstance = null;
+  });
+
+  it('installs one addEventListener per typed handler key', () => {
+    const tickHandler = vi.fn();
+    const heartbeatHandler = vi.fn();
+    renderHook(() =>
+      useEventSource('/api/test/stream', {
+        tick: tickHandler,
+        heartbeat: heartbeatHandler,
+      }),
+    );
+
+    const es = StubEventSource.lastInstance!;
+    expect(es).not.toBeNull();
+
+    act(() => {
+      es.dispatch('tick', { tickNumber: 42 });
+    });
+    expect(tickHandler).toHaveBeenCalledWith({ tickNumber: 42 });
+    expect(heartbeatHandler).not.toHaveBeenCalled();
+
+    act(() => {
+      es.dispatch('heartbeat', { status: 'green' });
+    });
+    expect(heartbeatHandler).toHaveBeenCalledWith({ status: 'green' });
+    expect(tickHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('untyped handler still receives default message events', () => {
+    const onMessage = vi.fn();
+    renderHook(() => useEventSource<{ value: number }>('/api/legacy/stream', onMessage));
+
+    const es = StubEventSource.lastInstance!;
+    act(() => {
+      es.dispatch('message', { value: 7 });
+    });
+    expect(onMessage).toHaveBeenCalledWith({ value: 7 });
+  });
+
+  it('null url renders the hook closed without opening a connection', () => {
+    renderHook(() => useEventSource(null, { tick: vi.fn() }));
+    expect(StubEventSource.lastInstance).toBeNull();
+  });
+
+  it('handler updates between renders are picked up via ref', () => {
+    const firstCall = vi.fn();
+    const { rerender } = renderHook(
+      ({ handler }: { handler: (data: unknown) => void }) =>
+        useEventSource('/api/test/stream', { tick: handler }),
+      { initialProps: { handler: firstCall } },
+    );
+
+    const es = StubEventSource.lastInstance!;
+    const secondCall = vi.fn();
+    rerender({ handler: secondCall });
+
+    act(() => {
+      es.dispatch('tick', { tickNumber: 99 });
+    });
+    expect(firstCall).not.toHaveBeenCalled();
+    expect(secondCall).toHaveBeenCalledWith({ tickNumber: 99 });
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/streams/useEventSource.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/streams/useEventSource.ts
@@ -4,13 +4,57 @@ type ConnectionState = 'connecting' | 'open' | 'closed';
 
 const RECONNECT_DELAY_MS = 3000;
 
+/**
+ * Map of SSE event type -> listener. The listener receives the parsed JSON payload for events of
+ * that type. Use this overload when the server emits typed `event: <type>` frames (#308).
+ *
+ * Each handler can declare its own payload type — the hook does not narrow them at compile time
+ * because EventSource's `addEventListener` is itself untyped. Cast inside the handler if needed.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type EventListenerMap = Record<string, (data: any) => void>;
+
+/**
+ * Subscribe to a Server-Sent Events stream.
+ *
+ * Two call shapes:
+ *
+ * 1. **Untyped (legacy)** — passes a single `onMessage` callback that receives every default
+ *    `message` event. Used by streams that emit `data: ...\n\n` frames without an `event:` prefix.
+ *
+ *    ```ts
+ *    useEventSource<HeartbeatPayload>(url, (data) => { ... });
+ *    ```
+ *
+ * 2. **Typed (#308)** — passes a `Record<eventType, handler>`. The hook installs one
+ *    `addEventListener` per key. Use for streams that emit `event: <type>\ndata: ...\n\n`. The
+ *    server's typed events carry the discriminator on the `event:` line, not in the JSON payload —
+ *    consumers narrow by handler key, not by switching on a `kind` field.
+ *
+ *    ```ts
+ *    useEventSource(url, {
+ *      heartbeat: (data: HeartbeatPayload) => { ... },
+ *      shutdown: () => { ... },
+ *    });
+ *    ```
+ *
+ * Both shapes share the same auto-reconnect behaviour (3 s delay) and `null`-url gating.
+ */
 export function useEventSource<T>(
   url: string | null,
   onMessage: (data: T) => void,
+): ConnectionState;
+export function useEventSource(
+  url: string | null,
+  listeners: EventListenerMap,
+): ConnectionState;
+export function useEventSource<T>(
+  url: string | null,
+  arg: ((data: T) => void) | EventListenerMap,
 ): ConnectionState {
   const [state, setState] = useState<ConnectionState>('closed');
-  const onMessageRef = useRef(onMessage);
-  onMessageRef.current = onMessage;
+  const argRef = useRef(arg);
+  argRef.current = arg;
 
   useEffect(() => {
     if (!url) {
@@ -30,14 +74,34 @@ export function useEventSource<T>(
         if (!cancelled) setState('open');
       };
 
-      es.onmessage = (event) => {
-        if (cancelled) return;
-        try {
-          onMessageRef.current(JSON.parse(event.data) as T);
-        } catch {
-          // ignore parse errors
+      const current = argRef.current;
+      if (typeof current === 'function') {
+        es.onmessage = (event) => {
+          if (cancelled) return;
+          try {
+            (argRef.current as (data: T) => void)(JSON.parse(event.data) as T);
+          } catch {
+            // ignore parse errors
+          }
+        };
+      } else {
+        // Typed-listener path — install one addEventListener per key. We resolve the handler from
+        // argRef.current at dispatch time so consumers swapping handlers between renders still get
+        // the latest closure (matches the legacy onMessage path's ref-pinning behaviour).
+        for (const eventType of Object.keys(current)) {
+          es.addEventListener(eventType, (event: MessageEvent) => {
+            if (cancelled) return;
+            const map = argRef.current as EventListenerMap;
+            const handler = map[eventType];
+            if (!handler) return;
+            try {
+              handler(JSON.parse(event.data));
+            } catch {
+              // ignore parse errors
+            }
+          });
         }
-      };
+      }
 
       es.onerror = () => {
         es.close();
@@ -56,6 +120,11 @@ export function useEventSource<T>(
       es?.close();
       setState('closed');
     };
+    // The `arg` value is intentionally not in the dep array — handlers are pinned via argRef so
+    // re-renders that recreate the handler reference don't tear down the SSE connection. The
+    // initial argument shape (function vs map) is captured on connect and stays consistent for the
+    // lifetime of the URL.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url]);
 
   return state;

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/streams/useHeartbeat.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/streams/useHeartbeat.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useSessionStore } from '@/stores/useSessionStore';
 import { useEventSource } from './useEventSource';
 
@@ -32,14 +32,21 @@ export function useHeartbeat(): HeartbeatState {
   // every time the StatusBar mounts under a profiler session. Gate the EventSource accordingly.
   const url = sessionId && kind === 'open' ? `/api/sessions/${sessionId}/heartbeat` : null;
 
-  const onMessage = useCallback((data: HeartbeatPayload) => {
-    setPayload(data);
-    setStatus('green');
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setStatus('grey'), STALE_THRESHOLD_MS);
-  }, []);
+  // Typed-listener shape (#308). The server emits `event: heartbeat\ndata: {...}\n\n` so we listen
+  // for the `heartbeat` event by name rather than the default `message` channel.
+  const listeners = useMemo(
+    () => ({
+      heartbeat: (data: HeartbeatPayload) => {
+        setPayload(data);
+        setStatus('green');
+        clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setStatus('grey'), STALE_THRESHOLD_MS);
+      },
+    }),
+    [],
+  );
 
-  useEventSource<HeartbeatPayload>(url, onMessage);
+  useEventSource(url, listeners);
 
   return { status, payload };
 }

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/streams/useResourceGraphStream.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/streams/useResourceGraphStream.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSessionStore } from '@/stores/useSessionStore';
 import { useEventSource } from './useEventSource';
@@ -14,7 +14,10 @@ export interface ResourceGraphEventPayload {
 /**
  * Subscribes the session to the engine's resource-graph mutation stream. On every event the hook
  * invalidates the resource-root query so the tree + fuse index re-fetch. The server coalesces
- * bursts to at most 10 events/sec per session so the invalidation cadence stays gentle.
+ * bursts to at most 10 events/sec per session so the invalidation cadence stays gentle. Each frame
+ * arrives as a typed `resource-mutation` SSE event (#308); the JSON payload still carries the
+ * domain-level <c>kind</c> field (Added / Removed / Mutated) — that's a domain enum, not the SSE
+ * discriminator.
  */
 export function useResourceGraphStream(): { state: 'connecting' | 'open' | 'closed' } {
   const sessionId = useSessionStore((s) => s.sessionId);
@@ -24,16 +27,18 @@ export function useResourceGraphStream(): { state: 'connecting' | 'open' | 'clos
   // SSE stream is Open-session only — server returns 401 for other kinds. Null URL = hook stays closed.
   const url = sessionId && kind === 'open' ? `/api/sessions/${sessionId}/resources/stream` : null;
 
-  const onMessage = useCallback(
-    (_evt: ResourceGraphEventPayload) => {
-      if (!sessionId) return;
-      queryClient.invalidateQueries({
-        queryKey: [`/api/sessions/${sessionId}/resources/root`],
-      });
-    },
+  const listeners = useMemo(
+    () => ({
+      'resource-mutation': (_evt: ResourceGraphEventPayload) => {
+        if (!sessionId) return;
+        queryClient.invalidateQueries({
+          queryKey: [`/api/sessions/${sessionId}/resources/root`],
+        });
+      },
+    }),
     [queryClient, sessionId],
   );
 
-  const state = useEventSource<ResourceGraphEventPayload>(url, onMessage);
+  const state = useEventSource(url, listeners);
   return { state };
 }

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/useKeyboardShortcuts.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/useKeyboardShortcuts.ts
@@ -4,6 +4,7 @@ import { usePaletteStore } from '@/stores/usePaletteStore';
 import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
 import { useProfilerViewStore } from '@/stores/useProfilerViewStore';
 import { useThemeStore } from '@/stores/useThemeStore';
+import { useUiPrefsStore } from '@/stores/useUiPrefsStore';
 import { toggleViewResourceTree } from '@/shell/commands/openSchemaBrowser';
 import { useShiftShift } from './useShiftShift';
 
@@ -68,7 +69,7 @@ export function useKeyboardShortcuts(): void {
       if (!e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey && (e.key === 'l' || e.key === 'L')) {
         if (isTypingInText()) return;
         e.preventDefault();
-        useProfilerViewStore.getState().toggleLegends();
+        useUiPrefsStore.getState().toggleLegends();
         return;
       }
       if (e.key === 'Home' && e.ctrlKey && !e.shiftKey && !e.altKey) {

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/useSelectionBootstrap.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/useSelectionBootstrap.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { installSelectionBridges } from '@/stores/selectionBridges';
+import {
+  applySelectionToStore,
+  installSelectionUrlSync,
+  parseSelectionFromSearch,
+} from '@/stores/selectionUrlSync';
+
+/**
+ * One-shot bootstrap for the cross-panel selection store. Runs at app mount in three steps:
+ *
+ *   1. Install per-panel ↔ unified-store bridges. They snapshot the current state, then forward
+ *      future changes both ways.
+ *   2. Apply URL → unified store. The bridges installed in (1) propagate URL-loaded values out to
+ *      the legacy per-panel stores so cold-load deep-linking reaches every consumer that still
+ *      reads from the legacy stores.
+ *   3. Install the unified-store → URL mirror. From here on, any stable-slot change writes back
+ *      to `window.location.search` via `history.replaceState`.
+ *
+ * Call this from a single top-level component (Shell). Calling it elsewhere doubles the
+ * subscriptions and produces redundant URL writes.
+ */
+export function useSelectionBootstrap(): void {
+  useEffect(() => {
+    const stopBridges = installSelectionBridges();
+    applySelectionToStore(parseSelectionFromSearch(window.location.search));
+    const stopUrlSync = installSelectionUrlSync();
+    return () => {
+      stopUrlSync();
+      stopBridges();
+    };
+  }, []);
+}

--- a/tools/Typhon.Workbench/ClientApp/src/libs/colors.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/colors.ts
@@ -1,0 +1,38 @@
+/**
+ * Colour helpers shared across canvas / SVG / HTML rendering. Kept minimal and dependency-free
+ * so any layer (profiler canvas, panel SVG, plain DOM) can import without dragging in renderer
+ * concepts.
+ */
+
+/**
+ * WCAG 2 relative-luminance (Y) of an sRGB hex colour. Input must be `#rrggbb` or `#rgb`.
+ * Returns 0..1; > 0.5 is "perceptually light, dark text wins" by the threshold convention.
+ *
+ * Lifted from `libs/profiler/canvas/timeArea.ts` so SVG / HTML callers can use the same maths
+ * the canvas-based span renderer uses for its bar labels.
+ */
+export function relativeLuminance(hex: string): number {
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hex.length === 7) {
+    r = parseInt(hex.slice(1, 3), 16) / 255;
+    g = parseInt(hex.slice(3, 5), 16) / 255;
+    b = parseInt(hex.slice(5, 7), 16) / 255;
+  } else if (hex.length === 4) {
+    r = parseInt(hex[1] + hex[1], 16) / 255;
+    g = parseInt(hex[2] + hex[2], 16) / 255;
+    b = parseInt(hex[3] + hex[3], 16) / 255;
+  }
+  const lin = (c: number): number => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/**
+ * Pick a high-contrast text colour for a given background `barHex`. Defaults: white on dark
+ * backgrounds, black on light. Override `light` / `dark` to project-specific tones (e.g. a
+ * theme's ink token instead of pure black/white).
+ */
+export function pickTextColorFor(barHex: string, light: string = '#000', dark: string = '#fff'): string {
+  return relativeLuminance(barHex) > 0.5 ? light : dark;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/canvas/timeArea.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/canvas/timeArea.ts
@@ -1,6 +1,7 @@
 import type { ChunkSpan, SpanData, TickData } from '@/libs/profiler/model/traceModel';
 import type { TimeRange, TrackLayout, Viewport } from '@/libs/profiler/model/uiTypes';
 import type { ProfilerSelection } from '@/stores/useProfilerSelectionStore';
+import { relativeLuminance } from '@/libs/colors';
 import {
   colorForChunk,
   colorForSpan,
@@ -84,24 +85,6 @@ function readableOnBar(barHex: string, theme: StudioTheme): string {
     _textOnBarCache.set(barHex, pick);
   }
   return pick === 'dark' ? theme.textOnLightBar : theme.textOnDarkBar;
-}
-
-/** WCAG 2 relative-luminance (Y) of an sRGB hex colour. Input must be `#rrggbb` or `#rgb`. */
-function relativeLuminance(hex: string): number {
-  let r = 0;
-  let g = 0;
-  let b = 0;
-  if (hex.length === 7) {
-    r = parseInt(hex.slice(1, 3), 16) / 255;
-    g = parseInt(hex.slice(3, 5), 16) / 255;
-    b = parseInt(hex.slice(5, 7), 16) / 255;
-  } else if (hex.length === 4) {
-    r = parseInt(hex[1] + hex[1], 16) / 255;
-    g = parseInt(hex[2] + hex[2], 16) / 255;
-    b = parseInt(hex[3] + hex[3], 16) / 255;
-  }
-  const lin = (c: number): number => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
-  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
 }
 
 // Diagonal-stripe pattern painted over tick ranges whose chunk data hasn't arrived yet. Gives the

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/decode/chunkDecoder.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/decode/chunkDecoder.ts
@@ -84,7 +84,9 @@ function isInstantKind(v: number): boolean {
   // Phase 4 follow-up (#289):
   //   241 (SchedulerMetronomeWait) — SPAN, falls through to false below.
   //   242 (SchedulerOverloadDetector) — instant.
-  if (v === 242) return true;
+  //   243 (RuntimePhaseSpan)        — SPAN, falls through.
+  //   244 (QueueTickEnd)            — instant rollup, hand-coded codec, no span-header extension.
+  if (v === 242 || v === 244) return true;
   return false;
 }
 
@@ -255,6 +257,23 @@ function decodeInstant(
           queueDepth: reader.readI32(payloadOffset + 18),
           overloadLevel: reader.readU8(payloadOffset + 22),
           tickMultiplier: reader.readU8(payloadOffset + 23),
+        };
+      }
+      if ((kind as number) === 244) {
+        // QueueTickEnd — per-(tick, queue) rollup. Wire layout (from `QueueTickEndCodec.Write`):
+        //   tickNumber u32 @ +0, queueId u16 @ +4, padding u16 @ +6,
+        //   peakDepth u32 @ +8, endOfTickDepth u32 @ +12, overflowCount u32 @ +16,
+        //   produced u32 @ +20, consumed u32 @ +24. (28 byte payload.)
+        // Surfacing here makes the rollup available to UI tooltips / queue drill-downs without
+        // round-tripping through the server-side cache section.
+        return {
+          kind, threadSlot, tickNumber, timestampUs,
+          queueId: reader.readU16(payloadOffset + 4),
+          queuePeakDepth: reader.readU32(payloadOffset + 8),
+          queueEndOfTickDepth: reader.readU32(payloadOffset + 12),
+          queueOverflowCount: reader.readU32(payloadOffset + 16),
+          queueProduced: reader.readU32(payloadOffset + 20),
+          queueConsumed: reader.readU32(payloadOffset + 24),
         };
       }
       return null;

--- a/tools/Typhon.Workbench/ClientApp/src/libs/profiler/model/types.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/profiler/model/types.ts
@@ -338,6 +338,10 @@ export const SpanKindNames: Record<number, string> = {
   // Phase 4 follow-up (#289) — answer "why is the engine waiting for nothing".
   241: 'Scheduler.Metronome.Wait',
   242: 'Scheduler.Overload.Detector',
+  // 243 (RuntimePhaseSpan) is a real span but its display name comes from `PHASE_NAMES[evt.phase]`
+  // in `traceModel.ts` — this entry is only the `Kind[N]`-fallback safety net.
+  243: 'Runtime.Phase',
+  244: 'Queue.TickEnd',
 
   // Runtime subtree (161-164, 235-240).
   161: 'Runtime.Phase.UoWCreate',
@@ -617,6 +621,17 @@ export interface TraceEvent {
   consecutiveQueueGrowth?: number;
   /** Total event-queue depth at this tick. */
   queueDepth?: number;
+
+  // QueueTickEnd (kind 244) — per-(tick, queue) rollup at end-of-tick. Folded by the server's
+  // IncrementalCacheBuilder into the v12 QueueTickSummaries cache section; surfaced here so
+  // chunk-decoded traces also expose the rollup (e.g., for queue-tooltip drill-downs). The wire
+  // format is hand-coded by `QueueTickEndCodec` — instant only, no span-header extension.
+  queueId?: number;
+  queuePeakDepth?: number;
+  queueEndOfTickDepth?: number;
+  queueOverflowCount?: number;
+  queueProduced?: number;
+  queueConsumed?: number;
 }
 
 /**

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathPanel.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { IDockviewPanelProps } from 'dockview-react';
+import { useTopology } from '@/hooks/data/useTopology';
+import { useProfilerMetadata } from '@/hooks/profiler/useProfilerMetadata';
+import { useSelectionStore } from '@/stores/useSelectionStore';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { deriveEdges } from '../SystemDag/edgeDerivation';
+import { timeToTickRange } from '../SystemDag/tickRangeMapping';
+import { computeCriticalPathForTick, dominantTickInRange } from './criticalPath';
+import CriticalPathToolbar from './CriticalPathToolbar';
+import CriticalPathView from './CriticalPathView';
+import { useCriticalPathViewStore } from './useCriticalPathViewStore';
+
+/**
+ * Dedicated Critical-Path panel — top-level dockable view, replaces the old in-DAG tape.
+ *
+ * **Tick source.** Same model as the System DAG aggregation range: read `useSelectionStore.time`
+ * (cross-panel-bound to the profiler's TimeArea), convert to ticks, then either honour the
+ * user-pinned `focusTick` or default to the dominant tick in the range. This keeps the four
+ * visible panels — profiler / DAG / critical-path / detail — consistent on what "the current
+ * window" means.
+ *
+ * **Composition.** Toolbar + zoomable view. The view owns its scroll viewport and SVG canvas; the
+ * panel only feeds it data and forwards the click selection. `fitSignal` is an increment counter
+ * the toolbar / `0` keybind bumps whenever the user wants the timeline to refit.
+ */
+export default function CriticalPathPanel(_props: IDockviewPanelProps) {
+  const sessionId = useSessionStore((s) => s.sessionId);
+  const { data: topology, isLoading: topoLoading, isError: topoError } = useTopology(sessionId);
+  const { data: metadata, isLoading: metaLoading } = useProfilerMetadata(sessionId);
+
+  const time = useSelectionStore((s) => s.time);
+  const range = useMemo(() => timeToTickRange(time, metadata?.tickSummaries), [time, metadata]);
+
+  const focusTick = useSelectionStore((s) => s.focusTick);
+  const setFocusTick = useSelectionStore((s) => s.setFocusTick);
+  const selectedSystemName = useSelectionStore((s) => s.system);
+  const setSystem = useSelectionStore((s) => s.setSystem);
+
+  const tickSummaries = metadata?.tickSummaries ?? null;
+  const tapeTick = useMemo(() => {
+    if (focusTick != null) return focusTick;
+    return dominantTickInRange(tickSummaries, range);
+  }, [focusTick, tickSummaries, range]);
+
+  const derivedEdges = useMemo(
+    () => (topology?.systems ? deriveEdges(topology.systems) : []),
+    [topology],
+  );
+
+  const bars = useMemo(() => {
+    if (tapeTick == null || !topology?.systems || !metadata) return null;
+    const tickRow = (metadata.tickSummaries ?? []).find((t) => Number(t.tickNumber) === tapeTick) ?? null;
+    return computeCriticalPathForTick({
+      tickNumber: tapeTick,
+      systems: topology.systems,
+      rows: metadata.systemTickSummaries ?? [],
+      edges: derivedEdges,
+      phases: topology.phases ?? [],
+      postTickRows: metadata.postTickSummaries ?? [],
+      tickSummaryRow: tickRow,
+    });
+  }, [tapeTick, topology, metadata, derivedEdges]);
+
+  // Fit signal — increments per "Fit" press / `0` keybind / middle-click / auto-fit. View
+  // watches and recomputes pxPerUs.
+  const [fitSignal, setFitSignal] = useState(0);
+  const requestFit = () => setFitSignal((n) => n + 1);
+
+  // Auto-fit on selection change — every time the displayed tick changes, refit so the new
+  // tick's work fills the viewport. Without this, the persisted `pxPerUs` from a different tick
+  // (whose wall-clock total may be 100× different) leaves the view either empty or overflowing.
+  // The `lockZoom` toggle in the toolbar disables this so power users can compare phases /
+  // systems across ticks at the same scale.
+  const lockZoom = useCriticalPathViewStore((s) => s.lockZoom);
+  useEffect(() => {
+    if (lockZoom) return;
+    if (tapeTick == null) return;
+    requestFit();
+    // requestFit identity is stable enough — it's a closure over the local setter — but we don't
+    // include it in deps to avoid re-firing for unrelated reasons. Only `tapeTick` and the
+    // `lockZoom` flag should drive auto-fit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tapeTick, lockZoom]);
+
+  // Keyboard zoom: `+`/`=` zoom in, `-` zoom out, `0` fit. Listens on the whole panel container
+  // so it works wherever the user clicks inside it. Doesn't fight inputs because there are none.
+  const zoomBy = useCriticalPathViewStore((s) => s.zoomBy);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === '+' || e.key === '=') {
+        e.preventDefault();
+        zoomBy(1.25);
+      } else if (e.key === '-' || e.key === '_') {
+        e.preventDefault();
+        zoomBy(1 / 1.25);
+      } else if (e.key === '0') {
+        e.preventDefault();
+        requestFit();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [zoomBy]);
+
+  if (!sessionId) {
+    return <EmptyState message="No session attached. Open a trace or attach to a live engine to see the critical path." />;
+  }
+  if (topoError) {
+    return <EmptyState message="Topology fetch failed — check the server log." tone="error" />;
+  }
+  if (topoLoading || metaLoading || !topology || !metadata) {
+    return <EmptyState message="Loading topology…" />;
+  }
+  if (!bars) {
+    return (
+      <div className="flex h-full w-full flex-col overflow-hidden bg-background">
+        <CriticalPathToolbar bars={null} onFit={requestFit} />
+        <EmptyState message="Snapshot or scrub the profiler to populate the view — and pick a focus tick by clicking a system on the DAG." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-background">
+      <CriticalPathToolbar bars={bars} onFit={requestFit} />
+      <div className="min-h-0 flex-1">
+        <CriticalPathView
+          bars={bars}
+          selectedSystemName={selectedSystemName}
+          fitSignal={fitSignal}
+          onFit={requestFit}
+          onSelectBar={(name, tickNumber) => {
+            setSystem(name);
+            setFocusTick(tickNumber);
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ message, tone = 'muted' }: { message: string; tone?: 'muted' | 'error' }) {
+  const colour = tone === 'error' ? 'text-destructive' : 'text-muted-foreground';
+  return (
+    <div className={`flex h-full w-full items-center justify-center bg-background text-[12px] ${colour}`}>
+      {message}
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathPanel.tsx
@@ -6,7 +6,7 @@ import { useSelectionStore } from '@/stores/useSelectionStore';
 import { useSessionStore } from '@/stores/useSessionStore';
 import { deriveEdges } from '../SystemDag/edgeDerivation';
 import { timeToTickRange } from '../SystemDag/tickRangeMapping';
-import { computeCriticalPathForTick, dominantTickInRange } from './criticalPath';
+import { computeAggregateCriticalPath, computeCriticalPathForTick, dominantTickInRange } from './criticalPath';
 import CriticalPathToolbar from './CriticalPathToolbar';
 import CriticalPathView from './CriticalPathView';
 import { useCriticalPathViewStore } from './useCriticalPathViewStore';
@@ -48,8 +48,23 @@ export default function CriticalPathPanel(_props: IDockviewPanelProps) {
     [topology],
   );
 
+  // In aggregate mode the displayed bars are means across the selected tick range — bypass the
+  // dominant-tick selector entirely. Single-tick (default) keeps the existing behaviour.
+  const aggregateMode = useCriticalPathViewStore((s) => s.aggregateMode);
   const bars = useMemo(() => {
-    if (tapeTick == null || !topology?.systems || !metadata) return null;
+    if (!topology?.systems || !metadata) return null;
+    if (aggregateMode) {
+      return computeAggregateCriticalPath({
+        systems: topology.systems,
+        rows: metadata.systemTickSummaries ?? [],
+        edges: derivedEdges,
+        phases: topology.phases ?? [],
+        postTickRows: metadata.postTickSummaries ?? [],
+        tickSummaries: metadata.tickSummaries ?? [],
+        range,
+      });
+    }
+    if (tapeTick == null) return null;
     const tickRow = (metadata.tickSummaries ?? []).find((t) => Number(t.tickNumber) === tapeTick) ?? null;
     return computeCriticalPathForTick({
       tickNumber: tapeTick,
@@ -60,28 +75,29 @@ export default function CriticalPathPanel(_props: IDockviewPanelProps) {
       postTickRows: metadata.postTickSummaries ?? [],
       tickSummaryRow: tickRow,
     });
-  }, [tapeTick, topology, metadata, derivedEdges]);
+  }, [aggregateMode, tapeTick, topology, metadata, derivedEdges, range]);
 
   // Fit signal — increments per "Fit" press / `0` keybind / middle-click / auto-fit. View
   // watches and recomputes pxPerUs.
   const [fitSignal, setFitSignal] = useState(0);
   const requestFit = () => setFitSignal((n) => n + 1);
 
-  // Auto-fit on selection change — every time the displayed tick changes, refit so the new
-  // tick's work fills the viewport. Without this, the persisted `pxPerUs` from a different tick
-  // (whose wall-clock total may be 100× different) leaves the view either empty or overflowing.
-  // The `lockZoom` toggle in the toolbar disables this so power users can compare phases /
-  // systems across ticks at the same scale.
+  // Auto-fit on selection change — every time the displayed tick changes (single mode) or the
+  // aggregate-mode toggle flips (the totalUs goes from one tick to a range mean), refit so the
+  // new wall-clock total fills the viewport. Without this, the persisted `pxPerUs` from a
+  // different tick / mode leaves the view either empty or overflowing. The `lockZoom` toggle in
+  // the toolbar disables this so power users can compare phases / systems across ticks at the
+  // same scale.
   const lockZoom = useCriticalPathViewStore((s) => s.lockZoom);
   useEffect(() => {
     if (lockZoom) return;
-    if (tapeTick == null) return;
+    if (!bars) return;
     requestFit();
     // requestFit identity is stable enough — it's a closure over the local setter — but we don't
-    // include it in deps to avoid re-firing for unrelated reasons. Only `tapeTick` and the
-    // `lockZoom` flag should drive auto-fit.
+    // include it in deps to avoid re-firing for unrelated reasons. Only the displayed bars and
+    // the `lockZoom` flag should drive auto-fit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tapeTick, lockZoom]);
+  }, [bars, lockZoom]);
 
   // Keyboard zoom: `+`/`=` zoom in, `-` zoom out, `0` fit. Listens on the whole panel container
   // so it works wherever the user clicks inside it. Doesn't fight inputs because there are none.

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathToolbar.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathToolbar.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useUiPrefsStore } from '@/stores/useUiPrefsStore';
+import type { TickPathBars } from './criticalPath';
+import { useCriticalPathViewStore, type CpScale, type Orientation } from './useCriticalPathViewStore';
+
+interface Props {
+  bars: TickPathBars | null;
+  onFit: () => void;
+}
+
+/**
+ * Top strip for the dedicated Critical-Path view. Carries the tick label, orientation +
+ * scale toggles, zoom indicator, and a Fit button. All view-state lives in
+ * {@link useCriticalPathViewStore} so the toggles are dumb pass-throughs.
+ */
+export default function CriticalPathToolbar({ bars, onFit }: Props) {
+  const orientation = useCriticalPathViewStore((s) => s.orientation);
+  const setOrientation = useCriticalPathViewStore((s) => s.setOrientation);
+  const scale = useCriticalPathViewStore((s) => s.scale);
+  const setScale = useCriticalPathViewStore((s) => s.setScale);
+  const pxPerUs = useCriticalPathViewStore((s) => s.pxPerUs);
+  const lockZoom = useCriticalPathViewStore((s) => s.lockZoom);
+  const setLockZoom = useCriticalPathViewStore((s) => s.setLockZoom);
+  // Help glyph follows the app-wide `legendsVisible` flag (toggled via the `l` key or the
+  // "Toggle Legends" palette command). Hidden when legends are off so chrome stays minimal.
+  const legendsVisible = useUiPrefsStore((s) => s.legendsVisible);
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  const isFallback = bars?.mode === 'execution-order';
+
+  return (
+    <div className="flex items-center gap-3 border-b border-border bg-background/80 px-3 py-1.5 font-mono text-[11px]">
+      <span className="font-semibold text-foreground">
+        {bars ? `Tick ${bars.tickNumber}` : 'Critical path'}
+      </span>
+      {isFallback && (
+        <span
+          className="rounded bg-amber-950/50 px-1 py-px text-[9px] uppercase text-amber-300"
+          title="Topology has no RFC 07 access declarations — bars are sorted by startUs, not by data-flow path."
+        >
+          execution order
+        </span>
+      )}
+      {bars && <span className="text-muted-foreground">{formatUs(bars.totalUs)}</span>}
+
+      <div className="ml-auto flex items-center gap-3">
+        <SegmentedControl<Orientation>
+          label="orientation"
+          value={orientation}
+          options={['auto', 'horizontal', 'vertical']}
+          onChange={setOrientation}
+        />
+        <SegmentedControl<CpScale>
+          label="scale"
+          value={scale}
+          options={['linear', 'log']}
+          onChange={setScale}
+        />
+        <span className="text-muted-foreground">{formatZoom(pxPerUs)}</span>
+        <label
+          className="flex cursor-pointer items-center gap-1 text-muted-foreground"
+          title="When unchecked, the view auto-fits whenever the displayed tick changes. Check to preserve your manual zoom across tick scrubs (handy for comparing the same phase or system across many ticks)."
+        >
+          <input
+            type="checkbox"
+            checked={lockZoom}
+            onChange={(e) => setLockZoom(e.target.checked)}
+            className="h-3 w-3"
+          />
+          lock zoom
+        </label>
+        <button
+          type="button"
+          onClick={onFit}
+          className="rounded border border-border bg-card px-2 py-0.5 text-foreground hover:bg-muted"
+          title="Fit timeline to viewport (or press 0, or middle-click the canvas)"
+        >
+          fit
+        </button>
+        {legendsVisible && (
+          <button
+            type="button"
+            onClick={() => setHelpOpen((o) => !o)}
+            className="flex h-5 w-5 items-center justify-center rounded-full border border-border bg-card text-foreground hover:bg-muted"
+            title="Show controls + legend (toggle inline help with `l`)"
+            aria-label="Show controls and legend"
+          >
+            ?
+          </button>
+        )}
+      </div>
+      {helpOpen && <HelpOverlay onClose={() => setHelpOpen(false)} />}
+    </div>
+  );
+}
+
+/**
+ * Modal-ish overlay describing every control + visual element in the Critical-Path view. Portaled
+ * to `document.body` so it escapes any dockview ancestor (transforms / overflow). Click-outside
+ * + Escape close it.
+ */
+function HelpOverlay({ onClose }: { onClose: () => void }) {
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60"
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      tabIndex={-1}
+    >
+      <div
+        className="max-h-[80vh] w-[640px] max-w-[90vw] overflow-auto rounded-lg border border-border bg-card p-5 font-mono text-[11px] text-foreground shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-[13px] font-semibold">Critical Path — controls & legend</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            ✕
+          </button>
+        </div>
+
+        <Section title="What you're looking at">
+          <p>One representative tick of the engine, flattened into a single timeline. Each system that ran on the critical path is a coloured bar; waits between systems show as hatched segments. The phase header band above the bars marks which phase each stretch belongs to (5 px coloured stripe + name). Post-tick serial work appears at the trailing edge.</p>
+          <p className="mt-1 text-muted-foreground">When the topology has no RFC 07 access declarations, the walker can't trace a real critical path — the view falls back to "execution order" (every system that ran, sorted by <code>startUs</code>) and shows an amber pill in the header.</p>
+        </Section>
+
+        <Section title="Mouse">
+          <KeyTable rows={[
+            ['Wheel',                     'Zoom in / out, anchored under the cursor'],
+            ['Shift + Wheel',             'Scroll along the time axis (5× step)'],
+            ['Ctrl + Wheel',              'Scroll perpendicular to the time axis'],
+            ['Horizontal wheel / tilt',   'Scroll horizontally'],
+            ['Middle-click',              'Fit timeline to viewport (work + post-tick)'],
+            ['Click a system bar',        'Select system + pin focus tick'],
+            ['Hover',                     'Tooltip: phase, duration, wait classes, parallelism'],
+          ]} />
+        </Section>
+
+        <Section title="Keyboard">
+          <KeyTable rows={[
+            ['+ / =',  'Zoom in (1.25×)'],
+            ['- / _',  'Zoom out (1 / 1.25)'],
+            ['0',      'Fit timeline to viewport'],
+            ['l',      'Toggle inline help (this button + future legends) — app-wide'],
+          ]} />
+        </Section>
+
+        <Section title="Colour / shape legend">
+          <ul className="list-disc space-y-1 pl-5">
+            <li><strong>Phase header stripe</strong> (5 px above the bars) — phase identity. Stable colour per phase across ticks.</li>
+            <li><strong>System bars</strong> — coloured by a stable hash of <code>systemName</code> using the profiler's 13-colour Turbo ramp (same one used for Cache Fetch / Allocate / Evicted / WAL / Checkpoint). Same system always gets the same hue. Bar text contrast is picked per-bar via WCAG luminance.</li>
+            <li><strong>Hatched segments</strong> — waits. <em>Worker-claim</em> (between deps cleared and a worker picking up), <em>chunk-dispatch</em> (work-stealing imbalance), <em>phase-fence</em> (waiting for the slowest non-CP system to clear the fence). Hover to see which.</li>
+            <li><strong>Leading hatched stripe</strong> — metronome wait, the gap from the previous TickEnd to this TickStart. Excluded from "Fit" so the work itself fills the viewport; scroll left to see it.</li>
+            <li><strong>Post-tick serial</strong> — trailing block: WriteTickFence, WAL flush, TierBudget, etc.</li>
+          </ul>
+        </Section>
+
+        <Section title="Scale">
+          <p><strong>Linear</strong> — segment pixel length is proportional to its µs. <strong>Log</strong> — log10 redistribution; small segments expand, large ones shrink, total pixel length preserved so zoom feels consistent across modes.</p>
+        </Section>
+
+        <Section title="Tick source">
+          <p>The displayed tick is either the user-pinned <code>focusTick</code> (set by clicking a system on the DAG or a bar here) or the dominant tick (longest <code>durationUs</code>) inside the selected time window. The window comes from the profiler's TimeArea — scrub there to update.</p>
+        </Section>
+
+        <Section title="Lock zoom">
+          <p>By default, the view auto-fits whenever the displayed tick changes — fresh tick → fresh wall-clock total → previous zoom is the wrong scale. Check <strong>lock zoom</strong> in the toolbar to preserve your manual zoom across tick scrubs (handy for comparing the same phase / system across many ticks at the same scale).</p>
+        </Section>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <h3 className="mb-1.5 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
+      <div className="space-y-1 leading-snug">{children}</div>
+    </div>
+  );
+}
+
+function KeyTable({ rows }: { rows: Array<[string, string]> }) {
+  return (
+    <table className="w-full">
+      <tbody>
+        {rows.map(([k, v]) => (
+          <tr key={k} className="align-top">
+            <td className="w-44 py-0.5 pr-3"><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px]">{k}</kbd></td>
+            <td className="py-0.5 text-muted-foreground">{v}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  options: readonly T[];
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex overflow-hidden rounded border border-border">
+        {options.map((opt) => {
+          const active = value === opt;
+          return (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => onChange(opt)}
+              className={`px-1.5 py-0.5 text-[10px] ${active ? 'bg-primary text-primary-foreground' : 'bg-card text-foreground hover:bg-muted'}`}
+            >
+              {opt}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatUs(us: number): string {
+  if (us < 1) return '0µs';
+  if (us < 1000) return `${Math.round(us)}µs`;
+  const ms = us / 1000;
+  return ms < 10 ? `${ms.toFixed(2)}ms` : `${ms.toFixed(1)}ms`;
+}
+
+function formatZoom(pxPerUs: number): string {
+  // Default zoom = 0.05 px/µs (50 px/ms) → "1.0×" for user-friendly display. Scale relative to
+  // that so common values (×1, ×2, ×8) read naturally.
+  const ratio = pxPerUs / 0.05;
+  if (ratio < 0.1) return `${ratio.toFixed(2)}×`;
+  if (ratio < 10) return `${ratio.toFixed(1)}×`;
+  return `${Math.round(ratio)}×`;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathToolbar.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathToolbar.tsx
@@ -22,6 +22,12 @@ export default function CriticalPathToolbar({ bars, onFit }: Props) {
   const pxPerUs = useCriticalPathViewStore((s) => s.pxPerUs);
   const lockZoom = useCriticalPathViewStore((s) => s.lockZoom);
   const setLockZoom = useCriticalPathViewStore((s) => s.setLockZoom);
+  const fullGantt = useCriticalPathViewStore((s) => s.fullGantt);
+  const setFullGantt = useCriticalPathViewStore((s) => s.setFullGantt);
+  const aggregateMode = useCriticalPathViewStore((s) => s.aggregateMode);
+  const setAggregateMode = useCriticalPathViewStore((s) => s.setAggregateMode);
+  const showMetronome = useCriticalPathViewStore((s) => s.showMetronome);
+  const setShowMetronome = useCriticalPathViewStore((s) => s.setShowMetronome);
   // Help glyph follows the app-wide `legendsVisible` flag (toggled via the `l` key or the
   // "Toggle Legends" palette command). Hidden when legends are off so chrome stays minimal.
   const legendsVisible = useUiPrefsStore((s) => s.legendsVisible);
@@ -32,7 +38,11 @@ export default function CriticalPathToolbar({ bars, onFit }: Props) {
   return (
     <div className="flex items-center gap-3 border-b border-border bg-background/80 px-3 py-1.5 font-mono text-[11px]">
       <span className="font-semibold text-foreground">
-        {bars ? `Tick ${bars.tickNumber}` : 'Critical path'}
+        {bars
+          ? bars.aggregate
+            ? `Aggregate · ${bars.aggregate.tickCount} ticks`
+            : `Tick ${bars.tickNumber}`
+          : 'Critical path'}
       </span>
       {isFallback && (
         <span
@@ -45,6 +55,12 @@ export default function CriticalPathToolbar({ bars, onFit }: Props) {
       {bars && <span className="text-muted-foreground">{formatUs(bars.totalUs)}</span>}
 
       <div className="ml-auto flex items-center gap-3">
+        <SegmentedControl<'single' | 'aggregate'>
+          label="mode"
+          value={aggregateMode ? 'aggregate' : 'single'}
+          options={['single', 'aggregate']}
+          onChange={(v) => setAggregateMode(v === 'aggregate')}
+        />
         <SegmentedControl<Orientation>
           label="orientation"
           value={orientation}
@@ -57,6 +73,30 @@ export default function CriticalPathToolbar({ bars, onFit }: Props) {
           options={['linear', 'log']}
           onChange={setScale}
         />
+        <label
+          className="flex cursor-pointer items-center gap-1 text-muted-foreground"
+          title="Append every system that ran (not just the critical path) — non-CP bars render dimmed alongside CP bars. Off by default; flip on to investigate 'what else was running'."
+        >
+          <input
+            type="checkbox"
+            checked={fullGantt}
+            onChange={(e) => setFullGantt(e.target.checked)}
+            className="h-3 w-3"
+          />
+          full Gantt
+        </label>
+        <label
+          className="flex cursor-pointer items-center gap-1 text-muted-foreground"
+          title="Show the leading metronome-wait stripe — the gap from the previous TickEnd to this TickStart. Off by default per spec; flip on to investigate engine throttling / sleep behaviour. The intent-class chip (Headroom / Throttled / CatchUp) is rendered on the stripe when there's room."
+        >
+          <input
+            type="checkbox"
+            checked={showMetronome}
+            onChange={(e) => setShowMetronome(e.target.checked)}
+            className="h-3 w-3"
+          />
+          metronome
+        </label>
         <span className="text-muted-foreground">{formatZoom(pxPerUs)}</span>
         <label
           className="flex cursor-pointer items-center gap-1 text-muted-foreground"

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathView.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathView.tsx
@@ -1,0 +1,848 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { pickTextColorFor } from '@/libs/colors';
+import { TIMELINE_PALETTE } from '@/libs/profiler/canvas/canvasUtils';
+import type { TickPathBar, TickPathBars, TickPathPhase, TickPathPostTick } from './criticalPath';
+import { colorForPhase } from './phaseColors';
+import { useCriticalPathViewStore, type CpScale, type Orientation } from './useCriticalPathViewStore';
+
+interface Props {
+  bars: TickPathBars;
+  selectedSystemName: string | null;
+  /** Click handler — wires to the panel which sets useSelectionStore.system + focusTick. */
+  onSelectBar: (systemName: string, tickNumber: number) => void;
+  /**
+   * Increment-signal: every time this changes, the view recomputes `pxPerUs` so the timeline fits
+   * exactly inside the current viewport on the major axis. Driven from the toolbar's "Fit"
+   * button and the `0` keybind in the panel.
+   */
+  fitSignal: number;
+  /**
+   * Imperative fit trigger — used by the middle-mouse-button shortcut. Equivalent to bumping
+   * `fitSignal` from outside; we keep both so the toolbar / keybind / button all funnel through
+   * the same panel-level counter while the view's local mouse handler can call this directly
+   * without round-tripping through panel state.
+   */
+  onFit: () => void;
+}
+
+/**
+ * Critical-path zoomable view — replaces the old fixed-width tape with a true timeline canvas.
+ *
+ * **Layout model.** Every "thing that took time" in a tick — system bars, the three wait classes,
+ * post-tick serial sub-blocks, and the metronome wait — is flattened into a single linear list
+ * of {@link Segment}s drawn in execution order along the major axis. The minor axis carries the
+ * phase stripe + phase labels in a band above (horizontal) or beside (vertical) the bars.
+ *
+ * **Zoom.** Truly unbounded. `pxPerUs` lives in {@link useCriticalPathViewStore}; the major-axis
+ * length is `totalUs × pxPerUs`. Wheel zoom multiplies the factor and re-anchors the scroll so
+ * the segment under the cursor stays put. Bar pixel sizes are NOT clamped — text is dropped when
+ * a bar is too narrow to fit it.
+ *
+ * **Scale.** Linear is `us × pxPerUs`. Log redistributes proportionally so total pixel length is
+ * preserved (so zoom feels consistent across modes). `segmentFraction = log10(us+1) / Σlog10(us+1)`.
+ *
+ * **Phase colour.** A 5 px stripe in the phase-header band, spanning each phase's stretch of the
+ * timeline. The phase name sits inside that band when there's room.
+ */
+export default function CriticalPathView({ bars, selectedSystemName, onSelectBar, fitSignal, onFit }: Props) {
+  const rawOrientation = useCriticalPathViewStore((s) => s.orientation);
+  const scale = useCriticalPathViewStore((s) => s.scale);
+  const pxPerUs = useCriticalPathViewStore((s) => s.pxPerUs);
+  const setPxPerUs = useCriticalPathViewStore((s) => s.setPxPerUs);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
+  // `stableViewportSize` lags `viewportSize` by `ORIENTATION_DEBOUNCE_MS` and drives the
+  // `auto` orientation calculation. Without the debounce, a viewport near a 1:1 ratio can
+  // oscillate during a dock-drag: orientation flips → scrollbar moves to the other axis →
+  // contentRect changes → flips back. The debounce lets the resize settle (100 ms is below
+  // human flicker perception while comfortably outside the per-frame ResizeObserver cadence).
+  // `viewportSize` itself stays immediate so fit / scroll maths use the freshest dimensions.
+  const [stableViewportSize, setStableViewportSize] = useState({ width: 0, height: 0 });
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+  // Effective orientation — "auto" resolves to horizontal/vertical based on the viewport's
+  // current aspect ratio. Re-evaluates on every *stable* resize so a dock-drag from a wide
+  // pane into a narrow tab swaps the layout automatically once the user stops dragging.
+  const orientation: Exclude<Orientation, 'auto'> = useMemo(
+    () => resolveOrientation(rawOrientation, stableViewportSize.width, stableViewportSize.height),
+    [rawOrientation, stableViewportSize.width, stableViewportSize.height],
+  );
+
+  // Live orientation ref — the wheel handler runs outside the React render cycle and needs the
+  // current effective orientation without re-attaching the listener on every change. Updated
+  // synchronously on each render so reads from event handlers are always current.
+  const orientationRef = useRef(orientation);
+  orientationRef.current = orientation;
+
+  // Auto-fit on orientation flip — `auto` mode swaps horizontal/vertical when the viewport
+  // ratio crosses 1:1. The major axis just changed length by a large factor, so the user's
+  // current `pxPerUs` is the wrong scale. Refit to make the work fill the new layout. Skipped
+  // when `lockZoom` is on so power users can compare the same scale across orientation flips.
+  // Skipped on the first render (the initial fit chain in the panel handles that path).
+  const previousOrientationRef = useRef(orientation);
+  useEffect(() => {
+    if (previousOrientationRef.current === orientation) return;
+    previousOrientationRef.current = orientation;
+    if (useCriticalPathViewStore.getState().lockZoom) return;
+    onFit();
+  }, [orientation, onFit]);
+
+  // Track viewport size so "Fit" / scroll calculations have current numbers. ResizeObserver fires
+  // on dock-resize, panel float, etc.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (r) setViewportSize({ width: r.width, height: r.height });
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  // Debounce stable viewport size — drives the `auto` orientation re-evaluation. 100 ms is the
+  // sweet spot: long enough to absorb scrollbar-swap oscillations near a 1:1 viewport ratio,
+  // short enough that the layout swap feels responsive after the user stops drag-resizing.
+  useEffect(() => {
+    const ORIENTATION_DEBOUNCE_MS = 100;
+    const t = setTimeout(() => {
+      setStableViewportSize({ width: viewportSize.width, height: viewportSize.height });
+    }, ORIENTATION_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [viewportSize.width, viewportSize.height]);
+
+  // Build the flat segment list once per `bars` change. Cheap (linear in segments).
+  const segments = useMemo(() => buildSegments(bars), [bars]);
+
+  // Major-axis logical-fraction table — drives both linear and log placement uniformly.
+  const placement = useMemo(() => placeSegments(segments, scale, bars.totalUs), [segments, scale, bars.totalUs]);
+
+  const majorTotalPx = Math.max(1, bars.totalUs * pxPerUs);
+
+  // Pending zoom-anchor: written by the wheel handler, applied by the layout effect *after*
+  // React commits the new SVG width. Using rAF here is unreliable — React 18's automatic
+  // batching can flush the commit AFTER the rAF fires, in which case the browser clamps
+  // scrollLeft to the still-old maxScroll and the anchor drifts.
+  const pendingAnchor = useRef<{ fraction: number; cursorMajor: number; orientation: Orientation } | null>(null);
+
+  // Wheel handler — plain = zoom (cursor-anchored), Shift = scroll major (5×), Ctrl = scroll
+  // minor. preventDefault on Ctrl+wheel suppresses the browser's page-zoom default.
+  // Reads pxPerUs / totalUs straight from the store to dodge stale-closure bugs across rapid
+  // wheel events (the listener attaches once on mount, doesn't re-attach per render).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      // Read the *committed* effective orientation from the live ref instead of resolving on
+      // the wheel event itself. Resolving here would skip the debounce — a wheel event during
+      // a near-1:1 oscillation could pick a different orientation from what the SVG just
+      // rendered with, miscomputing the cursor anchor.
+      const orient = orientationRef.current;
+      // Horizontal wheel input (tilt-wheel or trackpad swipe) — scroll horizontally regardless
+      // of orientation: this matches what every other scroll container in the UI does. We let
+      // any non-zero deltaX through and skip the zoom branch entirely so a horizontal swipe
+      // never zooms by accident.
+      if (e.deltaX !== 0) {
+        el.scrollLeft += e.deltaX;
+        return;
+      }
+      if (e.shiftKey) {
+        const delta = e.deltaY * 5;
+        if (orient === 'horizontal') el.scrollLeft += delta;
+        else el.scrollTop += delta;
+        return;
+      }
+      if (e.ctrlKey || e.metaKey) {
+        if (orient === 'horizontal') el.scrollTop += e.deltaY;
+        else el.scrollLeft += e.deltaY;
+        return;
+      }
+      // Cursor-anchored zoom. wheel-up → zoom in.
+      const cur = useCriticalPathViewStore.getState().pxPerUs;
+      const factor = Math.exp(-e.deltaY * 0.0015);
+      const cursorMajor = orient === 'horizontal' ? e.clientX - rect.left : e.clientY - rect.top;
+      const scrollMajor = orient === 'horizontal' ? el.scrollLeft : el.scrollTop;
+      const oldMajor = Math.max(1, bars.totalUs * cur);
+      const fraction = (scrollMajor + cursorMajor) / oldMajor;
+      pendingAnchor.current = { fraction, cursorMajor, orientation: orient };
+      useCriticalPathViewStore.getState().setPxPerUs(cur * factor);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [bars.totalUs]);
+
+  // Apply the pending anchor right after React commits the SVG resize. useLayoutEffect runs
+  // synchronously after the DOM update and before paint — by this point the SVG has its new
+  // width/height so scrollLeft/scrollTop can land at the correct value without browser clamping.
+  useLayoutEffect(() => {
+    const a = pendingAnchor.current;
+    if (!a) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const newMajor = Math.max(1, bars.totalUs * pxPerUs);
+    const newScroll = a.fraction * newMajor - a.cursorMajor;
+    if (a.orientation === 'horizontal') el.scrollLeft = newScroll;
+    else el.scrollTop = newScroll;
+    pendingAnchor.current = null;
+  }, [pxPerUs, bars.totalUs]);
+
+  // Fit-to-viewport: size the canvas so the *work* (tick + post-tick) fills the major axis —
+  // metronome wait is deliberately excluded from the fit budget. On idle ticks the metronome
+  // can dwarf the work (16 ms idle vs 1 ms tick), so including it would shrink the bars to a
+  // sliver. Metronome still renders as a leading stripe; the user scrolls left to see it.
+  //
+  // **Trigger discipline**: only `fitSignal` may dispatch a fit. Viewport / bars are read via
+  // refs so their *changes* don't re-trigger the effect. Without this, zoom-in causes the
+  // scrollbar to appear, which shrinks the viewport, fires ResizeObserver, runs the fit effect
+  // again, and dispatches `setPxPerUs(viewport / fitUs)` — reverting the user's wheel zoom in
+  // a visible flicker.
+  const fitInputsRef = useRef({ orientation, viewportSize, bars });
+  fitInputsRef.current = { orientation, viewportSize, bars };
+  const lastFitSignalRef = useRef(fitSignal);
+  const pendingFitScroll = useRef<number | null>(null);
+  useEffect(() => {
+    if (fitSignal === lastFitSignalRef.current) return;
+    lastFitSignalRef.current = fitSignal;
+    const { orientation: o, viewportSize: v, bars: b } = fitInputsRef.current;
+    const major = o === 'horizontal' ? v.width : v.height;
+    const fitUs = Math.max(1, b.totalUs - b.metronomeWaitUs);
+    if (major <= 0 || fitUs <= 0) return;
+    const newPxPerUs = major / fitUs;
+    setPxPerUs(newPxPerUs);
+    // Scroll past the metronome stripe so the work starts at the viewport's leading edge.
+    // Applied in a layout effect so the SVG has resized first — same pattern as wheel zoom.
+    pendingAnchor.current = null; // wheel anchor would conflict with fit; clear it.
+    pendingFitScroll.current = b.metronomeWaitUs * newPxPerUs;
+  }, [fitSignal, setPxPerUs]);
+
+  // Apply the pending fit scroll right after the SVG resize commits.
+  useLayoutEffect(() => {
+    const offset = pendingFitScroll.current;
+    if (offset == null) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    if (orientation === 'horizontal') {
+      el.scrollLeft = offset;
+      el.scrollTop = 0;
+    } else {
+      el.scrollTop = offset;
+      el.scrollLeft = 0;
+    }
+    pendingFitScroll.current = null;
+  }, [pxPerUs, orientation]);
+
+  // Phase stripe segments — coalesce consecutive segments belonging to the same phase so the
+  // header band shows one stripe per phase rather than many tiny ones.
+  const phaseStripes = useMemo(() => buildPhaseStripes(segments, placement, bars.totalUs), [segments, placement, bars.totalUs]);
+
+  const HEADER_BAND_PX = 18;
+  const BAR_HEIGHT_PX = 64;
+  // Minor-axis padding past the bars so the drop-shadow doesn't clip at the SVG edge. Without
+  // this, dy=2 on the shadow (horizontal layout) renders into clipped space and looks like
+  // "no shadow". 6 px ≥ shadow dy + stdDeviation; same value applies symmetrically in vertical.
+  const SHADOW_PAD_PX = 6;
+  const minorTotalPx = HEADER_BAND_PX + BAR_HEIGHT_PX + SHADOW_PAD_PX;
+
+  // SVG dimensions. Major = zoomed length; minor = fixed.
+  const svgWidth = orientation === 'horizontal' ? majorTotalPx : minorTotalPx;
+  const svgHeight = orientation === 'horizontal' ? minorTotalPx : majorTotalPx;
+
+  // Middle-mouse-button = fit. Bound natively (not via React's synthetic event) with
+  // `{ passive: false }` so `preventDefault()` reliably suppresses Chrome / Edge's middle-click
+  // autoscroll marker on `overflow: auto` containers — React's synthetic mousedown isn't always
+  // dispatched in time to stop the browser default. Also block `auxclick` for the same reason
+  // (some browsers trigger autoscroll on the up edge if mousedown's preventDefault didn't catch
+  // it).
+  // Declared BEFORE the early-return below — Rules of Hooks demand the same hook order on every
+  // render, and the empty-tick branch returns a different element so the hook can't appear after.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onDown = (e: MouseEvent) => {
+      if (e.button !== 1) return;
+      e.preventDefault();
+      onFit();
+    };
+    const onAux = (e: MouseEvent) => {
+      if (e.button === 1) e.preventDefault();
+    };
+    el.addEventListener('mousedown', onDown, { passive: false });
+    el.addEventListener('auxclick', onAux, { passive: false });
+    return () => {
+      el.removeEventListener('mousedown', onDown);
+      el.removeEventListener('auxclick', onAux);
+    };
+  }, [onFit]);
+
+  if (bars.totalUs === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background text-[12px] text-muted-foreground">
+        Tick {bars.tickNumber} has no measured work.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className="relative h-full w-full overflow-auto bg-background"
+      onMouseLeave={() => setTooltip(null)}
+    >
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        style={{ display: 'block' }}
+      >
+        {/*
+          Single hatch <pattern> at the SVG root — re-used by every wait/metronome rect via
+          fill="url(#cp-hatch)". Defining it inside per-segment groups (the previous shape) put
+          a <defs> inside every <g>, which broke event bubble / bbox calculations and is also
+          wasteful (one pattern per segment vs one global).
+        */}
+        <defs>
+          <pattern id="cp-hatch" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+            <line x1="0" y1="0" x2="0" y2="6" stroke="rgba(148,163,184,0.4)" strokeWidth="2" />
+          </pattern>
+          {/*
+            Drop-shadow filters applied to "active work" boxes (system + post-tick) — not the
+            hatched wait segments, which stay visually flat to read as "absence of work". Two
+            variants so the shadow extends along the *minor* axis in each layout (i.e. away from
+            the next neighbour bar in the stack): down in horizontal, right in vertical.
+          */}
+          <filter id="cp-shadow-h" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="0" dy="2" stdDeviation="2" floodColor="#000" floodOpacity="0.45" />
+          </filter>
+          <filter id="cp-shadow-v" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="2" dy="0" stdDeviation="2" floodColor="#000" floodOpacity="0.45" />
+          </filter>
+        </defs>
+        {/* Phase-header band — 5 px stripe + name per phase stretch. */}
+        {phaseStripes.map((stripe, i) => (
+          <PhaseStripe
+            key={i}
+            stripe={stripe}
+            orientation={orientation}
+            majorTotalPx={majorTotalPx}
+            headerBandPx={HEADER_BAND_PX}
+          />
+        ))}
+        {/* Bars row. */}
+        {segments.map((seg, i) => {
+          const place = placement[i];
+          const startPx = place.startFraction * majorTotalPx;
+          const lengthPx = place.lengthFraction * majorTotalPx;
+          return (
+            <SegmentShape
+              key={i}
+              seg={seg}
+              startPx={startPx}
+              lengthPx={lengthPx}
+              orientation={orientation}
+              barOffsetPx={HEADER_BAND_PX}
+              barHeightPx={BAR_HEIGHT_PX}
+              isSelected={seg.kind === 'system' && seg.bar.systemName === selectedSystemName}
+              onMouseEnter={(e) => {
+                const target = e.currentTarget as SVGElement;
+                const rect = target.getBoundingClientRect();
+                // Viewport coordinates — tooltip is portaled to document.body with
+                // position:fixed, so we don't need to compensate for container scroll or
+                // dockview ancestor transforms. Centre on the bar's bbox so the tooltip
+                // appears next to the segment, not the cursor (cursor-following would require
+                // mousemove tracking which we don't need for this v1).
+                setTooltip({
+                  segment: seg,
+                  x: rect.left + rect.width / 2,
+                  y: rect.top + rect.height / 2,
+                });
+              }}
+              onMouseLeave={() => setTooltip(null)}
+              onClick={() => {
+                if (seg.kind === 'system') onSelectBar(seg.bar.systemName, bars.tickNumber);
+              }}
+            />
+          );
+        })}
+      </svg>
+      {tooltip && <Tooltip tooltip={tooltip} />}
+      {bars.mode === 'execution-order' && <FallbackBadge />}
+    </div>
+  );
+}
+
+// ── Segment model — every drawable thing along the major axis ─────────────
+
+type Segment =
+  | { kind: 'system';            bar: TickPathBar;                  phaseName: string; phaseIndex: number; durationUs: number }
+  | { kind: 'worker-claim';      durationUs: number;                phaseName: string; phaseIndex: number; systemName: string }
+  | { kind: 'chunk-dispatch';    durationUs: number;                phaseName: string; phaseIndex: number; systemName: string }
+  | { kind: 'phase-fence';       durationUs: number;                phaseName: string; phaseIndex: number; straggler: string | null }
+  | { kind: 'post-tick';         durationUs: number; label: string; hue: number }
+  | { kind: 'metronome';         durationUs: number };
+
+function buildSegments(bars: TickPathBars): Segment[] {
+  const out: Segment[] = [];
+  // Metronome wait that PRECEDED this tick — sits at the start of the timeline (visually before
+  // the tick's first phase). Surface only when non-zero — zero is the steady-state "no jitter".
+  if (bars.metronomeWaitUs > 0) {
+    out.push({ kind: 'metronome', durationUs: bars.metronomeWaitUs });
+  }
+  bars.phases.forEach((phase, phaseIndex) => emitPhaseSegments(out, phase, phaseIndex));
+  emitPostTickSegments(out, bars.postTick);
+  return out;
+}
+
+function emitPhaseSegments(out: Segment[], phase: TickPathPhase, phaseIndex: number): void {
+  for (const bar of phase.bars) {
+    if (bar.workerClaimWaitUs > 0) {
+      out.push({ kind: 'worker-claim', durationUs: bar.workerClaimWaitUs, phaseName: phase.name, phaseIndex, systemName: bar.systemName });
+    }
+    if (bar.chunkDispatchWaitUs > 0) {
+      out.push({ kind: 'chunk-dispatch', durationUs: bar.chunkDispatchWaitUs, phaseName: phase.name, phaseIndex, systemName: bar.systemName });
+    }
+    out.push({ kind: 'system', bar, phaseName: phase.name, phaseIndex, durationUs: bar.durationUs });
+  }
+  if (phase.phaseFenceWaitUs > 0) {
+    out.push({ kind: 'phase-fence', durationUs: phase.phaseFenceWaitUs, phaseName: phase.name, phaseIndex, straggler: phase.phaseFenceStraggler });
+  }
+}
+
+const POST_TICK_ITEMS: Array<{ key: keyof TickPathPostTick; label: string; hue: number }> = [
+  { key: 'writeTickFenceUs',     label: 'WriteTickFence',     hue: 200 },
+  { key: 'walFlushUs',           label: 'WAL flush',          hue: 30 },
+  { key: 'tierBudgetUs',         label: 'TierBudget',         hue: 280 },
+  { key: 'subscriptionOutputUs', label: 'SubscriptionOutput', hue: 140 },
+  { key: 'tierIndexRebuildUs',   label: 'TierIndexRebuild',   hue: 250 },
+  { key: 'dormancySweepUs',      label: 'DormancySweep',      hue: 60 },
+];
+
+function emitPostTickSegments(out: Segment[], postTick: TickPathPostTick): void {
+  for (const item of POST_TICK_ITEMS) {
+    const us = postTick[item.key];
+    if (us > 0) {
+      out.push({ kind: 'post-tick', durationUs: us, label: item.label, hue: item.hue });
+    }
+  }
+}
+
+// ── Placement (linear vs log) ─────────────────────────────────────────────
+
+interface Placement {
+  startFraction: number;
+  lengthFraction: number;
+}
+
+/**
+ * Convert each segment's `durationUs` into `[startFraction, lengthFraction]` along the major
+ * axis (each fraction in [0, 1]). Linear is the trivial case `us / totalUs`. Log redistributes
+ * proportionally — small segments get more pixels relative to big ones — but the SUM of fractions
+ * still equals 1 so the timeline isn't truncated or padded.
+ */
+function placeSegments(segments: Segment[], scale: CpScale, totalUs: number): Placement[] {
+  if (segments.length === 0 || totalUs <= 0) return [];
+
+  if (scale === 'linear') {
+    const out: Placement[] = [];
+    let cursor = 0;
+    for (const seg of segments) {
+      const len = seg.durationUs / totalUs;
+      out.push({ startFraction: cursor, lengthFraction: len });
+      cursor += len;
+    }
+    return out;
+  }
+  // Log: weight = log10(us + 1). Total = sum of weights. Renormalize so fractions sum to 1.
+  let totalLog = 0;
+  for (const seg of segments) totalLog += Math.log10(seg.durationUs + 1);
+  if (totalLog <= 0) {
+    return segments.map(() => ({ startFraction: 0, lengthFraction: 0 }));
+  }
+  const out: Placement[] = [];
+  let cursor = 0;
+  for (const seg of segments) {
+    const len = Math.log10(seg.durationUs + 1) / totalLog;
+    out.push({ startFraction: cursor, lengthFraction: len });
+    cursor += len;
+  }
+  return out;
+}
+
+// ── Phase stripes (header band) ───────────────────────────────────────────
+
+interface PhaseStripeData {
+  phaseName: string;
+  phaseIndex: number;
+  startFraction: number;
+  endFraction: number;
+}
+
+/**
+ * Coalesce consecutive segments with the same phaseIndex into a single header-band stripe.
+ * Post-tick / metronome get their own stripes (`phaseIndex = -1` / `-2`) so the band always
+ * spans the full timeline.
+ */
+function buildPhaseStripes(segments: Segment[], placement: Placement[], _totalUs: number): PhaseStripeData[] {
+  const out: PhaseStripeData[] = [];
+  let current: PhaseStripeData | null = null;
+  segments.forEach((seg, i) => {
+    const phaseName = segmentPhaseName(seg);
+    const phaseIndex = segmentPhaseIndex(seg);
+    const start = placement[i].startFraction;
+    const end = start + placement[i].lengthFraction;
+    if (current && current.phaseIndex === phaseIndex && current.phaseName === phaseName) {
+      current.endFraction = end;
+    } else {
+      current = { phaseName, phaseIndex, startFraction: start, endFraction: end };
+      out.push(current);
+    }
+  });
+  return out;
+}
+
+function segmentPhaseName(seg: Segment): string {
+  switch (seg.kind) {
+    case 'system':
+    case 'worker-claim':
+    case 'chunk-dispatch':
+    case 'phase-fence':
+      return seg.phaseName;
+    case 'post-tick':
+      return 'Post-tick';
+    case 'metronome':
+      return 'Metronome wait';
+  }
+}
+
+function segmentPhaseIndex(seg: Segment): number {
+  switch (seg.kind) {
+    case 'system':
+    case 'worker-claim':
+    case 'chunk-dispatch':
+    case 'phase-fence':
+      return seg.phaseIndex;
+    case 'post-tick':
+      return -1;
+    case 'metronome':
+      return -2;
+  }
+}
+
+// ── PhaseStripe SVG node ──────────────────────────────────────────────────
+
+function PhaseStripe({
+  stripe,
+  orientation,
+  majorTotalPx,
+  headerBandPx,
+}: {
+  stripe: PhaseStripeData;
+  orientation: Orientation;
+  majorTotalPx: number;
+  headerBandPx: number;
+}) {
+  const colour = stripe.phaseIndex === -1
+    ? { stroke: 'hsl(220, 8%, 60%)', fill: 'hsl(220, 8%, 25%)' }
+    : stripe.phaseIndex === -2
+      ? { stroke: 'hsl(40, 60%, 60%)', fill: 'hsl(40, 50%, 25%)' }
+      : colorForPhase(stripe.phaseIndex);
+  const startPx = stripe.startFraction * majorTotalPx;
+  const lengthPx = (stripe.endFraction - stripe.startFraction) * majorTotalPx;
+  // 5 px stripe + 2 px gap between the stripe and the bar area, so the boxes stand out as a
+  // separate band rather than visually merging with the phase colour. Stripe sits at
+  // `headerBandPx - GAP - stripePx` and ends at `headerBandPx - GAP`; the GAP shows as the
+  // panel background between the two.
+  const stripePx = 5;
+  const stripeGapPx = 2;
+  const stripeEnd = headerBandPx - stripeGapPx;
+  const stripeStart = stripeEnd - stripePx;
+  if (orientation === 'horizontal') {
+    return (
+      <g>
+        <rect x={startPx} y={stripeStart} width={lengthPx} height={stripePx} fill={colour.stroke} />
+        {lengthPx >= 40 && (
+          <text
+            x={startPx + 4}
+            y={stripeStart - 3}
+            fontSize={9}
+            fontFamily="ui-monospace, monospace"
+            fill="currentColor"
+            className="fill-foreground"
+          >
+            {stripe.phaseName}
+          </text>
+        )}
+      </g>
+    );
+  }
+  // Vertical.
+  return (
+    <g>
+      <rect x={stripeStart} y={startPx} width={stripePx} height={lengthPx} fill={colour.stroke} />
+      {lengthPx >= 40 && (
+        <text
+          x={stripeStart - 3}
+          y={startPx + 10}
+          fontSize={9}
+          fontFamily="ui-monospace, monospace"
+          fill="currentColor"
+          textAnchor="end"
+          className="fill-foreground"
+        >
+          {stripe.phaseName}
+        </text>
+      )}
+    </g>
+  );
+}
+
+// ── Segment shape (one rect per segment) ──────────────────────────────────
+
+function SegmentShape({
+  seg,
+  startPx,
+  lengthPx,
+  orientation,
+  barOffsetPx,
+  barHeightPx,
+  isSelected,
+  onMouseEnter,
+  onMouseLeave,
+  onClick,
+}: {
+  seg: Segment;
+  startPx: number;
+  lengthPx: number;
+  orientation: Orientation;
+  barOffsetPx: number;
+  barHeightPx: number;
+  isSelected: boolean;
+  onMouseEnter: (e: React.MouseEvent<SVGElement>) => void;
+  onMouseLeave: () => void;
+  onClick: () => void;
+}) {
+  const fill = colourForSegment(seg);
+  // System bars use a hex from TIMELINE_PALETTE — pick a contrast-correct ink via WCAG luminance
+  // so the label is legible on both the dark indigo (#30123B) and bright lime (#C1EE3B) ends of
+  // the ramp. Post-tick fills are HSL with lightness 30 % so they're always dark — hard-code
+  // white ink rather than parsing HSL through the luminance helper. Wait segments are hatched
+  // overlays without labels, so they don't need a text colour.
+  const textFill =
+    seg.kind === 'system' ? pickTextColorFor(fill) :
+    seg.kind === 'post-tick' ? '#fff' :
+    undefined;
+  // Drop-shadow only on "active work" boxes — system + post-tick. Wait segments stay flat to
+  // visually read as "nothing happening here". `cp-shadow` is defined once at the SVG root.
+  const hasShadow = seg.kind === 'system' || seg.kind === 'post-tick';
+  const isClickable = seg.kind === 'system';
+  const showText = lengthPx >= 30 && (seg.kind === 'system' || seg.kind === 'post-tick');
+  const showHatch = seg.kind === 'worker-claim' || seg.kind === 'chunk-dispatch' || seg.kind === 'phase-fence' || seg.kind === 'metronome';
+
+  // Coordinates per orientation. Major = time axis; minor = bar row, offset by header band.
+  const x = orientation === 'horizontal' ? startPx : barOffsetPx;
+  const y = orientation === 'horizontal' ? barOffsetPx : startPx;
+  const width = orientation === 'horizontal' ? lengthPx : barHeightPx;
+  const height = orientation === 'horizontal' ? barHeightPx : lengthPx;
+
+  // Visual layers all `pointer-events="none"` so the transparent hit-rect at the bottom of the
+  // group is the SOLE owner of hit testing. Without this, the hatched overlay (drawn on top of
+  // the fill rect) would intercept events and break the parent <g>'s mouseenter bubble.
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={fill}
+        opacity={showHatch ? 0.35 : 1}
+        stroke={isSelected ? 'hsl(var(--primary))' : 'transparent'}
+        strokeWidth={isSelected ? 2 : 0}
+        filter={hasShadow ? (orientation === 'horizontal' ? 'url(#cp-shadow-h)' : 'url(#cp-shadow-v)') : undefined}
+        pointerEvents="none"
+      />
+      {showHatch && (
+        <rect
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          fill="url(#cp-hatch)"
+          pointerEvents="none"
+        />
+      )}
+      {showText && (
+        <text
+          x={x + width / 2}
+          y={y + height / 2 + 3}
+          fontSize={10}
+          fontFamily="ui-monospace, monospace"
+          fill={textFill ?? 'currentColor'}
+          className={textFill ? undefined : 'fill-foreground'}
+          textAnchor="middle"
+          pointerEvents="none"
+        >
+          {clipText(seg.kind === 'system' ? seg.bar.systemName : seg.kind === 'post-tick' ? seg.label : '', width - 8)}
+        </text>
+      )}
+      {/*
+        Transparent hit-rect — rendered last so it sits above every visual layer in the group
+        and owns all hover/click events. Without `fill="transparent"` (a paint that *does*
+        respond to pointer-events), an SVG rect with no fill is invisible to the hit-test.
+      */}
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill="transparent"
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onClick={isClickable ? onClick : undefined}
+        style={{ cursor: isClickable ? 'pointer' : 'default' }}
+      />
+    </g>
+  );
+}
+
+function colourForSegment(seg: Segment): string {
+  switch (seg.kind) {
+    case 'system':
+      // 13-colour Turbo ramp from the profiler's per-operation overview palette (`Cache Fetch`,
+      // `Cache Allocate`, `Cache Evicted`, …). Cycled by a stable hash of `systemName` so a
+      // given system always lands on the same hue across ticks / sessions. Phase identity comes
+      // from the header stripe; heat (duration) is conveyed by bar *length*, not colour.
+      return TIMELINE_PALETTE[hashString(seg.bar.systemName) % TIMELINE_PALETTE.length];
+    case 'worker-claim':
+    case 'chunk-dispatch':
+      return 'hsla(40, 30%, 40%, 0.5)';
+    case 'phase-fence':
+      return 'hsla(0, 30%, 40%, 0.5)';
+    case 'post-tick':
+      return `hsla(${seg.hue}, 50%, 30%, 0.7)`;
+    case 'metronome':
+      return 'hsla(40, 50%, 25%, 0.6)';
+  }
+}
+
+/**
+ * Resolve the user-facing orientation setting (which may be "auto") to the concrete layout the
+ * renderer needs ("horizontal" | "vertical"). Auto picks horizontal when the viewport is wider
+ * than tall, vertical otherwise; ties resolve to horizontal because that's the more natural
+ * default reading direction for timelines. Falls back to horizontal when the viewport hasn't
+ * been measured yet (initial mount, before ResizeObserver fires).
+ */
+function resolveOrientation(raw: Orientation, width: number, height: number): Exclude<Orientation, 'auto'> {
+  if (raw === 'horizontal') return 'horizontal';
+  if (raw === 'vertical') return 'vertical';
+  if (width <= 0 || height <= 0) return 'horizontal';
+  return width >= height ? 'horizontal' : 'vertical';
+}
+
+/** djb2 hash — small, deterministic, no allocations. Mod into the palette at the call site. */
+function hashString(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return h < 0 ? -h : h;
+}
+
+function clipText(text: string, maxWidth: number): string {
+  // Rough char-width heuristic — monospace 10 px ≈ 6 px/char. Saves measuring the canvas every
+  // segment.
+  const maxChars = Math.max(0, Math.floor(maxWidth / 6));
+  if (text.length <= maxChars) return text;
+  if (maxChars <= 1) return '';
+  return text.slice(0, maxChars - 1) + '…';
+}
+
+// ── Tooltip ───────────────────────────────────────────────────────────────
+
+interface TooltipState {
+  segment: Segment;
+  x: number;
+  y: number;
+}
+
+function Tooltip({ tooltip }: { tooltip: TooltipState }) {
+  const lines = describeSegment(tooltip.segment);
+  // Portaled to document.body with position:fixed so it escapes any ancestor that has
+  // overflow, transforms, or filters (dockview panels can have all three). Coordinates are
+  // viewport-space, so we clamp against window.innerWidth/innerHeight directly.
+  const TOOLTIP_W = 240;
+  const TOOLTIP_H = 14 * lines.length + 12;
+  let left = tooltip.x + 12;
+  let top = tooltip.y + 12;
+  if (left + TOOLTIP_W > window.innerWidth) left = tooltip.x - TOOLTIP_W - 12;
+  if (top + TOOLTIP_H > window.innerHeight) top = tooltip.y - TOOLTIP_H - 12;
+  return createPortal(
+    <div
+      className="pointer-events-none fixed z-[1000] rounded border border-border bg-card px-2 py-1.5 font-mono text-[10px] text-foreground shadow-md"
+      style={{ left, top, width: TOOLTIP_W }}
+    >
+      {lines.map((line, i) => (
+        <div key={i} className={i === 0 ? 'mb-1 font-semibold text-foreground' : 'text-muted-foreground'}>
+          {line}
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}
+
+function describeSegment(seg: Segment): string[] {
+  switch (seg.kind) {
+    case 'system': {
+      const lines: string[] = [`${seg.bar.systemName} — ${formatUs(seg.bar.durationUs)}`];
+      lines.push(`phase: ${seg.phaseName || '(unphased)'}`);
+      if (seg.bar.workerClaimWaitUs > 0) lines.push(`worker-claim wait: ${formatUs(seg.bar.workerClaimWaitUs)}`);
+      if (seg.bar.chunkDispatchWaitUs > 0) lines.push(`chunk-dispatch wait: ${formatUs(seg.bar.chunkDispatchWaitUs)}`);
+      if (seg.bar.isParallel) lines.push(`parallel: ${seg.bar.workersTouched} workers / ${seg.bar.chunksProcessed} chunks`);
+      return lines;
+    }
+    case 'worker-claim':
+      return [
+        `Worker-claim wait — ${formatUs(seg.durationUs)}`,
+        `before: ${seg.systemName}`,
+        `phase: ${seg.phaseName}`,
+        'Gap between deps cleared and a worker picking the system up.',
+      ];
+    case 'chunk-dispatch':
+      return [
+        `Chunk-dispatch wait — ${formatUs(seg.durationUs)}`,
+        `before: ${seg.systemName}`,
+        `phase: ${seg.phaseName}`,
+        'Work-stealing imbalance across workers.',
+      ];
+    case 'phase-fence':
+      return [
+        `Phase-fence wait — ${formatUs(seg.durationUs)}`,
+        `phase: ${seg.phaseName}`,
+        seg.straggler ? `straggler: ${seg.straggler}` : 'no straggler recorded',
+        'CP waited for the slowest non-CP system to clear the fence.',
+      ];
+    case 'post-tick':
+      return [`${seg.label} — ${formatUs(seg.durationUs)}`, 'Post-tick serial work.'];
+    case 'metronome':
+      return [`Metronome wait — ${formatUs(seg.durationUs)}`, 'Idle gap from previous TickEnd to this TickStart.'];
+  }
+}
+
+function formatUs(us: number): string {
+  if (us < 1) return '0µs';
+  if (us < 1000) return `${Math.round(us)}µs`;
+  const ms = us / 1000;
+  return ms < 10 ? `${ms.toFixed(2)}ms` : `${ms.toFixed(1)}ms`;
+}
+
+function FallbackBadge() {
+  return (
+    <div
+      className="pointer-events-none absolute right-2 top-2 z-40 rounded bg-amber-950/80 px-2 py-0.5 font-mono text-[9px] uppercase text-amber-300"
+      title="The topology has no RFC 07 access declarations — without dependency edges, the walker can't trace a critical path. Showing every system that ran, sorted by startUs."
+    >
+      execution order
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathView.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/CriticalPathView.tsx
@@ -2,7 +2,8 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { pickTextColorFor } from '@/libs/colors';
 import { TIMELINE_PALETTE } from '@/libs/profiler/canvas/canvasUtils';
-import type { TickPathBar, TickPathBars, TickPathPhase, TickPathPostTick } from './criticalPath';
+import { useHoverStore } from '@/stores/useHoverStore';
+import type { MetronomeIntentClass, TickPathBar, TickPathBars, TickPathPhase, TickPathPostTick } from './criticalPath';
 import { colorForPhase } from './phaseColors';
 import { useCriticalPathViewStore, type CpScale, type Orientation } from './useCriticalPathViewStore';
 
@@ -50,6 +51,12 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
   const scale = useCriticalPathViewStore((s) => s.scale);
   const pxPerUs = useCriticalPathViewStore((s) => s.pxPerUs);
   const setPxPerUs = useCriticalPathViewStore((s) => s.setPxPerUs);
+  const fullGantt = useCriticalPathViewStore((s) => s.fullGantt);
+  const showMetronome = useCriticalPathViewStore((s) => s.showMetronome);
+  const hoveredSystem = useHoverStore((s) => s.hoveredSystem);
+  const setHoveredSystem = useHoverStore((s) => s.setHoveredSystem);
+  const hoveredPhase = useHoverStore((s) => s.hoveredPhase);
+  const setHoveredPhase = useHoverStore((s) => s.setHoveredPhase);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
@@ -89,6 +96,27 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
     onFit();
   }, [orientation, onFit]);
 
+  // Auto-fit when full-Gantt toggles — the timeline either grows (non-CP bars added) or shrinks
+  // (CP-only) by a large factor, so the previous `pxPerUs` is the wrong scale. `lockZoom` opts
+  // power users out so they can compare CP-only vs full views at the same scale.
+  const previousFullGanttRef = useRef(fullGantt);
+  useEffect(() => {
+    if (previousFullGanttRef.current === fullGantt) return;
+    previousFullGanttRef.current = fullGantt;
+    if (useCriticalPathViewStore.getState().lockZoom) return;
+    onFit();
+  }, [fullGantt, onFit]);
+
+  // Same auto-fit dance for the metronome toggle — turning it on adds a leading stripe (often
+  // larger than the work itself on idle ticks); turning it off shrinks the timeline.
+  const previousShowMetronomeRef = useRef(showMetronome);
+  useEffect(() => {
+    if (previousShowMetronomeRef.current === showMetronome) return;
+    previousShowMetronomeRef.current = showMetronome;
+    if (useCriticalPathViewStore.getState().lockZoom) return;
+    onFit();
+  }, [showMetronome, onFit]);
+
   // Track viewport size so "Fit" / scroll calculations have current numbers. ResizeObserver fires
   // on dock-resize, panel float, etc.
   useEffect(() => {
@@ -113,13 +141,22 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
     return () => clearTimeout(t);
   }, [viewportSize.width, viewportSize.height]);
 
-  // Build the flat segment list once per `bars` change. Cheap (linear in segments).
-  const segments = useMemo(() => buildSegments(bars), [bars]);
+  // Build the flat segment list — `fullGantt` decides whether non-CP bars are appended into each
+  // phase. Cheap (linear in segments). `effectiveTotalUs` is the SUM of segment durations rather
+  // than `bars.totalUs`, because in full-Gantt mode non-CP additions inflate the timeline above
+  // the strict-wall-clock CP total. We use the effective value everywhere placement / zoom /
+  // fit-anchor calculations would otherwise round-trip through `bars.totalUs`.
+  const segments = useMemo(() => buildSegments(bars, fullGantt, showMetronome), [bars, fullGantt, showMetronome]);
+  const effectiveTotalUs = useMemo(() => {
+    let sum = 0;
+    for (const seg of segments) sum += seg.durationUs;
+    return Math.max(1, sum);
+  }, [segments]);
 
   // Major-axis logical-fraction table — drives both linear and log placement uniformly.
-  const placement = useMemo(() => placeSegments(segments, scale, bars.totalUs), [segments, scale, bars.totalUs]);
+  const placement = useMemo(() => placeSegments(segments, scale, effectiveTotalUs), [segments, scale, effectiveTotalUs]);
 
-  const majorTotalPx = Math.max(1, bars.totalUs * pxPerUs);
+  const majorTotalPx = Math.max(1, effectiveTotalUs * pxPerUs);
 
   // Pending zoom-anchor: written by the wheel handler, applied by the layout effect *after*
   // React commits the new SVG width. Using rAF here is unreliable — React 18's automatic
@@ -166,14 +203,14 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
       const factor = Math.exp(-e.deltaY * 0.0015);
       const cursorMajor = orient === 'horizontal' ? e.clientX - rect.left : e.clientY - rect.top;
       const scrollMajor = orient === 'horizontal' ? el.scrollLeft : el.scrollTop;
-      const oldMajor = Math.max(1, bars.totalUs * cur);
+      const oldMajor = Math.max(1, effectiveTotalUs * cur);
       const fraction = (scrollMajor + cursorMajor) / oldMajor;
       pendingAnchor.current = { fraction, cursorMajor, orientation: orient };
       useCriticalPathViewStore.getState().setPxPerUs(cur * factor);
     };
     el.addEventListener('wheel', onWheel, { passive: false });
     return () => el.removeEventListener('wheel', onWheel);
-  }, [bars.totalUs]);
+  }, [effectiveTotalUs]);
 
   // Apply the pending anchor right after React commits the SVG resize. useLayoutEffect runs
   // synchronously after the DOM update and before paint — by this point the SVG has its new
@@ -183,12 +220,12 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
     if (!a) return;
     const el = scrollRef.current;
     if (!el) return;
-    const newMajor = Math.max(1, bars.totalUs * pxPerUs);
+    const newMajor = Math.max(1, effectiveTotalUs * pxPerUs);
     const newScroll = a.fraction * newMajor - a.cursorMajor;
     if (a.orientation === 'horizontal') el.scrollLeft = newScroll;
     else el.scrollTop = newScroll;
     pendingAnchor.current = null;
-  }, [pxPerUs, bars.totalUs]);
+  }, [pxPerUs, effectiveTotalUs]);
 
   // Fit-to-viewport: size the canvas so the *work* (tick + post-tick) fills the major axis —
   // metronome wait is deliberately excluded from the fit budget. On idle ticks the metronome
@@ -200,23 +237,27 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
   // scrollbar to appear, which shrinks the viewport, fires ResizeObserver, runs the fit effect
   // again, and dispatches `setPxPerUs(viewport / fitUs)` — reverting the user's wheel zoom in
   // a visible flicker.
-  const fitInputsRef = useRef({ orientation, viewportSize, bars });
-  fitInputsRef.current = { orientation, viewportSize, bars };
+  const fitInputsRef = useRef({ orientation, viewportSize, bars, effectiveTotalUs, showMetronome });
+  fitInputsRef.current = { orientation, viewportSize, bars, effectiveTotalUs, showMetronome };
   const lastFitSignalRef = useRef(fitSignal);
   const pendingFitScroll = useRef<number | null>(null);
   useEffect(() => {
     if (fitSignal === lastFitSignalRef.current) return;
     lastFitSignalRef.current = fitSignal;
-    const { orientation: o, viewportSize: v, bars: b } = fitInputsRef.current;
+    const { orientation: o, viewportSize: v, bars: b, effectiveTotalUs: total, showMetronome: showMetro } = fitInputsRef.current;
     const major = o === 'horizontal' ? v.width : v.height;
-    const fitUs = Math.max(1, b.totalUs - b.metronomeWaitUs);
+    // Fit budget = "all the rendered work, minus the leading idle stripe IF the stripe is on".
+    // When `showMetronome` is off the segment isn't in the segment list — `effectiveTotalUs`
+    // already excludes it, so subtracting again would oversize the fit.
+    const metroSubtract = showMetro ? b.metronomeWaitUs : 0;
+    const fitUs = Math.max(1, total - metroSubtract);
     if (major <= 0 || fitUs <= 0) return;
     const newPxPerUs = major / fitUs;
     setPxPerUs(newPxPerUs);
-    // Scroll past the metronome stripe so the work starts at the viewport's leading edge.
-    // Applied in a layout effect so the SVG has resized first — same pattern as wheel zoom.
+    // Scroll past the metronome stripe so the work starts at the viewport's leading edge — but
+    // only when the stripe is rendered. With the toggle off we want scroll position 0.
     pendingAnchor.current = null; // wheel anchor would conflict with fit; clear it.
-    pendingFitScroll.current = b.metronomeWaitUs * newPxPerUs;
+    pendingFitScroll.current = metroSubtract * newPxPerUs;
   }, [fitSignal, setPxPerUs]);
 
   // Apply the pending fit scroll right after the SVG resize commits.
@@ -290,7 +331,10 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
     <div
       ref={scrollRef}
       className="relative h-full w-full overflow-auto bg-background"
-      onMouseLeave={() => setTooltip(null)}
+      onMouseLeave={() => {
+        setTooltip(null);
+        setHoveredSystem(null);
+      }}
     >
       <svg
         width={svgWidth}
@@ -328,6 +372,15 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
             orientation={orientation}
             majorTotalPx={majorTotalPx}
             headerBandPx={HEADER_BAND_PX}
+            isHovered={stripe.phaseIndex >= 0 && stripe.phaseName === hoveredPhase}
+            onMouseEnter={() => {
+              // Only sync real phases (post-tick / metronome have synthetic indices < 0). Otherwise
+              // hovering the post-tick stripe would broadcast a phase the DAG canvas can't match.
+              if (stripe.phaseIndex >= 0) setHoveredPhase(stripe.phaseName);
+            }}
+            onMouseLeave={() => {
+              if (stripe.phaseIndex >= 0) setHoveredPhase(null);
+            }}
           />
         ))}
         {/* Bars row. */}
@@ -344,7 +397,8 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
               orientation={orientation}
               barOffsetPx={HEADER_BAND_PX}
               barHeightPx={BAR_HEIGHT_PX}
-              isSelected={seg.kind === 'system' && seg.bar.systemName === selectedSystemName}
+              isSelected={(seg.kind === 'system' || seg.kind === 'non-cp-system') && seg.bar.systemName === selectedSystemName}
+              isHovered={(seg.kind === 'system' || seg.kind === 'non-cp-system') && seg.bar.systemName === hoveredSystem}
               onMouseEnter={(e) => {
                 const target = e.currentTarget as SVGElement;
                 const rect = target.getBoundingClientRect();
@@ -358,10 +412,38 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
                   x: rect.left + rect.width / 2,
                   y: rect.top + rect.height / 2,
                 });
+                // Cross-panel hover sync: writing here makes the matching DAG node pulse and
+                // any future panels that subscribe to hover light up too. Phase-fence / wait
+                // segments leave the hover slot alone — there's no "system" to point at.
+                if (seg.kind === 'system' || seg.kind === 'non-cp-system') {
+                  setHoveredSystem(seg.bar.systemName);
+                } else if (seg.kind === 'worker-claim') {
+                  // Hover the wait segment → highlight the system that was waiting. Symmetric
+                  // with the click-through; lets the user trace "this gap is in front of THAT
+                  // node" without having to click first.
+                  setHoveredSystem(seg.systemName);
+                }
               }}
-              onMouseLeave={() => setTooltip(null)}
+              onMouseLeave={() => {
+                setTooltip(null);
+                if (seg.kind === 'system' || seg.kind === 'non-cp-system' || seg.kind === 'worker-claim') {
+                  setHoveredSystem(null);
+                }
+              }}
               onClick={() => {
-                if (seg.kind === 'system') onSelectBar(seg.bar.systemName, bars.tickNumber);
+                if (seg.kind === 'system' || seg.kind === 'non-cp-system') {
+                  onSelectBar(seg.bar.systemName, bars.tickNumber);
+                } else if (seg.kind === 'phase-fence' && seg.straggler != null) {
+                  // Click-through to the straggler — same behaviour as a direct system-bar click,
+                  // so cross-panel selection sync (DAG node highlight, side-panel access) updates
+                  // automatically.
+                  onSelectBar(seg.straggler, bars.tickNumber);
+                } else if (seg.kind === 'worker-claim') {
+                  // Click-through to the system that was waiting on a worker — the natural pivot
+                  // for "why couldn't a worker pick this up?". Selects the system + opens its
+                  // side-panel (access decls, parallelism mode, prior chunks).
+                  onSelectBar(seg.systemName, bars.tickNumber);
+                }
               }}
             />
           );
@@ -377,25 +459,28 @@ export default function CriticalPathView({ bars, selectedSystemName, onSelectBar
 
 type Segment =
   | { kind: 'system';            bar: TickPathBar;                  phaseName: string; phaseIndex: number; durationUs: number }
+  | { kind: 'non-cp-system';     bar: TickPathBar;                  phaseName: string; phaseIndex: number; durationUs: number }
   | { kind: 'worker-claim';      durationUs: number;                phaseName: string; phaseIndex: number; systemName: string }
   | { kind: 'chunk-dispatch';    durationUs: number;                phaseName: string; phaseIndex: number; systemName: string }
   | { kind: 'phase-fence';       durationUs: number;                phaseName: string; phaseIndex: number; straggler: string | null }
   | { kind: 'post-tick';         durationUs: number; label: string; hue: number }
-  | { kind: 'metronome';         durationUs: number };
+  | { kind: 'metronome';         durationUs: number; intentClass: MetronomeIntentClass | null };
 
-function buildSegments(bars: TickPathBars): Segment[] {
+function buildSegments(bars: TickPathBars, fullGantt: boolean, showMetronome: boolean): Segment[] {
   const out: Segment[] = [];
   // Metronome wait that PRECEDED this tick — sits at the start of the timeline (visually before
-  // the tick's first phase). Surface only when non-zero — zero is the steady-state "no jitter".
-  if (bars.metronomeWaitUs > 0) {
-    out.push({ kind: 'metronome', durationUs: bars.metronomeWaitUs });
+  // the tick's first phase). Off by default per design §5.4 ("the metronome is what the engine
+  // wasn't doing — noise to most investigations"); flip the toolbar toggle to inspect throttling
+  // / sleep behaviour. Suppressed at zero either way (steady-state "no jitter").
+  if (showMetronome && bars.metronomeWaitUs > 0) {
+    out.push({ kind: 'metronome', durationUs: bars.metronomeWaitUs, intentClass: bars.metronomeIntentClass });
   }
-  bars.phases.forEach((phase, phaseIndex) => emitPhaseSegments(out, phase, phaseIndex));
+  bars.phases.forEach((phase, phaseIndex) => emitPhaseSegments(out, phase, phaseIndex, fullGantt));
   emitPostTickSegments(out, bars.postTick);
   return out;
 }
 
-function emitPhaseSegments(out: Segment[], phase: TickPathPhase, phaseIndex: number): void {
+function emitPhaseSegments(out: Segment[], phase: TickPathPhase, phaseIndex: number, fullGantt: boolean): void {
   for (const bar of phase.bars) {
     if (bar.workerClaimWaitUs > 0) {
       out.push({ kind: 'worker-claim', durationUs: bar.workerClaimWaitUs, phaseName: phase.name, phaseIndex, systemName: bar.systemName });
@@ -404,6 +489,15 @@ function emitPhaseSegments(out: Segment[], phase: TickPathPhase, phaseIndex: num
       out.push({ kind: 'chunk-dispatch', durationUs: bar.chunkDispatchWaitUs, phaseName: phase.name, phaseIndex, systemName: bar.systemName });
     }
     out.push({ kind: 'system', bar, phaseName: phase.name, phaseIndex, durationUs: bar.durationUs });
+  }
+  if (fullGantt) {
+    // Append non-CP bars after the CP bars in this phase. They render dimmed; their durations
+    // inflate `totalUs` (computed as the sum of segment durations later) so the timeline grows,
+    // but the CP focus stays visually distinct via the lower opacity. This is the v1 trade-off
+    // documented in `09-system-dag.md §5.6`: full-Gantt is "what else ran", not "real wall-clock".
+    for (const bar of phase.nonCpBars) {
+      out.push({ kind: 'non-cp-system', bar, phaseName: phase.name, phaseIndex, durationUs: bar.durationUs });
+    }
   }
   if (phase.phaseFenceWaitUs > 0) {
     out.push({ kind: 'phase-fence', durationUs: phase.phaseFenceWaitUs, phaseName: phase.name, phaseIndex, straggler: phase.phaseFenceStraggler });
@@ -505,6 +599,7 @@ function buildPhaseStripes(segments: Segment[], placement: Placement[], _totalUs
 function segmentPhaseName(seg: Segment): string {
   switch (seg.kind) {
     case 'system':
+    case 'non-cp-system':
     case 'worker-claim':
     case 'chunk-dispatch':
     case 'phase-fence':
@@ -519,6 +614,7 @@ function segmentPhaseName(seg: Segment): string {
 function segmentPhaseIndex(seg: Segment): number {
   switch (seg.kind) {
     case 'system':
+    case 'non-cp-system':
     case 'worker-claim':
     case 'chunk-dispatch':
     case 'phase-fence':
@@ -537,11 +633,17 @@ function PhaseStripe({
   orientation,
   majorTotalPx,
   headerBandPx,
+  isHovered,
+  onMouseEnter,
+  onMouseLeave,
 }: {
   stripe: PhaseStripeData;
   orientation: Orientation;
   majorTotalPx: number;
   headerBandPx: number;
+  isHovered: boolean;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
 }) {
   const colour = stripe.phaseIndex === -1
     ? { stroke: 'hsl(220, 8%, 60%)', fill: 'hsl(220, 8%, 25%)' }
@@ -558,10 +660,25 @@ function PhaseStripe({
   const stripeGapPx = 2;
   const stripeEnd = headerBandPx - stripeGapPx;
   const stripeStart = stripeEnd - stripePx;
+  // Hover visual: a slightly thicker, fully-opaque stripe + a faint band tint behind the stripe
+  // so the user can see the matched phase even when squinting at a tiny stripe segment.
+  const stripeFill = isHovered ? colour.stroke : colour.stroke;
+  const stripeOpacity = isHovered ? 1 : 0.95;
+  const stripeThickness = isHovered ? stripePx + 2 : stripePx;
   if (orientation === 'horizontal') {
     return (
       <g>
-        <rect x={startPx} y={stripeStart} width={lengthPx} height={stripePx} fill={colour.stroke} />
+        {isHovered && (
+          <rect x={startPx} y={0} width={lengthPx} height={headerBandPx} fill={colour.stroke} opacity={0.18} />
+        )}
+        <rect
+          x={startPx}
+          y={stripeStart - (stripeThickness - stripePx)}
+          width={lengthPx}
+          height={stripeThickness}
+          fill={stripeFill}
+          opacity={stripeOpacity}
+        />
         {lengthPx >= 40 && (
           <text
             x={startPx + 4}
@@ -574,13 +691,34 @@ function PhaseStripe({
             {stripe.phaseName}
           </text>
         )}
+        {/* Transparent hit-target spanning the full header band so hovering the label or the
+            empty band area also fires the sync, not just the 5 px stripe. */}
+        <rect
+          x={startPx}
+          y={0}
+          width={lengthPx}
+          height={headerBandPx}
+          fill="transparent"
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        />
       </g>
     );
   }
   // Vertical.
   return (
     <g>
-      <rect x={stripeStart} y={startPx} width={stripePx} height={lengthPx} fill={colour.stroke} />
+      {isHovered && (
+        <rect x={0} y={startPx} width={headerBandPx} height={lengthPx} fill={colour.stroke} opacity={0.18} />
+      )}
+      <rect
+        x={stripeStart - (stripeThickness - stripePx)}
+        y={startPx}
+        width={stripeThickness}
+        height={lengthPx}
+        fill={stripeFill}
+        opacity={stripeOpacity}
+      />
       {lengthPx >= 40 && (
         <text
           x={stripeStart - 3}
@@ -594,6 +732,15 @@ function PhaseStripe({
           {stripe.phaseName}
         </text>
       )}
+      <rect
+        x={0}
+        y={startPx}
+        width={headerBandPx}
+        height={lengthPx}
+        fill="transparent"
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      />
     </g>
   );
 }
@@ -608,6 +755,7 @@ function SegmentShape({
   barOffsetPx,
   barHeightPx,
   isSelected,
+  isHovered,
   onMouseEnter,
   onMouseLeave,
   onClick,
@@ -619,6 +767,7 @@ function SegmentShape({
   barOffsetPx: number;
   barHeightPx: number;
   isSelected: boolean;
+  isHovered: boolean;
   onMouseEnter: (e: React.MouseEvent<SVGElement>) => void;
   onMouseLeave: () => void;
   onClick: () => void;
@@ -630,14 +779,30 @@ function SegmentShape({
   // white ink rather than parsing HSL through the luminance helper. Wait segments are hatched
   // overlays without labels, so they don't need a text colour.
   const textFill =
-    seg.kind === 'system' ? pickTextColorFor(fill) :
+    seg.kind === 'system' || seg.kind === 'non-cp-system' ? pickTextColorFor(fill) :
     seg.kind === 'post-tick' ? '#fff' :
     undefined;
-  // Drop-shadow only on "active work" boxes — system + post-tick. Wait segments stay flat to
-  // visually read as "nothing happening here". `cp-shadow` is defined once at the SVG root.
+  // Drop-shadow only on "active work" boxes — system + post-tick. Wait segments + non-CP stay
+  // flat: non-CP runs are also "real work" but the dim opacity already reads as "supporting cast",
+  // and a shadow on them would compete with the CP-bar shadows for visual focus.
   const hasShadow = seg.kind === 'system' || seg.kind === 'post-tick';
-  const isClickable = seg.kind === 'system';
-  const showText = lengthPx >= 30 && (seg.kind === 'system' || seg.kind === 'post-tick');
+  // System bars (CP and non-CP) are clickable — selection jumps to the system either way. Phase-
+  // fence segments are clickable when a straggler is recorded — clicking jumps the selection to
+  // the straggler. Worker-claim waits are clickable too — they precede the system that was
+  // waiting, so clicking selects THAT system (the user's investigation target: "why couldn't a
+  // worker pick this up?"). Chunk-dispatch wait isn't clickable yet — placeholder kind in v1.
+  const isClickable = seg.kind === 'system'
+    || seg.kind === 'non-cp-system'
+    || (seg.kind === 'phase-fence' && seg.straggler != null)
+    || seg.kind === 'worker-claim';
+  // Metronome bars get a chip when an intentClass is known and there's enough room (~38 px). The
+  // chip text is short — `Headroom` / `Throttled` / `CatchUp` — so the threshold is lower than the
+  // 30 px we use for system / post-tick names. Drawn through the same showText path so it
+  // benefits from the per-orientation rotation logic.
+  const metronomeChip = seg.kind === 'metronome' && seg.intentClass != null && lengthPx >= 38
+    ? seg.intentClass
+    : null;
+  const showText = (lengthPx >= 30 && (seg.kind === 'system' || seg.kind === 'non-cp-system' || seg.kind === 'post-tick')) || metronomeChip != null;
   const showHatch = seg.kind === 'worker-claim' || seg.kind === 'chunk-dispatch' || seg.kind === 'phase-fence' || seg.kind === 'metronome';
 
   // Coordinates per orientation. Major = time axis; minor = bar row, offset by header band.
@@ -657,9 +822,15 @@ function SegmentShape({
         width={width}
         height={height}
         fill={fill}
-        opacity={showHatch ? 0.35 : 1}
-        stroke={isSelected ? 'hsl(var(--primary))' : 'transparent'}
-        strokeWidth={isSelected ? 2 : 0}
+        // Non-CP bars in full-Gantt mode read as "ran but off the critical path" via reduced
+        // opacity. CP bars stay opaque; wait/metronome use 0.35 to blend into the hatch.
+        opacity={showHatch ? 0.35 : seg.kind === 'non-cp-system' ? 0.4 : 1}
+        // Selection outranks hover — when a system is both clicked AND hovered, the primary
+        // ring stays put. Hover supplies a soft theme-foreground stroke at 60 % alpha, dialled
+        // down so it's visible against bright Turbo-palette fills without punching like ink in
+        // light theme.
+        stroke={isSelected ? 'hsl(var(--primary))' : isHovered ? 'hsl(var(--foreground) / 0.6)' : 'transparent'}
+        strokeWidth={isSelected ? 2 : isHovered ? 2 : 0}
         filter={hasShadow ? (orientation === 'horizontal' ? 'url(#cp-shadow-h)' : 'url(#cp-shadow-v)') : undefined}
         pointerEvents="none"
       />
@@ -684,7 +855,13 @@ function SegmentShape({
           textAnchor="middle"
           pointerEvents="none"
         >
-          {clipText(seg.kind === 'system' ? seg.bar.systemName : seg.kind === 'post-tick' ? seg.label : '', width - 8)}
+          {clipText(
+            seg.kind === 'system' ? seg.bar.systemName
+              : seg.kind === 'non-cp-system' ? seg.bar.systemName
+              : seg.kind === 'post-tick' ? seg.label
+              : metronomeChip ?? '',
+            width - 8,
+          )}
         </text>
       )}
       {/*
@@ -710,10 +887,13 @@ function SegmentShape({
 function colourForSegment(seg: Segment): string {
   switch (seg.kind) {
     case 'system':
+    case 'non-cp-system':
       // 13-colour Turbo ramp from the profiler's per-operation overview palette (`Cache Fetch`,
       // `Cache Allocate`, `Cache Evicted`, …). Cycled by a stable hash of `systemName` so a
       // given system always lands on the same hue across ticks / sessions. Phase identity comes
-      // from the header stripe; heat (duration) is conveyed by bar *length*, not colour.
+      // from the header stripe; heat (duration) is conveyed by bar *length*, not colour. Non-CP
+      // bars share the palette but render with reduced opacity (see `SegmentShape`) so they read
+      // as "ran but off the critical path".
       return TIMELINE_PALETTE[hashString(seg.bar.systemName) % TIMELINE_PALETTE.length];
     case 'worker-claim':
     case 'chunk-dispatch':
@@ -801,12 +981,20 @@ function describeSegment(seg: Segment): string[] {
       if (seg.bar.isParallel) lines.push(`parallel: ${seg.bar.workersTouched} workers / ${seg.bar.chunksProcessed} chunks`);
       return lines;
     }
+    case 'non-cp-system': {
+      const lines: string[] = [`${seg.bar.systemName} — ${formatUs(seg.bar.durationUs)}`];
+      lines.push(`phase: ${seg.phaseName || '(unphased)'}`);
+      lines.push('NOT on the critical path (full Gantt mode).');
+      if (seg.bar.isParallel) lines.push(`parallel: ${seg.bar.workersTouched} workers / ${seg.bar.chunksProcessed} chunks`);
+      return lines;
+    }
     case 'worker-claim':
       return [
         `Worker-claim wait — ${formatUs(seg.durationUs)}`,
         `before: ${seg.systemName}`,
         `phase: ${seg.phaseName}`,
         'Gap between deps cleared and a worker picking the system up.',
+        'Click to select the waiting system.',
       ];
     case 'chunk-dispatch':
       return [
@@ -815,17 +1003,32 @@ function describeSegment(seg: Segment): string[] {
         `phase: ${seg.phaseName}`,
         'Work-stealing imbalance across workers.',
       ];
-    case 'phase-fence':
-      return [
+    case 'phase-fence': {
+      const lines = [
         `Phase-fence wait — ${formatUs(seg.durationUs)}`,
         `phase: ${seg.phaseName}`,
         seg.straggler ? `straggler: ${seg.straggler}` : 'no straggler recorded',
         'CP waited for the slowest non-CP system to clear the fence.',
       ];
+      if (seg.straggler) lines.push('Click to jump to the straggler.');
+      return lines;
+    }
     case 'post-tick':
       return [`${seg.label} — ${formatUs(seg.durationUs)}`, 'Post-tick serial work.'];
-    case 'metronome':
-      return [`Metronome wait — ${formatUs(seg.durationUs)}`, 'Idle gap from previous TickEnd to this TickStart.'];
+    case 'metronome': {
+      const lines = [`Metronome wait — ${formatUs(seg.durationUs)}`];
+      if (seg.intentClass) lines.push(`intent: ${seg.intentClass} — ${describeIntent(seg.intentClass)}`);
+      lines.push('Idle gap from previous TickEnd to this TickStart.');
+      return lines;
+    }
+  }
+}
+
+function describeIntent(intent: MetronomeIntentClass): string {
+  switch (intent) {
+    case 'CatchUp':   return 'engine fell behind — wait elided';
+    case 'Throttled': return 'paced down for power / overload';
+    case 'Headroom':  return 'normal idle — work fits within tick budget';
   }
 }
 

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/__tests__/criticalPath.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/__tests__/criticalPath.test.ts
@@ -464,3 +464,59 @@ describe('dominantTickInRange', () => {
     expect(dominantTickInRange(ticks, { from: 3, to: 4 })).toBe(3);
   });
 });
+
+// ── Performance — #317 acceptance: 1024 ticks × 200 systems < 50 ms ───────
+
+describe('performance', () => {
+  /**
+   * Synthetic worst-case-ish workload: 200 systems split evenly across 5 phases (40 systems per
+   * phase), each phase forming a linear chain (40 intra-phase edges per phase = 200 edges total),
+   * 1024 ticks of rows. Mirrors the #317 acceptance threshold from `09-system-dag.md §11 Phase 3`.
+   *
+   * The walker is O(systems × ticks) per `computeCriticalPathParticipation`; on a typical dev box
+   * 1024 × 200 lands well under 50 ms. We assert against 200 ms instead of 50 to absorb CI
+   * variance (slow machines, GC pauses) without making the test flaky — the 50 ms target is the
+   * design budget on a typical workstation, not a hard ceiling enforceable in CI.
+   */
+  it('1024 ticks × 200 systems CP participation under 200 ms (target 50 ms)', () => {
+    const PHASE_COUNT = 5;
+    const PHASE_NAMES = Array.from({ length: PHASE_COUNT }, (_, i) => `p${i}`);
+    const SYSTEMS_PER_PHASE = 40;
+    const SYSTEM_COUNT = PHASE_COUNT * SYSTEMS_PER_PHASE;
+    const TICK_COUNT = 1024;
+
+    // Build systems with predecessors[] populated (engine-built path the walker prefers).
+    const systems: SystemDefinitionDto[] = [];
+    for (let p = 0; p < PHASE_COUNT; p++) {
+      for (let i = 0; i < SYSTEMS_PER_PHASE; i++) {
+        const idx = p * SYSTEMS_PER_PHASE + i;
+        const preds = i > 0 ? [idx - 1] : [];
+        systems.push(sys(`s${idx}`, idx, PHASE_NAMES[p], { predecessors: preds }));
+      }
+    }
+
+    // Per-tick rows for every system. Vary durations slightly per tick so different ticks pick
+    // different terminus systems — exercises the traceback path on every tick.
+    const rows: SystemTickSummary[] = [];
+    for (let t = 1; t <= TICK_COUNT; t++) {
+      for (let s = 0; s < SYSTEM_COUNT; s++) {
+        // Duration: hash of (tick, system) so results aren't degenerate (all-equal would let
+        // first-system always win the tie). 1..100 µs.
+        const dur = (((t * 31 + s) * 17) % 100) + 1;
+        rows.push(row(t, s, dur));
+      }
+    }
+
+    const start = performance.now();
+    const result = computeCriticalPathParticipation({
+      systems, rows, edges: [], phases: PHASE_NAMES, range: { from: 1, to: TICK_COUNT },
+    });
+    const elapsedMs = performance.now() - start;
+
+    expect(result.totalTicks).toBe(TICK_COUNT);
+    expect(elapsedMs).toBeLessThan(200);
+    // Sanity: every CP across the range should hit at least one system per phase (linear chain
+    // forces it). So the total perSystem map should have entries for some systems in every phase.
+    expect(result.perSystem.size).toBeGreaterThan(0);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/__tests__/criticalPath.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/__tests__/criticalPath.test.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from 'vitest';
+import type { PostTickSummary } from '@/api/generated/model/postTickSummary';
+import type { SystemDefinitionDto } from '@/api/generated/model/systemDefinitionDto';
+import type { SystemTickSummary } from '@/api/generated/model/systemTickSummary';
+import type { TickSummaryDto } from '@/api/generated/model/tickSummaryDto';
+import {
+  computeCriticalPathForTick,
+  computeCriticalPathParticipation,
+  dominantTickInRange,
+} from '../criticalPath';
+import type { DerivedEdge } from '../../SystemDag/edgeDerivation';
+
+/**
+ * Synthetic fixtures for the client-side critical-path algorithm. Each test fabricates a tiny
+ * topology + a per-tick row stream and asserts which systems land on the CP.
+ *
+ * The algorithm is per `09-system-dag.md §9.3`: client-side, no engine cost. v1 ignores wait
+ * classification (phase-fence vs worker-claim) and post-tick serial — these tests exercise the
+ * core "max-pathDurationTo with traceback" walk over a phase-ordered DAG.
+ */
+
+function sys(name: string, index: number, phase: string, opts?: Partial<SystemDefinitionDto>): SystemDefinitionDto {
+  return {
+    index,
+    name,
+    type: 0,
+    priority: 0,
+    isParallel: false,
+    tierFilter: 0x0F,
+    predecessors: [],
+    successors: [],
+    phaseName: phase,
+    isExclusivePhase: false,
+    reads: [],
+    readsFresh: [],
+    readsSnapshot: [],
+    additionalReads: [],
+    writes: [],
+    sideWrites: [],
+    writesEvents: [],
+    readsEvents: [],
+    writesResources: [],
+    readsResources: [],
+    explicitAfter: [],
+    explicitBefore: [],
+    ...opts,
+  } as SystemDefinitionDto;
+}
+
+function row(tick: number, sysIdx: number, durationUs: number): SystemTickSummary {
+  return {
+    tickNumber: tick,
+    systemIndex: sysIdx,
+    skipReasonCode: 0,
+    flags: 0,
+    startUs: 0,
+    endUs: durationUs,
+    readyUs: 0,
+    durationUs,
+    entitiesProcessed: 0,
+    workersTouched: 0,
+    chunksProcessed: 0,
+  } as unknown as SystemTickSummary;
+}
+
+function edge(source: string, target: string, kind: DerivedEdge['kind'] = 'fresh'): DerivedEdge {
+  return { id: `e-${source}-${target}`, source, target, kind, via: ['t'], reason: '' };
+}
+
+describe('computeCriticalPathParticipation', () => {
+  it('returns empty perSystem when no rows fall in range', () => {
+    const r = computeCriticalPathParticipation({
+      systems: [sys('A', 0, 'p1')],
+      rows: [],
+      edges: [],
+      phases: ['p1'],
+      range: null,
+    });
+    expect(r.perSystem.size).toBe(0);
+    expect(r.totalTicks).toBe(0);
+  });
+
+  it('linear chain: all three systems on CP every tick → rate 1.0 each', () => {
+    // p1: A → B → C (all in same phase, durations 100/200/50). CP = A→B→C every tick.
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1'), sys('C', 2, 'p1')];
+    const edges = [edge('A', 'B'), edge('B', 'C')];
+    const rows = [
+      row(1, 0, 100), row(1, 1, 200), row(1, 2, 50),
+      row(2, 0, 100), row(2, 1, 200), row(2, 2, 50),
+    ];
+    const r = computeCriticalPathParticipation({ systems, rows, edges, phases: ['p1'], range: null });
+    expect(r.totalTicks).toBe(2);
+    expect(r.perSystem.get('A')?.rate).toBe(1);
+    expect(r.perSystem.get('B')?.rate).toBe(1);
+    expect(r.perSystem.get('C')?.rate).toBe(1);
+  });
+
+  it('parallel branches: only the heavier branch is on the CP', () => {
+    // p1:  A ─→ B ─→ D
+    //        ╲    ╱
+    //         ╲  ╱
+    //          C  (lighter branch, both into D)
+    // Durations: A=10, B=100, C=10, D=10. Heavy path A→B→D dominates; C never on CP.
+    const systems = [
+      sys('A', 0, 'p1'),
+      sys('B', 1, 'p1'),
+      sys('C', 2, 'p1'),
+      sys('D', 3, 'p1'),
+    ];
+    const edges = [edge('A', 'B'), edge('A', 'C'), edge('B', 'D'), edge('C', 'D')];
+    const rows = [
+      row(1, 0, 10),
+      row(1, 1, 100),
+      row(1, 2, 10),
+      row(1, 3, 10),
+    ];
+    const r = computeCriticalPathParticipation({ systems, rows, edges, phases: ['p1'], range: null });
+    expect(r.perSystem.get('A')?.rate).toBe(1);
+    expect(r.perSystem.get('B')?.rate).toBe(1);
+    expect(r.perSystem.get('D')?.rate).toBe(1);
+    expect(r.perSystem.get('C')?.rate ?? 0).toBe(0);
+  });
+
+  it('branch dominance flips per tick → fractional rates reflect both', () => {
+    // Same topology as above. Tick 1: B heavy. Tick 2: C heavy. Each on CP for one of two ticks.
+    const systems = [
+      sys('A', 0, 'p1'),
+      sys('B', 1, 'p1'),
+      sys('C', 2, 'p1'),
+      sys('D', 3, 'p1'),
+    ];
+    const edges = [edge('A', 'B'), edge('A', 'C'), edge('B', 'D'), edge('C', 'D')];
+    const rows = [
+      // tick 1 — B heavy
+      row(1, 0, 10), row(1, 1, 100), row(1, 2, 10), row(1, 3, 10),
+      // tick 2 — C heavy
+      row(2, 0, 10), row(2, 1, 10), row(2, 2, 100), row(2, 3, 10),
+    ];
+    const r = computeCriticalPathParticipation({ systems, rows, edges, phases: ['p1'], range: null });
+    expect(r.totalTicks).toBe(2);
+    expect(r.perSystem.get('A')?.rate).toBe(1);
+    expect(r.perSystem.get('D')?.rate).toBe(1);
+    expect(r.perSystem.get('B')?.rate).toBe(0.5);
+    expect(r.perSystem.get('C')?.rate).toBe(0.5);
+  });
+
+  it('phase fence: phase-2 system inherits phase-1 max as its base path duration', () => {
+    // p1: A=100, B=10 (parallel, no edges). p2: C=20 (no in-phase preds → phase-fence).
+    // CP terminates at C; traceback should include A (phase-fence dominator) → C.
+    const systems = [
+      sys('A', 0, 'p1'),
+      sys('B', 1, 'p1'),
+      sys('C', 2, 'p2'),
+    ];
+    const rows = [row(1, 0, 100), row(1, 1, 10), row(1, 2, 20)];
+    const r = computeCriticalPathParticipation({ systems, rows, edges: [], phases: ['p1', 'p2'], range: null });
+    expect(r.perSystem.get('A')?.rate).toBe(1);
+    expect(r.perSystem.get('C')?.rate).toBe(1);
+    // B never on CP.
+    expect(r.perSystem.get('B')?.rate ?? 0).toBe(0);
+  });
+
+  it('skipped system (no row) cannot be on the CP', () => {
+    // If B has no row this tick (skipped — e.g. NoDirty), it must not appear on the CP.
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1')];
+    const edges = [edge('A', 'B')];
+    const rows = [
+      row(1, 0, 100),
+      // no row for B at tick 1 — it skipped
+    ];
+    const r = computeCriticalPathParticipation({ systems, rows, edges, phases: ['p1'], range: null });
+    expect(r.perSystem.get('A')?.rate).toBe(1);
+    expect(r.perSystem.get('B')?.rate ?? 0).toBe(0);
+  });
+
+  it('range filter: only ticks in [from, to] are counted', () => {
+    const systems = [sys('A', 0, 'p1')];
+    const rows = [row(1, 0, 10), row(2, 0, 10), row(3, 0, 10), row(4, 0, 10)];
+    const r = computeCriticalPathParticipation({
+      systems,
+      rows,
+      edges: [],
+      phases: ['p1'],
+      range: { from: 2, to: 3 },
+    });
+    expect(r.totalTicks).toBe(2);
+    expect(r.perSystem.get('A')?.onPathTicks).toBe(2);
+    expect(r.perSystem.get('A')?.rate).toBe(1);
+  });
+
+  it('rate is bounded to [0, 1]', () => {
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1')];
+    const rows = [
+      row(1, 0, 100), row(1, 1, 10),
+      row(2, 0, 10), row(2, 1, 100),
+      row(3, 0, 50), row(3, 1, 50), // tie → traceback picks one consistently; just make sure rate is [0,1]
+    ];
+    const r = computeCriticalPathParticipation({ systems, rows, edges: [], phases: ['p1'], range: null });
+    for (const stat of r.perSystem.values()) {
+      expect(stat.rate).toBeGreaterThanOrEqual(0);
+      expect(stat.rate).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('cross-phase edges are ignored (phase fence is the contract)', () => {
+    // Cross-phase edges shouldn't add to predecessor lists; phase fence handles ordering.
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p2')];
+    // A → B is cross-phase — algorithm must ignore the explicit edge and rely on the fence.
+    const edges = [edge('A', 'B')];
+    const rows = [row(1, 0, 30), row(1, 1, 70)];
+    const r = computeCriticalPathParticipation({ systems, rows, edges, phases: ['p1', 'p2'], range: null });
+    expect(r.perSystem.get('A')?.rate).toBe(1);
+    expect(r.perSystem.get('B')?.rate).toBe(1);
+  });
+});
+
+// ── per-tick tape data ────────────────────────────────────────────────────
+
+/** Richer row helper for tape tests — needs startUs, endUs, readyUs explicitly set. */
+function detailedRow(opts: {
+  tick: number; sysIdx: number; durationUs: number;
+  startUs?: number; endUs?: number; readyUs?: number;
+  workersTouched?: number; chunksProcessed?: number;
+}): SystemTickSummary {
+  return {
+    tickNumber: opts.tick,
+    systemIndex: opts.sysIdx,
+    skipReasonCode: 0,
+    flags: 0,
+    startUs: opts.startUs ?? 0,
+    endUs: opts.endUs ?? opts.durationUs,
+    readyUs: opts.readyUs ?? 0,
+    durationUs: opts.durationUs,
+    entitiesProcessed: 0,
+    workersTouched: opts.workersTouched ?? 0,
+    chunksProcessed: opts.chunksProcessed ?? 0,
+  } as unknown as SystemTickSummary;
+}
+
+function tickSummary(tickNumber: number, durationUs: number, metronomeWaitUs = 0): TickSummaryDto {
+  return {
+    tickNumber, durationUs, metronomeWaitUs,
+    eventCount: 0, maxSystemDurationUs: durationUs,
+    activeSystemsBitmask: '0', overloadLevel: 0, tickMultiplier: 0,
+    startUs: 0, metronomeIntentClass: 0, consecutiveOverrun: 0, consecutiveUnderrun: 0,
+  } as unknown as TickSummaryDto;
+}
+
+function postTick(tick: number, opts: Partial<PostTickSummary> = {}): PostTickSummary {
+  return {
+    tickNumber: tick,
+    writeTickFenceUs: 0, walFlushUs: 0, subscriptionOutputUs: 0,
+    tierIndexRebuildUs: 0, dormancySweepUs: 0, tierBudgetUs: 0,
+    ...opts,
+  } as unknown as PostTickSummary;
+}
+
+describe('computeCriticalPathForTick', () => {
+  it('returns null when no rows match the tick', () => {
+    const r = computeCriticalPathForTick({
+      tickNumber: 99,
+      systems: [sys('A', 0, 'p1')],
+      rows: [],
+      edges: [],
+      phases: ['p1'],
+      postTickRows: [],
+      tickSummaryRow: null,
+    });
+    expect(r).toBeNull();
+  });
+
+  it('orderedPath flows in forward execution order (root → terminus)', () => {
+    // Linear A → B → C; durations 100/50/200. CP = A→B→C; bars should appear A first, C last.
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1'), sys('C', 2, 'p1')];
+    const edges = [edge('A', 'B'), edge('B', 'C')];
+    const rows = [
+      detailedRow({ tick: 1, sysIdx: 0, durationUs: 100 }),
+      detailedRow({ tick: 1, sysIdx: 1, durationUs: 50 }),
+      detailedRow({ tick: 1, sysIdx: 2, durationUs: 200 }),
+    ];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges, phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 350),
+    });
+    expect(r).not.toBeNull();
+    expect(r!.phases).toHaveLength(1);
+    expect(r!.phases[0].bars.map((b) => b.systemName)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('worker-claim wait = startUs - readyUs when readyUs is captured', () => {
+    const systems = [sys('A', 0, 'p1')];
+    const rows = [detailedRow({ tick: 1, sysIdx: 0, durationUs: 100, readyUs: 10, startUs: 30, endUs: 130 })];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 130),
+    });
+    expect(r!.phases[0].bars[0].workerClaimWaitUs).toBe(20);
+  });
+
+  it('worker-claim wait suppressed when readyUs == 0 (pre-#311 traces)', () => {
+    const systems = [sys('A', 0, 'p1')];
+    const rows = [detailedRow({ tick: 1, sysIdx: 0, durationUs: 100, readyUs: 0, startUs: 30, endUs: 130 })];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 130),
+    });
+    expect(r!.phases[0].bars[0].workerClaimWaitUs).toBe(0);
+  });
+
+  it('phase-fence wait = phase max EndUs minus CP-tail EndUs', () => {
+    // A on the CP, finishes at endUs=100. B is a non-CP straggler, finishes at endUs=180.
+    // phase-fence wait should be 80, attributed to B.
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1')];
+    const rows = [
+      detailedRow({ tick: 1, sysIdx: 0, durationUs: 100, endUs: 100 }),
+      detailedRow({ tick: 1, sysIdx: 1, durationUs: 180, endUs: 180 }), // not on CP edge-wise
+    ];
+    // Edges: empty — A and B are independent. CP terminus = B (longer). Hmm.
+    // Tweak: make A larger so it dominates. A=200, B=180.
+    rows[0] = detailedRow({ tick: 1, sysIdx: 0, durationUs: 200, endUs: 200 });
+    rows[1] = detailedRow({ tick: 1, sysIdx: 1, durationUs: 180, endUs: 180 });
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 200),
+    });
+    // A is the CP terminus (endUs=200), so phase max == CP-tail end → no wait reported.
+    expect(r!.phases[0].phaseFenceWaitUs).toBe(0);
+
+    // Now flip: B has bigger endUs (straggler) but A is on the CP via edge ordering.
+    const edges2 = [edge('A', 'B')]; // forces A → B, B becomes CP terminus
+    rows[0] = detailedRow({ tick: 1, sysIdx: 0, durationUs: 100, endUs: 100 });
+    rows[1] = detailedRow({ tick: 1, sysIdx: 1, durationUs: 80, endUs: 180 });
+    const r2 = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: edges2, phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 180),
+    });
+    // B IS on CP (terminus); B is also the phase straggler — no wait because the CP holds it.
+    expect(r2!.phases[0].phaseFenceWaitUs).toBe(0);
+
+    // Real fence wait scenario: A and B in same phase, A is on CP (no edge to B), B is a
+    // straggler that finishes later — but A's path duration dominates. We use a self-loop on A
+    // to force critical-path mode (edges.length > 0) without otherwise perturbing the walk; a
+    // self-loop has no effect on path semantics because pathDurationTo[A] isn't yet set when
+    // computing A's own bestPredPathTo.
+    const rows3 = [
+      detailedRow({ tick: 1, sysIdx: 0, durationUs: 200, endUs: 200 }),
+      detailedRow({ tick: 1, sysIdx: 1, durationUs: 50, endUs: 220 }), // started later, finishes after A
+    ];
+    const r3 = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows: rows3, edges: [edge('A', 'A')], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 220),
+    });
+    expect(r3!.phases[0].phaseFenceWaitUs).toBe(20);
+    expect(r3!.phases[0].phaseFenceStraggler).toBe('B');
+  });
+
+  it('post-tick block populates from PostTickSummary', () => {
+    const systems = [sys('A', 0, 'p1')];
+    const rows = [detailedRow({ tick: 1, sysIdx: 0, durationUs: 100 })];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [postTick(1, { walFlushUs: 50, writeTickFenceUs: 10 })],
+      tickSummaryRow: tickSummary(1, 100),
+    });
+    expect(r!.postTick.walFlushUs).toBe(50);
+    expect(r!.postTick.writeTickFenceUs).toBe(10);
+    expect(r!.postTick.totalUs).toBe(60);
+  });
+
+  it('metronomeWaitUs propagated from tickSummaryRow', () => {
+    const systems = [sys('A', 0, 'p1')];
+    const rows = [detailedRow({ tick: 1, sysIdx: 0, durationUs: 100 })];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 100, /* metronomeWaitUs */ 250),
+    });
+    expect(r!.metronomeWaitUs).toBe(250);
+  });
+
+  it('fallback: no edges → all running systems on the path, sorted by startUs', () => {
+    // Three systems, no edges (e.g. trace lacks RFC 07 declarations). Without the dependency
+    // graph the dependency-aware walker would emit only the longest-duration system; the
+    // fallback should emit all three in startUs order.
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1'), sys('C', 2, 'p1')];
+    const rows = [
+      detailedRow({ tick: 1, sysIdx: 0, durationUs: 100, startUs: 200, endUs: 300 }),  // 2nd
+      detailedRow({ tick: 1, sysIdx: 1, durationUs: 50, startUs: 0, endUs: 50 }),       // 1st
+      detailedRow({ tick: 1, sysIdx: 2, durationUs: 30, startUs: 400, endUs: 430 }),    // 3rd
+    ];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 430),
+    });
+    expect(r).not.toBeNull();
+    expect(r!.mode).toBe('execution-order');
+    expect(r!.phases[0].bars.map((b) => b.systemName)).toEqual(['B', 'A', 'C']);
+  });
+
+  it('fallback: skipped systems (durationUs == 0) excluded from path', () => {
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1')];
+    const rows = [
+      detailedRow({ tick: 1, sysIdx: 0, durationUs: 100, startUs: 0, endUs: 100 }),
+      detailedRow({ tick: 1, sysIdx: 1, durationUs: 0, startUs: 0, endUs: 0 }),  // skipped
+    ];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 100),
+    });
+    expect(r!.phases[0].bars.map((b) => b.systemName)).toEqual(['A']);
+  });
+
+  it('mode reports critical-path when edges exist', () => {
+    const systems = [sys('A', 0, 'p1'), sys('B', 1, 'p1')];
+    const rows = [
+      detailedRow({ tick: 1, sysIdx: 0, durationUs: 100 }),
+      detailedRow({ tick: 1, sysIdx: 1, durationUs: 50 }),
+    ];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows,
+      edges: [edge('A', 'B')],
+      phases: ['p1'],
+      postTickRows: [],
+      tickSummaryRow: tickSummary(1, 150),
+    });
+    expect(r!.mode).toBe('critical-path');
+  });
+
+  it('chunkDispatchWaitUs is structurally present and zero in v1', () => {
+    const systems = [sys('A', 0, 'p1')];
+    const rows = [detailedRow({ tick: 1, sysIdx: 0, durationUs: 100, workersTouched: 4, chunksProcessed: 16 })];
+    const r = computeCriticalPathForTick({
+      tickNumber: 1, systems, rows, edges: [], phases: ['p1'],
+      postTickRows: [], tickSummaryRow: tickSummary(1, 100),
+    });
+    expect(r!.phases[0].bars[0].chunkDispatchWaitUs).toBe(0);
+    expect(r!.phases[0].bars[0].workersTouched).toBe(4);
+    expect(r!.phases[0].bars[0].chunksProcessed).toBe(16);
+  });
+});
+
+describe('dominantTickInRange', () => {
+  it('returns null on empty inputs', () => {
+    expect(dominantTickInRange(null, { from: 1, to: 10 })).toBeNull();
+    expect(dominantTickInRange([], { from: 1, to: 10 })).toBeNull();
+    expect(dominantTickInRange([tickSummary(1, 100)], null)).toBeNull();
+  });
+
+  it('picks the longest-durationUs tick in range', () => {
+    const ticks = [
+      tickSummary(1, 100),
+      tickSummary(2, 500),  // ← winner
+      tickSummary(3, 200),
+      tickSummary(4, 50),
+    ];
+    expect(dominantTickInRange(ticks, { from: 1, to: 4 })).toBe(2);
+  });
+
+  it('respects the range — out-of-range ticks ignored even if longer', () => {
+    const ticks = [
+      tickSummary(1, 50),
+      tickSummary(2, 9999), // out of range
+      tickSummary(3, 100),  // ← winner inside range
+    ];
+    expect(dominantTickInRange(ticks, { from: 3, to: 4 })).toBe(3);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/criticalPath.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/criticalPath.ts
@@ -1,0 +1,606 @@
+import type { PostTickSummary } from '@/api/generated/model/postTickSummary';
+import type { SystemDefinitionDto } from '@/api/generated/model/systemDefinitionDto';
+import type { SystemTickSummary } from '@/api/generated/model/systemTickSummary';
+import type { TickSummaryDto } from '@/api/generated/model/tickSummaryDto';
+import type { DerivedEdge } from '../SystemDag/edgeDerivation';
+import type { TickRange } from '../SystemDag/useDagViewStore';
+
+/**
+ * Critical-path computation — client-side per `09-system-dag.md §9.3` ("Why client-side: zero
+ * engine cost when the workbench isn't attached; iterate freely on the algorithm... without
+ * redeploying").
+ *
+ * v1 algorithm: per tick, walk systems in phase order; pathDurationTo[S] = duration[S] + max of
+ * (intra-phase predecessor pathDurationTo, previous-phase phase-fence). Traceback from the
+ * max-pathDurationTo system at the last phase yields the critical path for that tick. Per-system
+ * participation rate = (ticks on which the system was on the CP) / (total ticks examined).
+ *
+ * **What v1 does NOT model** (deferred to #317 Phase 3):
+ * - Wait classification (phase-fence vs worker-claim vs chunk-dispatch) — we use raw
+ *   pathDurationTo without distinguishing wait classes. The CP-rate stat doesn't depend on which
+ *   bucket the wait falls in; the §5.2 wait segments do.
+ * - Post-tick serial block — adds a constant tail, doesn't affect which user-system is on the CP.
+ * - Compound systems — treated atomically through their parent declaration; expanding to walk
+ *   into compound children needs `09-system-dag.md §4.4`'s parent-node feature first.
+ *
+ * **Returned shape** uses raw counts so callers can re-use the count in downstream displays
+ * ("on CP 73% — 743 of 1024 ticks") without recomputing.
+ */
+export interface CriticalPathParticipation {
+  /** systemName → participation. Systems that never ran in the range are absent from the map. */
+  perSystem: Map<string, { onPathTicks: number; rate: number }>;
+  /** Total ticks the algorithm examined — useful for "X of Y" displays. */
+  totalTicks: number;
+}
+
+export interface CriticalPathInputs {
+  systems: SystemDefinitionDto[];
+  /** Per-tick per-system rows from `metadata.systemTickSummaries`. */
+  rows: SystemTickSummary[];
+  /** Edges from {@link deriveEdges}. Inter-phase edges are tolerated and ignored at walk time. */
+  edges: DerivedEdge[];
+  /** Phase names in declared order (`topology.phases`). */
+  phases: string[];
+  /** Tick range to consider. `null` means all rows. */
+  range: TickRange | null;
+}
+
+export function computeCriticalPathParticipation(input: CriticalPathInputs): CriticalPathParticipation {
+  const { systems, rows, edges, phases, range } = input;
+
+  // ── Build name-keyed lookups once (re-used across all ticks). ───────────
+  const indexToName = new Map<number, string>();
+  const nameToPhase = new Map<string, string>();
+  for (const s of systems) {
+    if (!s.name) continue;
+    const idx = numberValue(s.index);
+    if (idx == null) continue;
+    indexToName.set(idx, s.name);
+    nameToPhase.set(s.name, s.phaseName ?? '');
+  }
+
+  // Predecessors map: targetSystemName → [sourceSystemNames]. Restricted to intra-phase edges
+  // (cross-phase pairs use the phase-fence rule instead of an explicit edge).
+  const predecessorsByName = new Map<string, string[]>();
+  for (const e of edges) {
+    const sPhase = nameToPhase.get(e.source);
+    const tPhase = nameToPhase.get(e.target);
+    if (!sPhase || !tPhase || sPhase !== tPhase) continue;
+    let preds = predecessorsByName.get(e.target);
+    if (!preds) {
+      preds = [];
+      predecessorsByName.set(e.target, preds);
+    }
+    preds.push(e.source);
+  }
+
+  // Phase index map for quick "is phase A before phase B" comparisons.
+  const phaseIndex = new Map<string, number>();
+  phases.forEach((p, i) => phaseIndex.set(p, i));
+
+  // Systems grouped by phase, in declared order; unknown-phase systems live in a synthetic last
+  // group keyed by '' (empty string).
+  const phasesWithSystems: Array<{ phase: string; names: string[] }> = [];
+  for (const p of phases) phasesWithSystems.push({ phase: p, names: [] });
+  const synthetic: { phase: string; names: string[] } = { phase: '', names: [] };
+  for (const s of systems) {
+    if (!s.name) continue;
+    const phase = s.phaseName ?? '';
+    if (phase && phaseIndex.has(phase)) {
+      phasesWithSystems[phaseIndex.get(phase)!].names.push(s.name);
+    } else {
+      synthetic.names.push(s.name);
+    }
+  }
+  if (synthetic.names.length > 0) phasesWithSystems.push(synthetic);
+
+  // ── Bucket rows by tick number, filtered to range. ─────────────────────
+  const byTick = new Map<number, Map<string, number>>(); // tick → systemName → durationUs
+  for (const r of rows) {
+    const tick = numberValue(r.tickNumber);
+    if (tick == null) continue;
+    if (range && (tick < range.from || tick > range.to)) continue;
+    const sysIdx = numberValue(r.systemIndex);
+    if (sysIdx == null) continue;
+    const name = indexToName.get(sysIdx);
+    if (!name) continue;
+    const duration = numberValue(r.durationUs) ?? 0;
+    let bucket = byTick.get(tick);
+    if (!bucket) {
+      bucket = new Map<string, number>();
+      byTick.set(tick, bucket);
+    }
+    bucket.set(name, duration);
+  }
+
+  const onPathTicksByName = new Map<string, number>();
+  let totalTicks = 0;
+
+  for (const [, durationByName] of byTick) {
+    totalTicks++;
+    const { onPath } = walkOneTick({
+      durationByName,
+      phasesWithSystems,
+      predecessorsByName,
+    });
+    for (const name of onPath) {
+      onPathTicksByName.set(name, (onPathTicksByName.get(name) ?? 0) + 1);
+    }
+  }
+
+  const perSystem = new Map<string, { onPathTicks: number; rate: number }>();
+  for (const [name, onPathTicks] of onPathTicksByName) {
+    perSystem.set(name, {
+      onPathTicks,
+      rate: totalTicks > 0 ? onPathTicks / totalTicks : 0,
+    });
+  }
+  return { perSystem, totalTicks };
+}
+
+// ── Per-tick walk ─────────────────────────────────────────────────────────
+
+interface WalkInput {
+  durationByName: Map<string, number>;
+  phasesWithSystems: Array<{ phase: string; names: string[] }>;
+  predecessorsByName: Map<string, string[]>;
+}
+
+interface WalkResult {
+  /** Membership set — used by participation-rate aggregation across many ticks. */
+  onPath: Set<string>;
+  /** Forward execution order — first system on the path → terminus. Used by the tape renderer. */
+  orderedPath: string[];
+}
+
+/**
+ * Returns the set + ordered list of system names on the critical path for a single tick. Systems
+ * that didn't run (no row this tick — i.e. skipped or filtered) contribute zero duration AND zero
+ * pathDurationTo — they cannot be on the critical path.
+ */
+function walkOneTick(input: WalkInput): WalkResult {
+  const { durationByName, phasesWithSystems, predecessorsByName } = input;
+  // pathDurationTo[name] = wall-clock to finish this system, summing predecessors.
+  const pathDurationTo = new Map<string, number>();
+  // bestPredecessor[name] = the source name that maximised pathDurationTo[name] — used for traceback.
+  // null sentinel means "no predecessor; root of the path."
+  const bestPredecessor = new Map<string, string | null>();
+
+  let phaseFenceFloor = 0;
+  let phaseFenceSystem: string | null = null;
+
+  for (const phase of phasesWithSystems) {
+    let phaseMax = 0;
+    let phaseMaxName: string | null = null;
+    for (const name of phase.names) {
+      const duration = durationByName.get(name);
+      if (duration == null || duration <= 0) {
+        // Skipped / didn't run — leave out of pathDurationTo so it can't be on the CP.
+        continue;
+      }
+      let bestPred: string | null = null;
+      let bestPredPathTo = 0;
+      const preds = predecessorsByName.get(name) ?? [];
+      for (const p of preds) {
+        const pathTo = pathDurationTo.get(p);
+        if (pathTo != null && pathTo > bestPredPathTo) {
+          bestPredPathTo = pathTo;
+          bestPred = p;
+        }
+      }
+      // Phase-fence rule: a fresh phase starts after all of the previous phase finishes. If the
+      // fence dominates an in-phase predecessor, the fence "predecessor" is the previous phase's
+      // max-pathDurationTo system.
+      let baseDuration: number;
+      let chosenPred: string | null;
+      if (bestPredPathTo >= phaseFenceFloor) {
+        baseDuration = bestPredPathTo;
+        chosenPred = bestPred;
+      } else {
+        baseDuration = phaseFenceFloor;
+        chosenPred = phaseFenceSystem;
+      }
+      const pathTo = baseDuration + duration;
+      pathDurationTo.set(name, pathTo);
+      bestPredecessor.set(name, chosenPred);
+      if (pathTo > phaseMax) {
+        phaseMax = pathTo;
+        phaseMaxName = name;
+      }
+    }
+    if (phaseMaxName != null && phaseMax > phaseFenceFloor) {
+      phaseFenceFloor = phaseMax;
+      phaseFenceSystem = phaseMaxName;
+    }
+  }
+
+  // Terminus = system with overall max pathDurationTo (last phase that produced anything).
+  let terminus: string | null = null;
+  let terminusPathTo = 0;
+  for (const [name, pathTo] of pathDurationTo) {
+    if (pathTo > terminusPathTo) {
+      terminusPathTo = pathTo;
+      terminus = name;
+    }
+  }
+  if (terminus == null) return { onPath: new Set<string>(), orderedPath: [] };
+
+  // Traceback walks back through bestPredecessor; we collect in reverse, then flip so the
+  // returned `orderedPath` is in forward execution order (root → terminus). The renderer wants
+  // forward order so bars stack top-to-bottom in time.
+  const onPath = new Set<string>();
+  const reverse: string[] = [];
+  let cursor: string | null = terminus;
+  // Bound the walk by total entries to avoid an infinite loop on a buggy bestPredecessor map.
+  let safety = pathDurationTo.size + 2;
+  while (cursor != null && safety-- > 0) {
+    onPath.add(cursor);
+    reverse.push(cursor);
+    cursor = bestPredecessor.get(cursor) ?? null;
+  }
+  return { onPath, orderedPath: reverse.reverse() };
+}
+
+function numberValue(v: unknown): number | null {
+  if (v == null) return null;
+  const n = typeof v === 'number' ? v : Number(v as string);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Per-system skip rate over a tick range — `(rows with SkipReasonCode > 0) / (total rows for that
+ * system)`. Skipped rows still have a SystemTickSummary entry (the engine records the skip decision
+ * as telemetry), so the denominator includes them. Returns `null` for systems with zero rows in
+ * the range — rendering should treat them as "didn't run" rather than "skipped 0%".
+ */
+export function computeSystemSkipRates(input: {
+  systems: SystemDefinitionDto[];
+  rows: SystemTickSummary[];
+  range: TickRange | null;
+}): Map<string, number> {
+  const { systems, rows, range } = input;
+  const indexToName = new Map<number, string>();
+  for (const s of systems) {
+    if (!s.name) continue;
+    const idx = numberValue((s as { index?: unknown }).index);
+    if (idx != null) indexToName.set(idx, s.name);
+  }
+
+  const totals = new Map<string, number>();
+  const skipped = new Map<string, number>();
+  for (const r of rows) {
+    const tick = numberValue((r as { tickNumber?: unknown }).tickNumber);
+    if (tick == null) continue;
+    if (range && (tick < range.from || tick > range.to)) continue;
+    const sysIdx = numberValue((r as { systemIndex?: unknown }).systemIndex);
+    if (sysIdx == null) continue;
+    const name = indexToName.get(sysIdx);
+    if (!name) continue;
+    totals.set(name, (totals.get(name) ?? 0) + 1);
+    const skip = numberValue((r as { skipReasonCode?: unknown }).skipReasonCode) ?? 0;
+    if (skip > 0) {
+      skipped.set(name, (skipped.get(name) ?? 0) + 1);
+    }
+  }
+
+  const out = new Map<string, number>();
+  for (const [name, total] of totals) {
+    if (total === 0) continue;
+    out.set(name, (skipped.get(name) ?? 0) / total);
+  }
+  return out;
+}
+
+// ── Per-tick tape data (#317 Phase 3 prep) ────────────────────────────────
+
+/**
+ * One CP-bar in the tape. `durationUs` is the system's wall-clock span; the wait fields are
+ * rendered as separate hatched segments above the bar.
+ *
+ * `chunkDispatchWaitUs` is structurally present but always 0 in v1 — per `09-system-dag.md §5.2`
+ * it requires per-chunk telemetry not yet on the wire. The field is reserved so the renderer can
+ * consume it as soon as the engine ships chunk-grain timing without a shape change here.
+ */
+export interface TickPathBar {
+  systemName: string;
+  durationUs: number;
+  /** Worker-claim wait (startUs - readyUs) — gap before a worker picked the system up. */
+  workerClaimWaitUs: number;
+  /** Chunk-dispatch wait — placeholder, always 0 in v1 (see comment above). */
+  chunkDispatchWaitUs: number;
+  /** True if this system used multiple workers — surfaces parallelism in the tooltip. */
+  isParallel: boolean;
+  workersTouched: number;
+  chunksProcessed: number;
+}
+
+export interface TickPathPhase {
+  name: string;
+  /** Bars for systems on the CP within this phase, in forward execution order. */
+  bars: TickPathBar[];
+  /**
+   * Phase-fence wait at the end of the phase: gap between the CP's last system finishing in this
+   * phase and the slowest non-CP straggler clearing the phase fence. Zero when the CP holds the
+   * straggler position itself.
+   */
+  phaseFenceWaitUs: number;
+  /** Identity of the straggler that defined the fence (for the tooltip). null when no wait. */
+  phaseFenceStraggler: string | null;
+  /** Sum of bars' durations + waits — i.e. the phase's wall-clock contribution to the tick. */
+  totalUs: number;
+}
+
+export interface TickPathPostTick {
+  writeTickFenceUs: number;
+  walFlushUs: number;
+  subscriptionOutputUs: number;
+  tierIndexRebuildUs: number;
+  dormancySweepUs: number;
+  tierBudgetUs: number;
+  totalUs: number;
+}
+
+/**
+ * Path semantics — drives the tape's header label. With RFC 07 declarations, the bars represent
+ * the actual dependency-driven critical path. Without declarations (no edges in the topology),
+ * the bars are every system that ran, in `startUs` order — semantically just an execution
+ * timeline, not a "longest data-flow path."
+ */
+export type PathMode = 'critical-path' | 'execution-order';
+
+export interface TickPathBars {
+  tickNumber: number;
+  mode: PathMode;
+  /** Phases in declared order; phases with no CP entries still appear (with empty bars) so the user sees the structure. */
+  phases: TickPathPhase[];
+  postTick: TickPathPostTick;
+  /** Metronome wait that PRECEDED this tick (µs, saturated at 65535 per TickSummary v9+). */
+  metronomeWaitUs: number;
+  /** Sum of every bar + wait across all phases + post-tick — the total wall-clock height of the tape. */
+  totalUs: number;
+}
+
+/**
+ * Pick the "dominant" tick in a range — the one with the longest wall-clock duration. Used as
+ * the default focus tick for the tape when the user hasn't picked one explicitly. Falls back to
+ * `null` when the range is empty.
+ */
+export function dominantTickInRange(
+  tickSummaries: TickSummaryDto[] | null | undefined,
+  range: TickRange | null,
+): number | null {
+  if (!tickSummaries || tickSummaries.length === 0 || !range) return null;
+  let bestTick: number | null = null;
+  let bestDuration = -1;
+  for (const t of tickSummaries) {
+    const tn = numberValue((t as { tickNumber?: unknown }).tickNumber);
+    if (tn == null || tn < range.from || tn > range.to) continue;
+    const dur = numberValue((t as { durationUs?: unknown }).durationUs) ?? 0;
+    if (dur > bestDuration) {
+      bestDuration = dur;
+      bestTick = tn;
+    }
+  }
+  return bestTick;
+}
+
+/**
+ * Compute the CP-tape data for ONE tick — per `09-system-dag.md §5`. Output drives the vertical
+ * timeline column rendering: bars in forward execution order, wait segments classified by the
+ * three §5.2 categories, post-tick serial block, and metronome wait that preceded the tick.
+ *
+ * Returns `null` when no rows match `tickNumber` (e.g. tick is out of cache range).
+ */
+export function computeCriticalPathForTick(input: {
+  tickNumber: number;
+  systems: SystemDefinitionDto[];
+  rows: SystemTickSummary[];
+  edges: DerivedEdge[];
+  phases: string[];
+  postTickRows: PostTickSummary[];
+  tickSummaryRow: TickSummaryDto | null;
+}): TickPathBars | null {
+  const { tickNumber, systems, rows, edges, phases, postTickRows, tickSummaryRow } = input;
+
+  // Build name-keyed lookups (mirrors computeCriticalPathParticipation; intentional duplication
+  // — keeping the two functions independent so changes to one don't ripple to the other).
+  const indexToName = new Map<number, string>();
+  const nameToPhase = new Map<string, string>();
+  for (const s of systems) {
+    if (!s.name) continue;
+    const idx = numberValue((s as { index?: unknown }).index);
+    if (idx != null) indexToName.set(idx, s.name);
+    nameToPhase.set(s.name, s.phaseName ?? '');
+  }
+  const nameToDef = new Map<string, SystemDefinitionDto>();
+  for (const s of systems) {
+    if (s.name) nameToDef.set(s.name, s);
+  }
+
+  const predecessorsByName = new Map<string, string[]>();
+  for (const e of edges) {
+    const sPhase = nameToPhase.get(e.source);
+    const tPhase = nameToPhase.get(e.target);
+    if (!sPhase || !tPhase || sPhase !== tPhase) continue;
+    let preds = predecessorsByName.get(e.target);
+    if (!preds) {
+      preds = [];
+      predecessorsByName.set(e.target, preds);
+    }
+    preds.push(e.source);
+  }
+
+  const phaseIndex = new Map<string, number>();
+  phases.forEach((p, i) => phaseIndex.set(p, i));
+
+  const phasesWithSystems: Array<{ phase: string; names: string[] }> = [];
+  for (const p of phases) phasesWithSystems.push({ phase: p, names: [] });
+  const synthetic: { phase: string; names: string[] } = { phase: '', names: [] };
+  for (const s of systems) {
+    if (!s.name) continue;
+    const phase = s.phaseName ?? '';
+    if (phase && phaseIndex.has(phase)) {
+      phasesWithSystems[phaseIndex.get(phase)!].names.push(s.name);
+    } else {
+      synthetic.names.push(s.name);
+    }
+  }
+  if (synthetic.names.length > 0) phasesWithSystems.push(synthetic);
+
+  // Index rows for THIS tick by system name.
+  const rowByName = new Map<string, SystemTickSummary>();
+  const durationByName = new Map<string, number>();
+  for (const r of rows) {
+    const tn = numberValue((r as { tickNumber?: unknown }).tickNumber);
+    if (tn !== tickNumber) continue;
+    const sysIdx = numberValue((r as { systemIndex?: unknown }).systemIndex);
+    if (sysIdx == null) continue;
+    const name = indexToName.get(sysIdx);
+    if (!name) continue;
+    rowByName.set(name, r);
+    durationByName.set(name, numberValue((r as { durationUs?: unknown }).durationUs) ?? 0);
+  }
+  if (rowByName.size === 0) return null;
+
+  // Branch on whether we have a dependency graph at all. With RFC 07 declarations on the wire,
+  // `edges` carries the producer→consumer / .After()/.Before() / event / resource graph and the
+  // CP walk traces a real wall-clock-longest path. Without declarations (pre-#310 traces, or
+  // engines whose systems never called SystemBuilder.AddReads/AddWrites) `edges` is empty —
+  // every system is a graph root, the walker would degenerate to "single-system path = the
+  // system with max duration." Fallback: show every system that ran in the tick, sorted by
+  // startUs. Same data structure consumed by the renderer; just no chain semantics.
+  const orderedPath = edges.length === 0
+    ? buildFallbackOrderByStartUs(rowByName)
+    : walkOneTick({ durationByName, phasesWithSystems, predecessorsByName }).orderedPath;
+  if (orderedPath.length === 0) return null;
+
+  // ── Bucket the ordered CP into phase rows. We keep ALL declared phases (even empty ones) so
+  // the tape shows the full structural scaffold even on light ticks. ─────
+  const phaseByName = (name: string): string => nameToPhase.get(name) ?? '';
+
+  const out: TickPathPhase[] = [];
+  for (const p of phases) {
+    out.push({ name: p, bars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 });
+  }
+  const synthRow: TickPathPhase = { name: '(unphased)', bars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 };
+  let synthEverNeeded = false;
+  for (const name of orderedPath) {
+    const phase = phaseByName(name);
+    const target = phase && phaseIndex.has(phase) ? out[phaseIndex.get(phase)!] : (synthEverNeeded = true, synthRow);
+    target.bars.push(makeBar(name, rowByName.get(name)!, nameToDef.get(name)));
+  }
+  if (synthEverNeeded) out.push(synthRow);
+
+  // Phase-fence wait per phase: max EndUs across ALL systems in the phase (CP or not) minus the
+  // CP's last system EndUs in that phase. Zero if the CP terminates at the straggler.
+  //
+  // **Skipped in execution-order fallback** — without a dependency graph, the "CP tail" is just
+  // "the alphabetically-last system tied at startUs=0", which has no well-defined relationship
+  // with the phase max endUs. Reporting a wait would be meaningless.
+  const inFallback = edges.length === 0;
+  for (const phaseRow of out) {
+    if (phaseRow.bars.length === 0) continue;
+    if (inFallback) {
+      // Tally totalUs without phase-fence wait — bars only.
+      let total = 0;
+      for (const bar of phaseRow.bars) {
+        total += bar.durationUs + bar.workerClaimWaitUs + bar.chunkDispatchWaitUs;
+      }
+      phaseRow.totalUs = total;
+      continue;
+    }
+
+    // Slowest endUs across every system in the phase that ran this tick.
+    let phaseMaxEnd = -Infinity;
+    let stragglerName: string | null = null;
+    for (const [name, row] of rowByName) {
+      if (phaseByName(name) !== (phaseRow.name === '(unphased)' ? '' : phaseRow.name)) continue;
+      const endUs = numberValue((row as { endUs?: unknown }).endUs) ?? 0;
+      if (endUs > phaseMaxEnd) {
+        phaseMaxEnd = endUs;
+        stragglerName = name;
+      }
+    }
+    // CP's last system in this phase = last bar in the phase row (forward order).
+    const cpLastName = phaseRow.bars[phaseRow.bars.length - 1].systemName;
+    const cpLastRow = rowByName.get(cpLastName);
+    const cpLastEnd = cpLastRow ? (numberValue((cpLastRow as { endUs?: unknown }).endUs) ?? 0) : 0;
+    const wait = Math.max(0, phaseMaxEnd - cpLastEnd);
+    if (wait > 0 && stragglerName !== cpLastName) {
+      phaseRow.phaseFenceWaitUs = wait;
+      phaseRow.phaseFenceStraggler = stragglerName;
+    }
+    // Total = sum of bar durations + bar waits + phase-fence wait.
+    let total = phaseRow.phaseFenceWaitUs;
+    for (const bar of phaseRow.bars) {
+      total += bar.durationUs + bar.workerClaimWaitUs + bar.chunkDispatchWaitUs;
+    }
+    phaseRow.totalUs = total;
+  }
+
+  // Post-tick block.
+  const postRow = postTickRows.find((r) => numberValue((r as { tickNumber?: unknown }).tickNumber) === tickNumber);
+  const postTick: TickPathPostTick = postRow
+    ? {
+        writeTickFenceUs: numberValue((postRow as { writeTickFenceUs?: unknown }).writeTickFenceUs) ?? 0,
+        walFlushUs: numberValue((postRow as { walFlushUs?: unknown }).walFlushUs) ?? 0,
+        subscriptionOutputUs: numberValue((postRow as { subscriptionOutputUs?: unknown }).subscriptionOutputUs) ?? 0,
+        tierIndexRebuildUs: numberValue((postRow as { tierIndexRebuildUs?: unknown }).tierIndexRebuildUs) ?? 0,
+        dormancySweepUs: numberValue((postRow as { dormancySweepUs?: unknown }).dormancySweepUs) ?? 0,
+        tierBudgetUs: numberValue((postRow as { tierBudgetUs?: unknown }).tierBudgetUs) ?? 0,
+        totalUs: 0,
+      }
+    : { writeTickFenceUs: 0, walFlushUs: 0, subscriptionOutputUs: 0, tierIndexRebuildUs: 0, dormancySweepUs: 0, tierBudgetUs: 0, totalUs: 0 };
+  postTick.totalUs =
+    postTick.writeTickFenceUs +
+    postTick.walFlushUs +
+    postTick.subscriptionOutputUs +
+    postTick.tierIndexRebuildUs +
+    postTick.dormancySweepUs +
+    postTick.tierBudgetUs;
+
+  const metronomeWaitUs = tickSummaryRow
+    ? numberValue((tickSummaryRow as { metronomeWaitUs?: unknown }).metronomeWaitUs) ?? 0
+    : 0;
+
+  let totalUs = postTick.totalUs + metronomeWaitUs;
+  for (const phaseRow of out) totalUs += phaseRow.totalUs;
+  const mode: PathMode = edges.length === 0 ? 'execution-order' : 'critical-path';
+  return { tickNumber, mode, phases: out, postTick, metronomeWaitUs, totalUs };
+}
+
+/**
+ * Fallback ordering used when the topology has no edges (engine isn't surfacing RFC 07 access
+ * declarations). Returns every system that genuinely ran (durationUs > 0) sorted by startUs
+ * ascending. Ties broken by name for determinism. Skipped rows are excluded — same rule as the
+ * dependency-aware walker.
+ */
+function buildFallbackOrderByStartUs(rowByName: Map<string, SystemTickSummary>): string[] {
+  const entries: Array<{ name: string; startUs: number }> = [];
+  for (const [name, row] of rowByName) {
+    const dur = numberValue((row as { durationUs?: unknown }).durationUs) ?? 0;
+    if (dur <= 0) continue;
+    const startUs = numberValue((row as { startUs?: unknown }).startUs) ?? 0;
+    entries.push({ name, startUs });
+  }
+  entries.sort((a, b) => (a.startUs - b.startUs) || a.name.localeCompare(b.name));
+  return entries.map((e) => e.name);
+}
+
+function makeBar(name: string, row: SystemTickSummary, def: SystemDefinitionDto | undefined): TickPathBar {
+  const durationUs = numberValue((row as { durationUs?: unknown }).durationUs) ?? 0;
+  const startUs = numberValue((row as { startUs?: unknown }).startUs) ?? 0;
+  const readyUs = numberValue((row as { readyUs?: unknown }).readyUs) ?? 0;
+  // readyUs == 0 in older traces (#311 was the version that started capturing it). Treat zero as
+  // "unknown" rather than a real "ready immediately at engine start" — render no claim wait.
+  const workerClaimWaitUs = readyUs > 0 ? Math.max(0, startUs - readyUs) : 0;
+  return {
+    systemName: name,
+    durationUs,
+    workerClaimWaitUs,
+    chunkDispatchWaitUs: 0,
+    isParallel: def?.isParallel ?? false,
+    workersTouched: numberValue((row as { workersTouched?: unknown }).workersTouched) ?? 0,
+    chunksProcessed: numberValue((row as { chunksProcessed?: unknown }).chunksProcessed) ?? 0,
+  };
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/criticalPath.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/criticalPath.ts
@@ -60,18 +60,41 @@ export function computeCriticalPathParticipation(input: CriticalPathInputs): Cri
   }
 
   // Predecessors map: targetSystemName → [sourceSystemNames]. Restricted to intra-phase edges
-  // (cross-phase pairs use the phase-fence rule instead of an explicit edge).
+  // (cross-phase pairs use the phase-fence rule instead of an explicit edge). Read directly
+  // from `system.predecessors` (engine-built — includes explicit `.After/.Before` chains the
+  // client-side `deriveEdges` can't see). Falls back to `edges` for legacy traces / synthetic
+  // test fixtures that pass edges without populating `system.predecessors`.
   const predecessorsByName = new Map<string, string[]>();
-  for (const e of edges) {
-    const sPhase = nameToPhase.get(e.source);
-    const tPhase = nameToPhase.get(e.target);
-    if (!sPhase || !tPhase || sPhase !== tPhase) continue;
-    let preds = predecessorsByName.get(e.target);
-    if (!preds) {
-      preds = [];
-      predecessorsByName.set(e.target, preds);
+  for (const s of systems) {
+    if (!s.name) continue;
+    const targetPhase = nameToPhase.get(s.name);
+    if (!targetPhase) continue;
+    const predIdxs = (s as { predecessors?: unknown }).predecessors;
+    if (!Array.isArray(predIdxs)) continue;
+    const preds: string[] = [];
+    for (const raw of predIdxs) {
+      const predIdx = numberValue(raw);
+      if (predIdx == null) continue;
+      const predName = indexToName.get(predIdx);
+      if (!predName) continue;
+      const sourcePhase = nameToPhase.get(predName);
+      if (sourcePhase !== targetPhase) continue;
+      preds.push(predName);
     }
-    preds.push(e.source);
+    if (preds.length > 0) predecessorsByName.set(s.name, preds);
+  }
+  if (predecessorsByName.size === 0) {
+    for (const e of edges) {
+      const sPhase = nameToPhase.get(e.source);
+      const tPhase = nameToPhase.get(e.target);
+      if (!sPhase || !tPhase || sPhase !== tPhase) continue;
+      let preds = predecessorsByName.get(e.target);
+      if (!preds) {
+        preds = [];
+        predecessorsByName.set(e.target, preds);
+      }
+      preds.push(e.source);
+    }
   }
 
   // Phase index map for quick "is phase A before phase B" comparisons.
@@ -319,6 +342,14 @@ export interface TickPathPhase {
   /** Bars for systems on the CP within this phase, in forward execution order. */
   bars: TickPathBar[];
   /**
+   * Every system in the phase that ran this tick but is NOT on the critical path, sorted by
+   * `startUs`. Always populated; the renderer decides whether to show them based on the
+   * `fullGantt` toggle. Excluded from `totalUs` — those values stay strictly wall-clock CP-only,
+   * so adding non-CP bars to the view inflates the visual length but doesn't reinterpret the
+   * core metric.
+   */
+  nonCpBars: TickPathBar[];
+  /**
    * Phase-fence wait at the end of the phase: gap between the CP's last system finishing in this
    * phase and the slowest non-CP straggler clearing the phase fence. Zero when the CP holds the
    * straggler position itself.
@@ -351,13 +382,43 @@ export type PathMode = 'critical-path' | 'execution-order';
 export interface TickPathBars {
   tickNumber: number;
   mode: PathMode;
+  /**
+   * Aggregate flag — `true` when the bars carry mean values across a tick range, `false` (or
+   * undefined) when this is a single tick's CP. Drives the toolbar pill ("aggregate of N ticks")
+   * and disables certain tooltip lines that don't make sense across many ticks.
+   */
+  aggregate?: { tickCount: number; range: { from: number; to: number } } | null;
   /** Phases in declared order; phases with no CP entries still appear (with empty bars) so the user sees the structure. */
   phases: TickPathPhase[];
   postTick: TickPathPostTick;
   /** Metronome wait that PRECEDED this tick (µs, saturated at 65535 per TickSummary v9+). */
   metronomeWaitUs: number;
+  /**
+   * intentClass for the metronome wait that preceded this tick. Drives the chip rendered on the
+   * leading metronome stripe / tooltip. `null` when the tick has no recorded TickSummary row
+   * (defensive — the renderer treats null as "unknown / suppress chip").
+   * Mapping: 0=CatchUp, 1=Throttled, 2=Headroom (see DagScheduler comment).
+   */
+  metronomeIntentClass: MetronomeIntentClass | null;
   /** Sum of every bar + wait across all phases + post-tick — the total wall-clock height of the tape. */
   totalUs: number;
+}
+
+export type MetronomeIntentClass = 'CatchUp' | 'Throttled' | 'Headroom';
+
+/**
+ * Decode the wire `intentClass` byte. Out-of-range or missing values return `null` — the renderer
+ * suppresses the chip rather than guessing.
+ */
+export function decodeMetronomeIntentClass(raw: unknown): MetronomeIntentClass | null {
+  const n = typeof raw === 'number' ? raw : Number(raw as string);
+  if (!Number.isFinite(n)) return null;
+  switch (n) {
+    case 0: return 'CatchUp';
+    case 1: return 'Throttled';
+    case 2: return 'Headroom';
+    default: return null;
+  }
 }
 
 /**
@@ -417,17 +478,47 @@ export function computeCriticalPathForTick(input: {
     if (s.name) nameToDef.set(s.name, s);
   }
 
+  // Predecessor map: read directly from the engine-built `predecessors` field on each system.
+  // The previous shape rebuilt this from `deriveEdges(systems)`, but `deriveEdges` only sees
+  // access-declared edges — it can't see explicit `.After()` / `.Before()` chains because the
+  // engine doesn't surface those on the wire (they fold into Successors at Build time and the
+  // RecordBuilder ships ExplicitAfter/Before as empty arrays). For tier-discriminated W×W
+  // chains (Brain_T0..T3, Metabolism_T0..T3, PheroDep_T0..T3) the chain edges are explicit-only,
+  // so the client-side derivation missed them entirely and the CP traceback collapsed to a
+  // single-system path. Using `system.predecessors` (computed engine-side from the full edge
+  // set including explicit) gives the walker the complete graph. Falls back to `edges` for
+  // legacy traces / synthetic test fixtures that pass edges without populating predecessors.
   const predecessorsByName = new Map<string, string[]>();
-  for (const e of edges) {
-    const sPhase = nameToPhase.get(e.source);
-    const tPhase = nameToPhase.get(e.target);
-    if (!sPhase || !tPhase || sPhase !== tPhase) continue;
-    let preds = predecessorsByName.get(e.target);
-    if (!preds) {
-      preds = [];
-      predecessorsByName.set(e.target, preds);
+  for (const s of systems) {
+    if (!s.name) continue;
+    const targetPhase = nameToPhase.get(s.name);
+    if (!targetPhase) continue;
+    const predIdxs = (s as { predecessors?: unknown }).predecessors;
+    if (!Array.isArray(predIdxs)) continue;
+    const preds: string[] = [];
+    for (const raw of predIdxs) {
+      const predIdx = numberValue(raw);
+      if (predIdx == null) continue;
+      const predName = indexToName.get(predIdx);
+      if (!predName) continue;
+      const sourcePhase = nameToPhase.get(predName);
+      if (sourcePhase !== targetPhase) continue; // intra-phase only — phase-fence rule covers cross-phase
+      preds.push(predName);
     }
-    preds.push(e.source);
+    if (preds.length > 0) predecessorsByName.set(s.name, preds);
+  }
+  if (predecessorsByName.size === 0) {
+    for (const e of edges) {
+      const sPhase = nameToPhase.get(e.source);
+      const tPhase = nameToPhase.get(e.target);
+      if (!sPhase || !tPhase || sPhase !== tPhase) continue;
+      let preds = predecessorsByName.get(e.target);
+      if (!preds) {
+        preds = [];
+        predecessorsByName.set(e.target, preds);
+      }
+      preds.push(e.source);
+    }
   }
 
   const phaseIndex = new Map<string, number>();
@@ -463,13 +554,15 @@ export function computeCriticalPathForTick(input: {
   if (rowByName.size === 0) return null;
 
   // Branch on whether we have a dependency graph at all. With RFC 07 declarations on the wire,
-  // `edges` carries the producer→consumer / .After()/.Before() / event / resource graph and the
-  // CP walk traces a real wall-clock-longest path. Without declarations (pre-#310 traces, or
-  // engines whose systems never called SystemBuilder.AddReads/AddWrites) `edges` is empty —
-  // every system is a graph root, the walker would degenerate to "single-system path = the
-  // system with max duration." Fallback: show every system that ran in the tick, sorted by
-  // startUs. Same data structure consumed by the renderer; just no chain semantics.
-  const orderedPath = edges.length === 0
+  // `predecessorsByName` (built from `system.predecessors`) carries the full graph and the CP
+  // walk traces a real wall-clock-longest path. The `edges` parameter is only checked as a
+  // legacy fallback signal — older traces / synthetic test fixtures might pass edges without
+  // populating `system.predecessors`. Either signal having content means we have a graph.
+  // Without either, every system is a graph root and the walker would degenerate to
+  // "single-system path = the system with max duration." Fallback: show every system that ran
+  // in the tick, sorted by startUs.
+  const hasGraph = predecessorsByName.size > 0 || edges.length > 0;
+  const orderedPath = !hasGraph
     ? buildFallbackOrderByStartUs(rowByName)
     : walkOneTick({ durationByName, phasesWithSystems, predecessorsByName }).orderedPath;
   if (orderedPath.length === 0) return null;
@@ -480,16 +573,47 @@ export function computeCriticalPathForTick(input: {
 
   const out: TickPathPhase[] = [];
   for (const p of phases) {
-    out.push({ name: p, bars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 });
+    out.push({ name: p, bars: [], nonCpBars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 });
   }
-  const synthRow: TickPathPhase = { name: '(unphased)', bars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 };
+  const synthRow: TickPathPhase = { name: '(unphased)', bars: [], nonCpBars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 };
   let synthEverNeeded = false;
+  const cpSet = new Set<string>();
   for (const name of orderedPath) {
     const phase = phaseByName(name);
     const target = phase && phaseIndex.has(phase) ? out[phaseIndex.get(phase)!] : (synthEverNeeded = true, synthRow);
     target.bars.push(makeBar(name, rowByName.get(name)!, nameToDef.get(name)));
+    cpSet.add(name);
   }
   if (synthEverNeeded) out.push(synthRow);
+
+  // Populate non-CP bars per phase — every system that ran this tick and isn't on the CP. Sorted
+  // by startUs so the full-Gantt rendering reads as "execution order within the phase". Skipped
+  // rows (durationUs <= 0) are excluded — same rule as the CP walker.
+  const nonCpEntries = new Map<string, Array<{ name: string; startUs: number }>>();
+  for (const [name, row] of rowByName) {
+    if (cpSet.has(name)) continue;
+    const dur = numberValue((row as { durationUs?: unknown }).durationUs) ?? 0;
+    if (dur <= 0) continue;
+    const phase = phaseByName(name);
+    const phaseKey = phase && phaseIndex.has(phase) ? phase : '';
+    const startUs = numberValue((row as { startUs?: unknown }).startUs) ?? 0;
+    let bucket = nonCpEntries.get(phaseKey);
+    if (!bucket) {
+      bucket = [];
+      nonCpEntries.set(phaseKey, bucket);
+    }
+    bucket.push({ name, startUs });
+  }
+  for (const [phaseKey, entries] of nonCpEntries) {
+    entries.sort((a, b) => (a.startUs - b.startUs) || a.name.localeCompare(b.name));
+    const target = phaseKey === ''
+      ? out.find((p) => p.name === '(unphased)') ?? null
+      : out[phaseIndex.get(phaseKey)!];
+    if (!target) continue;
+    for (const e of entries) {
+      target.nonCpBars.push(makeBar(e.name, rowByName.get(e.name)!, nameToDef.get(e.name)));
+    }
+  }
 
   // Phase-fence wait per phase: max EndUs across ALL systems in the phase (CP or not) minus the
   // CP's last system EndUs in that phase. Zero if the CP terminates at the straggler.
@@ -497,7 +621,7 @@ export function computeCriticalPathForTick(input: {
   // **Skipped in execution-order fallback** — without a dependency graph, the "CP tail" is just
   // "the alphabetically-last system tied at startUs=0", which has no well-defined relationship
   // with the phase max endUs. Reporting a wait would be meaningless.
-  const inFallback = edges.length === 0;
+  const inFallback = !hasGraph;
   for (const phaseRow of out) {
     if (phaseRow.bars.length === 0) continue;
     if (inFallback) {
@@ -562,11 +686,14 @@ export function computeCriticalPathForTick(input: {
   const metronomeWaitUs = tickSummaryRow
     ? numberValue((tickSummaryRow as { metronomeWaitUs?: unknown }).metronomeWaitUs) ?? 0
     : 0;
+  const metronomeIntentClass = tickSummaryRow
+    ? decodeMetronomeIntentClass((tickSummaryRow as { metronomeIntentClass?: unknown }).metronomeIntentClass)
+    : null;
 
   let totalUs = postTick.totalUs + metronomeWaitUs;
   for (const phaseRow of out) totalUs += phaseRow.totalUs;
-  const mode: PathMode = edges.length === 0 ? 'execution-order' : 'critical-path';
-  return { tickNumber, mode, phases: out, postTick, metronomeWaitUs, totalUs };
+  const mode: PathMode = hasGraph ? 'critical-path' : 'execution-order';
+  return { tickNumber, mode, phases: out, postTick, metronomeWaitUs, metronomeIntentClass, totalUs };
 }
 
 /**
@@ -585,6 +712,189 @@ function buildFallbackOrderByStartUs(rowByName: Map<string, SystemTickSummary>):
   }
   entries.sort((a, b) => (a.startUs - b.startUs) || a.name.localeCompare(b.name));
   return entries.map((e) => e.name);
+}
+
+// ── Aggregate (range) tape ────────────────────────────────────────────────
+
+/**
+ * Compute aggregate critical-path bars across a range of ticks. For each system that appeared on
+ * the CP at least once in the range, the bar carries `mean(durationUs over ticks-on-CP)`. Phase
+ * grouping mirrors single-tick mode; bars within a phase are sorted by mean duration descending
+ * (no execution-order is meaningful across many ticks). Wait segments + phase-fence are skipped
+ * — averaging waits across heterogeneous ticks is too noisy to surface in v1. Post-tick / metronome
+ * carry per-key means across the range.
+ *
+ * Returned shape uses `tickNumber = -1` as the "not a real tick" sentinel; the toolbar shows
+ * "aggregate of N ticks" in place of the tick label. `aggregate` carries the participation count
+ * and the actual range used. Returns `null` when no ticks fell in range.
+ */
+export function computeAggregateCriticalPath(input: {
+  systems: SystemDefinitionDto[];
+  rows: SystemTickSummary[];
+  edges: DerivedEdge[];
+  phases: string[];
+  postTickRows: PostTickSummary[];
+  tickSummaries: TickSummaryDto[];
+  range: TickRange | null;
+}): TickPathBars | null {
+  const { systems, rows, edges, phases, postTickRows, tickSummaries, range } = input;
+  if (!range) return null;
+
+  // Collect the set of ticks in range with at least one row. Reuse single-tick CP for each;
+  // accumulate per-system on-CP duration sums + counts.
+  const sumByName = new Map<string, number>();
+  const countByName = new Map<string, number>();
+  const phaseByNameMap = new Map<string, string>();
+  for (const s of systems) {
+    if (s.name) phaseByNameMap.set(s.name, s.phaseName ?? '');
+  }
+
+  const ticksSeen = new Set<number>();
+  for (const r of rows) {
+    const tn = numberValue((r as { tickNumber?: unknown }).tickNumber);
+    if (tn == null || tn < range.from || tn > range.to) continue;
+    ticksSeen.add(tn);
+  }
+  if (ticksSeen.size === 0) return null;
+
+  // Walk each tick's CP. Reuse `computeCriticalPathForTick` so the dependency / phase-fence /
+  // fallback logic stays identical.
+  for (const tickNumber of ticksSeen) {
+    const tickSummaryRow = tickSummaries.find((t) => Number(t.tickNumber) === tickNumber) ?? null;
+    const bars = computeCriticalPathForTick({
+      tickNumber, systems, rows, edges, phases, postTickRows, tickSummaryRow,
+    });
+    if (!bars) continue;
+    for (const phase of bars.phases) {
+      for (const bar of phase.bars) {
+        sumByName.set(bar.systemName, (sumByName.get(bar.systemName) ?? 0) + bar.durationUs);
+        countByName.set(bar.systemName, (countByName.get(bar.systemName) ?? 0) + 1);
+      }
+    }
+  }
+
+  if (sumByName.size === 0) return null;
+
+  // Bucket per phase + sort by mean desc.
+  const phaseIndex = new Map<string, number>();
+  phases.forEach((p, i) => phaseIndex.set(p, i));
+  const phaseRows: TickPathPhase[] = [];
+  for (const p of phases) phaseRows.push({ name: p, bars: [], nonCpBars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 });
+  const synth: TickPathPhase = { name: '(unphased)', bars: [], nonCpBars: [], phaseFenceWaitUs: 0, phaseFenceStraggler: null, totalUs: 0 };
+  let synthNeeded = false;
+
+  const nameToDef = new Map<string, SystemDefinitionDto>();
+  for (const s of systems) {
+    if (s.name) nameToDef.set(s.name, s);
+  }
+
+  const interim = new Map<string, Array<{ name: string; meanUs: number }>>();
+  for (const [name, sum] of sumByName) {
+    const count = countByName.get(name) ?? 1;
+    const meanUs = sum / count;
+    const phase = phaseByNameMap.get(name) ?? '';
+    const key = phase && phaseIndex.has(phase) ? phase : '';
+    let bucket = interim.get(key);
+    if (!bucket) {
+      bucket = [];
+      interim.set(key, bucket);
+    }
+    bucket.push({ name, meanUs });
+  }
+  for (const [key, entries] of interim) {
+    entries.sort((a, b) => b.meanUs - a.meanUs);
+    const target = key === '' ? (synthNeeded = true, synth) : phaseRows[phaseIndex.get(key)!];
+    for (const e of entries) {
+      const def = nameToDef.get(e.name);
+      target.bars.push({
+        systemName: e.name,
+        durationUs: e.meanUs,
+        workerClaimWaitUs: 0,
+        chunkDispatchWaitUs: 0,
+        isParallel: def?.isParallel ?? false,
+        workersTouched: 0,
+        chunksProcessed: 0,
+      });
+    }
+  }
+  if (synthNeeded) phaseRows.push(synth);
+  for (const phaseRow of phaseRows) {
+    let total = 0;
+    for (const bar of phaseRow.bars) total += bar.durationUs;
+    phaseRow.totalUs = total;
+  }
+
+  // Aggregate post-tick — per-key mean across the range. Skipped tickSummary rows (range filter)
+  // contribute zero; we count tickSummaries IN RANGE for the divisor so partial post-tick coverage
+  // doesn't wildly inflate the mean.
+  const postSums = { writeTickFenceUs: 0, walFlushUs: 0, subscriptionOutputUs: 0, tierIndexRebuildUs: 0, dormancySweepUs: 0, tierBudgetUs: 0 };
+  let postCount = 0;
+  for (const r of postTickRows) {
+    const tn = numberValue((r as { tickNumber?: unknown }).tickNumber);
+    if (tn == null || tn < range.from || tn > range.to) continue;
+    postCount++;
+    postSums.writeTickFenceUs     += numberValue((r as { writeTickFenceUs?: unknown }).writeTickFenceUs)     ?? 0;
+    postSums.walFlushUs           += numberValue((r as { walFlushUs?: unknown }).walFlushUs)                 ?? 0;
+    postSums.subscriptionOutputUs += numberValue((r as { subscriptionOutputUs?: unknown }).subscriptionOutputUs) ?? 0;
+    postSums.tierIndexRebuildUs   += numberValue((r as { tierIndexRebuildUs?: unknown }).tierIndexRebuildUs) ?? 0;
+    postSums.dormancySweepUs      += numberValue((r as { dormancySweepUs?: unknown }).dormancySweepUs)       ?? 0;
+    postSums.tierBudgetUs         += numberValue((r as { tierBudgetUs?: unknown }).tierBudgetUs)             ?? 0;
+  }
+  const div = Math.max(1, postCount);
+  const postTick: TickPathPostTick = {
+    writeTickFenceUs:     postSums.writeTickFenceUs / div,
+    walFlushUs:           postSums.walFlushUs / div,
+    subscriptionOutputUs: postSums.subscriptionOutputUs / div,
+    tierIndexRebuildUs:   postSums.tierIndexRebuildUs / div,
+    dormancySweepUs:      postSums.dormancySweepUs / div,
+    tierBudgetUs:         postSums.tierBudgetUs / div,
+    totalUs: 0,
+  };
+  postTick.totalUs = postTick.writeTickFenceUs + postTick.walFlushUs + postTick.subscriptionOutputUs
+    + postTick.tierIndexRebuildUs + postTick.dormancySweepUs + postTick.tierBudgetUs;
+
+  // Metronome aggregate — mean across in-range tickSummaries. intentClass is the modal value
+  // (most common); ties + mixed buckets degrade to null.
+  let metroSum = 0;
+  let metroCount = 0;
+  const intentTally = new Map<MetronomeIntentClass, number>();
+  for (const t of tickSummaries) {
+    const tn = numberValue((t as { tickNumber?: unknown }).tickNumber);
+    if (tn == null || tn < range.from || tn > range.to) continue;
+    metroSum += numberValue((t as { metronomeWaitUs?: unknown }).metronomeWaitUs) ?? 0;
+    metroCount++;
+    const intent = decodeMetronomeIntentClass((t as { metronomeIntentClass?: unknown }).metronomeIntentClass);
+    if (intent) intentTally.set(intent, (intentTally.get(intent) ?? 0) + 1);
+  }
+  const metronomeWaitUs = metroCount > 0 ? metroSum / metroCount : 0;
+  let topIntent: MetronomeIntentClass | null = null;
+  let topIntentCount = 0;
+  let intentTied = false;
+  for (const [k, v] of intentTally) {
+    if (v > topIntentCount) {
+      topIntent = k;
+      topIntentCount = v;
+      intentTied = false;
+    } else if (v === topIntentCount && k !== topIntent) {
+      intentTied = true;
+    }
+  }
+  const metronomeIntentClass: MetronomeIntentClass | null = intentTied ? null : topIntent;
+
+  let totalUs = postTick.totalUs + metronomeWaitUs;
+  for (const phaseRow of phaseRows) totalUs += phaseRow.totalUs;
+  const mode: PathMode = edges.length > 0 ? 'critical-path' : 'execution-order';
+
+  return {
+    tickNumber: -1,
+    mode,
+    aggregate: { tickCount: ticksSeen.size, range: { from: range.from, to: range.to } },
+    phases: phaseRows,
+    postTick,
+    metronomeWaitUs,
+    metronomeIntentClass,
+    totalUs,
+  };
 }
 
 function makeBar(name: string, row: SystemTickSummary, def: SystemDefinitionDto | undefined): TickPathBar {

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/phaseColors.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/phaseColors.ts
@@ -1,0 +1,34 @@
+/**
+ * Stable phase → colour mapping for the Critical-Path view's 5 px phase marker (per design
+ * intent: visually associate every system bar with its phase without relying on labels alone).
+ *
+ * The palette is curated rather than hue-hashed: a small set of well-spaced HSL hues that stay
+ * legible in both dark and light themes. Phase index drives the lookup (modulo palette size), so
+ * the same phase always gets the same colour within a session, and across sessions for any
+ * topology that declares phases in the same order.
+ */
+const PALETTE: Array<{ stroke: string; fill: string }> = [
+  // Hues spread across the wheel. Saturation/lightness chosen for dark theme readability against
+  // the muted bar background; the same values are still distinguishable in light theme.
+  { stroke: 'hsl(210, 70%, 60%)', fill: 'hsl(210, 50%, 35%)' }, // blue
+  { stroke: 'hsl(140, 60%, 55%)', fill: 'hsl(140, 45%, 30%)' }, // green
+  { stroke: 'hsl(40, 80%, 60%)',  fill: 'hsl(40, 60%, 35%)'  }, // amber
+  { stroke: 'hsl(280, 60%, 65%)', fill: 'hsl(280, 45%, 35%)' }, // violet
+  { stroke: 'hsl(0, 70%, 60%)',   fill: 'hsl(0, 50%, 35%)'   }, // red
+  { stroke: 'hsl(180, 60%, 55%)', fill: 'hsl(180, 45%, 30%)' }, // teal
+  { stroke: 'hsl(320, 65%, 65%)', fill: 'hsl(320, 50%, 35%)' }, // pink
+  { stroke: 'hsl(60, 60%, 55%)',  fill: 'hsl(60, 45%, 30%)'  }, // yellow-green
+];
+
+/**
+ * Returns the marker colour for a given phase. The marker is a 5 px line on the leading edge of
+ * each system bar in the requested orientation; `stroke` is the visible stripe, `fill` is the
+ * matching darker swatch used in the phase header.
+ *
+ * `phaseIndex` is the position in `topology.phases` (declared order). Pass `-1` for unphased
+ * systems — they get a neutral grey.
+ */
+export function colorForPhase(phaseIndex: number): { stroke: string; fill: string } {
+  if (phaseIndex < 0) return { stroke: 'hsl(220, 10%, 55%)', fill: 'hsl(220, 10%, 30%)' };
+  return PALETTE[phaseIndex % PALETTE.length];
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/useCriticalPathViewStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/useCriticalPathViewStore.ts
@@ -34,10 +34,33 @@ export interface CriticalPathViewState {
    * scale.
    */
   lockZoom: boolean;
+  /**
+   * When `true`, the tape includes every system that ran in each phase — not just the ones on the
+   * critical path. Non-CP bars render dimmed alongside CP bars so the user can see the rest of
+   * the work without losing the CP focus. Off by default per `09-system-dag.md §5.6` (the CP
+   * focus is the primary diagnostic, full Gantt is the "what else ran" pivot).
+   */
+  fullGantt: boolean;
+  /**
+   * Aggregate vs single-tick. When `true`, the tape shows means across the selected tick range
+   * instead of one representative tick. Per `09-system-dag.md §5.6` — useful for comparing the
+   * "shape of a tick" across a window without scrubbing tick-by-tick.
+   */
+  aggregateMode: boolean;
+  /**
+   * Show the leading metronome-wait stripe in the tape. Off by default per
+   * `09-system-dag.md §5.4` — the metronome wait is "what the engine wasn't doing", noise to most
+   * investigations. Flip on to investigate engine throttling / sleep behaviour, paired with the
+   * intent-class chip surfaced on the stripe.
+   */
+  showMetronome: boolean;
   setOrientation: (orientation: Orientation) => void;
   setScale: (scale: CpScale) => void;
   setPxPerUs: (pxPerUs: number) => void;
   setLockZoom: (lock: boolean) => void;
+  setFullGantt: (full: boolean) => void;
+  setAggregateMode: (agg: boolean) => void;
+  setShowMetronome: (show: boolean) => void;
   /**
    * Multiply zoom by `factor` — used by the wheel handler. Caller is responsible for any scroll
    * compensation needed to keep the cursor anchored.
@@ -69,10 +92,16 @@ export const useCriticalPathViewStore = create<CriticalPathViewState>()(
       scale: 'linear',
       pxPerUs: DEFAULT_PX_PER_US,
       lockZoom: false,
+      fullGantt: false,
+      aggregateMode: false,
+      showMetronome: false,
       setOrientation: (orientation) => set({ orientation }),
       setScale: (scale) => set({ scale }),
       setPxPerUs: (pxPerUs) => set({ pxPerUs: Math.max(1e-6, pxPerUs) }),
       setLockZoom: (lockZoom) => set({ lockZoom }),
+      setFullGantt: (fullGantt) => set({ fullGantt }),
+      setAggregateMode: (aggregateMode) => set({ aggregateMode }),
+      setShowMetronome: (showMetronome) => set({ showMetronome }),
       zoomBy: (factor) => set((state) => ({ pxPerUs: Math.max(1e-6, state.pxPerUs * factor) })),
     }),
     { name: 'typhon-cp-view', storage: safeStorage },

--- a/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/useCriticalPathViewStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/CriticalPath/useCriticalPathViewStore.ts
@@ -1,0 +1,80 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+/**
+ * View state for the dedicated Critical-Path panel. The panel reads its **tick** from
+ * `useSelectionStore` (cross-panel binding — same as the System DAG aggregation range), so the
+ * tick / range slots do NOT live here. This store owns purely visual concerns:
+ *
+ * - **orientation** — bars flow left→right (`horizontal`) or top→bottom (`vertical`).
+ * - **scale** — `linear` or `log`. Log helps when one phase dwarfs the others.
+ * - **pxPerUs** — zoom factor: pixels per microsecond on the major (time) axis. Truly unbounded.
+ *   Wheel-zoom multiplies this; "Fit" recomputes it from the current viewport size.
+ *
+ * Persisted across sessions because user preference is sticky (same pattern as `useThemeStore`
+ * and `useDagViewStore`).
+ */
+/**
+ * Orientation mode. `auto` (default) picks horizontal or vertical at runtime based on the
+ * viewport's width-to-height ratio — wider docks land on horizontal, taller docks land on
+ * vertical. `horizontal` / `vertical` lock the choice regardless of dock shape.
+ */
+export type Orientation = 'auto' | 'horizontal' | 'vertical';
+export type CpScale = 'linear' | 'log';
+
+export interface CriticalPathViewState {
+  orientation: Orientation;
+  scale: CpScale;
+  pxPerUs: number;
+  /**
+   * When `false` (default), the panel auto-fits the timeline whenever the displayed tick changes
+   * — fresh tick → fresh wall-clock total → previous `pxPerUs` is almost always the wrong scale.
+   * When `true`, the user's manual zoom is preserved across tick changes, which matters when
+   * scrubbing the profiler to compare a specific phase / system across many ticks at the same
+   * scale.
+   */
+  lockZoom: boolean;
+  setOrientation: (orientation: Orientation) => void;
+  setScale: (scale: CpScale) => void;
+  setPxPerUs: (pxPerUs: number) => void;
+  setLockZoom: (lock: boolean) => void;
+  /**
+   * Multiply zoom by `factor` — used by the wheel handler. Caller is responsible for any scroll
+   * compensation needed to keep the cursor anchored.
+   */
+  zoomBy: (factor: number) => void;
+}
+
+// Default: 0.05 px/µs = 50 px/ms. A typical 16 ms tick = 800 px on the major axis — fits a normal
+// viewport with room to scroll. User wheel-zoom adjusts from there.
+const DEFAULT_PX_PER_US = 0.05;
+
+// SSR/test-safe localStorage wrapper — same shape as `useThemeStore` / `useDagViewStore`.
+const safeStorage = createJSONStorage(() => ({
+  getItem: (name: string) => {
+    try { return localStorage.getItem(name); } catch { return null; }
+  },
+  setItem: (name: string, value: string) => {
+    try { localStorage.setItem(name, value); } catch { /* noop */ }
+  },
+  removeItem: (name: string) => {
+    try { localStorage.removeItem(name); } catch { /* noop */ }
+  },
+}));
+
+export const useCriticalPathViewStore = create<CriticalPathViewState>()(
+  persist(
+    (set) => ({
+      orientation: 'auto',
+      scale: 'linear',
+      pxPerUs: DEFAULT_PX_PER_US,
+      lockZoom: false,
+      setOrientation: (orientation) => set({ orientation }),
+      setScale: (scale) => set({ scale }),
+      setPxPerUs: (pxPerUs) => set({ pxPerUs: Math.max(1e-6, pxPerUs) }),
+      setLockZoom: (lockZoom) => set({ lockZoom }),
+      zoomBy: (factor) => set((state) => ({ pxPerUs: Math.max(1e-6, state.pxPerUs * factor) })),
+    }),
+    { name: 'typhon-cp-view', storage: safeStorage },
+  ),
+);

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SchemaInspector/AccessChips.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SchemaInspector/AccessChips.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+import { useTopology } from '@/hooks/data/useTopology';
+import { useSessionStore } from '@/stores/useSessionStore';
+
+interface AccessChipsProps {
+  componentTypeName: string;
+}
+
+/**
+ * Inline access-declaration summary for a focused component (RFC 07 §Q1 — Unit 6 surfacing).
+ * Pulls the declarations directly from the cached topology — single source of truth, no extra
+ * round-trip. When the topology is still loading or every system surfaces empty arrays (legacy
+ * v5 trace, or a session without phase declarations), the section renders nothing so it doesn't
+ * push other content around.
+ */
+export default function AccessChips({ componentTypeName }: AccessChipsProps) {
+  const sessionId = useSessionStore((s) => s.sessionId);
+  const { data: topology } = useTopology(sessionId);
+
+  const buckets = useMemo(() => {
+    const writes: string[] = [];
+    const sideWrites: string[] = [];
+    const readsFresh: string[] = [];
+    const readsSnapshot: string[] = [];
+    const reads: string[] = [];
+
+    for (const s of topology?.systems ?? []) {
+      const name = s.name ?? '<unnamed>';
+      if (s.writes?.includes(componentTypeName)) writes.push(name);
+      if (s.sideWrites?.includes(componentTypeName)) sideWrites.push(name);
+      if (s.readsFresh?.includes(componentTypeName)) readsFresh.push(name);
+      if (s.readsSnapshot?.includes(componentTypeName)) readsSnapshot.push(name);
+      if (s.reads?.includes(componentTypeName) || s.additionalReads?.includes(componentTypeName)) {
+        reads.push(name);
+      }
+    }
+    return { writes, sideWrites, readsFresh, readsSnapshot, reads };
+  }, [topology, componentTypeName]);
+
+  const hasAny =
+    buckets.writes.length +
+      buckets.sideWrites.length +
+      buckets.readsFresh.length +
+      buckets.readsSnapshot.length +
+      buckets.reads.length >
+    0;
+
+  if (!hasAny) {
+    return null;
+  }
+
+  return (
+    <div className="border-b border-border bg-muted/10 px-3 py-2">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Access (RFC 07)</div>
+      <div className="mt-1 flex flex-col gap-1.5">
+        <ChipRow label="writes" tone="write" names={buckets.writes} />
+        <ChipRow label="side-writes" tone="side-write" names={buckets.sideWrites} />
+        <ChipRow label="reads fresh" tone="fresh" names={buckets.readsFresh} />
+        <ChipRow label="reads snapshot" tone="snapshot" names={buckets.readsSnapshot} />
+        <ChipRow label="reads" tone="read" names={buckets.reads} />
+      </div>
+    </div>
+  );
+}
+
+interface ChipRowProps {
+  label: string;
+  tone: 'write' | 'side-write' | 'fresh' | 'snapshot' | 'read';
+  names: string[];
+}
+
+function ChipRow({ label, tone, names }: ChipRowProps) {
+  if (names.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="font-mono text-[10px] text-muted-foreground">{label}:</span>
+      {names.map((n) => (
+        <span key={n} className={`rounded border px-1.5 py-0.5 font-mono text-[10px] ${toneClasses(tone)}`}>
+          {n}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function toneClasses(tone: ChipRowProps['tone']): string {
+  switch (tone) {
+    case 'write':
+      return 'border-rose-700/50 bg-rose-950/40 text-rose-200';
+    case 'side-write':
+      return 'border-orange-700/50 bg-orange-950/40 text-orange-200';
+    case 'fresh':
+      return 'border-emerald-700/50 bg-emerald-950/40 text-emerald-200';
+    case 'snapshot':
+      return 'border-sky-700/50 bg-sky-950/40 text-sky-200';
+    case 'read':
+      return 'border-slate-600/50 bg-slate-900/40 text-slate-200';
+  }
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SchemaInspector/SchemaRelationshipsPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SchemaInspector/SchemaRelationshipsPanel.tsx
@@ -1,22 +1,22 @@
 import type { IDockviewPanelProps } from 'dockview-react';
 import { AlertTriangle, Info } from 'lucide-react';
-import { StatusBadge } from '@/components/ui/status-badge';
 import { useSchemaInspectorStore } from '@/stores/useSchemaInspectorStore';
 import { useSystemRelationships } from '@/hooks/schema/useSystemRelationships';
+import AccessChips from './AccessChips';
 import SchemaRelationshipsGraph from './SchemaRelationshipsGraph';
 
 /**
- * Relationships panel for the Schema Inspector. Shows systems that read or reactively trigger on
- * the focused component as a React Flow DAG.
+ * Relationships panel for the Schema Inspector. Two surfaces:
  *
- * <b>Writes are intentionally not tracked</b> — see
- * <c>claude/design/typhon-workbench/modules/03-schema-inspector.md §4.3</c> for the rationale
- * (Typhon's runtime uses manual DAG edges, not declared write sets).
+ *   1. <b>Access chips</b> ({@link AccessChips}) — read/write/snapshot/fresh/side-write
+ *      declarations sourced from the topology endpoint (RFC 07 — Unit 6 surfacing).
+ *   2. <b>Relationships graph</b> — systems that read or reactively trigger on the focused
+ *      component, rendered as a React Flow DAG.
  *
  * <b>Runtime hosting gate</b> — the Workbench does not host a <c>TyphonRuntime</c> in Phase 2.
- * When the server returns <c>runtimeHosted: false</c>, the panel renders a banner above an empty
- * preview of the graph (just the component node). Once runtime hosting lands (tracked separately),
- * the panel will populate with real system data without any client changes.
+ * When the server returns <c>runtimeHosted: false</c>, the relationships graph below renders an
+ * empty preview (just the component node). The access chips work regardless of runtime hosting:
+ * declarations come from the trace v6 wire format / live Init payload, not from a hosted runtime.
  */
 export default function SchemaRelationshipsPanel(_props: IDockviewPanelProps) {
   const selectedType = useSchemaInspectorStore((s) => s.selectedComponentType);
@@ -35,14 +35,9 @@ export default function SchemaRelationshipsPanel(_props: IDockviewPanelProps) {
       <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
         <h3 className="font-mono text-[12px] font-semibold text-foreground">{selectedType}</h3>
         <span className="text-[11px] text-muted-foreground">system relationships</span>
-        <StatusBadge
-          tone="warn"
-          className="ml-auto"
-          title="System access details (RFC 07) become available once Workbench hosts a live TyphonRuntime — see issue #275"
-        >
-          access details pending runtime hosting
-        </StatusBadge>
       </div>
+
+      <AccessChips componentTypeName={selectedType} />
 
       {!response.runtimeHosted && (
         <div className="flex items-start gap-2 border-b border-amber-700/40 bg-amber-950/30 px-3 py-2 text-[11px] text-amber-200">

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagCanvas.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagCanvas.tsx
@@ -1,0 +1,192 @@
+import { useMemo } from 'react';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import type { TopologyDto } from '@/api/generated/model/topologyDto';
+import { buildDagModel, type DagEdgeData, type DagNodeData } from './dagModel';
+import SystemDagNode from './SystemDagNode';
+import type { SystemStat } from './useSystemStats';
+import type { QueueBackpressureStat } from './useQueueBackpressure';
+import type { CriticalPathParticipation } from '../CriticalPath/criticalPath';
+import { useDagViewStore } from './useDagViewStore';
+
+interface Props {
+  topology: TopologyDto | null | undefined;
+  selectedSystemName: string | null;
+  onSelectSystem: (name: string | null) => void;
+  /** Optional per-system primary stat. When null, nodes render without heat colouring (Phase 1 view). */
+  systemStats: Map<string, SystemStat> | null;
+  /** Optional per-queue backpressure stats. When null, event edges keep their flat default style. */
+  queueStats: Map<string, QueueBackpressureStat> | null;
+  /** Optional per-system critical-path participation. Drives the ★ badge on nodes. */
+  cpParticipation: CriticalPathParticipation | null;
+  /** Optional per-system skip rates ∈ [0, 1]. Drives the ↪ chip on nodes. */
+  skipRates: Map<string, number> | null;
+}
+
+const NODE_TYPES = { system: SystemDagNode as never };
+
+export default function SystemDagCanvas({
+  topology,
+  selectedSystemName,
+  onSelectSystem,
+  systemStats,
+  queueStats,
+  cpParticipation,
+  skipRates,
+}: Props) {
+  // Layout is read straight from the store (avoids prop drilling). Switching layouts re-runs
+  // `buildDagModel` and `<ReactFlow fitView>` re-fits the viewport to the new bounds.
+  const layout = useDagViewStore((s) => s.layout);
+  const model = useMemo(() => buildDagModel(topology, layout), [topology, layout]);
+
+  // Merge selection state + stats + CP rate + skip rate into node.data in one pass — keeps the
+  // node renderer pure (it just reads what's on data) and lets the canvas re-render only when
+  // these inputs change.
+  const styledNodes = useMemo<
+    Node<DagNodeData & { stat?: SystemStat | null; cpRate?: number | null; skipRate?: number | null }>[]
+  >(() => {
+    return model.nodes.map((n) => {
+      const stat = systemStats?.get(n.id) ?? null;
+      const cpRate = cpParticipation?.perSystem.get(n.id)?.rate ?? null;
+      const skipRate = skipRates?.get(n.id) ?? null;
+      const isSelected = n.id === selectedSystemName;
+      return {
+        ...n,
+        selected: isSelected,
+        data: { ...n.data, stat, cpRate, skipRate },
+      };
+    });
+  }, [model.nodes, selectedSystemName, systemStats, cpParticipation, skipRates]);
+
+  // Apply backpressure styling to event-class edges. The first entry of `via` is the primary
+  // queue name (event edges almost always cite a single queue; multi-queue edges are degenerate).
+  // When the queue isn't in the stats map (no data, range cleared), the edge keeps its default
+  // dashed-violet look from `dagModel.toReactFlowEdge`.
+  const styledEdges = useMemo<Edge<DagEdgeData>[]>(() => {
+    if (!queueStats || queueStats.size === 0) return model.edges;
+    return model.edges.map((e) => {
+      if (e.data?.kind !== 'event') return e;
+      const queueName = e.data.via?.[0];
+      if (!queueName) return e;
+      const stat = queueStats.get(queueName);
+      if (!stat) return e;
+      const stroke = backpressureColour(stat);
+      const baseStyle = e.style ?? {};
+      const labelPrefix = stat.overflowSum > 0 ? `⚠ ${formatCount(stat.overflowSum)} drops · ` : '';
+      // Per design §4.5: stroke colour = peak-driven (worst moment), strokeWidth = end-of-tick-
+      // driven (chronic backlog). Two independent channels answering two different questions.
+      const strokeWidth = 1.5 + stat.outlineHeat * 1.5;
+      return {
+        ...e,
+        animated: stat.overflowSum > 0,
+        label: `${labelPrefix}${e.label ?? queueName}`,
+        labelStyle: { fontSize: 10, fill: stroke, fontFamily: 'monospace' },
+        style: { ...baseStyle, stroke, strokeWidth },
+      };
+    });
+  }, [model.edges, queueStats]);
+
+  const onNodeClick = useMemo<NodeMouseHandler<Node<DagNodeData>>>(() => {
+    return (_e, node) => onSelectSystem(node.id);
+  }, [onSelectSystem]);
+
+  const onPaneClick = useMemo(() => () => onSelectSystem(null), [onSelectSystem]);
+
+  if (model.nodes.length === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background text-[12px] text-muted-foreground">
+        No topology yet. Open a trace or attach a session to populate the DAG.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full bg-background">
+      {/*
+        Lane backgrounds — rendered behind the ReactFlow canvas as absolutely-positioned divs.
+        Lanes are emitted by `horizontal-lanes` and `vertical-lanes` only; `compact` and
+        `circular` produce empty `model.lanes` and this block renders nothing for them.
+      */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        {model.lanes.map((lane) => {
+          const isVertical = lane.labelEdge === 'top';
+          // Horizontal lanes span the full canvas width (lanes line up vertically); vertical lanes
+          // span the full canvas height. The model's width/height bounding box drives the cross-axis.
+          const left = isVertical ? lane.xLeft : 0;
+          const top = isVertical ? 0 : lane.yTop;
+          const width = isVertical ? lane.width : Math.max(lane.width, model.width);
+          const height = isVertical ? Math.max(lane.height, model.height) : lane.height;
+          return (
+            <div
+              key={lane.name}
+              className={`absolute ${isVertical ? 'border-x' : 'border-y'} border-border/40`}
+              style={{ left, top, width, height, backgroundColor: laneTint(lane.index) }}
+            >
+              <div
+                className={`${isVertical ? 'sticky top-0' : 'sticky left-0'} inline-block px-3 py-1.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground`}
+              >
+                {lane.name} · {lane.systemCount}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <ReactFlow
+        nodes={styledNodes}
+        edges={styledEdges}
+        nodeTypes={NODE_TYPES}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.3}
+        maxZoom={1.6}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable
+        onNodeClick={onNodeClick}
+        onPaneClick={onPaneClick}
+      >
+        <Background color="var(--border)" gap={16} />
+        <Controls showInteractive={false} position="bottom-left" />
+        <MiniMap pannable zoomable position="bottom-right" />
+      </ReactFlow>
+    </div>
+  );
+}
+
+const TINT_PALETTE = [
+  'rgba(56, 189, 248, 0.06)', // sky
+  'rgba(148, 163, 184, 0.04)', // slate
+  'rgba(251, 146, 60, 0.06)', // orange
+  'rgba(167, 139, 250, 0.06)', // violet
+  'rgba(74, 222, 128, 0.06)', // emerald
+];
+
+function laneTint(index: number): string {
+  if (index < 0) return 'rgba(0, 0, 0, 0)';
+  return TINT_PALETTE[index % TINT_PALETTE.length];
+}
+
+/**
+ * Backpressure → edge stroke colour. Cool (low traffic) → red (overflow). Per `09-system-dag.md
+ * §4.5`'s threshold ramp, but applied to the relative-heat fallback documented in
+ * {@link useQueueBackpressure}. Overflow always wins.
+ */
+function backpressureColour(stat: QueueBackpressureStat): string {
+  if (stat.overflowSum > 0) return 'hsl(0, 80%, 55%)'; // catastrophic — deep red
+  // 0 → violet (idle), 1 → orange (hot)
+  const hue = 270 - stat.heat * 240; // 270 (violet) → 30 (orange)
+  return `hsl(${hue}, 70%, 60%)`;
+}
+
+function formatCount(n: number): string {
+  if (n < 1000) return String(n);
+  return `${(n / 1000).toFixed(1)}k`;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagCanvas.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagCanvas.tsx
@@ -4,13 +4,16 @@ import {
   Background,
   Controls,
   MiniMap,
+  ViewportPortal,
   type Edge,
   type Node,
   type NodeMouseHandler,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import type { TopologyDto } from '@/api/generated/model/topologyDto';
-import { buildDagModel, type DagEdgeData, type DagNodeData } from './dagModel';
+import { useHoverStore } from '@/stores/useHoverStore';
+import { colorForPhase } from '../CriticalPath/phaseColors';
+import { buildDagModel, NODE_HEIGHT, NODE_WIDTH, type DagEdgeData, type DagNodeData } from './dagModel';
 import SystemDagNode from './SystemDagNode';
 import type { SystemStat } from './useSystemStats';
 import type { QueueBackpressureStat } from './useQueueBackpressure';
@@ -27,6 +30,12 @@ interface Props {
   queueStats: Map<string, QueueBackpressureStat> | null;
   /** Optional per-system critical-path participation. Drives the ★ badge on nodes. */
   cpParticipation: CriticalPathParticipation | null;
+  /**
+   * System names on the critical path of the dominant (longest) tick in the current range. Drives
+   * the red outline on nodes per `09-system-dag.md §11 Phase 3`. Distinct from `cpParticipation`,
+   * which is range-wide (badge), this is single-tick (per-tick spotlight).
+   */
+  dominantCpSystems: Set<string> | null;
   /** Optional per-system skip rates ∈ [0, 1]. Drives the ↪ chip on nodes. */
   skipRates: Map<string, number> | null;
 }
@@ -40,31 +49,57 @@ export default function SystemDagCanvas({
   systemStats,
   queueStats,
   cpParticipation,
+  dominantCpSystems,
   skipRates,
 }: Props) {
   // Layout is read straight from the store (avoids prop drilling). Switching layouts re-runs
   // `buildDagModel` and `<ReactFlow fitView>` re-fits the viewport to the new bounds.
   const layout = useDagViewStore((s) => s.layout);
   const model = useMemo(() => buildDagModel(topology, layout), [topology, layout]);
+  const hoveredSystem = useHoverStore((s) => s.hoveredSystem);
+  const setHoveredSystem = useHoverStore((s) => s.setHoveredSystem);
+  const hoveredPhase = useHoverStore((s) => s.hoveredPhase);
+  const setHoveredPhase = useHoverStore((s) => s.setHoveredPhase);
+
+  // Phase-highlight rects for the lane-less layouts (compact / circular). When a phase is
+  // hovered (in the CP tape, here in the lanes layouts, etc.) and we're in a layout that
+  // doesn't draw swim-lanes, paint a coloured backdrop + border behind every node belonging
+  // to that phase. Colour comes from `colorForPhase` — same palette as the Critical Path
+  // tape's phase stripe — so the cross-panel association reads instantly.
+  const phaseHighlights = useMemo(() => {
+    if (!hoveredPhase || model.lanes.length > 0 || !topology?.phases) return [];
+    const phaseIndex = topology.phases.indexOf(hoveredPhase);
+    if (phaseIndex < 0) return [];
+    const colour = colorForPhase(phaseIndex);
+    const out: Array<{ id: string; x: number; y: number; stroke: string; fill: string }> = [];
+    for (const n of model.nodes) {
+      if (n.data.phaseName === hoveredPhase) {
+        out.push({ id: n.id, x: n.position.x, y: n.position.y, stroke: colour.stroke, fill: colour.fill });
+      }
+    }
+    return out;
+  }, [hoveredPhase, model.lanes.length, model.nodes, topology]);
 
   // Merge selection state + stats + CP rate + skip rate into node.data in one pass — keeps the
   // node renderer pure (it just reads what's on data) and lets the canvas re-render only when
   // these inputs change.
   const styledNodes = useMemo<
-    Node<DagNodeData & { stat?: SystemStat | null; cpRate?: number | null; skipRate?: number | null }>[]
+    Node<DagNodeData & { stat?: SystemStat | null; cpRate?: number | null; skipRate?: number | null; isOnDominantCp?: boolean; isHovered?: boolean }>[]
   >(() => {
     return model.nodes.map((n) => {
       const stat = systemStats?.get(n.id) ?? null;
       const cpRate = cpParticipation?.perSystem.get(n.id)?.rate ?? null;
       const skipRate = skipRates?.get(n.id) ?? null;
       const isSelected = n.id === selectedSystemName;
+      const isOnDominantCp = dominantCpSystems?.has(n.id) ?? false;
+      const isHovered = n.id === hoveredSystem;
       return {
         ...n,
         selected: isSelected,
-        data: { ...n.data, stat, cpRate, skipRate },
+        data: { ...n.data, stat, cpRate, skipRate, isOnDominantCp, isHovered },
       };
     });
-  }, [model.nodes, selectedSystemName, systemStats, cpParticipation, skipRates]);
+  }, [model.nodes, selectedSystemName, systemStats, cpParticipation, dominantCpSystems, skipRates, hoveredSystem]);
 
   // Apply backpressure styling to event-class edges. The first entry of `via` is the primary
   // queue name (event edges almost always cite a single queue; multi-queue edges are degenerate).
@@ -98,6 +133,18 @@ export default function SystemDagCanvas({
     return (_e, node) => onSelectSystem(node.id);
   }, [onSelectSystem]);
 
+  // Cross-panel hover sync (#317 Phase 3 §11): mouseenter writes the node id to the shared hover
+  // store; the matching tape bar in the Critical Path view picks it up via the same store. Leave
+  // clears the slot; we don't try to debounce or trail because dockview re-parents propagate
+  // mouseleave correctly.
+  const onNodeMouseEnter = useMemo<NodeMouseHandler<Node<DagNodeData>>>(() => {
+    return (_e, node) => setHoveredSystem(node.id);
+  }, [setHoveredSystem]);
+
+  const onNodeMouseLeave = useMemo<NodeMouseHandler<Node<DagNodeData>>>(() => {
+    return () => setHoveredSystem(null);
+  }, [setHoveredSystem]);
+
   const onPaneClick = useMemo(() => () => onSelectSystem(null), [onSelectSystem]);
 
   if (model.nodes.length === 0) {
@@ -110,35 +157,6 @@ export default function SystemDagCanvas({
 
   return (
     <div className="relative h-full w-full bg-background">
-      {/*
-        Lane backgrounds — rendered behind the ReactFlow canvas as absolutely-positioned divs.
-        Lanes are emitted by `horizontal-lanes` and `vertical-lanes` only; `compact` and
-        `circular` produce empty `model.lanes` and this block renders nothing for them.
-      */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        {model.lanes.map((lane) => {
-          const isVertical = lane.labelEdge === 'top';
-          // Horizontal lanes span the full canvas width (lanes line up vertically); vertical lanes
-          // span the full canvas height. The model's width/height bounding box drives the cross-axis.
-          const left = isVertical ? lane.xLeft : 0;
-          const top = isVertical ? 0 : lane.yTop;
-          const width = isVertical ? lane.width : Math.max(lane.width, model.width);
-          const height = isVertical ? Math.max(lane.height, model.height) : lane.height;
-          return (
-            <div
-              key={lane.name}
-              className={`absolute ${isVertical ? 'border-x' : 'border-y'} border-border/40`}
-              style={{ left, top, width, height, backgroundColor: laneTint(lane.index) }}
-            >
-              <div
-                className={`${isVertical ? 'sticky top-0' : 'sticky left-0'} inline-block px-3 py-1.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground`}
-              >
-                {lane.name} · {lane.systemCount}
-              </div>
-            </div>
-          );
-        })}
-      </div>
       <ReactFlow
         nodes={styledNodes}
         edges={styledEdges}
@@ -151,8 +169,94 @@ export default function SystemDagCanvas({
         nodesConnectable={false}
         elementsSelectable
         onNodeClick={onNodeClick}
+        onNodeMouseEnter={onNodeMouseEnter}
+        onNodeMouseLeave={onNodeMouseLeave}
         onPaneClick={onPaneClick}
       >
+        {/*
+          Lane backgrounds — rendered inside `ViewportPortal` so they share the ReactFlow viewport
+          transform (translate + scale) with the nodes. Without this, the lanes are static in
+          screen space while the nodes pan/zoom underneath, creating the visual mis-alignment the
+          user reported. Coordinates here are in flow-space (same coordinate system as
+          `node.position`); the viewport applies the transform automatically.
+          Lanes are emitted by `horizontal-lanes` and `vertical-lanes` only; `compact` /
+          `circular` produce empty `model.lanes` and this block renders nothing for them.
+        */}
+        <ViewportPortal>
+          {/*
+            Phase-flow arrow — visualises the order phases run in (top→bottom for horizontal lanes,
+            left→right for vertical lanes). A single SVG positioned in the outer margin (left of
+            horizontal lanes / above vertical lanes) carrying a shaft + chevrons at each phase
+            boundary + a trailing arrowhead. Skipped when there are 0 or 1 phases — single phase
+            has no flow to show. Position is in flow-space so it pans/zooms with the rest of the
+            viewport.
+          */}
+          {model.lanes.length > 1 && <PhaseFlowArrow lanes={model.lanes} />}
+          {/*
+            Phase-highlight rects — drawn behind nodes when a phase is hovered AND the layout
+            has no swim-lanes (compact / circular). Each rect sits at the node's flow-space
+            position with a small padding so it reads as a backdrop, not a tile replacement.
+            Uses `laneTintHovered` so the colour matches the swim-lane hover tint exactly,
+            keeping the cross-layout cue consistent.
+          */}
+          {phaseHighlights.map((hl) => (
+            <div
+              key={hl.id}
+              className="pointer-events-none absolute rounded"
+              style={{
+                // 12 px padding around the node tile so the backdrop reads as visibly wider
+                // than the box it sits behind (the user's "twice as large" — relative to the
+                // node, not a stroke width).
+                left: hl.x - 12,
+                top: hl.y - 12,
+                width: NODE_WIDTH + 24,
+                height: NODE_HEIGHT + 24,
+                // Plain fill, no border. CP tape's phase-stripe `stroke` hue re-cast as HSLA
+                // at very low alpha — visible enough to register "this node is in the hovered
+                // phase", washed-out enough to stay subtle and not compete with the node tile.
+                backgroundColor: hl.stroke.replace('hsl(', 'hsla(').replace(')', ', 0.12)'),
+                zIndex: -1,
+              }}
+            />
+          ))}
+          {model.lanes.map((lane) => {
+            // Cross-panel phase-hover sync (#317 §5.5): when this lane's phase is hovered (here
+            // or in the CP tape's stripe), brighten the lane background. The lane keeps its
+            // tint baseline; we layer a higher-opacity version on top.
+            const isHovered = hoveredPhase != null && hoveredPhase === lane.name;
+            const isVertical = lane.labelEdge === 'top';
+            return (
+              <div
+                key={lane.name}
+                // `pointer-events: none` so clicks pass through to nodes / pane; the inner label
+                // re-enables them for the hover sync.
+                // `zIndex: -1` puts the lane below the edges + nodes ReactFlow renders inside
+                // the same viewport plane, so the band reads as a backdrop, not an overlay.
+                className={`pointer-events-none absolute ${isVertical ? (isHovered ? 'border-x-2' : 'border-x') : (isHovered ? 'border-y-2' : 'border-y')} ${isHovered ? 'border-foreground/60' : 'border-border/70'}`}
+                style={{
+                  left: lane.xLeft,
+                  top: lane.yTop,
+                  width: lane.width,
+                  height: lane.height,
+                  backgroundColor: isHovered ? laneTintHovered(lane.index) : laneTint(lane.index),
+                  zIndex: -1,
+                }}
+              >
+                {/* Label sits at the lane's flow-space top-left, panning/zooming with the
+                    lane (it's part of the same coordinate system). Sticky positioning was
+                    dropped — it relied on the parent being page-scroll-anchored, which no
+                    longer holds inside the transformed viewport plane. */}
+                <div
+                  className={`pointer-events-auto inline-block px-3 py-1.5 font-mono text-[10px] uppercase tracking-wide ${isHovered ? 'text-foreground/80' : 'text-muted-foreground'}`}
+                  onMouseEnter={() => setHoveredPhase(lane.name)}
+                  onMouseLeave={() => setHoveredPhase(null)}
+                >
+                  {lane.name} · {lane.systemCount}
+                </div>
+              </div>
+            );
+          })}
+        </ViewportPortal>
         <Background color="var(--border)" gap={16} />
         <Controls showInteractive={false} position="bottom-left" />
         <MiniMap pannable zoomable position="bottom-right" />
@@ -161,17 +265,189 @@ export default function SystemDagCanvas({
   );
 }
 
+// Baseline lane tints — readable at any zoom. The previous values (0.04–0.06 alpha) were so
+// faint they only registered when the lane filled most of the viewport; bumped to 0.14–0.18 so
+// the bands read as bands at zoom-out levels too without overpowering node tiles.
 const TINT_PALETTE = [
-  'rgba(56, 189, 248, 0.06)', // sky
-  'rgba(148, 163, 184, 0.04)', // slate
-  'rgba(251, 146, 60, 0.06)', // orange
-  'rgba(167, 139, 250, 0.06)', // violet
-  'rgba(74, 222, 128, 0.06)', // emerald
+  'rgba(56, 189, 248, 0.16)',  // sky
+  'rgba(148, 163, 184, 0.12)', // slate
+  'rgba(251, 146, 60, 0.16)',  // orange
+  'rgba(167, 139, 250, 0.16)', // violet
+  'rgba(74, 222, 128, 0.16)',  // emerald
 ];
 
 function laneTint(index: number): string {
   if (index < 0) return 'rgba(0, 0, 0, 0)';
   return TINT_PALETTE[index % TINT_PALETTE.length];
+}
+
+/**
+ * Higher-opacity twin of {@link laneTint} for the phase-hover state. Same hues, alpha roughly
+ * doubled vs. the baseline so the matched lane is unmistakable.
+ */
+const TINT_PALETTE_HOVERED = [
+  'rgba(56, 189, 248, 0.32)',
+  'rgba(148, 163, 184, 0.26)',
+  'rgba(251, 146, 60, 0.32)',
+  'rgba(167, 139, 250, 0.32)',
+  'rgba(74, 222, 128, 0.32)',
+];
+
+function laneTintHovered(index: number): string {
+  if (index < 0) return 'rgba(0, 0, 0, 0)';
+  return TINT_PALETTE_HOVERED[index % TINT_PALETTE_HOVERED.length];
+}
+
+/**
+ * Phase-flow arrows — one short arrow per lane boundary, spanning the gap between consecutive
+ * lanes. Communicates "phase i → phase i+1" without putting a single dominant spine on the
+ * canvas. Each arrow goes from the bottom (or right, vertical mode) edge of one lane to the top
+ * (or left) edge of the next, with the body inside the LANE_GAP empty space.
+ *
+ * **Alignment.** All arrows share a common position on the cross-flow axis (same x in horizontal
+ * mode, same y in vertical mode), so they form a clean column / row of pointers rather than
+ * scattered glyphs. The shared coordinate is the canvas centre on the cross-flow axis.
+ *
+ * **Subtle by design.** Opacity 0.2 over the muted-foreground tone — visible enough to register
+ * "things flow this direction", quiet enough not to compete with the actual data (nodes / edges).
+ *
+ * Pointer-events disabled so arrows don't intercept node hover / click. Rendered inside
+ * ViewportPortal with `currentColor` so theme switches and viewport pan/zoom Just Work.
+ */
+function PhaseFlowArrow({ lanes }: { lanes: ReadonlyArray<{ name: string; xLeft: number; yTop: number; width: number; height: number; labelEdge: 'left' | 'top' }> }) {
+  const isVertical = lanes[0].labelEdge === 'top';
+  const SHAFT_WIDTH = 1.5;
+  const ARROWHEAD_HALF = 5; // arrowhead width on the cross-flow axis
+  const ARROWHEAD_LEN = 8;  // arrowhead extent on the flow axis
+  const OPACITY = 0.2;
+
+  // Cross-axis position — arrows live in a leading margin area: 20 px in from the lane stack's
+  // leading edge (top in vertical-lanes mode, left in horizontal-lanes mode). Keeps the arrows
+  // off the node area and away from the dense centre of the canvas.
+  const LEADING_MARGIN = 20;
+
+  if (isVertical) {
+    // Vertical lanes — arrow goes from right edge of lane[i] to left edge of lane[i+1]; all
+    // arrows share the same y near the top of the lane stack.
+    const minY = Math.min(...lanes.map((l) => l.yTop));
+    const sharedY = minY + LEADING_MARGIN;
+    return (
+      <>
+        {lanes.slice(0, -1).map((lane, i) => {
+          const next = lanes[i + 1];
+          const startX = lane.xLeft + lane.width;
+          const endX = next.xLeft;
+          return (
+            <PhaseFlowSegment
+              key={i}
+              startX={startX}
+              startY={sharedY}
+              endX={endX}
+              endY={sharedY}
+              opacity={OPACITY}
+              shaftWidth={SHAFT_WIDTH}
+              arrowheadHalf={ARROWHEAD_HALF}
+              arrowheadLen={ARROWHEAD_LEN}
+              orientation="horizontal"
+            />
+          );
+        })}
+      </>
+    );
+  }
+
+  // Horizontal lanes — arrow goes from bottom edge of lane[i] to top edge of lane[i+1]; all
+  // arrows share the same x near the left of the lane stack.
+  const minX = Math.min(...lanes.map((l) => l.xLeft));
+  const sharedX = minX + LEADING_MARGIN;
+  return (
+    <>
+      {lanes.slice(0, -1).map((lane, i) => {
+        const next = lanes[i + 1];
+        const startY = lane.yTop + lane.height;
+        const endY = next.yTop;
+        return (
+          <PhaseFlowSegment
+            key={i}
+            startX={sharedX}
+            startY={startY}
+            endX={sharedX}
+            endY={endY}
+            opacity={OPACITY}
+            shaftWidth={SHAFT_WIDTH}
+            arrowheadHalf={ARROWHEAD_HALF}
+            arrowheadLen={ARROWHEAD_LEN}
+            orientation="vertical"
+          />
+        );
+      })}
+    </>
+  );
+}
+
+/**
+ * One short flow-arrow spanning the gap between two consecutive lanes. The shaft runs from
+ * `(startX, startY)` toward `(endX, endY)` and stops `arrowheadLen` short; the arrowhead
+ * triangle takes that final stretch and points at the destination edge. Wrapped in its own SVG
+ * so we can keep arrow segments self-contained inside `ViewportPortal` without manually
+ * computing a parent SVG bounding box.
+ */
+function PhaseFlowSegment({
+  startX, startY, endX, endY, opacity, shaftWidth, arrowheadHalf, arrowheadLen, orientation,
+}: {
+  startX: number; startY: number; endX: number; endY: number;
+  opacity: number; shaftWidth: number; arrowheadHalf: number; arrowheadLen: number;
+  orientation: 'vertical' | 'horizontal';
+}) {
+  // Render each segment as its own absolutely-positioned SVG inside ViewportPortal. We size
+  // the SVG just large enough to contain the arrow + arrowhead; `overflow: visible` makes the
+  // arrowhead triangle tolerant of tiny rounding mismatches without clipping.
+  const left = Math.min(startX, endX) - arrowheadHalf;
+  const top = Math.min(startY, endY) - arrowheadHalf;
+  const width = Math.abs(endX - startX) + arrowheadHalf * 2;
+  const height = Math.abs(endY - startY) + arrowheadHalf * 2;
+  // Convert absolute coords into SVG-local coords (subtract the SVG's flow-space origin).
+  const sx = startX - left;
+  const sy = startY - top;
+  const ex = endX - left;
+  const ey = endY - top;
+
+  if (orientation === 'vertical') {
+    // Vertical arrow — flow direction sign tells us which way the arrowhead points.
+    const dir = ey >= sy ? 1 : -1;
+    const shaftEndY = ey - arrowheadLen * dir;
+    return (
+      <svg
+        width={width}
+        height={height}
+        className="text-muted-foreground"
+        style={{ position: 'absolute', left, top, overflow: 'visible', pointerEvents: 'none', zIndex: -1, opacity }}
+      >
+        <line x1={sx} y1={sy} x2={ex} y2={shaftEndY} stroke="currentColor" strokeWidth={shaftWidth} />
+        <polygon
+          points={`${ex - arrowheadHalf},${shaftEndY} ${ex + arrowheadHalf},${shaftEndY} ${ex},${ey}`}
+          fill="currentColor"
+        />
+      </svg>
+    );
+  }
+  // Horizontal arrow.
+  const dir = ex >= sx ? 1 : -1;
+  const shaftEndX = ex - arrowheadLen * dir;
+  return (
+    <svg
+      width={width}
+      height={height}
+      className="text-muted-foreground"
+      style={{ position: 'absolute', left, top, overflow: 'visible', pointerEvents: 'none', zIndex: -1, opacity }}
+    >
+      <line x1={sx} y1={sy} x2={shaftEndX} y2={ey} stroke="currentColor" strokeWidth={shaftWidth} />
+      <polygon
+        points={`${shaftEndX},${ey - arrowheadHalf} ${shaftEndX},${ey + arrowheadHalf} ${ex},${ey}`}
+        fill="currentColor"
+      />
+    </svg>
+  );
 }
 
 /**

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagNode.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagNode.tsx
@@ -7,12 +7,24 @@ export default function SystemDagNode({
   data,
   selected,
 }: {
-  data: DagNodeData & { stat?: SystemStat | null; cpRate?: number | null; skipRate?: number | null };
+  data: DagNodeData & { stat?: SystemStat | null; cpRate?: number | null; skipRate?: number | null; isOnDominantCp?: boolean; isHovered?: boolean };
   selected?: boolean;
 }) {
   const kindClass = kindClasses(data.kind);
   const exclusiveBar = data.isExclusivePhase ? 'border-l-4 border-l-amber-500' : '';
-  const ring = selected ? 'ring-2 ring-primary' : '';
+  // Selection wins over hover — once you click the node the primary ring locks in; hover only
+  // illuminates when no harder selection is active. Hover comes from the cross-panel store, so
+  // hovering a tape bar lights this node and vice-versa.
+  const ring = selected
+    ? 'ring-2 ring-primary'
+    : data.isHovered
+      ? 'ring-2 ring-foreground/60'
+      : '';
+  // Per `09-system-dag.md §11 Phase 3`: nodes on the critical path of the dominant tick get a red
+  // outline. We use Tailwind's `outline` (not `border` or `ring`) so it stacks cleanly with the
+  // selection ring + heat border without fighting any of them. `outline-offset-1` keeps the red
+  // halo visually distinct from the heat colour painted on the actual border.
+  const dominantCpOutline = data.isOnDominantCp ? 'outline outline-2 outline-red-500 outline-offset-1' : '';
   const stat = data.stat ?? null;
   const heatStyle = stat ? heatBorder(stat.heat) : undefined;
   const cpRate = data.cpRate ?? null;
@@ -28,9 +40,10 @@ export default function SystemDagNode({
 
   return (
     <div
-      className={`relative flex h-[56px] w-[180px] flex-col rounded border bg-card shadow-sm ${exclusiveBar} ${ring}`}
+      className={`relative flex h-[56px] w-[180px] flex-col rounded border bg-card shadow-sm ${exclusiveBar} ${ring} ${dominantCpOutline}`}
       style={heatStyle}
       data-testid={`system-dag-node-${data.systemName}`}
+      title={data.isOnDominantCp ? 'On the critical path of the dominant tick' : undefined}
     >
       <Handle type="target" position={Position.Left} className="!h-2 !w-2 !border-0 !bg-muted-foreground" />
       <div className="flex items-center justify-between gap-1 px-2 pt-1">

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagNode.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagNode.tsx
@@ -1,0 +1,136 @@
+import { Handle, Position } from '@xyflow/react';
+import type { DagNodeData } from './dagModel';
+import type { SystemStat } from './useSystemStats';
+
+/** Renders a single system tile with kind chip, primary stat (when stats are loaded), CP-rate badge, skip chip, and filter chips. */
+export default function SystemDagNode({
+  data,
+  selected,
+}: {
+  data: DagNodeData & { stat?: SystemStat | null; cpRate?: number | null; skipRate?: number | null };
+  selected?: boolean;
+}) {
+  const kindClass = kindClasses(data.kind);
+  const exclusiveBar = data.isExclusivePhase ? 'border-l-4 border-l-amber-500' : '';
+  const ring = selected ? 'ring-2 ring-primary' : '';
+  const stat = data.stat ?? null;
+  const heatStyle = stat ? heatBorder(stat.heat) : undefined;
+  const cpRate = data.cpRate ?? null;
+  // Per `09-system-dag.md §4.2`: solid ★ at ≥50% CP participation, dimmed at 10–50%, none below.
+  const cpBadge = cpRate == null || cpRate < 0.1
+    ? null
+    : cpRate >= 0.5
+      ? { glyph: '★', tone: 'solid' as const, title: `On critical path ${(cpRate * 100).toFixed(0)}% of ticks` }
+      : { glyph: '★', tone: 'dim' as const, title: `On critical path ${(cpRate * 100).toFixed(0)}% of ticks` };
+  // Per design §4.2: skip-rate chip rendered when skipRate > 50%.
+  const skipRate = data.skipRate ?? null;
+  const showSkipChip = skipRate != null && skipRate > 0.5;
+
+  return (
+    <div
+      className={`relative flex h-[56px] w-[180px] flex-col rounded border bg-card shadow-sm ${exclusiveBar} ${ring}`}
+      style={heatStyle}
+      data-testid={`system-dag-node-${data.systemName}`}
+    >
+      <Handle type="target" position={Position.Left} className="!h-2 !w-2 !border-0 !bg-muted-foreground" />
+      <div className="flex items-center justify-between gap-1 px-2 pt-1">
+        <span className="truncate font-mono text-[11px] font-semibold text-foreground" title={data.systemName}>
+          {data.systemName}
+        </span>
+        <div className="flex items-center gap-1">
+          {cpBadge && (
+            <span
+              className={`text-[12px] leading-none ${cpBadge.tone === 'solid' ? 'text-amber-300' : 'text-amber-400/40'}`}
+              title={cpBadge.title}
+            >
+              {cpBadge.glyph}
+            </span>
+          )}
+          <span className={`rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase ${kindClass}`}>{data.kind}</span>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-1 px-2 pb-1 pt-0.5">
+        {stat ? (
+          <span
+            className="rounded border px-1 py-px font-mono text-[10px]"
+            style={heatChip(stat.heat)}
+            title={`${stat.value.toFixed(1)} µs`}
+          >
+            {formatStat(stat.value)}
+          </span>
+        ) : null}
+        {showSkipChip && skipRate != null && (
+          <Chip tone="muted">↪ {(skipRate * 100).toFixed(0)}%</Chip>
+        )}
+        {data.isParallel && <Chip>parallel</Chip>}
+        {data.isExclusivePhase && <Chip tone="warn">exclusive</Chip>}
+        {data.tierFilter !== 0x0F && <Chip tone="muted">tier {data.tierFilter}</Chip>}
+        {data.changeFilterTypes.length > 0 && <Chip tone="info">change:{data.changeFilterTypes.length}</Chip>}
+        {!data.hasAccess && !stat && <Chip tone="muted">no decls</Chip>}
+      </div>
+      <Handle type="source" position={Position.Right} className="!h-2 !w-2 !border-0 !bg-muted-foreground" />
+    </div>
+  );
+}
+
+interface ChipProps {
+  children: React.ReactNode;
+  tone?: 'default' | 'muted' | 'warn' | 'info';
+}
+
+function Chip({ children, tone = 'default' }: ChipProps) {
+  const cls =
+    tone === 'muted'
+      ? 'border-border bg-muted/40 text-muted-foreground'
+      : tone === 'warn'
+        ? 'border-amber-700/50 bg-amber-950/40 text-amber-200'
+        : tone === 'info'
+          ? 'border-sky-700/50 bg-sky-950/40 text-sky-200'
+          : 'border-slate-600/50 bg-slate-900/40 text-slate-200';
+  return <span className={`rounded border px-1 py-px text-[9px] font-mono ${cls}`}>{children}</span>;
+}
+
+function kindClasses(kind: DagNodeData['kind']): string {
+  switch (kind) {
+    case 'Pipeline':
+      return 'bg-emerald-900/40 text-emerald-200';
+    case 'Query':
+      return 'bg-sky-900/40 text-sky-200';
+    case 'Callback':
+      return 'bg-violet-900/40 text-violet-200';
+    case 'Unknown':
+    default:
+      return 'bg-slate-800 text-slate-300';
+  }
+}
+
+/**
+ * Heat ramp: cool (blue, low duration) → hot (red, high duration). The exact gradient is
+ * cosmetic — the goal is "scan the canvas, see which systems are hot." Hue interpolates
+ * from 220° (blue) → 0° (red); saturation flat 70%; alpha increases with heat so cold
+ * tiles stay readable.
+ */
+function heatBorder(heat: number): React.CSSProperties {
+  const hue = 220 - heat * 220; // 220 → 0
+  const alpha = 0.4 + heat * 0.5; // 0.4 → 0.9
+  return {
+    borderColor: `hsla(${hue}, 70%, 55%, ${alpha})`,
+    boxShadow: heat > 0.66 ? `0 0 8px hsla(${hue}, 70%, 55%, 0.35)` : undefined,
+  };
+}
+
+function heatChip(heat: number): React.CSSProperties {
+  const hue = 220 - heat * 220;
+  return {
+    backgroundColor: `hsla(${hue}, 70%, 35%, 0.4)`,
+    borderColor: `hsla(${hue}, 70%, 55%, 0.7)`,
+    color: `hsla(${hue}, 80%, 88%, 1)`,
+  };
+}
+
+/** Format µs in a width-stable way: <1ms in µs (e.g. "812µs"), ≥1ms in ms (e.g. "3.2ms"). */
+function formatStat(us: number): string {
+  if (us < 1000) return `${Math.round(us)}µs`;
+  const ms = us / 1000;
+  return ms < 10 ? `${ms.toFixed(2)}ms` : `${ms.toFixed(1)}ms`;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagPanel.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from 'react';
+import type { IDockviewPanelProps } from 'dockview-react';
+import { useTopology } from '@/hooks/data/useTopology';
+import { useProfilerMetadata } from '@/hooks/profiler/useProfilerMetadata';
+import { useSelectionStore } from '@/stores/useSelectionStore';
+import { useSessionStore } from '@/stores/useSessionStore';
+import {
+  computeCriticalPathParticipation,
+  computeSystemSkipRates,
+} from '../CriticalPath/criticalPath';
+import { toNodeData } from './dagModel';
+import { deriveEdges } from './edgeDerivation';
+import SystemDagCanvas from './SystemDagCanvas';
+import SystemDagSidePanel from './SystemDagSidePanel';
+import SystemDagToolbar from './SystemDagToolbar';
+import { timeToTickRange } from './tickRangeMapping';
+import { useDagViewStore } from './useDagViewStore';
+import { useQueueBackpressure } from './useQueueBackpressure';
+import { useSystemStats } from './useSystemStats';
+
+/**
+ * System DAG view — Phase 1 + Phase 2 (#315 + #316).
+ *
+ * Phase 1 shipped: topology-only canvas (phase swim-lanes, derived edges, declared access on click).
+ *
+ * Phase 2 (this file): Tier 1 node colouring driven by /aggregate over per-system tracks. Toolbar
+ * adds a "Snapshot last N ticks" pin and a stat-mode selector (mean / p50 / p95 / p99 / max). The
+ * panel auto-snapshots once on first metadata arrival so a fresh open shows useful colour without
+ * a click. Cross-panel TimeArea binding (Phase 2 final per design) is deferred — the panel owns
+ * the range until that wiring lands in a follow-up.
+ *
+ * Selection mirrors to {@link useSelectionStore.system} as before; reverse direction (other panel
+ * sets the system slot) opens the side panel here.
+ */
+export default function SystemDagPanel(_props: IDockviewPanelProps) {
+  const sessionId = useSessionStore((s) => s.sessionId);
+  const { data: topology, isLoading, isError } = useTopology(sessionId);
+  // Profiler metadata gives us the tick → µs mapping for the cross-panel binding plus the inputs
+  // for the CP / skip-rate algorithms. Shared TanStack cache with the profiler panel — no
+  // duplicate fetch.
+  const { data: metadata } = useProfilerMetadata(sessionId);
+  const statMode = useDagViewStore((s) => s.statMode);
+
+  // Cross-panel binding (#316 Phase 2 final per `09-system-dag.md §7.1`): the tick range comes
+  // from `useSelectionStore.time`, the same µs window the profiler's TimeArea writes to. The
+  // existing selection-bridge sync (selectionBridges.ts) already mirrors profiler.viewRange ↔
+  // selection.time, so scrubbing the profiler's TimeArea live-updates the DAG aggregations, and
+  // hitting "Snapshot last N ticks" in the DAG (which writes to selection.time) pins the
+  // profiler's TimeArea too.
+  //
+  // Conversion µs → tick happens at the panel boundary; downstream hooks (useSystemStats /
+  // useQueueBackpressure / CP / skip-rate) all take TickRange and stay tick-native.
+  const time = useSelectionStore((s) => s.time);
+  const range = useMemo(
+    () => timeToTickRange(time, metadata?.tickSummaries),
+    [time, metadata],
+  );
+
+  const selectedSystemName = useSelectionStore((s) => s.system);
+  const setSystem = useSelectionStore((s) => s.setSystem);
+
+  // Local view of the side-panel close button — the selection store is shared, so we don't want
+  // closing here to clear it for other panels. We hide the side panel when this local flag is
+  // set, even if the store still has a value.
+  const [sidePanelOverride, setSidePanelOverride] = useState<string | null>(null);
+  const sidePanelHidden = sidePanelOverride !== null && sidePanelOverride === selectedSystemName;
+
+  const systemNames = useMemo(() => {
+    if (!topology?.systems) return [];
+    const out: string[] = [];
+    for (const s of topology.systems) {
+      if (s.name) out.push(s.name);
+    }
+    return out;
+  }, [topology]);
+
+  // Resolve the side-panel's selected node by direct lookup on `topology.systems` instead of
+  // running the full dagre layout (`buildDagModel`) just to find one entry. The Canvas already
+  // computes the layout once; doing it a second time per click is O(systems × edges) wasted.
+  const selectedNode = useMemo(() => {
+    if (!selectedSystemName || !topology?.systems) return null;
+    for (const s of topology.systems) {
+      if (s.name === selectedSystemName) return toNodeData(s);
+    }
+    return null;
+  }, [topology, selectedSystemName]);
+
+  const showSidePanel = selectedNode !== null && !sidePanelHidden;
+
+  const { stats } = useSystemStats(sessionId, systemNames, range, statMode);
+
+  // Edges are derived once per topology; queue-name derivation and CP computation both consume
+  // this. Without this, both `useMemo`s below called `deriveEdges` redundantly on every change.
+  const derivedEdges = useMemo(
+    () => (topology?.systems ? deriveEdges(topology.systems) : []),
+    [topology],
+  );
+
+  const queueNames = useMemo(() => {
+    if (derivedEdges.length === 0) return [];
+    const names = new Set<string>();
+    for (const e of derivedEdges) {
+      if (e.kind !== 'event') continue;
+      for (const n of e.via) names.add(n);
+    }
+    return Array.from(names).sort();
+  }, [derivedEdges]);
+  const queueStats = useQueueBackpressure(sessionId, queueNames, range);
+
+  // Critical-path participation rate per system. Pure client-side computation per design §9.3.
+  // Recomputes only when topology rows or range change — `metadata.systemTickSummaries` is
+  // referentially stable while the cache is loaded.
+  const cpParticipation = useMemo(() => {
+    if (!topology?.systems || !metadata?.systemTickSummaries || metadata.systemTickSummaries.length === 0) {
+      return null;
+    }
+    return computeCriticalPathParticipation({
+      systems: topology.systems,
+      rows: metadata.systemTickSummaries,
+      edges: derivedEdges,
+      phases: topology.phases ?? [],
+      range,
+    });
+  }, [topology, metadata, range, derivedEdges]);
+
+  const skipRates = useMemo(() => {
+    if (!topology?.systems || !metadata?.systemTickSummaries || metadata.systemTickSummaries.length === 0) {
+      return null;
+    }
+    return computeSystemSkipRates({
+      systems: topology.systems,
+      rows: metadata.systemTickSummaries,
+      range,
+    });
+  }, [topology, metadata, range]);
+
+  const tickSummaries = metadata?.tickSummaries ?? null;
+
+  if (!sessionId) {
+    return <EmptyState message="No session attached. Open a trace or attach to a live engine to see the DAG." />;
+  }
+  if (isError) {
+    return <EmptyState message="Topology fetch failed — check the server log." tone="error" />;
+  }
+  if (isLoading || !topology) {
+    return <EmptyState message="Loading topology…" />;
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-background">
+      <SystemDagToolbar tickSummaries={tickSummaries} autoSnapshotEnabled />
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1 min-w-0">
+          <SystemDagCanvas
+            topology={topology}
+            selectedSystemName={selectedSystemName}
+            systemStats={range ? stats : null}
+            queueStats={range && queueStats.size > 0 ? queueStats : null}
+            cpParticipation={cpParticipation}
+            skipRates={skipRates}
+            onSelectSystem={(name) => {
+              setSystem(name);
+              setSidePanelOverride(null);
+            }}
+          />
+        </div>
+        {showSidePanel && selectedNode && (
+          <SystemDagSidePanel
+            node={selectedNode}
+            sessionId={sessionId}
+            range={range}
+            cpStat={cpParticipation?.perSystem.get(selectedNode.systemName) ?? null}
+            cpTotalTicks={cpParticipation?.totalTicks ?? null}
+            onClose={() => setSidePanelOverride(selectedSystemName)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ message, tone = 'muted' }: { message: string; tone?: 'muted' | 'error' }) {
+  const colour = tone === 'error' ? 'text-destructive' : 'text-muted-foreground';
+  return (
+    <div className={`flex h-full w-full items-center justify-center bg-background text-[12px] ${colour}`}>
+      {message}
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagPanel.tsx
@@ -5,8 +5,10 @@ import { useProfilerMetadata } from '@/hooks/profiler/useProfilerMetadata';
 import { useSelectionStore } from '@/stores/useSelectionStore';
 import { useSessionStore } from '@/stores/useSessionStore';
 import {
+  computeCriticalPathForTick,
   computeCriticalPathParticipation,
   computeSystemSkipRates,
+  dominantTickInRange,
 } from '../CriticalPath/criticalPath';
 import { toNodeData } from './dagModel';
 import { deriveEdges } from './edgeDerivation';
@@ -123,6 +125,33 @@ export default function SystemDagPanel(_props: IDockviewPanelProps) {
     });
   }, [topology, metadata, range, derivedEdges]);
 
+  // Dominant-tick CP set — drives the red outline on DAG nodes per `09-system-dag.md §11 Phase 3`
+  // ("Critical-path systems also render with a red border in the dominant tick of the range"). The
+  // ★ badge derives from range-wide participation; this cue is per-tick — the longest single tick
+  // in the window is what the user is most likely investigating, so it gets the spotlight. Empty
+  // ranges / tickless metadata leave the set null and the canvas renders without the cue.
+  const dominantCpSystems = useMemo<Set<string> | null>(() => {
+    if (!topology?.systems || !metadata) return null;
+    const tick = dominantTickInRange(metadata.tickSummaries ?? null, range);
+    if (tick == null) return null;
+    const tickRow = (metadata.tickSummaries ?? []).find((t) => Number(t.tickNumber) === tick) ?? null;
+    const bars = computeCriticalPathForTick({
+      tickNumber: tick,
+      systems: topology.systems,
+      rows: metadata.systemTickSummaries ?? [],
+      edges: derivedEdges,
+      phases: topology.phases ?? [],
+      postTickRows: metadata.postTickSummaries ?? [],
+      tickSummaryRow: tickRow,
+    });
+    if (!bars) return null;
+    const out = new Set<string>();
+    for (const phase of bars.phases) {
+      for (const bar of phase.bars) out.add(bar.systemName);
+    }
+    return out;
+  }, [topology, metadata, range, derivedEdges]);
+
   const skipRates = useMemo(() => {
     if (!topology?.systems || !metadata?.systemTickSummaries || metadata.systemTickSummaries.length === 0) {
       return null;
@@ -157,6 +186,7 @@ export default function SystemDagPanel(_props: IDockviewPanelProps) {
             systemStats={range ? stats : null}
             queueStats={range && queueStats.size > 0 ? queueStats : null}
             cpParticipation={cpParticipation}
+            dominantCpSystems={dominantCpSystems}
             skipRates={skipRates}
             onSelectSystem={(name) => {
               setSystem(name);

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagSidePanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagSidePanel.tsx
@@ -1,0 +1,357 @@
+import { useMemo } from 'react';
+import { X } from 'lucide-react';
+import { useAggregations } from '@/hooks/data/useAggregations';
+import type { AggregationQueryDto } from '@/api/generated/model/aggregationQueryDto';
+import type { HistogramBucketDto } from '@/api/generated/model/histogramBucketDto';
+import type { TopKEntryDto } from '@/api/generated/model/topKEntryDto';
+import type { DagNodeData } from './dagModel';
+import type { TickRange } from './useDagViewStore';
+
+/**
+ * Stats derived from the batched /aggregate response by the side-panel's `useMemo`. Replaces the
+ * earlier `ReturnType<typeof statsShape>` typeof-helper, which IDEs flagged as a runtime-unused
+ * function. Numeric fields are widened to `number | null` because `numericValue` parses string-
+ * encoded numbers (orval surfaces them as `number | string` per the OpenAPI patterns).
+ */
+interface PanelStats {
+  mean: number | null;
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+  max: number | null;
+  count: number | null;
+  histogram: HistogramBucketDto[] | null;
+  topk: TopKEntryDto[] | null;
+}
+
+interface Props {
+  node: DagNodeData;
+  sessionId: string | null;
+  range: TickRange | null;
+  /** Pre-computed CP participation for this system (or null if no metadata loaded yet). */
+  cpStat: { onPathTicks: number; rate: number } | null;
+  /** Total ticks the CP algorithm examined — used for the "X of Y" display. */
+  cpTotalTicks: number | null;
+  onClose: () => void;
+}
+
+const HISTOGRAM_BUCKETS = 20;
+const TOPK_N = 5;
+
+/**
+ * Side panel rendered to the right of the DAG canvas when a system tile is clicked.
+ *
+ * Phase 1 (#315) shipped the identity + RFC 07 declared-access view.
+ * Phase 2 (#316) layer adds — when a tick range is pinned — a stats section with the
+ * duration distribution histogram and the worst-N overrun ticks, both fetched in one batched
+ * /aggregate call. When no range is pinned, only the declared-access view shows.
+ */
+export default function SystemDagSidePanel({ node, sessionId, range, cpStat, cpTotalTicks, onClose }: Props) {
+  const queries = useMemo<AggregationQueryDto[]>(() => {
+    if (!range || !node.systemName) return [];
+    const trackId = `system/${node.systemName}`;
+    return [
+      { trackId, field: 'durationUs', op: 'mean', range: [range.from, range.to] },
+      { trackId, field: 'durationUs', op: 'p50', range: [range.from, range.to] },
+      { trackId, field: 'durationUs', op: 'p95', range: [range.from, range.to] },
+      { trackId, field: 'durationUs', op: 'p99', range: [range.from, range.to] },
+      { trackId, field: 'durationUs', op: 'max', range: [range.from, range.to] },
+      { trackId, field: 'durationUs', op: 'count', range: [range.from, range.to] },
+      { trackId, field: 'durationUs', op: 'histogram', range: [range.from, range.to], buckets: HISTOGRAM_BUCKETS },
+      { trackId, field: 'durationUs', op: 'topk', range: [range.from, range.to], n: TOPK_N },
+    ];
+  }, [range, node.systemName]);
+
+  const { data, isLoading, error } = useAggregations(sessionId, queries);
+
+  const stats = useMemo<PanelStats | null>(() => {
+    if (!data?.results) return null;
+    const r = data.results;
+    return {
+      mean: numericValue(r[0]?.value),
+      p50: numericValue(r[1]?.value),
+      p95: numericValue(r[2]?.value),
+      p99: numericValue(r[3]?.value),
+      max: numericValue(r[4]?.value),
+      count: numericValue(r[5]?.value),
+      histogram: r[6]?.histogram ?? null,
+      topk: r[7]?.topK ?? null,
+    };
+  }, [data]);
+
+  return (
+    <div className="flex h-full w-[300px] flex-col border-l border-border bg-background">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <h3 className="truncate font-mono text-[12px] font-semibold text-foreground" title={node.systemName}>
+          {node.systemName}
+        </h3>
+        <span className="rounded bg-muted/40 px-1.5 py-0.5 text-[9px] font-mono uppercase text-muted-foreground">
+          {node.kind}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="ml-auto rounded p-1 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+          title="Close"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-3 py-2">
+        <Section label="Phase">
+          <span className="font-mono text-[11px] text-foreground">{node.phaseName || '(unphased)'}</span>
+        </Section>
+        <Section label="Flags">
+          <ChipRow>
+            {node.isParallel && <span className="rounded border border-slate-600/50 bg-slate-900/40 px-1.5 py-0.5 font-mono text-[10px] text-slate-200">parallel</span>}
+            {node.isExclusivePhase && <span className="rounded border border-amber-700/50 bg-amber-950/40 px-1.5 py-0.5 font-mono text-[10px] text-amber-200">exclusive</span>}
+            {node.tierFilter !== 0x0F && <span className="rounded border border-slate-600/50 bg-slate-900/40 px-1.5 py-0.5 font-mono text-[10px] text-slate-200">tier {node.tierFilter}</span>}
+            {!node.isParallel && !node.isExclusivePhase && node.tierFilter === 0x0F && (
+              <span className="font-mono text-[10px] text-muted-foreground">none</span>
+            )}
+          </ChipRow>
+        </Section>
+
+        {cpStat && cpTotalTicks != null && cpTotalTicks > 0 && (
+          <Section label="critical-path participation">
+            <CriticalPathRow rate={cpStat.rate} onPathTicks={cpStat.onPathTicks} totalTicks={cpTotalTicks} />
+          </Section>
+        )}
+
+        {range && (
+          <StatsSection
+            range={range}
+            stats={stats}
+            isLoading={isLoading}
+            error={error as Error | null}
+          />
+        )}
+
+        <AccessGroup label="reads" tone="read" items={node.reads} />
+        <AccessGroup label="reads fresh" tone="fresh" items={node.readsFresh} />
+        <AccessGroup label="reads snapshot" tone="snapshot" items={node.readsSnapshot} />
+        <AccessGroup label="writes" tone="write" items={node.writes} />
+        <AccessGroup label="side-writes" tone="side-write" items={node.sideWrites} />
+
+        {!node.hasAccess && (
+          <div className="mt-3 rounded border border-amber-700/40 bg-amber-950/30 px-2 py-1.5 text-[10px] text-amber-200">
+            This system has no RFC 07 declarations on the wire. The trace may predate v6 of the
+            wire format, or the host has not been recompiled after #310.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatsSection({
+  range,
+  stats,
+  isLoading,
+  error,
+}: {
+  range: TickRange;
+  stats: PanelStats | null;
+  isLoading: boolean;
+  error: Error | null;
+}) {
+  return (
+    <Section label={`stats over ticks ${range.from}–${range.to}`}>
+      {error ? (
+        <div className="font-mono text-[10px] text-destructive">{error.message}</div>
+      ) : isLoading || !stats ? (
+        <div className="font-mono text-[10px] text-muted-foreground">Loading…</div>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-x-2 gap-y-1 font-mono text-[10px] text-foreground">
+            <Stat label="count" value={stats.count} unit="" />
+            <Stat label="mean" value={stats.mean} unit="µs" />
+            <Stat label="max" value={stats.max} unit="µs" />
+            <Stat label="p50" value={stats.p50} unit="µs" />
+            <Stat label="p95" value={stats.p95} unit="µs" />
+            <Stat label="p99" value={stats.p99} unit="µs" />
+          </div>
+          {stats.histogram && stats.histogram.length > 0 && (
+            <div className="mt-2">
+              <div className="mb-1 font-mono text-[9px] uppercase tracking-wide text-muted-foreground">
+                duration distribution
+              </div>
+              <Histogram buckets={stats.histogram} />
+            </div>
+          )}
+          {stats.topk && stats.topk.length > 0 && (
+            <div className="mt-2">
+              <div className="mb-1 font-mono text-[9px] uppercase tracking-wide text-muted-foreground">
+                top-{stats.topk.length} overruns
+              </div>
+              <div className="space-y-0.5 font-mono text-[10px]">
+                {stats.topk.map((entry, i) => (
+                  <div key={`${entry.tickNumber}-${i}`} className="flex justify-between">
+                    <span className="text-muted-foreground">tick {String(entry.tickNumber)}</span>
+                    <span className="text-foreground">{formatUs(numericValue(entry.value) ?? 0)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </Section>
+  );
+}
+
+function CriticalPathRow({
+  rate,
+  onPathTicks,
+  totalTicks,
+}: {
+  rate: number;
+  onPathTicks: number;
+  totalTicks: number;
+}) {
+  const pct = (rate * 100).toFixed(0);
+  const tone = rate >= 0.5 ? 'text-amber-300' : rate >= 0.1 ? 'text-amber-400/70' : 'text-muted-foreground';
+  const headline = rate >= 0.5
+    ? 'Bottleneck — fix here first'
+    : rate >= 0.1
+      ? 'Occasional spike — not the dominant cost'
+      : 'Never holds the tick — safe to deprioritise';
+  return (
+    <div className="space-y-0.5">
+      <div className="flex items-baseline justify-between font-mono">
+        <span className={`text-[14px] tabular-nums ${tone}`}>{pct}%</span>
+        <span className="text-[10px] text-muted-foreground">
+          {onPathTicks} / {totalTicks} ticks
+        </span>
+      </div>
+      <div className="font-mono text-[10px] text-muted-foreground">{headline}</div>
+    </div>
+  );
+}
+
+function Stat({ label, value, unit }: { label: string; value: number | null; unit: string }) {
+  return (
+    <div>
+      <div className="text-[8px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="text-[11px] tabular-nums">
+        {value == null ? '—' : `${formatNumber(value)}${unit ? ' ' + unit : ''}`}
+      </div>
+    </div>
+  );
+}
+
+function Histogram({ buckets }: { buckets: PanelStats['histogram'] }) {
+  // SVG bar chart. Cosmetic — design says ~280×140 for Tier 3, but inside a 300px panel we go
+  // a touch narrower.
+  const safeBuckets = buckets ?? [];
+  let max = 0;
+  for (const b of safeBuckets) {
+    const c = numericValue(b.count) ?? 0;
+    if (c > max) max = c;
+  }
+  if (max === 0 || safeBuckets.length === 0) {
+    return <div className="font-mono text-[10px] text-muted-foreground">No data in range.</div>;
+  }
+  const width = 260;
+  const height = 80;
+  const barW = width / safeBuckets.length;
+  return (
+    <svg width={width} height={height} className="block">
+      {safeBuckets.map((b, i) => {
+        const c = numericValue(b.count) ?? 0;
+        const h = (c / max) * (height - 16);
+        const x = i * barW;
+        const y = height - h - 12;
+        return (
+          <g key={i}>
+            <rect x={x + 0.5} y={y} width={Math.max(0, barW - 1)} height={h} fill="hsl(var(--primary, 220 70% 60%))" opacity={0.7} />
+          </g>
+        );
+      })}
+      <text x={0} y={height - 1} className="font-mono" fontSize={9} fill="currentColor" opacity={0.5}>
+        {formatUs(numericValue(safeBuckets[0]?.bucketStart) ?? 0)}
+      </text>
+      <text
+        x={width}
+        y={height - 1}
+        textAnchor="end"
+        className="font-mono"
+        fontSize={9}
+        fill="currentColor"
+        opacity={0.5}
+      >
+        {formatUs(numericValue(safeBuckets[safeBuckets.length - 1]?.bucketEnd) ?? 0)}
+      </text>
+    </svg>
+  );
+}
+
+function numericValue(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000) return n.toFixed(0);
+  if (n >= 100) return n.toFixed(1);
+  return n.toFixed(2);
+}
+
+function formatUs(us: number): string {
+  if (us < 1000) return `${Math.round(us)}µs`;
+  const ms = us / 1000;
+  return ms < 10 ? `${ms.toFixed(2)}ms` : `${ms.toFixed(1)}ms`;
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-2.5">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-0.5">{children}</div>
+    </div>
+  );
+}
+
+function ChipRow({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-wrap items-center gap-1">{children}</div>;
+}
+
+function AccessGroup({
+  label,
+  tone,
+  items,
+}: {
+  label: string;
+  tone: 'read' | 'fresh' | 'snapshot' | 'write' | 'side-write';
+  items: string[];
+}) {
+  if (items.length === 0) return null;
+  return (
+    <Section label={label}>
+      <ChipRow>
+        {items.map((item) => (
+          <span key={item} className={`rounded border px-1.5 py-0.5 font-mono text-[10px] ${toneClasses(tone)}`}>
+            {item}
+          </span>
+        ))}
+      </ChipRow>
+    </Section>
+  );
+}
+
+function toneClasses(tone: 'read' | 'fresh' | 'snapshot' | 'write' | 'side-write'): string {
+  switch (tone) {
+    case 'read':
+      return 'border-slate-600/50 bg-slate-900/40 text-slate-200';
+    case 'fresh':
+      return 'border-emerald-700/50 bg-emerald-950/40 text-emerald-200';
+    case 'snapshot':
+      return 'border-sky-700/50 bg-sky-950/40 text-sky-200';
+    case 'write':
+      return 'border-rose-700/50 bg-rose-950/40 text-rose-200';
+    case 'side-write':
+      return 'border-orange-700/50 bg-orange-950/40 text-orange-200';
+  }
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagToolbar.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagToolbar.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Camera } from 'lucide-react';
 import type { TickSummaryDto } from '@/api/generated/model/tickSummaryDto';
 import { useSelectionStore } from '@/stores/useSelectionStore';
+import { useUiPrefsStore } from '@/stores/useUiPrefsStore';
 import { lastNTicksToTime, timeToTickRange } from './tickRangeMapping';
 import { useDagViewStore, type LayoutMode, type StatMode } from './useDagViewStore';
 
@@ -54,6 +56,10 @@ export default function SystemDagToolbar({ tickSummaries, autoSnapshotEnabled }:
   const setStatMode = useDagViewStore((s) => s.setStatMode);
   const layout = useDagViewStore((s) => s.layout);
   const setLayout = useDagViewStore((s) => s.setLayout);
+  // Help glyph follows the app-wide `legendsVisible` flag (toggled via the `l` key or the
+  // "Toggle Legends" palette command). Hidden when legends are off so chrome stays minimal.
+  const legendsVisible = useUiPrefsStore((s) => s.legendsVisible);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   const hasTicks = tickSummaries != null && tickSummaries.length > 0;
 
@@ -154,7 +160,298 @@ export default function SystemDagToolbar({ tickSummaries, autoSnapshotEnabled }:
         ) : (
           <span>No range — snapshot or scrub the profiler to enable stats.</span>
         )}
+        {legendsVisible && (
+          <button
+            type="button"
+            onClick={() => setHelpOpen((o) => !o)}
+            className="flex h-5 w-5 items-center justify-center rounded-full border border-border bg-card text-foreground hover:bg-muted"
+            title="Show controls + legend (toggle inline help with `l`)"
+            aria-label="Show controls and legend"
+          >
+            ?
+          </button>
+        )}
       </div>
+      {helpOpen && <HelpOverlay onClose={() => setHelpOpen(false)} />}
     </div>
+  );
+}
+
+/**
+ * Modal-ish overlay describing every control + visual element in the System DAG view. Portaled
+ * to `document.body` so it escapes any dockview ancestor (transforms / overflow). Click-outside
+ * + Escape close it.
+ */
+function HelpOverlay({ onClose }: { onClose: () => void }) {
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60"
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      tabIndex={-1}
+    >
+      <div
+        className="max-h-[88vh] w-[840px] max-w-[94vw] overflow-auto rounded-lg border border-border bg-card p-6 font-mono text-[12px] leading-relaxed text-foreground shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-[15px] font-semibold">System DAG — controls & legend</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            ✕
+          </button>
+        </div>
+
+        <Section title="What you're looking at">
+          <p>
+            Every system the engine schedules, drawn as a tile, with arrows showing the dependencies that order them. The tiles
+            colour-code <em>how slow</em> each system is on average; the arrows colour-code <em>why one runs before another</em>.
+            Click a tile to open the side panel, which shows the system's declared component / event / resource access — the raw
+            facts the engine derives the dependency graph from.
+          </p>
+          <p className="mt-2 text-muted-foreground">
+            The DAG is a <strong>topology view</strong> (what runs after what), not a <strong>timeline</strong> (when it ran).
+            Pair it with the Critical Path panel to see where time actually went on a given tick.
+          </p>
+        </Section>
+
+        <Section title="Layouts">
+          <ul className="list-disc space-y-1.5 pl-5">
+            <li>
+              <strong>Horizontal lanes</strong> — phases stack top-to-bottom (Input, Movement, Lifecycle, …); systems flow
+              left-to-right within each phase. Coloured swim-lane bands behind the tiles make phase membership obvious at a glance.
+              Best layout for understanding the per-tick lifecycle.
+            </li>
+            <li>
+              <strong>Vertical lanes</strong> — same idea, rotated. Phases as side-by-side columns; systems flow top-to-bottom.
+              Useful when the dock pane is taller than wide.
+            </li>
+            <li>
+              <strong>Compact</strong> — flat layered layout, no swim-lanes. Cross-phase edges become visible. Good when you
+              want to see the full dependency mesh without the phase scaffolding.
+            </li>
+            <li>
+              <strong>Circular</strong> — systems on a circle, ordered by phase then name. All edges drawn. Niche; useful for
+              spotting accidental cycles or visualising heavily-cross-phase event traffic.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Node tile — what every visual layer means">
+          <p className="mb-2">A single system tile has up to seven distinct visual signals stacked on it:</p>
+          <ul className="list-disc space-y-2 pl-5">
+            <li>
+              <strong>Heat border</strong> — main border colour. Driven by the system's primary stat over the selected tick
+              range. Cool blue (220°) at slow-end-of-zero up through green to red (0°) at the hottest. Hottest-third tiles also
+              get a soft glow. <em>No range selected → no heat (default neutral border).</em>
+              <div className="mt-1.5 flex items-center gap-3 text-muted-foreground">
+                <span className="inline-flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-sm border-2" style={{ borderColor: 'hsla(220, 70%, 55%, 0.5)' }} /> cool / fast</span>
+                <span className="inline-flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-sm border-2" style={{ borderColor: 'hsla(110, 70%, 55%, 0.7)' }} /> mid</span>
+                <span className="inline-flex items-center gap-1.5"><span className="inline-block h-3 w-3 rounded-sm border-2" style={{ borderColor: 'hsla(0, 70%, 55%, 0.9)' }} /> hot / slow</span>
+              </div>
+            </li>
+            <li>
+              <strong>Stat chip</strong> (small µs / ms label, top-left of the tile body) — the system's actual aggregated
+              duration in the selected range. Hover for the precise value.
+            </li>
+            <li>
+              <strong>Kind chip</strong> (top-right) — system type:
+              <span className="ml-1 inline-flex items-center gap-1 rounded bg-emerald-900/40 px-1 py-px text-emerald-200">PIPELINE</span>{' '}
+              <span className="inline-flex items-center gap-1 rounded bg-sky-900/40 px-1 py-px text-sky-200">QUERY</span>{' '}
+              <span className="inline-flex items-center gap-1 rounded bg-violet-900/40 px-1 py-px text-violet-200">CALLBACK</span>{' '}
+              <span className="inline-flex items-center gap-1 rounded bg-slate-800 px-1 py-px text-slate-300">UNKNOWN</span>.
+              Pipeline = chunked sequential, Query = ECS query (often parallel), Callback = single-shot.
+            </li>
+            <li>
+              <strong>★ badge</strong> — critical-path participation rate. <em>Solid amber star</em> when the system is on the
+              CP in ≥50 % of ticks in the range; <em>dim star</em> for 10–50 %; nothing below 10 %.
+              Hover for the exact percentage.
+            </li>
+            <li>
+              <strong>Red outline</strong> (around the tile, slightly offset) — system is on the critical path of the
+              <strong> dominant tick</strong> (the longest tick in the current range). Single-tick spotlight, distinct from the ★
+              badge which is range-wide.
+            </li>
+            <li>
+              <strong>Amber left bar</strong> (4 px on the left edge) — exclusive-phase system. The phase containing this system
+              runs nothing else in parallel; useful for spotting accidental serialisation.
+            </li>
+            <li>
+              <strong>Inline chips</strong> below the name — flags about the system:
+              <ul className="mt-1 list-disc space-y-0.5 pl-5 text-muted-foreground">
+                <li><strong>parallel</strong> — runs across multiple workers (chunked).</li>
+                <li><strong>exclusive</strong> — same idea as the amber left bar, surfaced as a chip too.</li>
+                <li><strong>tier N</strong> — only runs against entities at tier <code>N</code> (LOD / detail bucket).</li>
+                <li><strong>change:N</strong> — has <code>N</code> change-filter declarations (only runs when those components changed).</li>
+                <li><strong>↪ NN%</strong> — skip rate. Surfaced when {`>`} 50 %; means the system's <code>RunIf</code> /
+                  <code>ReactiveSkip</code> bailed on the majority of ticks.</li>
+                <li><strong>no decls</strong> — the system has no declared access. Common for <code>CallbackSystem</code>; not
+                  necessarily a bug, but the engine has no way to derive dependencies for it.</li>
+              </ul>
+            </li>
+            <li>
+              <strong>Selection ring</strong> (theme primary colour, 2 px) — you've clicked the tile.
+              <strong> Hover ring</strong> (neutral foreground at 60 %) — the cross-panel hover store says this system is being
+              pointed at (here or in the CP tape).
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Edges — colour and dash code the kind of dependency">
+          <p className="mb-2">Five edge kinds, each with a fixed colour + dash pattern:</p>
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="py-1 pr-3 font-normal">kind</th>
+                <th className="py-1 pr-3 font-normal">style</th>
+                <th className="py-1 font-normal">means</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-border/40 align-top">
+                <td className="py-1.5 pr-3"><strong className="text-amber-400">fresh</strong></td>
+                <td className="py-1.5 pr-3"><EdgeSwatch colour="#f59e0b" /></td>
+                <td className="py-1.5">Solid amber. <code>Writes&lt;T&gt;</code> → another system's <code>ReadsFresh&lt;T&gt;</code>, same phase. The reader sees the writer's update.</td>
+              </tr>
+              <tr className="border-b border-border/40 align-top">
+                <td className="py-1.5 pr-3"><strong className="text-sky-400">snapshot</strong></td>
+                <td className="py-1.5 pr-3"><EdgeSwatch colour="#3b82f6" /></td>
+                <td className="py-1.5">Solid blue. Snapshot reader runs <em>before</em> the writer (edge direction reverses): the reader gets the pre-tick value.</td>
+              </tr>
+              <tr className="border-b border-border/40 align-top">
+                <td className="py-1.5 pr-3"><strong className="text-slate-400">manual</strong></td>
+                <td className="py-1.5 pr-3"><EdgeSwatch colour="#94a3b8" /></td>
+                <td className="py-1.5">Solid slate. Explicit <code>.After()</code> / <code>.Before()</code> ordering — the user pinned the order by hand, not derivable from access.</td>
+              </tr>
+              <tr className="border-b border-border/40 align-top">
+                <td className="py-1.5 pr-3"><strong className="text-violet-400">event</strong></td>
+                <td className="py-1.5 pr-3"><EdgeSwatch colour="#a78bfa" dashed /></td>
+                <td className="py-1.5">Dashed violet. <code>WritesEvents&lt;Q&gt;</code> producer → <code>ReadsEvents&lt;Q&gt;</code> consumer. Crosses phase boundaries (events buffer between ticks). <em>Live styling overlay below.</em></td>
+              </tr>
+              <tr className="align-top">
+                <td className="py-1.5 pr-3"><strong className="text-red-400">resource</strong></td>
+                <td className="py-1.5 pr-3"><EdgeSwatch colour="#ef4444" dotted /></td>
+                <td className="py-1.5">Dotted red. Two systems touching the same named resource where at least one writes — a conflict that forced an ordering.</td>
+              </tr>
+            </tbody>
+          </table>
+          <p className="mt-2 text-muted-foreground">The label on each arrow names the component / queue / resource that justifies it. If multiple, shows <code>firstName +N</code>.</p>
+        </Section>
+
+        <Section title="Event edges — live backpressure overlay">
+          <p>
+            When a tick range is selected, event edges (the dashed ones) get re-coloured by the queue's actual behaviour
+            in the range. The dash pattern stays violet by default but the stroke shifts:
+          </p>
+          <ul className="mt-1 list-disc space-y-0.5 pl-5">
+            <li><strong>Default violet</strong> — idle / no traffic.</li>
+            <li><strong>Heating up to orange</strong> — peak depth growing. Hue ramps 270° (violet) → 30° (orange) with relative load.</li>
+            <li><strong>Deep red + animated dashes</strong> — queue overflowed (events were dropped). Label gets a <span className="text-red-400">⚠ Nk drops</span> prefix.</li>
+            <li><strong>Stroke width</strong> bumps up with chronic backlog (end-of-tick depth, separate channel from peak).</li>
+          </ul>
+          <p className="mt-1 text-muted-foreground">Two independent channels — colour answers "worst moment", width answers "always backlogged".</p>
+        </Section>
+
+        <Section title="Toolbar controls">
+          <KeyTable rows={[
+            ['Snapshot last 600 ticks', 'Pin both DAG aggregations and the profiler TimeArea to the most recent 600 ticks. Auto-fired once on first metadata arrival so a fresh open is useful without a click.'],
+            ['stat: mean / p50 / p95 / p99 / max', 'Aggregation function for the per-system primary stat that drives the heat border + chip. mean = average duration; p99 = "the tick where this system was unusually slow"; max = worst single tick.'],
+            ['layout', 'Pick one of the four layouts described above. Switching re-runs the layout engine and re-fits the viewport.'],
+            ['Ticks A–B (N)', 'Range read-out. Shows the tick window currently driving the stats. clear strips the time selection — node stats hide until you snapshot or scrub the profiler.'],
+            ['?', 'Open this panel.'],
+          ]} />
+        </Section>
+
+        <Section title="Mouse">
+          <KeyTable rows={[
+            ['Click node',          'Select system + open the side panel. Cross-panel binding means the CP tape pins focus to the same system.'],
+            ['Click pane',          'Deselect. Closes side panel.'],
+            ['Hover node',          'Cross-panel hover sync — matching bar in the CP tape lights up.'],
+            ['Hover lane label',    'Hover sync at the phase level — matching CP tape phase stripe brightens.'],
+            ['Drag pane',           'Pan the canvas.'],
+            ['Wheel',               'Zoom in / out.'],
+            ['MiniMap (bottom-right)', 'Click / drag a region to navigate; shows the full canvas at a glance.'],
+            ['Controls (bottom-left)', 'Buttons for fit-view + zoom in/out without scrolling.'],
+          ]} />
+        </Section>
+
+        <Section title="Cross-panel sync">
+          <p>The DAG shares state with the rest of the workbench via three slots:</p>
+          <ul className="mt-1 list-disc space-y-1 pl-5">
+            <li>
+              <strong>Time window</strong> (<code>useSelectionStore.time</code>) — the µs range driving aggregations. Set by
+              the Snapshot button here, by scrubbing the profiler's TimeArea, or by deep-linking via URL.
+            </li>
+            <li>
+              <strong>Selected system</strong> (<code>useSelectionStore.system</code>) — the clicked system. Drives the side
+              panel here, the bar selection in the CP tape, and the focus tick when applicable.
+            </li>
+            <li>
+              <strong>Hovered system / phase</strong> (<code>useHoverStore</code>) — volatile, cleared on mouse-leave. Pure UI;
+              not URL-synced. Drives the matching highlights between the DAG canvas and the CP tape.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Side panel — declared access">
+          <p>
+            Clicking a tile opens the side panel. It shows the raw access declarations for the selected system: the
+            <code>Reads</code> / <code>ReadsFresh</code> / <code>ReadsSnapshot</code> / <code>Writes</code> components, the
+            event queues it produces / consumes, the resources it touches, the explicit <code>.After/.Before</code> ordering
+            it pinned, plus its phase, priority, parallelism mode, and tier filter. This is the source of truth the engine
+            derived the dependency graph from — if an arrow surprises you, the side panel will tell you which declaration
+            forced it.
+          </p>
+        </Section>
+
+        <Section title="When the DAG is empty">
+          <ul className="list-disc space-y-1 pl-5">
+            <li><strong>"No topology yet"</strong> — open a trace or attach a session. The DAG is built from the topology, which the engine ships once at startup.</li>
+            <li><strong>Tiles render but no heat colour</strong> — no time range selected. Snapshot here or scrub the profiler.</li>
+            <li><strong>"no decls" chip on most tiles</strong> — the engine isn't surfacing RFC 07 access declarations on the wire; arrows are derived only from explicit <code>.After/.Before</code>. Common for old traces / pre-RFC-07 codebases.</li>
+          </ul>
+        </Section>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-5">
+      <h3 className="mb-2 text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
+      <div className="space-y-1 leading-relaxed">{children}</div>
+    </div>
+  );
+}
+
+function KeyTable({ rows }: { rows: Array<[string, string]> }) {
+  return (
+    <table className="w-full">
+      <tbody>
+        {rows.map(([k, v]) => (
+          <tr key={k} className="align-top">
+            <td className="w-52 py-0.5 pr-3"><kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px]">{k}</kbd></td>
+            <td className="py-0.5 text-muted-foreground">{v}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** Tiny inline edge sample — coloured line with optional dash / dot pattern, matching the actual edge styling on the canvas. */
+function EdgeSwatch({ colour, dashed = false, dotted = false }: { colour: string; dashed?: boolean; dotted?: boolean }) {
+  const dasharray = dashed ? '6 4' : dotted ? '2 4' : undefined;
+  return (
+    <svg width="64" height="10" className="inline-block align-middle">
+      <line x1="0" y1="5" x2="64" y2="5" stroke={colour} strokeWidth="2" strokeDasharray={dasharray} />
+    </svg>
   );
 }

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagToolbar.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/SystemDagToolbar.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo } from 'react';
+import { Camera } from 'lucide-react';
+import type { TickSummaryDto } from '@/api/generated/model/tickSummaryDto';
+import { useSelectionStore } from '@/stores/useSelectionStore';
+import { lastNTicksToTime, timeToTickRange } from './tickRangeMapping';
+import { useDagViewStore, type LayoutMode, type StatMode } from './useDagViewStore';
+
+interface Props {
+  /** Profiler-metadata tick rows — used for both the µs↔tick conversion and the auto-snapshot decision. */
+  tickSummaries: readonly TickSummaryDto[] | null;
+  /** Auto-snapshot once on first arrival of metadata when no time selection exists yet. */
+  autoSnapshotEnabled: boolean;
+}
+
+const STAT_OPTIONS: Array<{ key: StatMode; label: string }> = [
+  { key: 'mean', label: 'mean' },
+  { key: 'p50', label: 'p50' },
+  { key: 'p95', label: 'p95' },
+  { key: 'p99', label: 'p99' },
+  { key: 'max', label: 'max' },
+];
+
+/**
+ * Layout choices exposed in the toolbar combo. Phase-aware layouts (horizontal/vertical lanes)
+ * preserve the design's swim-lane skeleton; phase-agnostic layouts (compact/circular) drop the
+ * lanes for cases where the user wants a different angle on the same topology.
+ */
+const LAYOUT_OPTIONS: Array<{ key: LayoutMode; label: string; description: string }> = [
+  { key: 'horizontal-lanes', label: 'Horizontal lanes', description: 'Phases stack top-to-bottom; systems flow left-to-right within each phase' },
+  { key: 'vertical-lanes', label: 'Vertical lanes', description: 'Phases as side-by-side columns; systems flow top-to-bottom within each phase' },
+  { key: 'compact', label: 'Compact', description: 'Flat layered layout. No swim lanes; cross-phase edges are visible' },
+  { key: 'circular', label: 'Circular', description: 'Systems on a circle, ordered by phase then name. All edges visible' },
+];
+
+const SNAPSHOT_TICK_COUNT = 600;
+
+/**
+ * Top-of-panel toolbar for the System DAG. Two controls per `09-system-dag.md §6.1` + §7.2:
+ * the **stat-mode** selector that swaps the per-node primary stat aggregation, and the
+ * **Snapshot last N ticks** action that pins both panels (DAG aggregation range + profiler
+ * TimeArea) to a frozen window via `useSelectionStore.time`.
+ *
+ * After cross-panel binding (§7.1), the range readout reflects whatever µs window the user has
+ * selected — whether they snapshotted here or scrubbed in the profiler. The selection store and
+ * its bridges keep the two views in lockstep automatically.
+ *
+ * Auto-snapshot fires once on first metadata arrival when the time slot is null AND nothing has
+ * been deep-linked from a URL — so a fresh open shows useful colour without a click.
+ */
+export default function SystemDagToolbar({ tickSummaries, autoSnapshotEnabled }: Props) {
+  const time = useSelectionStore((s) => s.time);
+  const setTime = useSelectionStore((s) => s.setTime);
+  const statMode = useDagViewStore((s) => s.statMode);
+  const setStatMode = useDagViewStore((s) => s.setStatMode);
+  const layout = useDagViewStore((s) => s.layout);
+  const setLayout = useDagViewStore((s) => s.setLayout);
+
+  const hasTicks = tickSummaries != null && tickSummaries.length > 0;
+
+  // Translate the current time-window (µs) back to ticks for the readout. Cross-panel scrubs
+  // round through the converter so the user sees consistent tick numbers regardless of who set
+  // the window.
+  const tickRange = useMemo(() => timeToTickRange(time, tickSummaries), [time, tickSummaries]);
+
+  // Auto-snapshot once on first arrival when the time slot is unset. After that, snapshot is
+  // user-driven (per §7.3 — no continuous live updates).
+  useEffect(() => {
+    if (!autoSnapshotEnabled) return;
+    if (!hasTicks || time != null || tickSummaries == null) return;
+    const next = lastNTicksToTime(SNAPSHOT_TICK_COUNT, tickSummaries);
+    if (next) setTime(next);
+  }, [autoSnapshotEnabled, hasTicks, time, tickSummaries, setTime]);
+
+  const onSnapshotClick = () => {
+    if (tickSummaries == null) return;
+    const next = lastNTicksToTime(SNAPSHOT_TICK_COUNT, tickSummaries);
+    if (next) setTime(next);
+  };
+
+  const onClearClick = () => setTime(null);
+
+  return (
+    <div className="flex items-center gap-3 border-b border-border bg-background/95 px-3 py-1.5">
+      <button
+        type="button"
+        disabled={!hasTicks}
+        onClick={onSnapshotClick}
+        className="flex items-center gap-1.5 rounded border border-border bg-card px-2 py-1 font-mono text-[11px] text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+        title={hasTicks ? `Pin both views to the last ${SNAPSHOT_TICK_COUNT} ticks` : 'Waiting for ticks…'}
+      >
+        <Camera className="h-3 w-3" />
+        Snapshot last {SNAPSHOT_TICK_COUNT} ticks
+      </button>
+
+      <div className="flex items-center gap-1">
+        <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">stat</span>
+        <div className="flex overflow-hidden rounded border border-border">
+          {STAT_OPTIONS.map((opt) => {
+            const active = statMode === opt.key;
+            return (
+              <button
+                key={opt.key}
+                type="button"
+                onClick={() => setStatMode(opt.key)}
+                className={`px-2 py-0.5 font-mono text-[11px] ${active
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-card text-foreground hover:bg-muted'
+                  }`}
+                title={`Show ${opt.label} duration per system`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <span className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">layout</span>
+        <select
+          value={layout}
+          onChange={(e) => setLayout(e.target.value as LayoutMode)}
+          className="rounded border border-border bg-card px-2 py-0.5 font-mono text-[11px] text-foreground hover:bg-muted focus:outline-none focus:ring-1 focus:ring-primary"
+          title={LAYOUT_OPTIONS.find((o) => o.key === layout)?.description ?? ''}
+        >
+          {LAYOUT_OPTIONS.map((opt) => (
+            <option key={opt.key} value={opt.key} title={opt.description}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="ml-auto flex items-center gap-2 font-mono text-[10px] text-muted-foreground">
+        {tickRange ? (
+          <>
+            <span>
+              Ticks {tickRange.from}–{tickRange.to}{' '}
+              <span className="text-muted-foreground/60">({tickRange.to - tickRange.from + 1})</span>
+            </span>
+            <button
+              type="button"
+              onClick={onClearClick}
+              className="rounded px-1.5 py-0.5 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+              title="Clear the time selection — node stats hidden until you snapshot or scrub the profiler"
+            >
+              clear
+            </button>
+          </>
+        ) : time != null ? (
+          // Time slot is set but the window doesn't intersect any tick (e.g. selection scrubbed
+          // before the first tick). Show a hint instead of a stale tick range.
+          <span>Selection has no ticks — scrub or snapshot.</span>
+        ) : (
+          <span>No range — snapshot or scrub the profiler to enable stats.</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/__tests__/dagModel.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/__tests__/dagModel.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import type { SystemDefinitionDto } from '@/api/generated/model/systemDefinitionDto';
+import type { TopologyDto } from '@/api/generated/model/topologyDto';
+import { LANE_GAP, buildDagModel } from '../dagModel';
+
+function sys(overrides: Partial<SystemDefinitionDto> & { name: string }): SystemDefinitionDto {
+  return {
+    index: 0,
+    type: 0,
+    priority: 0,
+    isParallel: false,
+    tierFilter: 15,
+    predecessors: [],
+    successors: [],
+    isExclusivePhase: false,
+    phaseName: 'Simulation',
+    reads: [],
+    readsFresh: [],
+    readsSnapshot: [],
+    additionalReads: [],
+    writes: [],
+    sideWrites: [],
+    writesEvents: [],
+    readsEvents: [],
+    writesResources: [],
+    readsResources: [],
+    explicitAfter: [],
+    explicitBefore: [],
+    ...overrides,
+  };
+}
+
+function topo(systems: SystemDefinitionDto[], phases: string[] = ['Input', 'Simulation', 'Output']): TopologyDto {
+  return { systems, archetypes: [], componentTypes: [], phases };
+}
+
+describe('buildDagModel', () => {
+  it('returns an empty model for null/empty topology', () => {
+    expect(buildDagModel(null)).toEqual({ nodes: [], edges: [], lanes: [], width: 0, height: 0 });
+    expect(buildDagModel(topo([]))).toEqual({ nodes: [], edges: [], lanes: [], width: 0, height: 0 });
+  });
+
+  it('places one lane per non-empty phase, in canonical order', () => {
+    const t = topo([
+      sys({ name: 'In1', phaseName: 'Input' }),
+      sys({ name: 'Sim1', phaseName: 'Simulation' }),
+      sys({ name: 'Out1', phaseName: 'Output' }),
+    ]);
+    const model = buildDagModel(t);
+    expect(model.lanes.map((l) => l.name)).toEqual(['Input', 'Simulation', 'Output']);
+    expect(model.lanes.every((l) => l.systemCount === 1)).toBe(true);
+    // Lanes stack top-to-bottom.
+    for (let i = 1; i < model.lanes.length; i++) {
+      expect(model.lanes[i].yTop).toBeGreaterThanOrEqual(model.lanes[i - 1].yTop + model.lanes[i - 1].height + LANE_GAP - 1);
+    }
+  });
+
+  it('skips phases that have no systems', () => {
+    const t = topo([
+      sys({ name: 'Sim1', phaseName: 'Simulation' }),
+    ]);
+    const model = buildDagModel(t);
+    expect(model.lanes.map((l) => l.name)).toEqual(['Simulation']);
+  });
+
+  it('routes systems with unknown phase into a synthetic (unphased) lane at the end', () => {
+    const t = topo([
+      sys({ name: 'Sim1', phaseName: 'Simulation' }),
+      sys({ name: 'Orphan', phaseName: 'NotInList' }),
+      sys({ name: 'Empty', phaseName: '' }),
+    ]);
+    const model = buildDagModel(t);
+    expect(model.lanes.map((l) => l.name)).toEqual(['Simulation', '(unphased)']);
+    expect(model.lanes[1].systemCount).toBe(2);
+  });
+
+  it('emits one React-Flow node per system with topology data attached', () => {
+    const t = topo([
+      sys({ name: 'Movement', writes: ['Position'], type: 1, isParallel: true }),
+    ]);
+    const model = buildDagModel(t);
+    expect(model.nodes).toHaveLength(1);
+    const n = model.nodes[0];
+    expect(n.id).toBe('Movement');
+    expect(n.type).toBe('system');
+    expect(n.data.kind).toBe('Query');
+    expect(n.data.isParallel).toBe(true);
+    expect(n.data.writes).toEqual(['Position']);
+    expect(n.data.hasAccess).toBe(true);
+  });
+
+  it('emits intra-phase edges and drops cross-phase edges', () => {
+    const t = topo([
+      sys({ name: 'Movement', writes: ['Position'], phaseName: 'Simulation' }),
+      sys({ name: 'AI', readsFresh: ['Position'], phaseName: 'Simulation' }),
+      // Cross-phase pair — must NOT produce an edge in the model.
+      sys({ name: 'Render', readsSnapshot: ['Position'], phaseName: 'Output' }),
+    ]);
+    const model = buildDagModel(t);
+    const edgeKinds = model.edges.map((e) => `${e.data?.kind}:${e.source}->${e.target}`);
+    expect(edgeKinds).toEqual(['fresh:Movement->AI']);
+  });
+
+  it('translates dagre coordinates so each phase lane sits below its predecessor', () => {
+    const t = topo([
+      sys({ name: 'In1', phaseName: 'Input' }),
+      sys({ name: 'Sim1', phaseName: 'Simulation' }),
+    ]);
+    const model = buildDagModel(t);
+    const inputNode = model.nodes.find((n) => n.id === 'In1')!;
+    const simNode = model.nodes.find((n) => n.id === 'Sim1')!;
+    expect(simNode.position.y).toBeGreaterThan(inputNode.position.y);
+  });
+
+  it('node x-positions account for the lane label margin', () => {
+    const t = topo([sys({ name: 'A' })]);
+    const model = buildDagModel(t);
+    expect(model.nodes[0].position.x).toBeGreaterThan(0);
+  });
+});
+
+// ── Alternate layouts (introduced in #316 follow-up) ─────────────────────
+
+describe('buildDagModel — vertical-lanes layout', () => {
+  it('emits lanes with top-edge labels and stacks them horizontally', () => {
+    const a = sys({ name: 'A', phaseName: 'Input' });
+    const b = sys({ name: 'B', phaseName: 'Simulation' });
+    const c = sys({ name: 'C', phaseName: 'Output' });
+    const model = buildDagModel(topo([a, b, c]), 'vertical-lanes');
+    expect(model.lanes).toHaveLength(3);
+    for (const lane of model.lanes) expect(lane.labelEdge).toBe('top');
+    // Lanes stack horizontally — each xLeft strictly greater than the previous.
+    for (let i = 1; i < model.lanes.length; i++) {
+      expect(model.lanes[i].xLeft).toBeGreaterThan(model.lanes[i - 1].xLeft);
+    }
+  });
+
+  it('all lanes share the same yTop (origin)', () => {
+    const model = buildDagModel(
+      topo([sys({ name: 'A', phaseName: 'Input' }), sys({ name: 'B', phaseName: 'Simulation' })]),
+      'vertical-lanes',
+    );
+    for (const lane of model.lanes) expect(lane.yTop).toBe(0);
+  });
+});
+
+describe('buildDagModel — compact layout', () => {
+  it('emits no lanes', () => {
+    const model = buildDagModel(
+      topo([sys({ name: 'A', phaseName: 'Input' }), sys({ name: 'B', phaseName: 'Simulation' })]),
+      'compact',
+    );
+    expect(model.lanes).toEqual([]);
+  });
+
+  it('keeps cross-phase edges that the lane-based layouts would drop', () => {
+    // Manual .After across phases: A in Input, B in Simulation, B.After(A).
+    const a = sys({ name: 'A', phaseName: 'Input' });
+    const b = sys({ name: 'B', phaseName: 'Simulation', explicitAfter: ['A'] });
+    const compact = buildDagModel(topo([a, b]), 'compact');
+    const horizontal = buildDagModel(topo([a, b]), 'horizontal-lanes');
+    // Compact preserves the cross-phase manual edge; lane-based layout filters it out.
+    expect(compact.edges.find((e) => e.source === 'A' && e.target === 'B')).toBeDefined();
+    expect(horizontal.edges.find((e) => e.source === 'A' && e.target === 'B')).toBeUndefined();
+  });
+});
+
+describe('buildDagModel — circular layout', () => {
+  it('emits no lanes and places all systems', () => {
+    const systems = ['A', 'B', 'C', 'D'].map((name) => sys({ name, phaseName: 'Simulation' }));
+    const model = buildDagModel(topo(systems), 'circular');
+    expect(model.lanes).toEqual([]);
+    expect(model.nodes).toHaveLength(4);
+  });
+
+  it('yields a square bounding box (width === height) — invariant of the geometry', () => {
+    const systems = ['A', 'B', 'C', 'D', 'E'].map((name) => sys({ name }));
+    const model = buildDagModel(topo(systems), 'circular');
+    expect(model.width).toBe(model.height);
+    expect(model.width).toBeGreaterThan(0);
+  });
+
+  it('places nodes at distinct positions', () => {
+    const systems = ['A', 'B', 'C'].map((name) => sys({ name }));
+    const model = buildDagModel(topo(systems), 'circular');
+    const positions = model.nodes.map((n) => `${n.position.x.toFixed(0)},${n.position.y.toFixed(0)}`);
+    expect(new Set(positions).size).toBe(3);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/__tests__/edgeDerivation.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/__tests__/edgeDerivation.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import type { SystemDefinitionDto } from '@/api/generated/model/systemDefinitionDto';
+import { deriveEdges, type DerivedEdge, type DerivedEdgeKind } from '../edgeDerivation';
+
+function sys(overrides: Partial<SystemDefinitionDto> & { name: string }): SystemDefinitionDto {
+  return {
+    index: 0,
+    type: 0,
+    priority: 0,
+    isParallel: false,
+    tierFilter: 15,
+    predecessors: [],
+    successors: [],
+    isExclusivePhase: false,
+    phaseName: 'Simulation',
+    reads: [],
+    readsFresh: [],
+    readsSnapshot: [],
+    additionalReads: [],
+    writes: [],
+    sideWrites: [],
+    writesEvents: [],
+    readsEvents: [],
+    writesResources: [],
+    readsResources: [],
+    explicitAfter: [],
+    explicitBefore: [],
+    ...overrides,
+  };
+}
+
+function summarise(edges: DerivedEdge[]): { kind: DerivedEdgeKind; source: string; target: string; via: string[] }[] {
+  return edges.map((e) => ({ kind: e.kind, source: e.source, target: e.target, via: e.via }));
+}
+
+describe('deriveEdges', () => {
+  it('returns no edges for an empty system list', () => {
+    expect(deriveEdges([])).toEqual([]);
+  });
+
+  it('emits a fresh-read edge writer → reader', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Movement', writes: ['Position'] }),
+      sys({ name: 'AI', readsFresh: ['Position'] }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'fresh', source: 'Movement', target: 'AI', via: ['Position'] },
+    ]);
+    expect(edges[0].reason).toContain('AI reads Position fresh');
+    expect(edges[0].reason).toContain('runs after Movement');
+  });
+
+  it('emits a snapshot edge reader → writer (reader runs before writer)', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Movement', writes: ['Position'] }),
+      sys({ name: 'Render', readsSnapshot: ['Position'] }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'snapshot', source: 'Render', target: 'Movement', via: ['Position'] },
+    ]);
+  });
+
+  it('plain Reads (ambiguous freshness) does NOT produce an edge', () => {
+    // Per RFC 07: plain Reads<T> alongside a same-phase writer is a Build()-time error, not a
+    // derived edge. The DAG view trusts the engine to reject those, so no edge here.
+    const edges = deriveEdges([
+      sys({ name: 'Movement', writes: ['Position'] }),
+      sys({ name: 'Auditor', reads: ['Position'] }),
+    ]);
+    expect(edges).toEqual([]);
+  });
+
+  it('skips edges across phases', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Movement', writes: ['Position'], phaseName: 'Simulation' }),
+      sys({ name: 'Render', readsSnapshot: ['Position'], phaseName: 'Output' }),
+    ]);
+    expect(edges).toEqual([]);
+  });
+
+  it('emits a manual After edge', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Movement' }),
+      sys({ name: 'Clamp', explicitAfter: ['Movement'] }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'manual', source: 'Movement', target: 'Clamp', via: ['Movement'] },
+    ]);
+    expect(edges[0].reason).toBe('Manual edge: Clamp.After(Movement)');
+  });
+
+  it('emits a manual Before edge with reversed direction', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Audit', explicitBefore: ['Cleanup'] }),
+      sys({ name: 'Cleanup' }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'manual', source: 'Audit', target: 'Cleanup', via: ['Cleanup'] },
+    ]);
+  });
+
+  it('emits an event-queue edge producer → consumer', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Combat', writesEvents: ['DamageQueue'] }),
+      sys({ name: 'Health', readsEvents: ['DamageQueue'] }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'event', source: 'Combat', target: 'Health', via: ['DamageQueue'] },
+    ]);
+  });
+
+  it('emits a resource conflict edge from writer to other system', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Physics', writesResources: ['PhysicsWorld'] }),
+      sys({ name: 'Sensors', readsResources: ['PhysicsWorld'] }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'resource', source: 'Physics', target: 'Sensors', via: ['PhysicsWorld'] },
+    ]);
+  });
+
+  it('two read-only-resource systems produce no edge', () => {
+    const edges = deriveEdges([
+      sys({ name: 'A', readsResources: ['shared'] }),
+      sys({ name: 'B', readsResources: ['shared'] }),
+    ]);
+    expect(edges).toEqual([]);
+  });
+
+  it('two write-resource systems produce a single alphabetical resource edge', () => {
+    const edges = deriveEdges([
+      sys({ name: 'WriterA', writesResources: ['shared'] }),
+      sys({ name: 'WriterB', writesResources: ['shared'] }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'resource', source: 'WriterA', target: 'WriterB', via: ['shared'] },
+    ]);
+  });
+
+  it('merges multiple components on the same (writer, reader) pair into one edge', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Movement', writes: ['Position', 'Velocity'] }),
+      sys({ name: 'AI', readsFresh: ['Position', 'Velocity'] }),
+    ]);
+    expect(summarise(edges)).toEqual([
+      { kind: 'fresh', source: 'Movement', target: 'AI', via: ['Position', 'Velocity'] },
+    ]);
+  });
+
+  it('emits separate edges per (kind, source, target) on the same pair', () => {
+    // Movement writes Position; AI reads Position fresh AND Health snapshot.
+    const edges = deriveEdges([
+      sys({ name: 'Movement', writes: ['Position'] }),
+      sys({ name: 'AI', readsFresh: ['Position'], readsSnapshot: ['Health'] }),
+      sys({ name: 'Healing', writes: ['Health'] }),
+    ]);
+    const summary = summarise(edges);
+    // fresh: Movement → AI ; snapshot: AI → Healing
+    expect(summary).toContainEqual({ kind: 'fresh', source: 'Movement', target: 'AI', via: ['Position'] });
+    expect(summary).toContainEqual({ kind: 'snapshot', source: 'AI', target: 'Healing', via: ['Health'] });
+  });
+
+  it('does not emit an edge between a system and itself', () => {
+    const edges = deriveEdges([
+      // Pathological self-reference. Real schedulers would reject this; the deriver must not crash.
+      sys({ name: 'Loopy', writes: ['X'], readsFresh: ['X'] }),
+    ]);
+    expect(edges).toEqual([]);
+  });
+
+  it('output is sorted by (kind, source, target) for deterministic snapshots', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Z', writes: ['T'] }),
+      sys({ name: 'A', readsFresh: ['T'] }),
+      sys({ name: 'M', readsFresh: ['T'] }),
+    ]);
+    const summary = summarise(edges);
+    expect(summary).toEqual([
+      { kind: 'fresh', source: 'Z', target: 'A', via: ['T'] },
+      { kind: 'fresh', source: 'Z', target: 'M', via: ['T'] },
+    ]);
+  });
+
+  it('SideWrites do NOT produce an edge', () => {
+    const edges = deriveEdges([
+      sys({ name: 'Inventory', sideWrites: ['Inventory'] }),
+      sys({ name: 'AI', readsFresh: ['Inventory'] }),
+    ]);
+    expect(edges).toEqual([]);
+  });
+
+  it('AdditionalReads paired with a writer produces no edge by itself', () => {
+    // AdditionalReads is "I read this beyond my input view" — same staleness ambiguity as Reads.
+    // No automatic edge until the user picks fresh / snapshot.
+    const edges = deriveEdges([
+      sys({ name: 'Movement', writes: ['Position'] }),
+      sys({ name: 'AI', additionalReads: ['Position'] }),
+    ]);
+    expect(edges).toEqual([]);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/__tests__/tickRangeMapping.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/__tests__/tickRangeMapping.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { TickSummaryDto } from '@/api/generated/model/tickSummaryDto';
+import { lastNTicksToTime, timeToTickRange } from '../tickRangeMapping';
+
+/**
+ * Boundary-case fixtures for the µs↔tick-range converter. These guarantees matter for the
+ * cross-panel binding: a stale or off-by-one selection in the profiler's TimeArea must not
+ * smear an extra tick into a DAG aggregation, and an empty roundtrip must not fire spurious
+ * /aggregate queries.
+ */
+
+function tick(tickNumber: number, startUs: number, durationUs: number): TickSummaryDto {
+  return {
+    tickNumber,
+    startUs,
+    durationUs,
+    eventCount: 0,
+    maxSystemDurationUs: 0,
+    activeSystemsBitmask: '0',
+    overloadLevel: 0,
+    tickMultiplier: 0,
+    metronomeWaitUs: 0,
+    metronomeIntentClass: 0,
+    consecutiveOverrun: 0,
+    consecutiveUnderrun: 0,
+  } as unknown as TickSummaryDto;
+}
+
+// 5 ticks at 1000 µs apart, each 800 µs long.  startUs: 0, 1000, 2000, 3000, 4000.
+const FIVE_TICKS: TickSummaryDto[] = [
+  tick(1, 0, 800),
+  tick(2, 1000, 800),
+  tick(3, 2000, 800),
+  tick(4, 3000, 800),
+  tick(5, 4000, 800),
+];
+
+describe('timeToTickRange', () => {
+  it('returns null on null time', () => {
+    expect(timeToTickRange(null, FIVE_TICKS)).toBeNull();
+  });
+
+  it('returns null on empty tick array', () => {
+    expect(timeToTickRange({ start: 0, end: 5000 }, [])).toBeNull();
+    expect(timeToTickRange({ start: 0, end: 5000 }, null)).toBeNull();
+  });
+
+  it('full window covers all ticks', () => {
+    expect(timeToTickRange({ start: 0, end: 10000 }, FIVE_TICKS)).toEqual({ from: 1, to: 5 });
+  });
+
+  it('window matching exactly one tick startUs (inclusive start)', () => {
+    // start at 2000 → tick 3 included; end at 3000 (exclusive) → tick 4 excluded.
+    expect(timeToTickRange({ start: 2000, end: 3000 }, FIVE_TICKS)).toEqual({ from: 3, to: 3 });
+  });
+
+  it('end-exclusive boundary excludes the tick at end', () => {
+    // tick 4 has startUs=3000. end=3000 means "up to but not including 3000".
+    expect(timeToTickRange({ start: 0, end: 3000 }, FIVE_TICKS)).toEqual({ from: 1, to: 3 });
+  });
+
+  it('window before any tick returns null', () => {
+    expect(timeToTickRange({ start: -1000, end: 0 }, FIVE_TICKS)).toBeNull();
+  });
+
+  it('window after all ticks returns null', () => {
+    // ticks end startUs at 4000; window starts at 5000 → no tick has startUs >= 5000.
+    expect(timeToTickRange({ start: 5000, end: 10000 }, FIVE_TICKS)).toBeNull();
+  });
+
+  it('partial overlap — start mid-tick still picks the next tick', () => {
+    // start at 1500 (between tick 2 startUs=1000 and tick 3 startUs=2000) → tick 2 has startUs<1500
+    // so it's excluded; tick 3 has startUs=2000 >= 1500 so it's the first match.
+    expect(timeToTickRange({ start: 1500, end: 4000 }, FIVE_TICKS)).toEqual({ from: 3, to: 4 });
+  });
+
+  it('zero-width window finds nothing', () => {
+    expect(timeToTickRange({ start: 1000, end: 1000 }, FIVE_TICKS)).toBeNull();
+  });
+});
+
+describe('lastNTicksToTime', () => {
+  it('returns null on empty / non-positive', () => {
+    expect(lastNTicksToTime(0, FIVE_TICKS)).toBeNull();
+    expect(lastNTicksToTime(-5, FIVE_TICKS)).toBeNull();
+    expect(lastNTicksToTime(5, [])).toBeNull();
+    expect(lastNTicksToTime(5, null)).toBeNull();
+  });
+
+  it('window covers exactly the last N ticks', () => {
+    // last 3 ticks: tick 3 (startUs=2000), tick 4, tick 5 (startUs=4000, durationUs=800).
+    // start=2000, end=4000+800=4800.
+    expect(lastNTicksToTime(3, FIVE_TICKS)).toEqual({ start: 2000, end: 4800 });
+  });
+
+  it('roundtrips through timeToTickRange to the same tick range', () => {
+    // Snapshot last 3 ticks → time selection → back to tick range = ticks 3..5.
+    const time = lastNTicksToTime(3, FIVE_TICKS);
+    expect(time).not.toBeNull();
+    expect(timeToTickRange(time, FIVE_TICKS)).toEqual({ from: 3, to: 5 });
+  });
+
+  it('clamps when fewer than N ticks exist', () => {
+    expect(lastNTicksToTime(100, FIVE_TICKS)).toEqual({ start: 0, end: 4800 });
+  });
+
+  it('zero-duration last tick still includes it via +1 µs epsilon', () => {
+    // If the last tick has durationUs == 0 (rare), end = startUs + 1 ensures the strict-less
+    // comparator in timeToTickRange still includes it on roundtrip.
+    const ticks = [tick(1, 0, 800), tick(2, 1000, 0)];
+    const time = lastNTicksToTime(1, ticks);
+    expect(time).toEqual({ start: 1000, end: 1001 });
+    expect(timeToTickRange(time, ticks)).toEqual({ from: 2, to: 2 });
+  });
+
+  it('roundtrips on a single-tick capture', () => {
+    const time = lastNTicksToTime(1, FIVE_TICKS);
+    expect(timeToTickRange(time, FIVE_TICKS)).toEqual({ from: 5, to: 5 });
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/dagModel.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/dagModel.ts
@@ -1,0 +1,487 @@
+import dagre from 'dagre';
+import type { Edge, Node } from '@xyflow/react';
+import type { SystemDefinitionDto } from '@/api/generated/model/systemDefinitionDto';
+import type { TopologyDto } from '@/api/generated/model/topologyDto';
+import { deriveEdges, type DerivedEdge, type DerivedEdgeKind } from './edgeDerivation';
+import type { LayoutMode } from './useDagViewStore';
+
+/**
+ * DAG model — pure transform from topology DTO → React Flow nodes/edges. Four layout strategies
+ * are supported (see {@link LayoutMode}):
+ *
+ * - `horizontal-lanes` (default per `09-system-dag.md §4.1`): phases stack vertically as swim-
+ *   lanes; systems flow LR within each phase via dagre. Inter-phase edges are dropped — the lane
+ *   order IS the phase contract; rendering them is O(systems²) noise.
+ * - `vertical-lanes`: phases as side-by-side columns; systems flow TB within each phase.
+ * - `compact`: flat dagre LR over all systems; lanes are not rendered AND cross-phase edges are
+ *   surfaced (the user explicitly opted out of the swim-lane contract).
+ * - `circular`: systems on a single circle, ordered by phase then by name. No lanes, no dagre.
+ *
+ * Systems whose phase isn't in `topology.phases` (or whose phaseName is empty) fall into a
+ * synthetic `(unphased)` group — last lane / last bucket — present in non-RFC-07 traces.
+ */
+
+export interface DagNodeData extends Record<string, unknown> {
+  systemName: string;
+  kind: 'Pipeline' | 'Query' | 'Callback' | 'Unknown';
+  phaseName: string;
+  isParallel: boolean;
+  isExclusivePhase: boolean;
+  tierFilter: number;
+  // Display chips — derived from access declarations. Kept as raw arrays so the renderer can
+  // chip them without re-parsing.
+  reads: string[];
+  readsFresh: string[];
+  readsSnapshot: string[];
+  writes: string[];
+  sideWrites: string[];
+  changeFilterTypes: string[]; // not in DTO yet — placeholder for future field
+  /** True if this system's declarations produced any access — used to dim "blank" tiles. */
+  hasAccess: boolean;
+}
+
+export interface DagEdgeData extends Record<string, unknown> {
+  kind: DerivedEdgeKind;
+  via: string[];
+  reason: string;
+}
+
+export type DagNode = Node<DagNodeData>;
+export type DagEdge = Edge<DagEdgeData>;
+
+export interface PhaseLane {
+  /** Phase name, or `(unphased)` for the fallback lane. */
+  name: string;
+  /** Order index in the canonical phase list (-1 for `(unphased)`). */
+  index: number;
+  systemCount: number;
+  /** Absolute x of the lane's left edge (px). */
+  xLeft: number;
+  /** Absolute y of the lane's top edge (px). Kept under `yTop` (rather than `y`) for back-compat with existing tests. */
+  yTop: number;
+  /** Lane height (px). */
+  height: number;
+  /** Lane width (px). */
+  width: number;
+  /**
+   * Where the lane label sits relative to the lane bounding box. `'left'` for horizontal lanes
+   * (sticky-left); `'top'` for vertical lanes (sticky-top). Phase-agnostic layouts (`compact`,
+   * `circular`) emit no lanes, so this field is never observed for them.
+   */
+  labelEdge: 'left' | 'top';
+}
+
+export interface DagModel {
+  nodes: DagNode[];
+  edges: DagEdge[];
+  lanes: PhaseLane[];
+  /** Total bounding-box width — useful for sizing the lane background tiles. */
+  width: number;
+  /** Total bounding-box height. */
+  height: number;
+}
+
+/** Tile dimensions used by the dagre layout and the React-Flow renderer. */
+export const NODE_WIDTH = 180;
+export const NODE_HEIGHT = 56;
+
+/** Vertical gap between phase lanes. */
+export const LANE_GAP = 32;
+/** Padding inside a lane (top + bottom + left). The lane label sits in the left margin. */
+export const LANE_PADDING = 16;
+const LANE_LABEL_WIDTH = 160;
+/** Vertical space reserved above the systems in a vertical lane for the phase label. */
+const LANE_LABEL_HEIGHT = 28;
+
+const SYNTHETIC_PHASE = '(unphased)';
+
+/** Narrowed topology — `systems` and `phases` are guaranteed non-null after the buildDagModel guard. */
+interface ResolvedTopology {
+  systems: SystemDefinitionDto[];
+  phases: string[];
+}
+
+/**
+ * Build the full model for an entire topology DTO. Pure function — no React, no DOM.
+ *
+ * `layout` defaults to `'horizontal-lanes'` so existing call sites and tests don't change shape.
+ */
+export function buildDagModel(
+  topology: TopologyDto | null | undefined,
+  layout: LayoutMode = 'horizontal-lanes',
+): DagModel {
+  if (!topology || !topology.systems || topology.systems.length === 0) {
+    return { nodes: [], edges: [], lanes: [], width: 0, height: 0 };
+  }
+  const resolved: ResolvedTopology = {
+    systems: topology.systems,
+    phases: topology.phases ?? [],
+  };
+
+  switch (layout) {
+    case 'horizontal-lanes':
+      return layoutHorizontalLanes(resolved);
+    case 'vertical-lanes':
+      return layoutVerticalLanes(resolved);
+    case 'compact':
+      return layoutCompact(resolved);
+    case 'circular':
+      return layoutCircular(resolved);
+  }
+}
+
+// ── Phase bucketing helper (shared by both lane-based layouts) ───────────
+
+interface OrderedPhase {
+  name: string;
+  index: number;
+  systems: SystemDefinitionDto[];
+}
+
+function bucketByPhase(topology: ResolvedTopology): OrderedPhase[] {
+  const phaseOrder = topology.phases.filter((p): p is string => !!p);
+  const phaseToIndex = new Map<string, number>();
+  phaseOrder.forEach((p, i) => phaseToIndex.set(p, i));
+
+  const buckets = new Map<string, SystemDefinitionDto[]>();
+  for (const s of topology.systems) {
+    const key = (s.phaseName && phaseToIndex.has(s.phaseName)) ? s.phaseName : SYNTHETIC_PHASE;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(key, bucket);
+    }
+    bucket.push(s);
+  }
+
+  const ordered: OrderedPhase[] = [];
+  for (const name of phaseOrder) {
+    const bucket = buckets.get(name);
+    if (bucket && bucket.length > 0) {
+      ordered.push({ name, index: phaseToIndex.get(name)!, systems: bucket });
+    }
+  }
+  const synthBucket = buckets.get(SYNTHETIC_PHASE);
+  if (synthBucket && synthBucket.length > 0) {
+    ordered.push({ name: SYNTHETIC_PHASE, index: -1, systems: synthBucket });
+  }
+  return ordered;
+}
+
+function intraPhaseEdgesOnly(derived: DerivedEdge[], orderedPhases: OrderedPhase[]): DagEdge[] {
+  const phaseOf = new Map<string, string>();
+  for (const phase of orderedPhases) {
+    for (const s of phase.systems) {
+      if (s.name) phaseOf.set(s.name, phase.name);
+    }
+  }
+  const edges: DagEdge[] = [];
+  for (const d of derived) {
+    if (phaseOf.get(d.source) !== phaseOf.get(d.target)) continue;
+    edges.push(toReactFlowEdge(d));
+  }
+  return edges;
+}
+
+// ── horizontal-lanes (default per `09-system-dag.md §4.1`) ───────────────
+
+function layoutHorizontalLanes(topology: ResolvedTopology): DagModel {
+  const derived = deriveEdges(topology.systems);
+  const orderedPhases = bucketByPhase(topology);
+
+  const nodes: DagNode[] = [];
+  const lanes: PhaseLane[] = [];
+  let yCursor = 0;
+  let maxWidth = 0;
+
+  for (const phase of orderedPhases) {
+    const phaseSystemNames = new Set(phase.systems.map((s) => s.name).filter((n): n is string => !!n));
+    const phaseEdges = derived.filter((e) => phaseSystemNames.has(e.source) && phaseSystemNames.has(e.target));
+    const layout = layoutPhase(phase.systems, phaseEdges, 'LR');
+
+    const xOffset = LANE_LABEL_WIDTH + LANE_PADDING;
+    const yOffset = yCursor + LANE_PADDING;
+    for (const node of layout.nodes) {
+      nodes.push({ ...node, position: { x: node.position.x + xOffset, y: node.position.y + yOffset } });
+    }
+
+    const laneHeight = layout.height + LANE_PADDING * 2;
+    const laneWidth = LANE_LABEL_WIDTH + LANE_PADDING * 2 + layout.width;
+    lanes.push({
+      name: phase.name,
+      index: phase.index,
+      systemCount: phase.systems.length,
+      xLeft: 0,
+      yTop: yCursor,
+      height: laneHeight,
+      width: laneWidth,
+      labelEdge: 'left',
+    });
+
+    if (laneWidth > maxWidth) maxWidth = laneWidth;
+    yCursor += laneHeight + LANE_GAP;
+  }
+
+  return {
+    nodes,
+    edges: intraPhaseEdgesOnly(derived, orderedPhases),
+    lanes,
+    width: maxWidth,
+    height: yCursor > 0 ? yCursor - LANE_GAP : 0,
+  };
+}
+
+// ── vertical-lanes ───────────────────────────────────────────────────────
+
+function layoutVerticalLanes(topology: ResolvedTopology): DagModel {
+  const derived = deriveEdges(topology.systems);
+  const orderedPhases = bucketByPhase(topology);
+
+  const nodes: DagNode[] = [];
+  const lanes: PhaseLane[] = [];
+  let xCursor = 0;
+  let maxHeight = 0;
+
+  for (const phase of orderedPhases) {
+    const phaseSystemNames = new Set(phase.systems.map((s) => s.name).filter((n): n is string => !!n));
+    const phaseEdges = derived.filter((e) => phaseSystemNames.has(e.source) && phaseSystemNames.has(e.target));
+    const layout = layoutPhase(phase.systems, phaseEdges, 'TB');
+
+    const xOffset = xCursor + LANE_PADDING;
+    const yOffset = LANE_LABEL_HEIGHT + LANE_PADDING;
+    for (const node of layout.nodes) {
+      nodes.push({ ...node, position: { x: node.position.x + xOffset, y: node.position.y + yOffset } });
+    }
+
+    const laneWidth = layout.width + LANE_PADDING * 2;
+    const laneHeight = LANE_LABEL_HEIGHT + LANE_PADDING * 2 + layout.height;
+    lanes.push({
+      name: phase.name,
+      index: phase.index,
+      systemCount: phase.systems.length,
+      xLeft: xCursor,
+      yTop: 0,
+      height: laneHeight,
+      width: laneWidth,
+      labelEdge: 'top',
+    });
+
+    if (laneHeight > maxHeight) maxHeight = laneHeight;
+    xCursor += laneWidth + LANE_GAP;
+  }
+
+  return {
+    nodes,
+    edges: intraPhaseEdgesOnly(derived, orderedPhases),
+    lanes,
+    width: xCursor > 0 ? xCursor - LANE_GAP : 0,
+    height: maxHeight,
+  };
+}
+
+// ── compact (flat dagre, no swim-lanes, cross-phase edges visible) ───────
+
+function layoutCompact(topology: ResolvedTopology): DagModel {
+  const derived = deriveEdges(topology.systems);
+  const layout = layoutPhase(topology.systems, derived, 'LR');
+
+  // No lanes; cross-phase edges are kept (the user explicitly opted out of the swim-lane contract).
+  const edges: DagEdge[] = [];
+  for (const d of derived) edges.push(toReactFlowEdge(d));
+
+  return {
+    nodes: layout.nodes,
+    edges,
+    lanes: [],
+    width: layout.width,
+    height: layout.height,
+  };
+}
+
+// ── circular ─────────────────────────────────────────────────────────────
+
+function layoutCircular(topology: ResolvedTopology): DagModel {
+  const derived = deriveEdges(topology.systems);
+
+  // Order systems by phase (declared order), then by name within phase. Without phase data we
+  // fall back to plain name order — works for non-RFC-07 traces.
+  const orderedPhases = bucketByPhase(topology);
+  const ordered: SystemDefinitionDto[] = [];
+  for (const phase of orderedPhases) {
+    const sortedNames = phase.systems
+      .filter((s): s is SystemDefinitionDto & { name: string } => !!s.name)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const s of sortedNames) ordered.push(s);
+  }
+  const n = ordered.length;
+  if (n === 0) {
+    return { nodes: [], edges: [], lanes: [], width: 0, height: 0 };
+  }
+
+  // Radius scales so the circumference accommodates n tiles with a comfortable gap. The minimum
+  // radius prevents tiny circles for trivial topologies.
+  const tileSpacing = NODE_WIDTH + 60;
+  const minRadius = NODE_WIDTH * 1.5;
+  const radius = Math.max(minRadius, (tileSpacing * n) / (2 * Math.PI));
+  const cx = radius + NODE_WIDTH / 2;
+  const cy = radius + NODE_HEIGHT / 2;
+
+  const nodes: DagNode[] = [];
+  for (let i = 0; i < n; i++) {
+    const s = ordered[i];
+    if (!s.name) continue;
+    // Start at the top (-π/2) and walk clockwise.
+    const theta = -Math.PI / 2 + (2 * Math.PI * i) / n;
+    const x = cx + radius * Math.cos(theta) - NODE_WIDTH / 2;
+    const y = cy + radius * Math.sin(theta) - NODE_HEIGHT / 2;
+    nodes.push({
+      id: s.name,
+      type: 'system',
+      position: { x, y },
+      data: toNodeData(s),
+    });
+  }
+
+  // All edges visible (cross-phase included) — the circle has no phase contract.
+  const edges: DagEdge[] = [];
+  for (const d of derived) edges.push(toReactFlowEdge(d));
+
+  const total = 2 * radius + NODE_WIDTH;
+  return { nodes, edges, lanes: [], width: total, height: total };
+}
+
+// ── shared dagre helper ──────────────────────────────────────────────────
+
+interface PhaseLayoutResult {
+  nodes: DagNode[];
+  width: number;
+  height: number;
+}
+
+function layoutPhase(
+  systems: SystemDefinitionDto[],
+  edges: DerivedEdge[],
+  rankdir: 'LR' | 'TB',
+): PhaseLayoutResult {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir, ranksep: 80, nodesep: 30, marginx: 0, marginy: 0 });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const s of systems) {
+    if (!s.name) continue;
+    g.setNode(s.name, { width: NODE_WIDTH, height: NODE_HEIGHT });
+  }
+  for (const e of edges) {
+    g.setEdge(e.source, e.target);
+  }
+  dagre.layout(g);
+
+  const nodes: DagNode[] = [];
+  let maxX = 0;
+  let maxY = 0;
+  for (const s of systems) {
+    if (!s.name) continue;
+    const node = g.node(s.name);
+    if (!node) continue;
+    const x = node.x - NODE_WIDTH / 2;
+    const y = node.y - NODE_HEIGHT / 2;
+    nodes.push({
+      id: s.name,
+      type: 'system',
+      position: { x, y },
+      data: toNodeData(s),
+    });
+    if (x + NODE_WIDTH > maxX) maxX = x + NODE_WIDTH;
+    if (y + NODE_HEIGHT > maxY) maxY = y + NODE_HEIGHT;
+  }
+  return { nodes, width: maxX, height: maxY };
+}
+
+/**
+ * Pure transform from a single {@link SystemDefinitionDto} to {@link DagNodeData}. Exported so
+ * panels can resolve node-shaped data for a specific system (e.g. side panel on selection)
+ * **without** rebuilding the whole DAG layout, which is O(systems × edges) per dagre call.
+ */
+export function toNodeData(s: SystemDefinitionDto): DagNodeData {
+  const access = (
+    (s.reads?.length ?? 0)
+    + (s.readsFresh?.length ?? 0)
+    + (s.readsSnapshot?.length ?? 0)
+    + (s.writes?.length ?? 0)
+    + (s.sideWrites?.length ?? 0)
+    + (s.writesEvents?.length ?? 0)
+    + (s.readsEvents?.length ?? 0)
+    + (s.writesResources?.length ?? 0)
+    + (s.readsResources?.length ?? 0)
+  );
+  return {
+    systemName: s.name ?? '',
+    kind: kindFromByte(s.type),
+    phaseName: s.phaseName ?? '',
+    isParallel: s.isParallel,
+    isExclusivePhase: s.isExclusivePhase,
+    tierFilter: typeof s.tierFilter === 'number' ? s.tierFilter : Number(s.tierFilter),
+    reads: s.reads ?? [],
+    readsFresh: s.readsFresh ?? [],
+    readsSnapshot: s.readsSnapshot ?? [],
+    writes: s.writes ?? [],
+    sideWrites: s.sideWrites ?? [],
+    changeFilterTypes: [], // not surfaced through topology DTO yet — placeholder
+    hasAccess: access > 0,
+  };
+}
+
+function kindFromByte(type: number | string): DagNodeData['kind'] {
+  const n = typeof type === 'number' ? type : Number(type);
+  switch (n) {
+    case 0:
+      return 'Pipeline';
+    case 1:
+      return 'Query';
+    case 2:
+      return 'Callback';
+    default:
+      return 'Unknown';
+  }
+}
+
+function toReactFlowEdge(d: DerivedEdge): DagEdge {
+  const style = edgeStyle(d.kind);
+  return {
+    id: d.id,
+    source: d.source,
+    target: d.target,
+    type: style.type,
+    label: d.via.length > 1 ? `${d.via[0]} +${d.via.length - 1}` : d.via[0],
+    labelStyle: { fontSize: 10, fill: style.colour, fontFamily: 'monospace' },
+    labelBgStyle: { fill: 'var(--background)', fillOpacity: 0.85 },
+    style: { stroke: style.colour, strokeDasharray: style.dasharray },
+    animated: false,
+    data: {
+      kind: d.kind,
+      via: d.via,
+      reason: d.reason,
+    },
+  };
+}
+
+interface EdgeStyle {
+  colour: string;
+  dasharray: string | undefined;
+  type: 'default' | 'smoothstep';
+}
+
+function edgeStyle(kind: DerivedEdgeKind): EdgeStyle {
+  switch (kind) {
+    case 'fresh':
+      return { colour: '#f59e0b', dasharray: undefined, type: 'smoothstep' }; // amber/orange
+    case 'snapshot':
+      return { colour: '#3b82f6', dasharray: undefined, type: 'smoothstep' }; // blue
+    case 'manual':
+      return { colour: '#94a3b8', dasharray: undefined, type: 'smoothstep' }; // slate
+    case 'event':
+      return { colour: '#a78bfa', dasharray: '6 4', type: 'smoothstep' }; // violet, dashed
+    case 'resource':
+      return { colour: '#ef4444', dasharray: '2 4', type: 'smoothstep' }; // red, dotted
+  }
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/edgeDerivation.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/edgeDerivation.ts
@@ -1,0 +1,211 @@
+import type { SystemDefinitionDto } from '@/api/generated/model/systemDefinitionDto';
+
+/**
+ * Edge derivation for the System DAG view (RFC 07 §Q4 / `09-system-dag.md` §4.3).
+ *
+ * Pure function — no React, no DOM, fully testable. Mirrors the engine's `Build()`-time DAG
+ * derivation: every edge is derived from declared access (`Reads*` / `Writes*` / event queues /
+ * resources) plus explicit `.After()` / `.Before()` overrides. Deduplication is by
+ * `(source, target, kind)` — multiple shared components produce a single edge per kind, with the
+ * combined component list in {@link DerivedEdge.via}.
+ *
+ * Inter-phase edges are NOT emitted: the lane order *is* the phase contract (per RFC 07's
+ * "phases are the skeleton"). Cross-phase pairs share components but the scheduler enforces order
+ * via the phase fence, so rendering them as edges would be O(systems²) noise.
+ */
+export type DerivedEdgeKind = 'fresh' | 'snapshot' | 'manual' | 'event' | 'resource';
+
+export interface DerivedEdge {
+  /** Stable id usable as React Flow edge id. */
+  id: string;
+  /** System name of the writer / producer / earlier system. */
+  source: string;
+  /** System name of the reader / consumer / later system. */
+  target: string;
+  kind: DerivedEdgeKind;
+  /** Component / queue / resource names that justify the edge. Sorted alphabetically. */
+  via: string[];
+  /** One-line natural-language reason rendered in the tooltip. */
+  reason: string;
+}
+
+/**
+ * Build the full edge set for a topology. Returns edges in declaration-stable order: edges with
+ * the same (source, target, kind) are merged, the merged `via` is sorted, and the array is
+ * sorted by `(kind, source, target)` so test snapshots are deterministic.
+ */
+export function deriveEdges(systems: SystemDefinitionDto[]): DerivedEdge[] {
+  const buckets = new Map<string, DerivedEdge>();
+
+  for (let i = 0; i < systems.length; i++) {
+    const a = systems[i];
+    const aName = a.name ?? '';
+    if (!aName) continue;
+
+    // Manual `.After()` / `.Before()` — explicit overrides, always within or across phases. The
+    // design says cross-phase edges are not drawn, but we don't have phase info here; the layout
+    // layer filters by phase. Emit unconditionally; the renderer drops cross-phase ones.
+    for (const earlier of a.explicitAfter ?? []) {
+      addEdge(buckets, earlier, aName, 'manual', earlier, `Manual edge: ${aName}.After(${earlier})`);
+    }
+    for (const later of a.explicitBefore ?? []) {
+      addEdge(buckets, aName, later, 'manual', later, `Manual edge: ${aName}.Before(${later})`);
+    }
+
+    for (let j = 0; j < systems.length; j++) {
+      if (i === j) continue;
+      const b = systems[j];
+      const bName = b.name ?? '';
+      if (!bName) continue;
+
+      // Same-phase rule (RFC 07): fresh-reads + snapshot-reads only fire inside one phase. We
+      // emit unconditionally — the layout layer filters cross-phase edges.
+      const samePhase = (a.phaseName ?? '') === (b.phaseName ?? '') && (a.phaseName ?? '') !== '';
+
+      // ReadsFresh<T> ← Writes<T>: the reader runs AFTER the writer. Edge points writer → reader.
+      if (samePhase) {
+        const sharedFresh = intersect(a.writes, b.readsFresh);
+        for (const t of sharedFresh) {
+          addEdge(
+            buckets,
+            aName,
+            bName,
+            'fresh',
+            t,
+            `${bName} reads ${t} fresh; ${aName} writes ${t} → ${bName} runs after ${aName}`,
+          );
+        }
+
+        // Writes<T> → ReadsSnapshot<T>: the snapshot reader runs BEFORE the writer. Edge points
+        // reader → writer (so the layout puts the reader earlier).
+        const sharedSnap = intersect(a.writes, b.readsSnapshot);
+        for (const t of sharedSnap) {
+          addEdge(
+            buckets,
+            bName,
+            aName,
+            'snapshot',
+            t,
+            `${bName} reads ${t} snapshot; ${aName} writes ${t} → ${bName} runs before ${aName}`,
+          );
+        }
+      }
+
+      // Event queue: producer (writesEvents) → consumer (readsEvents). Cross-phase allowed by
+      // design (events buffer across phase fences); however the renderer still filters to
+      // intra-phase to honour the "no inter-phase edges" rule.
+      if (samePhase) {
+        const sharedEvents = intersect(a.writesEvents, b.readsEvents);
+        for (const q of sharedEvents) {
+          addEdge(
+            buckets,
+            aName,
+            bName,
+            'event',
+            q,
+            `${aName} produces ${q}; ${bName} consumes`,
+          );
+        }
+      }
+
+      // Named-resource conflict: any pair touching the same resource where at least one writes.
+      // Edge direction = writer → reader (or for write-write, both directions get recorded as one
+      // edge in alphabetical (source, target) so the dedup is stable).
+      if (samePhase) {
+        const aTouches = unionOf(a.writesResources, a.readsResources);
+        const bTouches = unionOf(b.writesResources, b.readsResources);
+        const shared = intersectArrays(aTouches, bTouches);
+        for (const r of shared) {
+          // Dedup symmetric pairs: only emit if (i < j) so the bucket key wins once.
+          if (i >= j) continue;
+          const aWrites = (a.writesResources ?? []).includes(r);
+          const bWrites = (b.writesResources ?? []).includes(r);
+          if (!aWrites && !bWrites) continue; // both read-only → no scheduling conflict
+          // Direction: writer → other; if both write, alphabetical.
+          let src = aName;
+          let tgt = bName;
+          if (aWrites && !bWrites) {
+            src = aName;
+            tgt = bName;
+          } else if (!aWrites && bWrites) {
+            src = bName;
+            tgt = aName;
+          } else {
+            // Both write — pick alphabetical for stability.
+            src = aName < bName ? aName : bName;
+            tgt = aName < bName ? bName : aName;
+          }
+          addEdge(buckets, src, tgt, 'resource', r, resourceReason(src, tgt, r));
+        }
+      }
+    }
+  }
+
+  const out = [...buckets.values()];
+  out.sort((x, y) => {
+    if (x.kind !== y.kind) return x.kind.localeCompare(y.kind);
+    if (x.source !== y.source) return x.source.localeCompare(y.source);
+    return x.target.localeCompare(y.target);
+  });
+  for (const e of out) e.via.sort();
+  return out;
+}
+
+function addEdge(
+  buckets: Map<string, DerivedEdge>,
+  source: string,
+  target: string,
+  kind: DerivedEdgeKind,
+  via: string,
+  reason: string,
+): void {
+  if (source === target) return;
+  const key = `${kind}|${source}|${target}`;
+  const existing = buckets.get(key);
+  if (existing) {
+    if (!existing.via.includes(via)) {
+      existing.via.push(via);
+      existing.reason = `${existing.reason}; ${reason}`;
+    }
+    return;
+  }
+  buckets.set(key, {
+    id: `e-${kind}-${source}-${target}`,
+    source,
+    target,
+    kind,
+    via: [via],
+    reason,
+  });
+}
+
+function intersect(a: string[] | null | undefined, b: string[] | null | undefined): string[] {
+  if (!a || !b || a.length === 0 || b.length === 0) return [];
+  const setB = new Set(b);
+  const out: string[] = [];
+  for (const x of a) {
+    if (setB.has(x)) out.push(x);
+  }
+  return out;
+}
+
+function unionOf(a: string[] | null | undefined, b: string[] | null | undefined): string[] {
+  const set = new Set<string>();
+  for (const x of a ?? []) set.add(x);
+  for (const x of b ?? []) set.add(x);
+  return [...set];
+}
+
+function intersectArrays(a: string[], b: string[]): string[] {
+  if (a.length === 0 || b.length === 0) return [];
+  const setB = new Set(b);
+  const out: string[] = [];
+  for (const x of a) {
+    if (setB.has(x)) out.push(x);
+  }
+  return out;
+}
+
+function resourceReason(src: string, tgt: string, resource: string): string {
+  return `Both touch resource ${resource} (${src} writes / ${tgt} reads or writes)`;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/tickRangeMapping.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/tickRangeMapping.ts
@@ -1,0 +1,99 @@
+import type { TickSummaryDto } from '@/api/generated/model/tickSummaryDto';
+import type { TimeSelection } from '@/stores/useSelectionStore';
+import type { TickRange } from './useDagViewStore';
+
+/**
+ * Converts a µs `[start, end)` time selection (the units used by the profiler's TimeArea and
+ * `useSelectionStore.time`) into the inclusive `[from, to]` tick-number range that the
+ * `/aggregate` endpoint and the DAG panel's downstream hooks consume.
+ *
+ * `tickSummaries` is assumed to be tick-ordered with monotonically non-decreasing `startUs` —
+ * this matches the wire contract (cache writes ticks in order). Binary search is O(log N) so the
+ * conversion is cheap to call on every TimeArea scrub.
+ *
+ * Semantics:
+ * - `[time.start, time.end)` is the µs window. A tick is **in** the window iff `startUs` falls
+ *   in that half-open interval. (End-exclusive matches the {@link TimeSelection} contract.)
+ * - Returns `null` when no ticks fall in the window — the caller should skip aggregation rather
+ *   than fire empty queries.
+ *
+ * Edge cases tested in the companion spec.
+ */
+export function timeToTickRange(
+  time: TimeSelection | null,
+  tickSummaries: readonly TickSummaryDto[] | null | undefined,
+): TickRange | null {
+  if (!time || !tickSummaries || tickSummaries.length === 0) return null;
+
+  // First tick with startUs >= time.start (inclusive lower bound).
+  const firstIdx = firstIndexWithStartUsGte(tickSummaries, time.start);
+  if (firstIdx >= tickSummaries.length) return null; // window starts after every tick.
+
+  // Last tick with startUs < time.end (end is exclusive — first index past it, minus 1).
+  const lastIdx = firstIndexWithStartUsGte(tickSummaries, time.end) - 1;
+  if (lastIdx < firstIdx) return null; // window contains no tick.
+
+  const fromTick = numericValue(tickSummaries[firstIdx].tickNumber);
+  const toTick = numericValue(tickSummaries[lastIdx].tickNumber);
+  if (fromTick == null || toTick == null) return null;
+  return { from: fromTick, to: toTick };
+}
+
+/**
+ * Computes the µs `[start, end)` window that covers exactly the last `n` ticks. Used by the
+ * "Snapshot last N ticks" toolbar action: it writes the result to {@link useSelectionStore.time}
+ * which the bridge fans out to both the profiler's TimeArea and back through {@link timeToTickRange}
+ * for the DAG aggregations.
+ *
+ * If fewer than `n` ticks exist, returns the window covering all available ticks (degrades
+ * gracefully on early-session captures). Returns `null` if no ticks are loaded.
+ */
+export function lastNTicksToTime(
+  n: number,
+  tickSummaries: readonly TickSummaryDto[] | null | undefined,
+): TimeSelection | null {
+  if (!tickSummaries || tickSummaries.length === 0 || n <= 0) return null;
+
+  const total = tickSummaries.length;
+  const startIdx = Math.max(0, total - n);
+  const lastIdx = total - 1;
+
+  const start = numericValue(tickSummaries[startIdx].startUs);
+  const lastStart = numericValue(tickSummaries[lastIdx].startUs);
+  const lastDuration = numericValue(tickSummaries[lastIdx].durationUs) ?? 0;
+  if (start == null || lastStart == null) return null;
+
+  // End is the moment AFTER the last tick finishes — matches the end-exclusive convention so the
+  // last tick is included by `timeToTickRange`. `+ 1` provides a tiny epsilon in the (unusual)
+  // case `durationUs == 0`, ensuring the strict `<` comparator includes the final tick.
+  const end = lastStart + Math.max(lastDuration, 1);
+  return { start, end };
+}
+
+// ── internals ────────────────────────────────────────────────────────────
+
+/**
+ * Smallest index `i` with `startUs(i) >= value`. Returns `length` if no tick satisfies. Used for
+ * both ends of the window: directly for the inclusive lower bound, and `result - 1` gives the
+ * largest index with `startUs < value` for the exclusive upper bound.
+ */
+function firstIndexWithStartUsGte(rows: readonly TickSummaryDto[], value: number): number {
+  let lo = 0;
+  let hi = rows.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    const start = numericValue(rows[mid].startUs);
+    if (start == null || start < value) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+function numericValue(v: unknown): number | null {
+  if (v == null) return null;
+  const n = typeof v === 'number' ? v : Number(v as string);
+  return Number.isFinite(n) ? n : null;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/useDagViewStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/useDagViewStore.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+/**
+ * Panel-local view state for the System DAG. After cross-panel binding (per `09-system-dag.md §7.1`)
+ * the **tick range no longer lives here** — it's derived from {@link useSelectionStore.time}, which
+ * is the single source of truth shared with the profiler's TimeArea. This store now holds:
+ *
+ * - **stat mode** (mean / p50 / p95 / p99 / max) — drives the per-node primary stat per §6.1.
+ * - **layout mode** — chooses how nodes occupy the canvas. Persisted across sessions because user
+ *   layout preference is sticky (per the `useThemeStore` precedent).
+ *
+ * The {@link TickRange} type is still exported here because every downstream consumer
+ * (`useSystemStats`, `useQueueBackpressure`, `criticalPath`) takes a tick-numbered range — the panel
+ * converts the µs `useSelectionStore.time` to ticks at the boundary via {@link tickRangeMapping}.
+ */
+export type StatMode = 'mean' | 'p50' | 'p95' | 'p99' | 'max';
+
+/**
+ * Available DAG layouts. Phase-aware ones (`horizontal-lanes`, `vertical-lanes`) preserve the
+ * design's swim-lane skeleton (§4.1 — phases ARE the structural mental model). Phase-agnostic ones
+ * (`compact`, `circular`) drop the lanes for cases where the user wants a different visual angle on
+ * the same topology. `compact` additionally surfaces cross-phase edges, which the swim-lane
+ * layouts hide as O(systems²) noise.
+ */
+export type LayoutMode = 'horizontal-lanes' | 'vertical-lanes' | 'compact' | 'circular';
+
+export interface TickRange {
+  /** Inclusive first tick. */
+  from: number;
+  /** Inclusive last tick. */
+  to: number;
+}
+
+export interface DagViewState {
+  /** Primary stat shown on each node tile and used for heat colouring. */
+  statMode: StatMode;
+  /** Node placement strategy — see {@link LayoutMode}. */
+  layout: LayoutMode;
+  setStatMode: (mode: StatMode) => void;
+  setLayout: (layout: LayoutMode) => void;
+}
+
+// SSR/test-safe localStorage wrapper — same shape as `useThemeStore`.
+const safeStorage = createJSONStorage(() => ({
+  getItem: (name: string) => {
+    try { return localStorage.getItem(name); } catch { return null; }
+  },
+  setItem: (name: string, value: string) => {
+    try { localStorage.setItem(name, value); } catch { /* noop */ }
+  },
+  removeItem: (name: string) => {
+    try { localStorage.removeItem(name); } catch { /* noop */ }
+  },
+}));
+
+export const useDagViewStore = create<DagViewState>()(
+  persist(
+    (set) => ({
+      statMode: 'mean',
+      layout: 'horizontal-lanes',
+      setStatMode: (statMode) => set({ statMode }),
+      setLayout: (layout) => set({ layout }),
+    }),
+    { name: 'typhon-dag-view', storage: safeStorage },
+  ),
+);

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/useQueueBackpressure.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/useQueueBackpressure.ts
@@ -1,0 +1,106 @@
+import { useMemo } from 'react';
+import { useAggregations } from '@/hooks/data/useAggregations';
+import type { AggregationQueryDto } from '@/api/generated/model/aggregationQueryDto';
+import type { TickRange } from './useDagViewStore';
+
+/**
+ * Per-queue backpressure stats over a tick range, fetched in one batched /aggregate call:
+ * `peakDepth` max, `endOfTickDepth` p50, `overflowCount` sum. Heat is relative across the
+ * queues in the same fetch (max peak depth = 1.0, lowest = 0.0).
+ *
+ * **v1 limitation — no queue capacity on the wire.** Per `09-system-dag.md §4.5`, ideal
+ * encoding normalises peak by capacity. The engine doesn't surface capacity yet (engine work,
+ * tracked separately); we substitute a relative heat across the visible queues. This loses
+ * absolute meaning ("how close to dropping?") but still surfaces "which queue is the worst."
+ * Overflow count compensates: when it's non-zero, that's a binary catastrophe signal that
+ * doesn't depend on capacity.
+ */
+export interface QueueBackpressureStat {
+  /** max peakDepth in the range. */
+  peakMax: number;
+  /** median end-of-tick depth in the range. */
+  endTickMedian: number;
+  /** sum of overflowCount in the range — binary "events were dropped" signal. */
+  overflowSum: number;
+  /**
+   * Peak-derived heat ∈ [0, 1] across the queues. Drives the **fill colour** per design §4.5
+   * ("how close to dropping events at the worst moment"). Independent from {@link outlineHeat}
+   * so the two channels answer two different questions.
+   */
+  heat: number;
+  /**
+   * End-of-tick-derived heat ∈ [0, 1] across the queues. Drives the **outline thickness** per
+   * design §4.5 ("captures sustained backlog — thin = consumer keeping up; thick = chronically
+   * lagging"). A queue with high peak but low median end-of-tick is hot in colour but thin in
+   * outline (one-tick spike); the inverse is cool but thick (chronic-but-mild backlog).
+   */
+  outlineHeat: number;
+}
+
+export function useQueueBackpressure(
+  sessionId: string | null,
+  queueNames: string[],
+  range: TickRange | null,
+): Map<string, QueueBackpressureStat> {
+  const queries = useMemo<AggregationQueryDto[]>(() => {
+    if (!range || queueNames.length === 0) return [];
+    const out: AggregationQueryDto[] = [];
+    for (const name of queueNames) {
+      const trackId = `queue/${name}`;
+      out.push({ trackId, field: 'peakDepth', op: 'max', range: [range.from, range.to] });
+      out.push({ trackId, field: 'endOfTickDepth', op: 'p50', range: [range.from, range.to] });
+      out.push({ trackId, field: 'overflowCount', op: 'sum', range: [range.from, range.to] });
+    }
+    return out;
+  }, [range, queueNames]);
+
+  const { data } = useAggregations(sessionId, queries);
+
+  return useMemo(() => {
+    const map = new Map<string, QueueBackpressureStat>();
+    if (!data?.results) return map;
+    const raw: Array<{ name: string; peak: number; endTick: number; overflow: number }> = [];
+    for (let i = 0; i < queueNames.length; i++) {
+      const peak = numericValue(data.results[i * 3]?.value);
+      const endTick = numericValue(data.results[i * 3 + 1]?.value);
+      const overflow = numericValue(data.results[i * 3 + 2]?.value);
+      if (peak == null) continue;
+      raw.push({
+        name: queueNames[i],
+        peak,
+        endTick: endTick ?? 0,
+        overflow: overflow ?? 0,
+      });
+    }
+    let peakMin = Number.POSITIVE_INFINITY;
+    let peakMax = Number.NEGATIVE_INFINITY;
+    let endTickMin = Number.POSITIVE_INFINITY;
+    let endTickMax = Number.NEGATIVE_INFINITY;
+    for (const r of raw) {
+      if (r.peak < peakMin) peakMin = r.peak;
+      if (r.peak > peakMax) peakMax = r.peak;
+      if (r.endTick < endTickMin) endTickMin = r.endTick;
+      if (r.endTick > endTickMax) endTickMax = r.endTick;
+    }
+    const peakSpan = peakMax - peakMin;
+    const endTickSpan = endTickMax - endTickMin;
+    for (const r of raw) {
+      const heat = peakSpan > 0 ? (r.peak - peakMin) / peakSpan : 0;
+      const outlineHeat = endTickSpan > 0 ? (r.endTick - endTickMin) / endTickSpan : 0;
+      map.set(r.name, {
+        peakMax: r.peak,
+        endTickMedian: r.endTick,
+        overflowSum: r.overflow,
+        heat,
+        outlineHeat,
+      });
+    }
+    return map;
+  }, [data, queueNames]);
+}
+
+function numericValue(v: number | string | null | undefined): number | null {
+  if (v == null) return null;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/useSystemStats.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/SystemDag/useSystemStats.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import { useAggregations } from '@/hooks/data/useAggregations';
+import type { AggregationQueryDto } from '@/api/generated/model/aggregationQueryDto';
+import type { TickRange, StatMode } from './useDagViewStore';
+
+/**
+ * Per-system primary stat (µs, with relative heat) over a tick range. One batched POST to
+ * `/api/sessions/{id}/aggregate` with N queries (one per system) — see
+ * `10-internal-data-api.md §12.3`. Returned as a map for O(1) node lookup at render time.
+ *
+ * Heat is `(value - min) / (max - min)` clamped to [0, 1] across the systems in the same fetch
+ * — purely visual, not statistical, so a single hot system doesn't drown the rest.
+ */
+export interface SystemStat {
+  /** µs from the chosen aggregation operator (mean / p95 / etc.). */
+  value: number;
+  /** Relative heat ∈ [0, 1]. 0 = coldest in the batch, 1 = hottest. */
+  heat: number;
+}
+
+export interface SystemStatsResult {
+  stats: Map<string, SystemStat>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useSystemStats(
+  sessionId: string | null,
+  systemNames: string[],
+  range: TickRange | null,
+  statMode: StatMode,
+): SystemStatsResult {
+  const queries = useMemo<AggregationQueryDto[]>(() => {
+    if (!range || systemNames.length === 0) return [];
+    return systemNames.map((name) => ({
+      trackId: `system/${name}`,
+      field: 'durationUs',
+      op: statMode,
+      range: [range.from, range.to],
+    }));
+  }, [range, statMode, systemNames]);
+
+  const { data, isLoading, error } = useAggregations(sessionId, queries);
+
+  const stats = useMemo(() => {
+    const map = new Map<string, SystemStat>();
+    if (!data?.results) return map;
+
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
+    const raw: Array<{ name: string; value: number }> = [];
+    for (let i = 0; i < systemNames.length; i++) {
+      const r = data.results[i];
+      const v = typeof r?.value === 'number' ? r.value : null;
+      if (v == null || !Number.isFinite(v)) continue;
+      raw.push({ name: systemNames[i], value: v });
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+    const span = max - min;
+    for (const { name, value } of raw) {
+      const heat = span > 0 ? (value - min) / span : 0;
+      map.set(name, { value, heat });
+    }
+    return map;
+  }, [data, systemNames]);
+
+  return { stats, isLoading, error: (error as Error) ?? null };
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/OverloadStrip.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/OverloadStrip.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Expand, X } from 'lucide-react';
 import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
-import { useProfilerViewStore } from '@/stores/useProfilerViewStore';
 import { useThemeStore } from '@/stores/useThemeStore';
+import { useUiPrefsStore } from '@/stores/useUiPrefsStore';
 import { setupCanvas } from '@/libs/profiler/canvas/canvasUtils';
 import { getStudioThemeTokens } from '@/libs/profiler/canvas/theme';
 import {
@@ -133,7 +133,7 @@ interface OverloadCanvasProps {
 }
 
 function OverloadCanvas({ rows, targetMsForBaseRate, scrollable, showExpandButton, onExpandClick }: OverloadCanvasProps): React.JSX.Element {
-  const legendsVisible = useProfilerViewStore((s) => s.legendsVisible);
+  const legendsVisible = useUiPrefsStore((s) => s.legendsVisible);
   useThemeStore((s) => s.theme); // subscribe so the component re-renders on theme switch
 
   const canvasRef   = useRef<HTMLCanvasElement>(null);

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TickOverview.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TickOverview.tsx
@@ -20,6 +20,7 @@ import { HelpOverlay } from '@/panels/profiler/components/HelpOverlay';
 import { useProfilerSelectionStore } from '@/stores/useProfilerSelectionStore';
 import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
 import { useProfilerViewStore } from '@/stores/useProfilerViewStore';
+import { useUiPrefsStore } from '@/stores/useUiPrefsStore';
 import { useThemeStore } from '@/stores/useThemeStore';
 import type { TimeRange } from '@/libs/profiler/model/uiTypes';
 
@@ -122,7 +123,7 @@ export default function TickOverview({ isLive = false }: Props) {
   const setLiveFollowActive = useProfilerSessionStore((s) => s.setLiveFollowActive);
   const viewRange = useProfilerViewStore((s) => s.viewRange);
   const setViewRange = useProfilerViewStore((s) => s.setViewRange);
-  const legendsVisible = useProfilerViewStore((s) => s.legendsVisible);
+  const legendsVisible = useUiPrefsStore((s) => s.legendsVisible);
   // Range-drag in TickOverview clears any stale span/chunk/marker click selection so the
   // right-pane's range-stats fallback ("Selection") takes over instead of the click-detail card.
   // Without this, an old TimeArea click sticks indefinitely and blocks the range stats from showing.

--- a/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TimeArea.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/profiler/sections/TimeArea.tsx
@@ -20,6 +20,7 @@ import { useProfilerSelectionStore } from '@/stores/useProfilerSelectionStore';
 import { useProfilerViewStore } from '@/stores/useProfilerViewStore';
 import { useSourceLocationStore } from '@/stores/useSourceLocationStore';
 import { useThemeStore } from '@/stores/useThemeStore';
+import { useUiPrefsStore } from '@/stores/useUiPrefsStore';
 
 /**
  * Main time area — renders the ruler + phases + thread-slot lanes (chunks + nested spans) +
@@ -69,7 +70,7 @@ export default function TimeArea({ ticks, gaugeData, threadNames: threadNamesMap
   const setLiveFollowActive = useProfilerSessionStore((s) => s.setLiveFollowActive);
   const viewRange = useProfilerViewStore((s) => s.viewRange);
   const setViewRange = useProfilerViewStore((s) => s.setViewRange);
-  const legendsVisible = useProfilerViewStore((s) => s.legendsVisible);
+  const legendsVisible = useUiPrefsStore((s) => s.legendsVisible);
 
   // Centralised viewRange mutation. In live mode, any explicit user pan/zoom must pause auto-follow
   // so the next tick batch (≤100 ms) doesn't snap viewRange back to the live tail. Funnel every

--- a/tools/Typhon.Workbench/ClientApp/src/shell/DockHost.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/DockHost.tsx
@@ -13,6 +13,8 @@ import SchemaLayoutPanel from '@/panels/SchemaInspector/SchemaLayoutPanel';
 import SchemaArchetypePanel from '@/panels/SchemaInspector/SchemaArchetypePanel';
 import SchemaIndexPanel from '@/panels/SchemaInspector/SchemaIndexPanel';
 import SchemaRelationshipsPanel from '@/panels/SchemaInspector/SchemaRelationshipsPanel';
+import SystemDagPanel from '@/panels/SystemDag/SystemDagPanel';
+import CriticalPathPanel from '@/panels/CriticalPath/CriticalPathPanel';
 import ProfilerPanel from '@/panels/profiler/ProfilerPanel';
 import TopSpansPanel from '@/panels/profiler/TopSpansPanel';
 import OptionsPanel from '@/panels/options/OptionsPanel';
@@ -47,6 +49,8 @@ const components: Record<string, React.FC<IDockviewPanelProps>> = {
   SchemaArchetypes: SchemaArchetypePanel,
   SchemaIndexes: SchemaIndexPanel,
   SchemaRelationships: SchemaRelationshipsPanel,
+  SystemDag: SystemDagPanel,
+  CriticalPath: CriticalPathPanel,
   Profiler: ProfilerPanel,
   TopSpans: TopSpansPanel,
   Options: OptionsPanel,

--- a/tools/Typhon.Workbench/ClientApp/src/shell/MenuBar.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/MenuBar.tsx
@@ -30,7 +30,7 @@ import {
   toggleViewSchemaRelationships,
   saveLayoutAsDefault,
 } from './commands/openSchemaBrowser';
-import { toggleViewProfiler, toggleViewTopSpans, registerOpenSaveReplay } from './commands/profilerCommands';
+import { toggleViewCriticalPath, toggleViewProfiler, toggleViewTopSpans, registerOpenSaveReplay } from './commands/profilerCommands';
 import { logError, logInfo } from '@/stores/useLogStore';
 
 export default function MenuBar() {
@@ -152,6 +152,13 @@ export default function MenuBar() {
  title={isProfilerSession ? undefined : 'Open a profiler trace or attach a session first'}
  >
  Top Spans
+ </MenubarItem>
+ <MenubarItem
+ disabled={!isProfilerSession}
+ onClick={toggleViewCriticalPath}
+ title={isProfilerSession ? undefined : 'Open a profiler trace or attach a session first'}
+ >
+ Critical Path
  </MenubarItem>
  <MenubarSeparator />
  <MenubarItem

--- a/tools/Typhon.Workbench/ClientApp/src/shell/Shell.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/Shell.tsx
@@ -1,4 +1,5 @@
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { useSelectionBootstrap } from '@/hooks/useSelectionBootstrap';
 import { useSessionStore } from '@/stores/useSessionStore';
 import DockHost from './DockHost';
 import MenuBar from './MenuBar';
@@ -10,6 +11,7 @@ export default function Shell() {
   const sessionId = useSessionStore((s) => s.sessionId);
 
   useKeyboardShortcuts();
+  useSelectionBootstrap();
 
   return (
     <div className="flex h-full flex-col bg-background text-foreground">

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/baseCommands.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/baseCommands.ts
@@ -11,6 +11,7 @@ import {
   toggleViewSchemaArchetypes,
   toggleViewSchemaIndexes,
   toggleViewSchemaRelationships,
+  toggleViewSystemDag,
   openSourcePreviewForCurrentSpan,
   saveLayoutAsDefault,
 } from './openSchemaBrowser';
@@ -44,6 +45,7 @@ export function buildBaseCommands(): CommandItem[] {
     { id: 'toggle-view-schema-archetypes',    label: 'Toggle View Component Archetypes', keywords: 'schema archetypes cluster storage',           action: toggleViewSchemaArchetypes },
     { id: 'toggle-view-schema-indexes',       label: 'Toggle View Component Indexes',    keywords: 'schema indexes btree fields',                 action: toggleViewSchemaIndexes },
     { id: 'toggle-view-schema-relationships', label: 'Toggle View Component Relationships', keywords: 'schema systems relationships',             action: toggleViewSchemaRelationships },
+    { id: 'toggle-view-system-dag',           label: 'Toggle View System DAG',              keywords: 'system dag scheduler topology phases rfc07', action: toggleViewSystemDag },
     { id: 'toggle-view-resource-tree',        label: 'Toggle View Resource Tree',        keywords: 'resource tree sidebar explorer',              action: toggleViewResourceTree },
     { id: 'toggle-view-detail',               label: 'Toggle View Detail',               keywords: 'detail inspector selection',                  action: toggleViewDetail },
     { id: 'toggle-view-options',              label: 'Toggle View Options',              keywords: 'options preferences settings editor',         action: toggleViewOptions },

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/openSchemaBrowser.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/openSchemaBrowser.ts
@@ -120,6 +120,10 @@ export function toggleViewSchemaRelationships(): void {
   toggleDockPanel('schema-relationships', 'SchemaRelationships', 'Component Relationships');
 }
 
+export function toggleViewSystemDag(): void {
+  toggleDockPanel('system-dag', 'SystemDag', 'System DAG');
+}
+
 export function toggleViewOptions(): void {
   toggleDockPanel('options', 'Options', 'Options');
 }

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/profilerCommands.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/profilerCommands.ts
@@ -1,6 +1,7 @@
 import type { DockviewApi } from 'dockview-react';
 import { useProfilerSessionStore } from '@/stores/useProfilerSessionStore';
 import { useProfilerViewStore } from '@/stores/useProfilerViewStore';
+import { useUiPrefsStore } from '@/stores/useUiPrefsStore';
 import type { TimeRange } from '@/libs/profiler/model/uiTypes';
 import type { CommandItem } from './baseCommands';
 
@@ -20,6 +21,22 @@ export function toggleViewProfiler(): void {
   const api = registeredApi;
   if (!api) return;
   api.getPanel('profiler')?.focus();
+}
+
+/**
+ * Toggle the Critical-Path panel — a dynamic dock panel (closed by default, no edge-group home).
+ * First call adds it to the center area; subsequent calls remove it. Same shape as
+ * {@link toggleViewComponentBrowser} but without the schema-browser dependencies.
+ */
+export function toggleViewCriticalPath(): void {
+  const api = registeredApi;
+  if (!api) return;
+  const existing = api.getPanel('critical-path');
+  if (existing) {
+    api.removePanel(existing);
+    return;
+  }
+  api.addPanel({ id: 'critical-path', component: 'CriticalPath', title: 'Critical Path' });
 }
 
 /**
@@ -104,10 +121,11 @@ export function openSaveReplayDialog(): void {
 export function buildProfilerPaletteCommands(): CommandItem[] {
   return [
     { id: 'toggle-view-profiler',     label: 'Toggle View Profiler',  keywords: 'profiler open show',               action: toggleViewProfiler },
+    { id: 'toggle-view-critical-path', label: 'Toggle View Critical Path', keywords: 'critical path tape timeline cp wall-clock tick', action: toggleViewCriticalPath },
     { id: 'toggle-view-top-spans',   label: 'Toggle View Top Spans', keywords: 'profiler top spans table slow expensive sortable', action: toggleViewTopSpans },
     { id: 'profiler-save-replay',    label: 'Save Session as .typhon-replay…', keywords: 'save replay export attach session', action: openSaveReplayDialog },
     { id: 'profiler-toggle-gauges',  label: 'Toggle Gauge Region',   keywords: 'gauges canvas profiler g',         action: () => useProfilerViewStore.getState().toggleGaugeRegion() },
-    { id: 'profiler-toggle-legends', label: 'Toggle Legends',        keywords: 'legends labels profiler l',        action: () => useProfilerViewStore.getState().toggleLegends() },
+    { id: 'toggle-legends',          label: 'Toggle Legends',        keywords: 'legends labels help legend l app-wide',        action: () => useUiPrefsStore.getState().toggleLegends() },
     { id: 'profiler-toggle-systems', label: 'Toggle Per-System Lanes', keywords: 'systems lanes profiler',         action: () => useProfilerViewStore.getState().togglePerSystemLanes() },
     { id: 'profiler-zoom-full',      label: 'Zoom to Full Trace',    keywords: 'zoom full profiler reset home',    action: zoomToFullTrace },
     { id: 'profiler-pan-left',       label: 'Pan Left',              keywords: 'pan left profiler',                action: () => panViewport(-1) },

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/selectionBridges.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/selectionBridges.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ResourceNodeDto } from '@/api/generated/model/resourceNodeDto';
+import { installSelectionBridges } from '../selectionBridges';
+import { useProfilerSelectionStore, type ProfilerSelection } from '../useProfilerSelectionStore';
+import { useProfilerViewStore } from '../useProfilerViewStore';
+import { useSchemaInspectorStore } from '../useSchemaInspectorStore';
+import { useSelectedResourceStore, type SelectedResource } from '../useSelectedResourceStore';
+import { useSelectionStore } from '../useSelectionStore';
+
+let stopBridges: () => void;
+
+beforeEach(() => {
+  useSelectionStore.getState().clear();
+  useProfilerSelectionStore.setState({ selected: null, touchedAt: 0 });
+  useProfilerViewStore.getState().setViewRange({ startUs: 0, endUs: 0 });
+  useSelectedResourceStore.setState({ selected: null, touchedAt: 0 });
+  useSchemaInspectorStore.getState().reset();
+  stopBridges = installSelectionBridges();
+});
+
+afterEach(() => {
+  stopBridges();
+});
+
+describe('profiler viewRange ↔ selection.time', () => {
+  it('publishes profiler viewRange changes to selection.time', () => {
+    useProfilerViewStore.getState().setViewRange({ startUs: 1000, endUs: 5000 });
+    expect(useSelectionStore.getState().time).toEqual({ start: 1000, end: 5000 });
+  });
+
+  it('does NOT publish the {0,0} sentinel as a clear when unified.time is null', () => {
+    // Sentinel arrives on every metadata reset in trace mode. With no cross-panel time set,
+    // it stays profiler-internal — unified.time stays null, no URL write.
+    useProfilerViewStore.getState().setViewRange({ startUs: 0, endUs: 0 });
+    expect(useSelectionStore.getState().time).toBeNull();
+  });
+
+  it('reasserts a deep-linked unified.time when profiler resets to {0,0}', () => {
+    // C1: ProfilerPanel writes {0,0} on metadata arrival. With a URL deep-linked range in the
+    // unified store, the bridge must override the reset by pushing the range back into viewRange.
+    useSelectionStore.getState().setTime({ start: 120_000, end: 134_000 });
+    expect(useProfilerViewStore.getState().viewRange).toEqual({ startUs: 120_000, endUs: 134_000 });
+
+    // Simulate the metadata-arrival reset in ProfilerPanel.
+    useProfilerViewStore.getState().setViewRange({ startUs: 0, endUs: 0 });
+
+    // Bridge must have re-pushed the unified.time back into viewRange.
+    expect(useProfilerViewStore.getState().viewRange).toEqual({ startUs: 120_000, endUs: 134_000 });
+    // And unified.time must be unchanged (sentinel does not clear).
+    expect(useSelectionStore.getState().time).toEqual({ start: 120_000, end: 134_000 });
+  });
+
+  it('writes selection.time changes back into profiler viewRange', () => {
+    useSelectionStore.getState().setTime({ start: 2000, end: 8000 });
+    expect(useProfilerViewStore.getState().viewRange).toEqual({ startUs: 2000, endUs: 8000 });
+  });
+
+  it('does not feedback-loop when both stores agree', () => {
+    let viewWrites = 0;
+    let selWrites = 0;
+    const offV = useProfilerViewStore.subscribe((s, p) => {
+      if (s.viewRange !== p.viewRange) viewWrites++;
+    });
+    const offS = useSelectionStore.subscribe((s, p) => {
+      if (s.time !== p.time) selWrites++;
+    });
+
+    useProfilerViewStore.getState().setViewRange({ startUs: 100, endUs: 200 });
+    expect(viewWrites).toBe(1);
+    expect(selWrites).toBe(1);
+
+    useSelectionStore.getState().setTime({ start: 100, end: 200 });
+    // Equal value; both stores stay quiet.
+    expect(viewWrites).toBe(1);
+    expect(selWrites).toBe(1);
+
+    offV();
+    offS();
+  });
+
+  it('selection.time = null does not clobber profiler viewRange', () => {
+    useProfilerViewStore.getState().setViewRange({ startUs: 1000, endUs: 5000 });
+    useSelectionStore.getState().setTime(null);
+    // Bridge ignores null in the unified→profiler direction.
+    expect(useProfilerViewStore.getState().viewRange).toEqual({ startUs: 1000, endUs: 5000 });
+  });
+});
+
+describe('profiler selection ↔ selection.focusTick', () => {
+  it('mirrors a tick selection to focusTick', () => {
+    const sel: ProfilerSelection = { kind: 'tick', tickNumber: 42 };
+    useProfilerSelectionStore.getState().setSelected(sel);
+    expect(useSelectionStore.getState().focusTick).toBe(42);
+  });
+
+  it('mirrors a phase selection to focusTick', () => {
+    const sel: ProfilerSelection = {
+      kind: 'phase',
+      tickNumber: 7,
+      phase: { kind: 'phase', phaseId: 'WriteTickFence', startUs: 0, endUs: 100 } as never,
+    };
+    useProfilerSelectionStore.getState().setSelected(sel);
+    expect(useSelectionStore.getState().focusTick).toBe(7);
+  });
+
+  it('does not move focusTick for span/chunk/marker selections', () => {
+    const sel: ProfilerSelection = {
+      kind: 'span',
+      span: { name: 'Tx.Commit', startUs: 0, endUs: 100, threadSlot: 0, depth: 0 } as never,
+    };
+    useProfilerSelectionStore.getState().setSelected(sel);
+    expect(useSelectionStore.getState().focusTick).toBeNull();
+  });
+});
+
+describe('selected resource ↔ selection.resource', () => {
+  it('mirrors resourceId to selection.resource', () => {
+    const raw: ResourceNodeDto = {
+      id: 'storage/paged-mmf',
+      name: 'PagedMMF',
+      type: 'Segment',
+      entityCount: null,
+      children: [],
+    };
+    const sample: SelectedResource = {
+      resourceId: 'storage/paged-mmf',
+      kind: 'Segment',
+      name: 'PagedMMF',
+      path: ['storage', 'paged-mmf'],
+      raw,
+    };
+    useSelectedResourceStore.getState().setSelected(sample);
+    expect(useSelectionStore.getState().resource).toBe('storage/paged-mmf');
+  });
+
+  it('clears selection.resource when the per-panel store clears', () => {
+    useSelectedResourceStore.setState({
+      selected: {
+        resourceId: 'x',
+        kind: 'k',
+        name: 'n',
+        path: ['x'],
+        raw: { id: 'x', name: 'n', type: 'k', entityCount: null, children: [] } as ResourceNodeDto,
+      },
+      touchedAt: 1,
+    });
+    expect(useSelectionStore.getState().resource).toBe('x');
+    useSelectedResourceStore.getState().clear();
+    expect(useSelectionStore.getState().resource).toBeNull();
+  });
+});
+
+describe('schema inspector ↔ selection.component', () => {
+  it('mirrors component selection both ways', () => {
+    useSchemaInspectorStore.getState().selectComponent('Position');
+    expect(useSelectionStore.getState().component).toBe('Position');
+
+    useSelectionStore.getState().setComponent('Velocity');
+    expect(useSchemaInspectorStore.getState().selectedComponentType).toBe('Velocity');
+  });
+
+  it('clearing the unified slot clears the legacy store', () => {
+    useSchemaInspectorStore.getState().selectComponent('Position');
+    useSelectionStore.getState().setComponent(null);
+    expect(useSchemaInspectorStore.getState().selectedComponentType).toBeNull();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/selectionUrlSync.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/selectionUrlSync.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSelectionStore } from '../useSelectionStore';
+import {
+  applySelectionToStore,
+  buildSelectionSearch,
+  installSelectionUrlSync,
+  parseSelectionFromSearch,
+} from '../selectionUrlSync';
+
+beforeEach(() => {
+  useSelectionStore.getState().clear();
+});
+
+describe('parseSelectionFromSearch', () => {
+  it('parses every stable slot', () => {
+    const parsed = parseSelectionFromSearch(
+      '?session=abc&time=120000-134000&system=AI&component=Position&queue=Damage&resource=storage/paged-mmf&entity=e-42',
+    );
+    expect(parsed.time).toEqual({ start: 120_000, end: 134_000 });
+    expect(parsed.system).toBe('AI');
+    expect(parsed.component).toBe('Position');
+    expect(parsed.queue).toBe('Damage');
+    expect(parsed.resource).toBe('storage/paged-mmf');
+    expect(parsed.entity).toBe('e-42');
+  });
+
+  it('returns nulls for missing params', () => {
+    const parsed = parseSelectionFromSearch('?session=abc');
+    expect(parsed.time).toBeNull();
+    expect(parsed.system).toBeNull();
+  });
+
+  it('rejects malformed time ranges', () => {
+    expect(parseSelectionFromSearch('?time=foo').time).toBeNull();
+    expect(parseSelectionFromSearch('?time=100').time).toBeNull();
+    expect(parseSelectionFromSearch('?time=200-100').time).toBeNull(); // end <= start
+    expect(parseSelectionFromSearch('?time=100-100').time).toBeNull();
+  });
+
+  it('ignores volatile slots even if present in the URL', () => {
+    const parsed = parseSelectionFromSearch('?focusTick=7&worker=3');
+    // Volatile slots are not in the parsed shape — the URL is the wrong place for them.
+    expect(parsed).not.toHaveProperty('focusTick');
+    expect(parsed).not.toHaveProperty('worker');
+  });
+});
+
+describe('buildSelectionSearch', () => {
+  it('serialises stable slots and preserves unrelated params', () => {
+    const out = buildSelectionSearch(new URLSearchParams('session=abc&extra=keep'), {
+      time: { start: 100, end: 200 },
+      system: 'AI',
+      component: null,
+      queue: 'Damage',
+      resource: null,
+      entity: null,
+    });
+    const s = out.toString();
+    expect(s).toContain('session=abc');
+    expect(s).toContain('extra=keep');
+    expect(s).toContain('time=100-200');
+    expect(s).toContain('system=AI');
+    expect(s).toContain('queue=Damage');
+    expect(s).not.toContain('component');
+    expect(s).not.toContain('resource');
+  });
+
+  it('removes stale stable params when slots clear', () => {
+    const out = buildSelectionSearch(new URLSearchParams('system=Old&queue=Old'), {
+      time: null,
+      system: null,
+      component: null,
+      queue: null,
+      resource: null,
+      entity: null,
+    });
+    expect(out.toString()).toBe('');
+  });
+});
+
+describe('parse / build round-trip', () => {
+  it('survives a complete cycle', () => {
+    const original =
+      'session=abc&time=120000-134000&system=AI&component=Position&queue=Damage&resource=storage/paged-mmf&entity=e-42';
+    const parsed = parseSelectionFromSearch(`?${original}`);
+    const built = buildSelectionSearch(new URLSearchParams('session=abc'), {
+      time: parsed.time,
+      system: parsed.system,
+      component: parsed.component,
+      queue: parsed.queue,
+      resource: parsed.resource,
+      entity: parsed.entity,
+    });
+    const reparsed = parseSelectionFromSearch(`?${built.toString()}`);
+    expect(reparsed).toEqual(parsed);
+  });
+});
+
+describe('applySelectionToStore', () => {
+  it('writes parsed values into the store', () => {
+    applySelectionToStore({
+      time: { start: 1000, end: 2000 },
+      system: 'AI',
+      component: null,
+      queue: 'Damage',
+      resource: null,
+      entity: null,
+    });
+    const s = useSelectionStore.getState();
+    expect(s.time).toEqual({ start: 1000, end: 2000 });
+    expect(s.system).toBe('AI');
+    expect(s.queue).toBe('Damage');
+    expect(s.component).toBeNull();
+  });
+});
+
+describe('installSelectionUrlSync', () => {
+  it('writes to URL on stable-slot changes and ignores volatile slots', () => {
+    const replaceState = vi.fn<(search: string) => void>();
+    const readSearch = () => '?session=abc';
+    const unsubscribe = installSelectionUrlSync({ replaceState, readSearch });
+
+    useSelectionStore.getState().setSystem('AI');
+    expect(replaceState).toHaveBeenCalledTimes(1);
+    expect(replaceState.mock.calls[0][0]).toContain('session=abc');
+    expect(replaceState.mock.calls[0][0]).toContain('system=AI');
+
+    // Volatile slot — must not trigger a URL write.
+    useSelectionStore.getState().setFocusTick(7);
+    useSelectionStore.getState().setWorker(3);
+    expect(replaceState).toHaveBeenCalledTimes(1);
+
+    useSelectionStore.getState().setQueue('Damage');
+    expect(replaceState).toHaveBeenCalledTimes(2);
+    expect(replaceState.mock.calls[1][0]).toContain('queue=Damage');
+
+    unsubscribe();
+  });
+
+  it('clears the search when every stable slot becomes null', () => {
+    const replaceState = vi.fn<(search: string) => void>();
+    const readSearch = () => '';
+    const unsub = installSelectionUrlSync({ replaceState, readSearch });
+
+    useSelectionStore.getState().setSystem('AI');
+    useSelectionStore.getState().setSystem(null);
+    const last = replaceState.mock.calls.at(-1)?.[0];
+    expect(last).toBe('');
+
+    unsub();
+  });
+
+  it('stops emitting after unsubscribe', () => {
+    const replaceState = vi.fn<(search: string) => void>();
+    const unsub = installSelectionUrlSync({ replaceState, readSearch: () => '' });
+    unsub();
+    useSelectionStore.getState().setSystem('AI');
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useProfilerSessionStore.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useProfilerSessionStore.test.ts
@@ -29,6 +29,11 @@ function makeMetadata(overrides: Partial<ProfilerMetadataDto> = {}): ProfilerMet
     tickSummaries: [],
     chunkManifest: [],
     gcSuspensions: [],
+    phases: [],
+    systemTickSummaries: [],
+    queueTickSummaries: [],
+    postTickSummaries: [],
+    queueIdToName: {},
     ...overrides,
   };
 }

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useProfilerViewStore.migration.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useProfilerViewStore.migration.test.ts
@@ -40,7 +40,6 @@ describe('useProfilerViewStore — v0 → v1 migration', () => {
     useProfilerViewStore.setState({
       gaugeCollapse: {},
       gaugeRegionVisible: true,
-      legendsVisible: true,
       perSystemLanesVisible: true,
     });
   });
@@ -114,6 +113,5 @@ describe('useProfilerViewStore — v0 → v1 migration', () => {
     const state = useProfilerViewStore.getState();
     expect(state.gaugeCollapse).toEqual({});
     expect(state.gaugeRegionVisible).toBe(true);
-    expect(state.legendsVisible).toBe(true);
   });
 });

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useSelectionStore.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useSelectionStore.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSelectionStore } from '../useSelectionStore';
+
+beforeEach(() => {
+  useSelectionStore.getState().clear();
+});
+
+describe('useSelectionStore', () => {
+  it('starts with every slot null', () => {
+    const s = useSelectionStore.getState();
+    expect(s.time).toBeNull();
+    expect(s.focusTick).toBeNull();
+    expect(s.system).toBeNull();
+    expect(s.component).toBeNull();
+    expect(s.queue).toBeNull();
+    expect(s.resource).toBeNull();
+    expect(s.entity).toBeNull();
+    expect(s.worker).toBeNull();
+  });
+
+  it('per-slot setters update only their own slot', () => {
+    const s = useSelectionStore.getState();
+    s.setSystem('AI');
+    s.setQueue('Damage');
+    expect(useSelectionStore.getState().system).toBe('AI');
+    expect(useSelectionStore.getState().queue).toBe('Damage');
+    expect(useSelectionStore.getState().component).toBeNull();
+  });
+
+  it('setTime stores the range', () => {
+    useSelectionStore.getState().setTime({ start: 120_000, end: 134_000 });
+    expect(useSelectionStore.getState().time).toEqual({ start: 120_000, end: 134_000 });
+  });
+
+  it('selector subscribers only fire when their slot changes', () => {
+    const systemListener = vi.fn();
+    const queueListener = vi.fn();
+    const unsubSystem = useSelectionStore.subscribe((s, prev) => {
+      if (s.system !== prev.system) systemListener(s.system);
+    });
+    const unsubQueue = useSelectionStore.subscribe((s, prev) => {
+      if (s.queue !== prev.queue) queueListener(s.queue);
+    });
+
+    useSelectionStore.getState().setSystem('AI');
+    expect(systemListener).toHaveBeenCalledTimes(1);
+    expect(queueListener).not.toHaveBeenCalled();
+
+    useSelectionStore.getState().setQueue('Damage');
+    expect(systemListener).toHaveBeenCalledTimes(1);
+    expect(queueListener).toHaveBeenCalledTimes(1);
+
+    // Setting the same value is a no-op for selectors (zustand shallow eq on the slot).
+    useSelectionStore.getState().setSystem('AI');
+    expect(systemListener).toHaveBeenCalledTimes(1);
+
+    unsubSystem();
+    unsubQueue();
+  });
+
+  it('clear resets every slot to null', () => {
+    const s = useSelectionStore.getState();
+    s.setSystem('AI');
+    s.setComponent('Position');
+    s.setQueue('Damage');
+    s.setResource('storage/paged-mmf');
+    s.setEntity('e-42');
+    s.setWorker(3);
+    s.setTime({ start: 0, end: 1000 });
+    s.setFocusTick(7);
+
+    s.clear();
+
+    const after = useSelectionStore.getState();
+    expect(after.system).toBeNull();
+    expect(after.component).toBeNull();
+    expect(after.queue).toBeNull();
+    expect(after.resource).toBeNull();
+    expect(after.entity).toBeNull();
+    expect(after.worker).toBeNull();
+    expect(after.time).toBeNull();
+    expect(after.focusTick).toBeNull();
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/stores/selectionBridges.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/selectionBridges.ts
@@ -1,0 +1,179 @@
+import type { TimeRange } from '@/libs/profiler/model/uiTypes';
+import { useProfilerSelectionStore } from './useProfilerSelectionStore';
+import { useProfilerViewStore } from './useProfilerViewStore';
+import { useSchemaInspectorStore } from './useSchemaInspectorStore';
+import { useSelectedResourceStore } from './useSelectedResourceStore';
+import { useSelectionStore, type TimeSelection } from './useSelectionStore';
+
+// TODO(#309 follow-up): the resource and (eventually) entity slots only mirror legacy → unified.
+// The reverse (unified → legacy) needs the resource-graph cache to resolve a `resourceId` into a
+// rich `SelectedResource` payload. Until that exists, URL deep-links like `?resource=...` populate
+// `useSelectionStore.resource` but do not light up the ResourceTreePanel highlight on cold load.
+
+/**
+ * Bidirectional bridges that keep the cross-cutting projections of the legacy per-panel stores
+ * synchronised with {@link useSelectionStore}. Per `claude/design/workbench/10-internal-data-api.md §9.2`,
+ * Phase C of the migration: old stores become write-throughs to the new store, deletion deferred.
+ *
+ * Each bridge is a paired `subscribe` — A→B and B→A — guarded against feedback loops by a single
+ * boolean flag per pair. Idempotent at the value level (no-op if equal), so the guard is belt-and-
+ * suspenders. Volatile slots (`focusTick`, `worker`) and panel-internal sub-selections (span/chunk/
+ * marker payloads, schema field, resource raw payload) stay in their respective per-panel stores.
+ */
+
+function rangeEqual(a: TimeRange, b: TimeSelection | null): boolean {
+  if (!b) return false;
+  return a.startUs === b.start && a.endUs === b.end;
+}
+
+function bridgeProfilerViewRangeAndSelectionTime(): () => void {
+  let suppress = false;
+
+  const offProfiler = useProfilerViewStore.subscribe((s, prev) => {
+    if (suppress) return;
+    if (s.viewRange === prev.viewRange) return;
+    const r = s.viewRange;
+    const current = useSelectionStore.getState().time;
+    // `{0, 0}` is a profiler-internal "no preference" sentinel — set on every metadata arrival in
+    // trace mode (ProfilerPanel.tsx). It is NOT a cross-panel "clear time" signal. Two cases:
+    //   - cross-panel time is null → leave both alone.
+    //   - cross-panel time is set (URL deep-link, DAG view, etc.) → reassert it back into
+    //     viewRange so the metadata-arrival reset doesn't blow away a deep-linked range.
+    if (r.startUs === 0 && r.endUs === 0) {
+      if (current === null) return;
+      suppress = true;
+      try {
+        useProfilerViewStore.getState().setViewRange({ startUs: current.start, endUs: current.end });
+      } finally {
+        suppress = false;
+      }
+      return;
+    }
+    if (rangeEqual(r, current)) return;
+    suppress = true;
+    try {
+      useSelectionStore.getState().setTime({ start: r.startUs, end: r.endUs });
+    } finally {
+      suppress = false;
+    }
+  });
+
+  const offSelection = useSelectionStore.subscribe((s, prev) => {
+    if (suppress) return;
+    if (s.time === prev.time) return;
+    if (s.time === null) return; // Don't clobber profiler's viewRange on a cross-panel clear.
+    if (rangeEqual(useProfilerViewStore.getState().viewRange, s.time)) return;
+    suppress = true;
+    try {
+      useProfilerViewStore.getState().setViewRange({ startUs: s.time.start, endUs: s.time.end });
+    } finally {
+      suppress = false;
+    }
+  });
+
+  return () => {
+    offProfiler();
+    offSelection();
+  };
+}
+
+function bridgeProfilerSelectionAndFocusTick(): () => void {
+  let suppress = false;
+
+  const offProfiler = useProfilerSelectionStore.subscribe((s, prev) => {
+    if (suppress) return;
+    if (s.selected === prev.selected) return;
+    const tick = extractTick(s.selected);
+    suppress = true;
+    try {
+      useSelectionStore.getState().setFocusTick(tick);
+    } finally {
+      suppress = false;
+    }
+  });
+
+  return offProfiler;
+}
+
+function extractTick(selected: ReturnType<typeof useProfilerSelectionStore.getState>['selected']): number | null {
+  if (!selected) return null;
+  switch (selected.kind) {
+    case 'tick':
+    case 'phase':
+    case 'phase-marker':
+      return selected.tickNumber;
+    case 'span':
+    case 'chunk':
+    case 'marker':
+      // Panel-internal selections; they don't move the cross-panel focus tick. (Spans/chunks are
+      // sub-tick-scope; markers are not tick-aligned in the cross-panel sense.)
+      return null;
+  }
+}
+
+function bridgeSelectedResource(): () => void {
+  let suppress = false;
+
+  const offResource = useSelectedResourceStore.subscribe((s, prev) => {
+    if (suppress) return;
+    if (s.selected === prev.selected) return;
+    const id = s.selected?.resourceId ?? null;
+    suppress = true;
+    try {
+      useSelectionStore.getState().setResource(id);
+    } finally {
+      suppress = false;
+    }
+  });
+
+  return offResource;
+}
+
+function bridgeSelectedComponent(): () => void {
+  let suppress = false;
+
+  const offSchema = useSchemaInspectorStore.subscribe((s, prev) => {
+    if (suppress) return;
+    if (s.selectedComponentType === prev.selectedComponentType) return;
+    suppress = true;
+    try {
+      useSelectionStore.getState().setComponent(s.selectedComponentType);
+    } finally {
+      suppress = false;
+    }
+  });
+
+  const offSelection = useSelectionStore.subscribe((s, prev) => {
+    if (suppress) return;
+    if (s.component === prev.component) return;
+    if (useSchemaInspectorStore.getState().selectedComponentType === s.component) return;
+    suppress = true;
+    try {
+      useSchemaInspectorStore.getState().selectComponent(s.component);
+    } finally {
+      suppress = false;
+    }
+  });
+
+  return () => {
+    offSchema();
+    offSelection();
+  };
+}
+
+/**
+ * Installs every per-panel ↔ unified bridge. Returns a single unsubscribe handle that tears them
+ * all down. Call once at app boot — calling twice doubles the subscriptions and produces redundant
+ * (but idempotent) writes.
+ */
+export function installSelectionBridges(): () => void {
+  const offs = [
+    bridgeProfilerViewRangeAndSelectionTime(),
+    bridgeProfilerSelectionAndFocusTick(),
+    bridgeSelectedResource(),
+    bridgeSelectedComponent(),
+  ];
+  return () => {
+    for (const off of offs) off();
+  };
+}

--- a/tools/Typhon.Workbench/ClientApp/src/stores/selectionUrlSync.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/selectionUrlSync.ts
@@ -1,0 +1,168 @@
+import { timeEqual, useSelectionStore, type SelectionState, type TimeSelection } from './useSelectionStore';
+
+/**
+ * URL ↔ selection-store sync for stable dimensions.
+ *
+ * Stable (URL-synced): `time`, `system`, `component`, `queue`, `resource`, `entity`.
+ * Volatile (in-memory only): `focusTick`, `worker`, panel-internal sub-selections.
+ *
+ * See `claude/design/workbench/10-internal-data-api.md §9.3`.
+ *
+ * Wire format example: `?session=...&time=120000-134000&system=AI&queue=Damage`.
+ */
+
+const PARAM_TIME = 'time';
+const PARAM_SYSTEM = 'system';
+const PARAM_COMPONENT = 'component';
+const PARAM_QUEUE = 'queue';
+const PARAM_RESOURCE = 'resource';
+const PARAM_ENTITY = 'entity';
+
+const STABLE_PARAMS = [
+  PARAM_TIME,
+  PARAM_SYSTEM,
+  PARAM_COMPONENT,
+  PARAM_QUEUE,
+  PARAM_RESOURCE,
+  PARAM_ENTITY,
+] as const;
+
+export interface ParsedSelection {
+  time: TimeSelection | null;
+  system: string | null;
+  component: string | null;
+  queue: string | null;
+  resource: string | null;
+  entity: string | null;
+}
+
+function parseTimeRange(raw: string | null): TimeSelection | null {
+  if (!raw) return null;
+  const dash = raw.indexOf('-');
+  if (dash <= 0) return null;
+  const start = Number(raw.slice(0, dash));
+  const end = Number(raw.slice(dash + 1));
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  if (end <= start) return null;
+  return { start, end };
+}
+
+function formatTimeRange(t: TimeSelection): string {
+  return `${t.start}-${t.end}`;
+}
+
+/**
+ * Parses the stable selection slots from a URL query string. Returns null for missing or
+ * malformed entries — never throws. Volatile slots (`focusTick`, `worker`) are not parsed.
+ */
+export function parseSelectionFromSearch(search: string): ParsedSelection {
+  const params = new URLSearchParams(search);
+  return {
+    time: parseTimeRange(params.get(PARAM_TIME)),
+    system: params.get(PARAM_SYSTEM),
+    component: params.get(PARAM_COMPONENT),
+    queue: params.get(PARAM_QUEUE),
+    resource: params.get(PARAM_RESOURCE),
+    entity: params.get(PARAM_ENTITY),
+  };
+}
+
+/**
+ * Builds an updated `URLSearchParams` from `current` by writing the stable slots of `state`.
+ * Non-selection params (e.g. `?session=...`) are preserved. Null slots are removed.
+ */
+export function buildSelectionSearch(
+  current: URLSearchParams,
+  state: Pick<SelectionState, 'time' | 'system' | 'component' | 'queue' | 'resource' | 'entity'>,
+): URLSearchParams {
+  const out = new URLSearchParams(current);
+  // Wipe any prior stable-selection params first so removals propagate.
+  for (const name of STABLE_PARAMS) out.delete(name);
+  if (state.time) out.set(PARAM_TIME, formatTimeRange(state.time));
+  if (state.system) out.set(PARAM_SYSTEM, state.system);
+  if (state.component) out.set(PARAM_COMPONENT, state.component);
+  if (state.queue) out.set(PARAM_QUEUE, state.queue);
+  if (state.resource) out.set(PARAM_RESOURCE, state.resource);
+  if (state.entity) out.set(PARAM_ENTITY, state.entity);
+  return out;
+}
+
+/**
+ * Apply a parsed selection to the store. Setters are value-equal-aware (see
+ * {@link useSelectionStore}), so calling each unconditionally is cheap.
+ */
+export function applySelectionToStore(parsed: ParsedSelection): void {
+  const s = useSelectionStore.getState();
+  s.setTime(parsed.time);
+  s.setSystem(parsed.system);
+  s.setComponent(parsed.component);
+  s.setQueue(parsed.queue);
+  s.setResource(parsed.resource);
+  s.setEntity(parsed.entity);
+}
+
+function stableSnapshot(s: SelectionState) {
+  return {
+    time: s.time,
+    system: s.system,
+    component: s.component,
+    queue: s.queue,
+    resource: s.resource,
+    entity: s.entity,
+  };
+}
+
+function stableEqual(a: ReturnType<typeof stableSnapshot>, b: ReturnType<typeof stableSnapshot>) {
+  return (
+    timeEqual(a.time, b.time) &&
+    a.system === b.system &&
+    a.component === b.component &&
+    a.queue === b.queue &&
+    a.resource === b.resource &&
+    a.entity === b.entity
+  );
+}
+
+export interface UrlSyncOptions {
+  /**
+   * History API surface — pulled out so tests can inject a fake. Defaults to
+   * `window.history.replaceState` bound to the current location.
+   */
+  replaceState?: (search: string) => void;
+  /** Defaults to `window.location.search`. */
+  readSearch?: () => string;
+}
+
+/**
+ * Installs a subscription that mirrors stable selection slots to the URL via `replaceState`.
+ * Returns an unsubscribe handle. Idempotent — calling it twice yields two independent subs;
+ * tests should always tear down via the returned function.
+ *
+ * Cold-load behaviour is the caller's responsibility: invoke {@link applySelectionToStore}
+ * with the result of {@link parseSelectionFromSearch} once at app mount, then install this.
+ */
+export function installSelectionUrlSync(options: UrlSyncOptions = {}): () => void {
+  const replace = options.replaceState ?? defaultReplaceState;
+  const readSearch = options.readSearch ?? defaultReadSearch;
+  let last = stableSnapshot(useSelectionStore.getState());
+
+  return useSelectionStore.subscribe((s) => {
+    const next = stableSnapshot(s);
+    if (stableEqual(last, next)) return;
+    last = next;
+    const params = buildSelectionSearch(new URLSearchParams(readSearch()), next);
+    const query = params.toString();
+    replace(query.length > 0 ? `?${query}` : '');
+  });
+}
+
+function defaultReplaceState(search: string): void {
+  if (typeof window === 'undefined') return;
+  const url = `${window.location.pathname}${search}${window.location.hash}`;
+  window.history.replaceState(window.history.state, '', url);
+}
+
+function defaultReadSearch(): string {
+  if (typeof window === 'undefined') return '';
+  return window.location.search;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useHoverStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useHoverStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+/**
+ * Cross-panel hover state — currently a single slot (`hoveredSystem`) shared between the System
+ * DAG canvas and the Critical Path tape per `09-system-dag.md §11 Phase 3` ("Hover bar in tape →
+ * corresponding DAG node pulses; Hover DAG node (if on critical path): tape bar highlights").
+ *
+ * Kept separate from {@link useSelectionStore} because hover is volatile (cleared on
+ * MouseLeave) and shouldn't round-trip through the URL or any persisted slot. Subscribers read
+ * with a slot selector so non-relevant panels don't re-render on every mouseover.
+ */
+export interface HoverState {
+  hoveredSystem: string | null;
+  /**
+   * Phase name currently being hovered in either the System DAG (swim-lane label) or the Critical
+   * Path tape (phase stripe label). Same volatile-cross-panel pattern as `hoveredSystem` —
+   * subscribers brighten the matching ribbon / lane when this matches their phase identity.
+   */
+  hoveredPhase: string | null;
+  setHoveredSystem: (name: string | null) => void;
+  setHoveredPhase: (phase: string | null) => void;
+}
+
+export const useHoverStore = create<HoverState>()((set, get) => ({
+  hoveredSystem: null,
+  hoveredPhase: null,
+  setHoveredSystem: (name) => {
+    if (get().hoveredSystem === name) return;
+    set({ hoveredSystem: name });
+  },
+  setHoveredPhase: (phase) => {
+    if (get().hoveredPhase === phase) return;
+    set({ hoveredPhase: phase });
+  },
+}));

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useOptionsStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useOptionsStore.ts
@@ -59,7 +59,9 @@ function ensureOptionsStreamSubscription(set: (partial: Partial<OptionsState>) =
   if (typeof EventSource === 'undefined') return;
   if (_optionsStreamHandle) return;
   const es = new EventSource('/api/options/stream');
-  es.onmessage = (event) => {
+  // Server emits typed `options-changed` SSE events (#308); listen by name rather than the default
+  // `message` channel so the wire format matches the rest of the Workbench's typed-event streams.
+  es.addEventListener('options-changed', (event: MessageEvent) => {
     try {
       const next = JSON.parse(event.data) as WorkbenchOptions;
       set({ options: next });
@@ -67,7 +69,7 @@ function ensureOptionsStreamSubscription(set: (partial: Partial<OptionsState>) =
       // Malformed frame — ignore. Server-side serializer is the source of truth; a parse failure
       // here is a developer-time bug, not a runtime user concern.
     }
-  };
+  });
   es.onerror = () => {
     // Browser auto-reconnects on transient failures; reset the handle on permanent close so a
     // future fetch() can re-subscribe.

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useProfilerViewStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useProfilerViewStore.ts
@@ -31,8 +31,6 @@ interface ProfilerViewState {
   liveFollowWindowUs: number;
   /** Toggled by the `g` key. Hides the full gauge region. */
   gaugeRegionVisible: boolean;
-  /** Toggled by the `l` key. Hides inline legends across all sections. */
-  legendsVisible: boolean;
   /** Per-system chunk-lanes section visibility. */
   perSystemLanesVisible: boolean;
   /**
@@ -68,7 +66,6 @@ interface ProfilerViewState {
   setViewRange: (r: TimeRange) => void;
   setLiveFollowWindowUs: (us: number) => void;
   toggleGaugeRegion: () => void;
-  toggleLegends: () => void;
   togglePerSystemLanes: () => void;
   setGaugeCollapse: (groupId: string, state: TrackState) => void;
   setManyGaugeCollapse: (updates: Record<string, TrackState>) => void;
@@ -106,7 +103,6 @@ export const useProfilerViewStore = create<ProfilerViewState>()(
       viewRange: INITIAL_VIEW_RANGE,
       liveFollowWindowUs: DEFAULT_LIVE_FOLLOW_WINDOW_US,
       gaugeRegionVisible: true,
-      legendsVisible: true,
       perSystemLanesVisible: true,
       gaugeCollapse: {},
       gaugeVisibility: {},
@@ -117,7 +113,6 @@ export const useProfilerViewStore = create<ProfilerViewState>()(
       setViewRange: (r) => set({ viewRange: r }),
       setLiveFollowWindowUs: (us) => set({ liveFollowWindowUs: Math.max(1, us) }),
       toggleGaugeRegion: () => set((s) => ({ gaugeRegionVisible: !s.gaugeRegionVisible })),
-      toggleLegends: () => set((s) => ({ legendsVisible: !s.legendsVisible })),
       togglePerSystemLanes: () => set((s) => ({ perSystemLanesVisible: !s.perSystemLanesVisible })),
       setGaugeCollapse: (groupId, state) =>
         set((s) => ({ gaugeCollapse: { ...s.gaugeCollapse, [groupId]: state } })),
@@ -184,7 +179,6 @@ export const useProfilerViewStore = create<ProfilerViewState>()(
       partialize: (s) => ({
         liveFollowWindowUs: s.liveFollowWindowUs,
         gaugeRegionVisible: s.gaugeRegionVisible,
-        legendsVisible: s.legendsVisible,
         perSystemLanesVisible: s.perSystemLanesVisible,
         gaugeCollapse: s.gaugeCollapse,
         gaugeVisibility: s.gaugeVisibility,

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useSelectionStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useSelectionStore.ts
@@ -1,0 +1,100 @@
+import { create } from 'zustand';
+
+/**
+ * Cross-panel selection state — see `claude/design/workbench/10-internal-data-api.md §9`.
+ *
+ * Eight independently-observable dimension slots. Panels subscribe via
+ * `useSelectionStore(s => s.system)` and only re-render when *that* slot changes.
+ *
+ * `time` is the TimeArea range in absolute µs timestamps (matches profiler convention).
+ * `focusTick` and `worker` are volatile (not URL-synced); the rest are stable and
+ * round-trip through the URL via {@link selectionUrlSync}.
+ */
+export interface TimeSelection {
+  /** Inclusive start (µs). */
+  start: number;
+  /** Exclusive end (µs). */
+  end: number;
+}
+
+export interface SelectionState {
+  time: TimeSelection | null;
+  focusTick: number | null;
+  system: string | null;
+  component: string | null;
+  queue: string | null;
+  resource: string | null;
+  entity: string | null;
+  worker: number | null;
+
+  setTime: (range: TimeSelection | null) => void;
+  setFocusTick: (tick: number | null) => void;
+  setSystem: (name: string | null) => void;
+  setComponent: (name: string | null) => void;
+  setQueue: (name: string | null) => void;
+  setResource: (id: string | null) => void;
+  setEntity: (id: string | null) => void;
+  setWorker: (id: number | null) => void;
+
+  clear: () => void;
+}
+
+const INITIAL: Pick<
+  SelectionState,
+  'time' | 'focusTick' | 'system' | 'component' | 'queue' | 'resource' | 'entity' | 'worker'
+> = {
+  time: null,
+  focusTick: null,
+  system: null,
+  component: null,
+  queue: null,
+  resource: null,
+  entity: null,
+  worker: null,
+};
+
+/** Value-equality for {@link TimeSelection}. Exported for use in cross-store bridges and URL sync. */
+export function timeEqual(a: TimeSelection | null, b: TimeSelection | null): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  return a.start === b.start && a.end === b.end;
+}
+
+export const useSelectionStore = create<SelectionState>()((set, get) => ({
+  ...INITIAL,
+  // Setters are value-equal-aware: writing the current value is a silent no-op so subscribers
+  // (especially the URL-sync mirror) don't fire on idempotent writes from the bridges.
+  setTime: (range) => {
+    if (timeEqual(get().time, range)) return;
+    set({ time: range });
+  },
+  setFocusTick: (tick) => {
+    if (get().focusTick === tick) return;
+    set({ focusTick: tick });
+  },
+  setSystem: (name) => {
+    if (get().system === name) return;
+    set({ system: name });
+  },
+  setComponent: (name) => {
+    if (get().component === name) return;
+    set({ component: name });
+  },
+  setQueue: (name) => {
+    if (get().queue === name) return;
+    set({ queue: name });
+  },
+  setResource: (id) => {
+    if (get().resource === id) return;
+    set({ resource: id });
+  },
+  setEntity: (id) => {
+    if (get().entity === id) return;
+    set({ entity: id });
+  },
+  setWorker: (id) => {
+    if (get().worker === id) return;
+    set({ worker: id });
+  },
+  clear: () => set({ ...INITIAL }),
+}));

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useUiPrefsStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useUiPrefsStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+/**
+ * App-wide UI preferences shared across panels.
+ *
+ * `legendsVisible` started life inside `useProfilerViewStore` (the profiler's `l` keybind toggled
+ * it for the gauge / span legends), but every panel that overlays user-help affordances —
+ * Critical Path, future System DAG legends, etc. — needs the same toggle. Promoting it here lets a
+ * single command (`Toggle Legends` in the palette + the `l` keybind) drive every panel's "show
+ * inline help" state, instead of each panel rolling its own.
+ */
+interface UiPrefsState {
+  /** Inline legends + per-panel "?" help glyph visibility. App-wide. */
+  legendsVisible: boolean;
+  toggleLegends: () => void;
+  setLegendsVisible: (visible: boolean) => void;
+}
+
+const safeStorage = createJSONStorage(() => ({
+  getItem: (name: string) => {
+    try { return localStorage.getItem(name); } catch { return null; }
+  },
+  setItem: (name: string, value: string) => {
+    try { localStorage.setItem(name, value); } catch { /* noop */ }
+  },
+  removeItem: (name: string) => {
+    try { localStorage.removeItem(name); } catch { /* noop */ }
+  },
+}));
+
+export const useUiPrefsStore = create<UiPrefsState>()(
+  persist(
+    (set) => ({
+      legendsVisible: true,
+      toggleLegends: () => set((s) => ({ legendsVisible: !s.legendsVisible })),
+      setLegendsVisible: (legendsVisible) => set({ legendsVisible }),
+    }),
+    { name: 'workbench-ui-prefs', storage: safeStorage },
+  ),
+);

--- a/tools/Typhon.Workbench/Controllers/DataController.cs
+++ b/tools/Typhon.Workbench/Controllers/DataController.cs
@@ -1,0 +1,534 @@
+using Microsoft.AspNetCore.Mvc;
+using Typhon.Workbench.Dtos.Data;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Middleware;
+using Typhon.Workbench.Services;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Controllers;
+
+/// <summary>
+/// Session-scoped Data API v1 endpoints. Serves topology, track schemas, track data slices, and
+/// aggregation results. Backed by <see cref="ProfilerMetadataDto"/> on the session's runtime.
+/// </summary>
+[ApiController]
+[Route("api/sessions/{sessionId:guid}")]
+[Tags("Data")]
+[RequireBootstrapToken]
+[RequireSession]
+[RequireApiVersion]
+public sealed class DataController : ControllerBase
+{
+    private readonly StreamSubscriptionRegistry _subscriptionRegistry;
+
+    public DataController(StreamSubscriptionRegistry subscriptionRegistry)
+    {
+        _subscriptionRegistry = subscriptionRegistry;
+    }
+
+    // Static track schema — constructed once, returned on every /tracks request.
+    private static readonly TracksResponseDto _tracksSchema = new(
+    [
+        new TrackSchemaDto("tick/summary", "perTick",
+        [
+            new TrackFieldDescriptorDto("tickNumber",           "u32"),
+            new TrackFieldDescriptorDto("startUs",              "f64"),
+            new TrackFieldDescriptorDto("durationUs",           "f32"),
+            new TrackFieldDescriptorDto("eventCount",           "u32"),
+            new TrackFieldDescriptorDto("maxSystemDurationUs",  "f32"),
+            new TrackFieldDescriptorDto("overloadLevel",        "u8"),
+            new TrackFieldDescriptorDto("tickMultiplier",       "u8"),
+            new TrackFieldDescriptorDto("consecutiveOverrun",   "u16"),
+            new TrackFieldDescriptorDto("consecutiveUnderrun",  "u16"),
+        ]),
+        new TrackSchemaDto("metronome/wait", "perTick",
+        [
+            new TrackFieldDescriptorDto("tickNumber",  "u32"),
+            new TrackFieldDescriptorDto("waitUs",      "u16"),
+            new TrackFieldDescriptorDto("intentClass", "u8"),
+        ]),
+        // ── v2 tracks (#311) ─────────────────────────────────────────────────
+        // Per-system tracks: one logical track per system, addressed as `system/<name>`. The schema is identical for
+        // every system; the client substitutes the name when constructing the URL.
+        new TrackSchemaDto("system/<name>", "perTickPerSystem",
+        [
+            new TrackFieldDescriptorDto("tickNumber",        "u32"),
+            new TrackFieldDescriptorDto("startUs",           "f64"),
+            new TrackFieldDescriptorDto("endUs",             "f64"),
+            new TrackFieldDescriptorDto("readyUs",           "f64"),
+            new TrackFieldDescriptorDto("durationUs",        "f32"),
+            new TrackFieldDescriptorDto("entitiesProcessed", "u32"),
+            new TrackFieldDescriptorDto("workersTouched",    "u8"),
+            new TrackFieldDescriptorDto("chunksProcessed",   "u16"),
+            new TrackFieldDescriptorDto("skipReason",        "u8"),
+        ]),
+        // Per-queue tracks: one logical track per event queue, addressed as `queue/<name>`.
+        new TrackSchemaDto("queue/<name>", "perTickPerQueue",
+        [
+            new TrackFieldDescriptorDto("tickNumber",     "u32"),
+            new TrackFieldDescriptorDto("peakDepth",      "u32"),
+            new TrackFieldDescriptorDto("endOfTickDepth", "u32"),
+            new TrackFieldDescriptorDto("overflowCount",  "u32"),
+            new TrackFieldDescriptorDto("produced",       "u32"),
+            new TrackFieldDescriptorDto("consumed",       "u32"),
+        ]),
+        // Post-tick tracks: per-tick scalar duration for one of the named post-tick phases. Track id family:
+        // posttick/walFlush, posttick/writeTickFence, posttick/tierBudget, posttick/subscriptionOutput,
+        // posttick/tierIndexRebuild, posttick/dormancySweep.
+        new TrackSchemaDto("posttick/<phase>", "perTick",
+        [
+            new TrackFieldDescriptorDto("tickNumber", "u32"),
+            new TrackFieldDescriptorDto("durationUs", "f32"),
+        ]),
+    ]);
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4a. Topology
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the ECS topology snapshot — systems, archetypes, and component types — once the session
+    /// has finished loading. Returns 202 Accepted while metadata is still in flight; 409 Conflict for
+    /// session kinds that carry no topology.
+    /// </summary>
+    [HttpGet("topology")]
+    public ActionResult<TopologyDto> GetTopology(Guid sessionId)
+    {
+        var metadata = ResolveMetadata(out var mismatch);
+        if (mismatch != null)
+        {
+            return mismatch;
+        }
+
+        if (metadata == null)
+        {
+            Response.Headers["Retry-After"] = "1";
+            return StatusCode(StatusCodes.Status202Accepted);
+        }
+
+        return Ok(new TopologyDto(metadata.Systems, metadata.Archetypes, metadata.ComponentTypes, metadata.Phases));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4a-bis. Topology queries (RFC 07 surfacing — #275 mvp)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the systems that write the named component (any of <c>Writes</c> + <c>SideWrites</c>). O(systems × declarations).
+    /// Component name is matched against <see cref="SystemDefinitionDto"/> arrays exactly — typically a CLR <c>FullName</c>.
+    /// </summary>
+    [HttpGet("queries/who-writes/{component}")]
+    public ActionResult<SystemListDto> GetWhoWrites(Guid sessionId, string component)
+    {
+        var metadata = ResolveMetadata(out var mismatch);
+        if (mismatch != null) return mismatch;
+        if (metadata == null) { Response.Headers["Retry-After"] = "1"; return StatusCode(StatusCodes.Status202Accepted); }
+
+        var matches = new List<SystemDefinitionDto>();
+        foreach (var s in metadata.Systems)
+        {
+            if (Array.IndexOf(s.Writes, component) >= 0 || Array.IndexOf(s.SideWrites, component) >= 0)
+            {
+                matches.Add(s);
+            }
+        }
+        return Ok(new SystemListDto(component, matches.ToArray()));
+    }
+
+    /// <summary>
+    /// Returns the systems that read the named component (any of <c>Reads</c> + <c>ReadsFresh</c> + <c>ReadsSnapshot</c> +
+    /// <c>AdditionalReads</c>). O(systems × declarations).
+    /// </summary>
+    [HttpGet("queries/who-reads/{component}")]
+    public ActionResult<SystemListDto> GetWhoReads(Guid sessionId, string component)
+    {
+        var metadata = ResolveMetadata(out var mismatch);
+        if (mismatch != null) return mismatch;
+        if (metadata == null) { Response.Headers["Retry-After"] = "1"; return StatusCode(StatusCodes.Status202Accepted); }
+
+        var matches = new List<SystemDefinitionDto>();
+        foreach (var s in metadata.Systems)
+        {
+            if (Array.IndexOf(s.Reads, component) >= 0
+                || Array.IndexOf(s.ReadsFresh, component) >= 0
+                || Array.IndexOf(s.ReadsSnapshot, component) >= 0
+                || Array.IndexOf(s.AdditionalReads, component) >= 0)
+            {
+                matches.Add(s);
+            }
+        }
+        return Ok(new SystemListDto(component, matches.ToArray()));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4b. Track discovery
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the static v1 track schema — the list of available tracks and their field descriptors.
+    /// Requires the session to be ready (same 202/409 guards as <see cref="GetTopology"/>).
+    /// </summary>
+    [HttpGet("tracks")]
+    public ActionResult<TracksResponseDto> GetTracks(Guid sessionId)
+    {
+        var metadata = ResolveMetadata(out var mismatch);
+        if (mismatch != null)
+        {
+            return mismatch;
+        }
+
+        if (metadata == null)
+        {
+            Response.Headers["Retry-After"] = "1";
+            return StatusCode(StatusCodes.Status202Accepted);
+        }
+
+        return Ok(_tracksSchema);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4c. Track data
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns a slice of per-tick records for the requested track. <paramref name="from"/> and
+    /// <paramref name="to"/> are inclusive tick-number bounds; omitting <paramref name="to"/> returns
+    /// all ticks from <paramref name="from"/> onward.
+    /// </summary>
+    [HttpGet("track/{**trackId}")]
+    public ActionResult<TrackDataResponseDto> GetTrackData(
+        Guid sessionId,
+        string trackId,
+        [FromQuery] uint from = 0,
+        [FromQuery] uint to = uint.MaxValue)
+    {
+        if (trackId != "tick/summary" && trackId != "metronome/wait"
+            && !trackId.StartsWith("system/", StringComparison.Ordinal)
+            && !trackId.StartsWith("queue/", StringComparison.Ordinal)
+            && !trackId.StartsWith("posttick/", StringComparison.Ordinal))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "unknown-track",
+                Detail = $"Unknown track: '{trackId}'. Available tracks: tick/summary, metronome/wait, system/<name>, queue/<name>, posttick/*.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        if (from > to)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "bad-range",
+                Detail = "from must be <= to.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        var metadata = ResolveMetadata(out var mismatch);
+        if (mismatch != null)
+        {
+            return mismatch;
+        }
+
+        if (metadata == null)
+        {
+            Response.Headers["Retry-After"] = "1";
+            return StatusCode(StatusCodes.Status202Accepted);
+        }
+
+        // v12 (#311): dispatch to the new track families before the v1 record layout assumes shape.
+        if (trackId.StartsWith("system/", StringComparison.Ordinal))
+        {
+            return GetSystemTrackData(metadata, trackId, from, to);
+        }
+        if (trackId.StartsWith("queue/", StringComparison.Ordinal))
+        {
+            return GetQueueTrackData(metadata, trackId, from, to);
+        }
+        if (trackId.StartsWith("posttick/", StringComparison.Ordinal))
+        {
+            return GetPostTickTrackData(metadata, trackId, from, to);
+        }
+
+        var ticks = metadata.TickSummaries;
+        object[] records;
+
+        if (trackId == "tick/summary")
+        {
+            // Pass 1: count matching ticks so we can pre-size the array and avoid a List + copy.
+            var count = 0;
+            for (var i = 0; i < ticks.Length; i++)
+            {
+                var n = ticks[i].TickNumber;
+                if (n >= from && n <= to) { count++; }
+                else if (n > to) { break; }
+            }
+
+            var typed = new TickSummaryRecordDto[count];
+            var idx = 0;
+            for (var i = 0; i < ticks.Length && idx < count; i++)
+            {
+                var t = ticks[i];
+                if (t.TickNumber >= from && t.TickNumber <= to)
+                {
+                    typed[idx++] = new TickSummaryRecordDto(
+                        t.TickNumber, t.StartUs, t.DurationUs, t.EventCount,
+                        t.MaxSystemDurationUs, t.OverloadLevel, t.TickMultiplier,
+                        t.ConsecutiveOverrun, t.ConsecutiveUnderrun);
+                }
+            }
+
+            records = typed; // TickSummaryRecordDto is a reference type — covariant cast, no copy.
+        }
+        else
+        {
+            // metronome/wait — same two-pass pattern.
+            var count = 0;
+            for (var i = 0; i < ticks.Length; i++)
+            {
+                var n = ticks[i].TickNumber;
+                if (n >= from && n <= to) { count++; }
+                else if (n > to) { break; }
+            }
+
+            var typed = new MetronomeWaitRecordDto[count];
+            var idx = 0;
+            for (var i = 0; i < ticks.Length && idx < count; i++)
+            {
+                var t = ticks[i];
+                if (t.TickNumber >= from && t.TickNumber <= to)
+                {
+                    typed[idx++] = new MetronomeWaitRecordDto(t.TickNumber, t.MetronomeWaitUs, t.MetronomeIntentClass);
+                }
+            }
+
+            records = typed; // MetronomeWaitRecordDto is a reference type — covariant cast, no copy.
+        }
+
+        return Ok(new TrackDataResponseDto(trackId, records));
+    }
+
+    // ── v12 track family handlers (#311) ─────────────────────────────────────
+
+    private ActionResult<TrackDataResponseDto> GetSystemTrackData(ProfilerMetadataDto metadata, string trackId, uint from, uint to)
+    {
+        var systemName = trackId["system/".Length..];
+        ushort? sysIdx = null;
+        for (var i = 0; i < metadata.Systems.Length; i++)
+        {
+            if (metadata.Systems[i].Name == systemName) { sysIdx = metadata.Systems[i].Index; break; }
+        }
+        if (sysIdx == null)
+        {
+            return NotFound(new ProblemDetails { Title = "unknown-system", Detail = $"No system named '{systemName}' in topology.", Status = StatusCodes.Status404NotFound });
+        }
+        var rows = metadata.SystemTickSummaries;
+        var output = new List<SystemTickRecordDto>();
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var r = rows[i];
+            if (r.SystemIndex != sysIdx.Value) continue;
+            if (r.TickNumber < from || r.TickNumber > to) continue;
+            output.Add(new SystemTickRecordDto(r.TickNumber, r.StartUs, r.EndUs, r.ReadyUs, r.DurationUs,
+                r.EntitiesProcessed, r.WorkersTouched, r.ChunksProcessed, r.SkipReasonCode));
+        }
+        return Ok(new TrackDataResponseDto(trackId, output.ToArray()));
+    }
+
+    private ActionResult<TrackDataResponseDto> GetQueueTrackData(ProfilerMetadataDto metadata, string trackId, uint from, uint to)
+    {
+        var queueName = trackId["queue/".Length..];
+        ushort? qid = null;
+        foreach (var (id, name) in metadata.QueueIdToName)
+        {
+            if (name == queueName) { qid = id; break; }
+        }
+        if (qid == null)
+        {
+            return NotFound(new ProblemDetails { Title = "unknown-queue", Detail = $"No queue named '{queueName}' in topology.", Status = StatusCodes.Status404NotFound });
+        }
+        var rows = metadata.QueueTickSummaries;
+        var output = new List<QueueTickRecordDto>();
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var r = rows[i];
+            if (r.QueueId != qid.Value) continue;
+            if (r.TickNumber < from || r.TickNumber > to) continue;
+            output.Add(new QueueTickRecordDto(r.TickNumber, r.PeakDepth, r.EndOfTickDepth, r.OverflowCount, r.Produced, r.Consumed));
+        }
+        return Ok(new TrackDataResponseDto(trackId, output.ToArray()));
+    }
+
+    private ActionResult<TrackDataResponseDto> GetPostTickTrackData(ProfilerMetadataDto metadata, string trackId, uint from, uint to)
+    {
+        var phase = trackId["posttick/".Length..];
+        var rows = metadata.PostTickSummaries;
+        var output = new List<PostTickRecordDto>();
+        for (var i = 0; i < rows.Length; i++)
+        {
+            var r = rows[i];
+            if (r.TickNumber < from || r.TickNumber > to) continue;
+            var us = phase switch
+            {
+                "walFlush" => r.WalFlushUs,
+                "writeTickFence" => r.WriteTickFenceUs,
+                "tierBudget" => r.TierBudgetUs,
+                "subscriptionOutput" => r.SubscriptionOutputUs,
+                "tierIndexRebuild" => r.TierIndexRebuildUs,
+                "dormancySweep" => r.DormancySweepUs,
+                _ => float.NaN,
+            };
+            if (float.IsNaN(us))
+            {
+                return BadRequest(new ProblemDetails { Title = "unknown-posttick-phase", Detail = $"Unknown post-tick phase '{phase}'. Available: walFlush, writeTickFence, tierBudget, subscriptionOutput, tierIndexRebuild, dormancySweep.", Status = StatusCodes.Status400BadRequest });
+            }
+            output.Add(new PostTickRecordDto(r.TickNumber, us));
+        }
+        return Ok(new TrackDataResponseDto(trackId, output.ToArray()));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4d. Aggregations
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Evaluates one or more aggregation queries (mean, min, max, sum, percentiles, …) over the session's
+    /// tick summaries and returns one result per query. Computation is delegated to
+    /// <see cref="AggregationService.Compute"/>; invalid queries surface as 400 via the global exception handler.
+    /// </summary>
+    [HttpPost("aggregate")]
+    public ActionResult<AggregationResponseDto> Aggregate(
+        Guid sessionId,
+        [FromBody] AggregationRequestDto request)
+    {
+        if (request == null || request.Queries == null || request.Queries.Length == 0)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "invalid_request",
+                Detail = "queries must be a non-empty array.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        var metadata = ResolveMetadata(out var mismatch);
+        if (mismatch != null)
+        {
+            return mismatch;
+        }
+
+        if (metadata == null)
+        {
+            Response.Headers["Retry-After"] = "1";
+            return StatusCode(StatusCodes.Status202Accepted);
+        }
+
+        var results = AggregationService.Compute(metadata, request.Queries);
+        return Ok(new AggregationResponseDto(results));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // 4e. Stream subscription management (#308 Phase C)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Adds <paramref name="request.Events"/> to the subscription set for the unified data stream
+    /// connection identified by <paramref name="request.StreamId"/>. The streamId comes from the
+    /// <c>stream-id</c> SSE event emitted on connect to <c>GET /api/sessions/{id}/stream</c>.
+    /// </summary>
+    /// <returns>
+    /// 204 NoContent on success. 400 if the body is missing / malformed. 404 if the streamId is
+    /// unknown — the connection has likely already disconnected.
+    /// </returns>
+    [HttpPost("subscribe")]
+    public ActionResult Subscribe(Guid sessionId, [FromBody] StreamSubscriptionRequestDto request)
+    {
+        var validation = ValidateSubscriptionRequest(request);
+        if (validation != null)
+        {
+            return validation;
+        }
+        if (!_subscriptionRegistry.Subscribe(request.StreamId, request.Events))
+        {
+            return UnknownStreamIdResult(request.StreamId);
+        }
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Removes <paramref name="request.Events"/> from the subscription set. Mirror of
+    /// <see cref="Subscribe"/>; same error semantics.
+    /// </summary>
+    [HttpPost("unsubscribe")]
+    public ActionResult Unsubscribe(Guid sessionId, [FromBody] StreamSubscriptionRequestDto request)
+    {
+        var validation = ValidateSubscriptionRequest(request);
+        if (validation != null)
+        {
+            return validation;
+        }
+        if (!_subscriptionRegistry.Unsubscribe(request.StreamId, request.Events))
+        {
+            return UnknownStreamIdResult(request.StreamId);
+        }
+        return NoContent();
+    }
+
+    private ActionResult ValidateSubscriptionRequest(StreamSubscriptionRequestDto request)
+    {
+        if (request == null || request.StreamId == Guid.Empty || request.Events == null)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "invalid_request",
+                Detail = "Body must contain a non-empty streamId and an events array (events MAY be empty for a no-op).",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+        return null;
+    }
+
+    private ActionResult UnknownStreamIdResult(Guid streamId)
+    {
+        return NotFound(new ProblemDetails
+        {
+            Title = "unknown_stream",
+            Detail = $"No active stream with id '{streamId}'. The connection may have already closed.",
+            Status = StatusCodes.Status404NotFound,
+        });
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Resolves session metadata from <c>HttpContext.Items["Session"]</c>.
+    /// Returns <c>null</c> metadata when the session is valid but not yet ready (caller should 202).
+    /// Sets <paramref name="mismatchResult"/> when the session kind is unsupported (caller should return it).
+    /// </summary>
+    private ProfilerMetadataDto ResolveMetadata(out ActionResult mismatchResult)
+    {
+        mismatchResult = null;
+        var session = HttpContext.Items["Session"];
+
+        if (session is TraceSession trace)
+        {
+            return trace.Runtime.Metadata;
+        }
+
+        if (session is AttachSession attach)
+        {
+            return attach.Runtime.Metadata;
+        }
+
+        mismatchResult = Conflict(new ProblemDetails
+        {
+            Title = "session_kind_mismatch",
+            Detail = "Topology is only available for Trace and Attach sessions.",
+            Status = StatusCodes.Status409Conflict,
+        });
+        return null;
+    }
+}

--- a/tools/Typhon.Workbench/Controllers/SessionsController.cs
+++ b/tools/Typhon.Workbench/Controllers/SessionsController.cs
@@ -134,6 +134,14 @@ public sealed partial class SessionsController : ControllerBase
         return Ok(ToDto(session));
     }
 
+    [HttpGet("{id:guid}/state")]
+    [RequireSession]
+    public ActionResult<SessionStateDto> GetState(Guid id)
+    {
+        var session = (WbSession)HttpContext.Items["Session"]!;
+        return Ok(ToStateDto(session));
+    }
+
     [HttpDelete("{id:guid}")]
     [RequireSession]
     public IActionResult DeleteSession(Guid id)
@@ -165,6 +173,13 @@ public sealed partial class SessionsController : ControllerBase
             var diags = os.SchemaDiagnostics?
                 .Select(d => new SessionDiagnosticDto(d.ComponentName, d.Kind, d.Detail))
                 .ToArray();
+            var schemaCompatibility = os.State switch
+            {
+                SessionState.Ready => "Compatible",
+                SessionState.MigrationRequired => "MigrationRequired",
+                SessionState.Incompatible => "Incompatible",
+                _ => "Compatible",
+            };
             return new SessionDto(
                 os.Id,
                 os.Kind.ToString(),
@@ -173,9 +188,85 @@ public sealed partial class SessionsController : ControllerBase
                 os.SchemaDllPaths,
                 os.SchemaStatus,
                 os.LoadedComponentTypes,
-                diags);
+                diags,
+                Lifecycle: "Ready",
+                SchemaCompatibility: schemaCompatibility);
         }
-        return new SessionDto(s.Id, s.Kind.ToString(), s.State.ToString(), s.FilePath);
+        if (s is AttachSession attach)
+        {
+            var isReady = attach.Runtime.Metadata != null;
+            return new SessionDto(
+                attach.Id,
+                attach.Kind.ToString(),
+                attach.State.ToString(),
+                attach.FilePath,
+                Lifecycle: isReady ? "Ready" : "Loading",
+                IsStreaming: isReady);
+        }
+        if (s is TraceSession trace)
+        {
+            var lifecycle = !trace.Runtime.IsBuildComplete ? "Loading"
+                : trace.Runtime.Metadata != null ? "Ready"
+                : "Closed";
+            return new SessionDto(
+                trace.Id,
+                trace.Kind.ToString(),
+                trace.State.ToString(),
+                trace.FilePath,
+                Lifecycle: lifecycle,
+                Reason: lifecycle == "Closed" ? "build-failed" : null);
+        }
+        return new SessionDto(s.Id, s.Kind.ToString(), s.State.ToString(), s.FilePath, Lifecycle: "Ready");
+    }
+
+    private static SessionStateDto ToStateDto(WbSession s)
+    {
+        if (s is OpenSession os)
+        {
+            var schemaCompatibility = os.State switch
+            {
+                SessionState.Ready => "Compatible",
+                SessionState.MigrationRequired => "MigrationRequired",
+                SessionState.Incompatible => "Incompatible",
+                _ => "Compatible",
+            };
+            return new SessionStateDto(
+                os.Kind.ToString(),
+                Lifecycle: "Ready",
+                IsStreaming: false,
+                IsPaused: false,
+                IsReattaching: false,
+                SchemaCompatibility: schemaCompatibility,
+                Reason: null);
+        }
+        if (s is AttachSession attach)
+        {
+            var isReady = attach.Runtime.Metadata != null;
+            return new SessionStateDto(
+                attach.Kind.ToString(),
+                Lifecycle: isReady ? "Ready" : "Loading",
+                IsStreaming: isReady,
+                IsPaused: false,
+                IsReattaching: false,
+                SchemaCompatibility: null,
+                Reason: null);
+        }
+        if (s is TraceSession trace)
+        {
+            var lifecycle = !trace.Runtime.IsBuildComplete ? "Loading"
+                : trace.Runtime.Metadata != null ? "Ready"
+                : "Closed";
+            return new SessionStateDto(
+                trace.Kind.ToString(),
+                Lifecycle: lifecycle,
+                IsStreaming: false,
+                IsPaused: false,
+                IsReattaching: false,
+                SchemaCompatibility: null,
+                Reason: lifecycle == "Closed" ? "build-failed" : null);
+        }
+        return new SessionStateDto(s.Kind.ToString(), Lifecycle: "Ready", IsStreaming: false, IsPaused: false,
+            IsReattaching: false, SchemaCompatibility: null, Reason: null);
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Session {SessionId} created via {Mode}")]

--- a/tools/Typhon.Workbench/Dtos/Data/AggregationDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Data/AggregationDto.cs
@@ -1,0 +1,45 @@
+namespace Typhon.Workbench.Dtos.Data;
+
+/// <summary>
+/// One aggregation query. Tier 2 ops (#312) supply extra params via the optional fields:
+/// <list type="bullet">
+///   <item><c>histogram</c>: <see cref="Buckets"/> = number of equal-width buckets (must be &gt; 0).</item>
+///   <item><c>topk</c>: <see cref="N"/> = number of top values to return.</item>
+///   <item><c>cdf</c>: <see cref="Samples"/> = number of evenly-spaced quantile sample points.</item>
+///   <item><c>criticalPathParticipationRate</c>: ignored — uses Range only; the field is "system/&lt;name&gt;" implied
+///       by the trackId.</item>
+/// </list>
+/// </summary>
+public record AggregationQueryDto(
+    string TrackId,
+    string Field,
+    string Op,
+    uint[] Range,         // [t0, t1] inclusive tick numbers
+    int? Buckets = null,  // histogram
+    int? N = null,        // topk
+    int? Samples = null); // cdf
+
+public record AggregationRequestDto(AggregationQueryDto[] Queries);
+
+/// <summary>
+/// Per-query result — only one of the typed payload fields is populated per result, matching the operator that produced it.
+/// Scalar ops (mean / min / max / sum / count / stddev / variance / percentiles / criticalPathParticipationRate) populate
+/// <see cref="Value"/>. Tier 2 shaped ops populate the matching payload (<see cref="Histogram"/> / <see cref="TopK"/> /
+/// <see cref="Cdf"/>). All shape fields default to null so existing v1 consumers can keep reading <see cref="Value"/> only.
+/// </summary>
+public record AggregationResultDto(
+    double? Value = null,                   // scalar ops
+    HistogramBucketDto[] Histogram = null,  // histogram op
+    TopKEntryDto[] TopK = null,             // topk op
+    CdfSampleDto[] Cdf = null);             // cdf op
+
+public record AggregationResponseDto(AggregationResultDto[] Results);
+
+/// <summary>One bucket in a histogram result. Range is half-open [<see cref="BucketStart"/>, <see cref="BucketEnd"/>).</summary>
+public record HistogramBucketDto(double BucketStart, double BucketEnd, int Count);
+
+/// <summary>One entry in a topk result. <see cref="TickNumber"/> identifies the tick that produced the value.</summary>
+public record TopKEntryDto(uint TickNumber, double Value);
+
+/// <summary>One sample in a CDF result. <see cref="Quantile"/> ∈ [0,1]; <see cref="Value"/> is the corresponding observed value.</summary>
+public record CdfSampleDto(double Quantile, double Value);

--- a/tools/Typhon.Workbench/Dtos/Data/StreamSubscriptionDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Data/StreamSubscriptionDto.cs
@@ -1,0 +1,17 @@
+namespace Typhon.Workbench.Dtos.Data;
+
+/// <summary>
+/// Wire shape for <c>POST /api/sessions/{id}/subscribe</c> and
+/// <c>POST /api/sessions/{id}/unsubscribe</c> requests on the unified data stream (#308 Phase C).
+/// </summary>
+/// <param name="StreamId">
+/// The connection identifier emitted on the very first SSE frame as a <c>stream-id</c> event.
+/// Required so multi-tab clients can target subscription state at a specific connection rather
+/// than the session.
+/// </param>
+/// <param name="Events">
+/// Event types to add to / remove from the subscription set. Unknown event types are accepted
+/// silently — the server doesn't validate against a closed enum because the supported event types
+/// evolve across API versions and clients negotiate via <c>X-Workbench-Api</c>.
+/// </param>
+public record StreamSubscriptionRequestDto(Guid StreamId, string[] Events);

--- a/tools/Typhon.Workbench/Dtos/Data/SystemListDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Data/SystemListDto.cs
@@ -1,0 +1,11 @@
+using Typhon.Workbench.Dtos.Profiler;
+
+namespace Typhon.Workbench.Dtos.Data;
+
+/// <summary>
+/// Result of a topology-query endpoint (<c>/queries/who-writes/{component}</c>, <c>/queries/who-reads/{component}</c>).
+/// Echoes the queried name + the matching systems so callers don't need to remember which key they searched for.
+/// </summary>
+/// <param name="Query">The component (or future event/resource) name the caller asked about.</param>
+/// <param name="Systems">Zero or more systems whose RFC 07 declarations match the query.</param>
+public record SystemListDto(string Query, SystemDefinitionDto[] Systems);

--- a/tools/Typhon.Workbench/Dtos/Data/TopologyDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Data/TopologyDto.cs
@@ -1,0 +1,15 @@
+using Typhon.Workbench.Dtos.Profiler;
+
+namespace Typhon.Workbench.Dtos.Data;
+
+/// <summary>
+/// Topology snapshot — system DAG, archetypes, component types, and phase order. Static for the lifetime of a session;
+/// fetched once per attach. RFC 07 access declarations live on each <see cref="SystemDefinitionDto"/>.
+/// </summary>
+/// <param name="Phases">User-defined phase order from <c>RuntimeOptions.Phases</c> (RFC 07 §Q3). Empty for sessions
+/// without phase declarations or for legacy v5 traces.</param>
+public record TopologyDto(
+    SystemDefinitionDto[] Systems,
+    ArchetypeDto[] Archetypes,
+    ComponentTypeDto[] ComponentTypes,
+    string[] Phases);

--- a/tools/Typhon.Workbench/Dtos/Data/TrackDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Data/TrackDto.cs
@@ -1,0 +1,46 @@
+namespace Typhon.Workbench.Dtos.Data;
+
+public record TrackFieldDescriptorDto(string Name, string Type); // Type = "u32", "f32", "f64", "u8", "u16"
+public record TrackSchemaDto(string Id, string Kind, TrackFieldDescriptorDto[] Fields); // Kind = "perTick"
+public record TracksResponseDto(TrackSchemaDto[] Tracks);
+
+public record TickSummaryRecordDto(
+    uint TickNumber,
+    double StartUs,
+    float DurationUs,
+    uint EventCount,
+    float MaxSystemDurationUs,
+    byte OverloadLevel,
+    byte TickMultiplier,
+    ushort ConsecutiveOverrun,
+    ushort ConsecutiveUnderrun);
+
+public record MetronomeWaitRecordDto(uint TickNumber, ushort WaitUs, byte IntentClass);
+
+// ── v2 tracks (#311) ─────────────────────────────────────────────────────────
+
+/// <summary>One row in a <c>system/&lt;name&gt;</c> track. Captures per-tick execution data for a single system.</summary>
+public record SystemTickRecordDto(
+    uint TickNumber,
+    double StartUs,
+    double EndUs,
+    double ReadyUs,
+    float DurationUs,
+    uint EntitiesProcessed,
+    byte WorkersTouched,
+    ushort ChunksProcessed,
+    byte SkipReason);
+
+/// <summary>One row in a <c>queue/&lt;name&gt;</c> track. Captures per-tick depth telemetry for a single event queue.</summary>
+public record QueueTickRecordDto(
+    uint TickNumber,
+    uint PeakDepth,
+    uint EndOfTickDepth,
+    uint OverflowCount,
+    uint Produced,
+    uint Consumed);
+
+/// <summary>One row in a <c>posttick/*</c> track. Single-field record (the duration of the named phase for a tick).</summary>
+public record PostTickRecordDto(uint TickNumber, float DurationUs);
+
+public record TrackDataResponseDto(string TrackId, object[] Records);

--- a/tools/Typhon.Workbench/Dtos/Profiler/BuildProgressDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Profiler/BuildProgressDto.cs
@@ -1,17 +1,16 @@
 namespace Typhon.Workbench.Dtos.Profiler;
 
 /// <summary>
-/// Wire shape emitted on the build-progress SSE endpoint. Phase describes the current build state; bytes / counts are
-/// non-null only during <c>building</c>, and <see cref="Message"/> is non-null only during <c>error</c>.
+/// Wire shape carried by the <c>progress</c>, <c>done</c>, and <c>error</c> typed SSE events on the
+/// build-progress stream (#308). The event type is the SSE <c>event:</c> line; the payload here
+/// carries only the per-event data:
+/// <list type="bullet">
+///   <item><c>progress</c> — bytes / counts populated; <see cref="Message"/> null.</item>
+///   <item><c>done</c> — empty payload (<c>{}</c>).</item>
+///   <item><c>error</c> — <see cref="Message"/> non-null; counts null.</item>
+/// </list>
 /// </summary>
-/// <param name="Phase"><c>"building"</c>, <c>"done"</c>, or <c>"error"</c>.</param>
-/// <param name="BytesRead">Source bytes consumed so far — null unless <c>Phase == "building"</c>.</param>
-/// <param name="TotalBytes">Source file size — null unless <c>Phase == "building"</c>.</param>
-/// <param name="TickCount">Ticks encountered so far — null unless <c>Phase == "building"</c>.</param>
-/// <param name="EventCount">Events encountered so far — null unless <c>Phase == "building"</c>.</param>
-/// <param name="Message">Error message text — non-null only when <c>Phase == "error"</c>.</param>
 public record BuildProgressDto(
-    string Phase,
     long? BytesRead = null,
     long? TotalBytes = null,
     int? TickCount = null,

--- a/tools/Typhon.Workbench/Dtos/Profiler/LiveStreamEventDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Profiler/LiveStreamEventDto.cs
@@ -1,21 +1,25 @@
+using System.Text.Json.Serialization;
+
 namespace Typhon.Workbench.Dtos.Profiler;
 
 /// <summary>
-/// Wire shape for the profiler live SSE delta stream (#289 unified pipeline). Discriminated by <see cref="Kind"/>:
+/// In-process channel envelope for the profiler live SSE delta stream (#289 unified pipeline,
+/// retyped for #308). The <see cref="Kind"/> field is the SSE event type carried on the wire as
+/// <c>event: &lt;kind&gt;</c> — clients listen with <c>addEventListener(&lt;kind&gt;, ...)</c> and
+/// receive the per-kind sub-object directly. <see cref="Kind"/> is <see cref="JsonIgnoreAttribute"/>'d
+/// so it never appears in the JSON payload.
 /// <list type="bullet">
-///   <item><c>"metadata"</c> — <see cref="Metadata"/> non-null. Full snapshot, emitted on connect / reconnect.</item>
-///   <item><c>"tickSummaryAdded"</c> — <see cref="TickSummary"/> non-null. One per tick the builder finalizes.</item>
-///   <item><c>"chunkAdded"</c> — <see cref="ChunkEntry"/> non-null. One per chunk the builder flushes.</item>
-///   <item><c>"threadInfoAdded"</c> — <see cref="ThreadInfo"/> non-null. One per (slot, name) pair as workers claim slots.</item>
-///   <item><c>"globalMetricsUpdated"</c> — <see cref="GlobalMetrics"/> non-null. ~1 Hz coalesced.</item>
-///   <item><c>"heartbeat"</c> — <see cref="Status"/> non-null. Connection-state change or 5 s idle pulse.</item>
-///   <item><c>"shutdown"</c> — emitted when the engine sends a Shutdown frame; clients render a final state.</item>
+///   <item><c>metadata</c> — <see cref="Metadata"/> non-null. Full snapshot, emitted on connect / reconnect.</item>
+///   <item><c>tickSummaryAdded</c> — <see cref="TickSummary"/> non-null. One per tick the builder finalizes.</item>
+///   <item><c>chunkAdded</c> — <see cref="ChunkEntry"/> non-null. One per chunk the builder flushes.</item>
+///   <item><c>threadInfoAdded</c> — <see cref="ThreadInfo"/> non-null. One per (slot, name) pair as workers claim slots.</item>
+///   <item><c>globalMetricsUpdated</c> — <see cref="GlobalMetrics"/> non-null. ~1 Hz coalesced.</item>
+///   <item><c>heartbeat</c> — <see cref="Status"/> non-null. Connection-state change or 5 s idle pulse.</item>
+///   <item><c>shutdown</c> — emitted when the engine sends a Shutdown frame; clients render a final state.</item>
 /// </list>
-/// Every frame ships as a default SSE <c>message</c> event (no <c>event:</c> prefix) because the client's
-/// <c>useEventSource</c> hook only listens to <c>onmessage</c>. Clients switch on <see cref="Kind"/>.
 /// </summary>
 public record LiveStreamEventDto(
-    string Kind,
+    [property: JsonIgnore] string Kind,
     ProfilerMetadataDto Metadata = null,
     TickSummaryDto TickSummary = null,
     ChunkManifestEntryDto ChunkEntry = null,

--- a/tools/Typhon.Workbench/Dtos/Profiler/ProfilerMetadataDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Profiler/ProfilerMetadataDto.cs
@@ -15,7 +15,13 @@ public record ProfilerMetadataDto(
     GlobalMetricsDto GlobalMetrics,
     TickSummaryDto[] TickSummaries,
     ChunkManifestEntryDto[] ChunkManifest,
-    GcSuspensionDto[] GcSuspensions);
+    GcSuspensionDto[] GcSuspensions,
+    string[] Phases,
+    // v12 (#311) — per-system / per-queue / post-tick rollups + queue-name table.
+    Typhon.Profiler.SystemTickSummary[] SystemTickSummaries,
+    Typhon.Profiler.QueueTickSummary[] QueueTickSummaries,
+    Typhon.Profiler.PostTickSummary[] PostTickSummaries,
+    System.Collections.Generic.Dictionary<ushort, string> QueueIdToName);
 
 /// <summary>Header fields projected from <c>TraceFileHeader</c>. All primitive types — JSON-friendly.</summary>
 public record ProfilerHeaderDto(
@@ -30,6 +36,12 @@ public record ProfilerHeaderDto(
     long SamplingSessionStartQpc);
 
 /// <summary>One system in the DAG.</summary>
+/// <remarks>
+/// RFC 07 access declaration fields (<paramref name="PhaseName"/>, <paramref name="Reads"/>, <paramref name="Writes"/>, etc.)
+/// are populated from trace v6+ traces and live attach sessions whose engine emits the v6 Init payload. Older v5 traces
+/// surface empty arrays for every access field — the wire reader fills empties on the v5 read path so consumers don't
+/// need a presence bit.
+/// </remarks>
 public record SystemDefinitionDto(
     ushort Index,
     string Name,
@@ -38,7 +50,21 @@ public record SystemDefinitionDto(
     bool IsParallel,
     byte TierFilter,
     ushort[] Predecessors,
-    ushort[] Successors);
+    ushort[] Successors,
+    string PhaseName,
+    bool IsExclusivePhase,
+    string[] Reads,
+    string[] ReadsFresh,
+    string[] ReadsSnapshot,
+    string[] AdditionalReads,
+    string[] Writes,
+    string[] SideWrites,
+    string[] WritesEvents,
+    string[] ReadsEvents,
+    string[] WritesResources,
+    string[] ReadsResources,
+    string[] ExplicitAfter,
+    string[] ExplicitBefore);
 
 /// <summary>Archetype-id → name mapping.</summary>
 public record ArchetypeDto(ushort ArchetypeId, string Name);

--- a/tools/Typhon.Workbench/Dtos/Sessions/SessionDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Sessions/SessionDto.cs
@@ -3,11 +3,18 @@ namespace Typhon.Workbench.Dtos.Sessions;
 public record SessionDto(
     Guid SessionId,
     string Kind,
-    string State,
+    string State,              // kept — old consumers read this
     string FilePath,
     string[] SchemaDllPaths = null,
     string SchemaStatus = null,
     int LoadedComponentTypes = 0,
-    SessionDiagnosticDto[] SchemaDiagnostics = null);
+    SessionDiagnosticDto[] SchemaDiagnostics = null,
+    // v1 lifecycle fields:
+    string Lifecycle = null,               // "Loading" | "Ready" | "Closed"
+    bool IsStreaming = false,
+    bool IsPaused = false,
+    bool IsReattaching = false,
+    string SchemaCompatibility = null,     // "Compatible" | "MigrationRequired" | "Incompatible"
+    string Reason = null);
 
 public record SessionDiagnosticDto(string ComponentName, string Kind, string Detail);

--- a/tools/Typhon.Workbench/Dtos/Sessions/SessionStateDto.cs
+++ b/tools/Typhon.Workbench/Dtos/Sessions/SessionStateDto.cs
@@ -1,0 +1,10 @@
+namespace Typhon.Workbench.Dtos.Sessions;
+
+public record SessionStateDto(
+    string Kind,               // "Open" | "Attach" | "Trace"
+    string Lifecycle,          // "Loading" | "Ready" | "Closed"
+    bool IsStreaming,
+    bool IsPaused,
+    bool IsReattaching,
+    string SchemaCompatibility, // "Compatible" | "MigrationRequired" | "Incompatible"
+    string Reason);            // null unless Closed

--- a/tools/Typhon.Workbench/Hosting/ServiceExtensions.cs
+++ b/tools/Typhon.Workbench/Hosting/ServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Typhon.Workbench.Fs;
 using Typhon.Workbench.Schema;
 using Typhon.Workbench.Security;
+using Typhon.Workbench.Services;
 using Typhon.Workbench.Sessions;
 using Typhon.Workbench.Streams;
 
@@ -20,6 +21,8 @@ public static class ServiceExtensions
         services.AddSingleton<OptionsStore>();
         // #302 Phase 6: editor handoff dispatcher (per-OS adapters: VS Code / Cursor / Rider / VS / Custom).
         services.AddSingleton<EditorLauncher>();
+        // #308: per-connection event-subscription state for the unified data stream.
+        services.AddSingleton<StreamSubscriptionRegistry>();
         return services;
     }
 
@@ -33,6 +36,8 @@ public static class ServiceExtensions
            .WithTags("Profiler");
         app.MapGet("/api/sessions/{sessionId:guid}/profiler/stream", ProfilerLiveStream.HandleAsync)
            .WithTags("Profiler");
+        app.MapGet("/api/sessions/{sessionId:guid}/stream", UnifiedDataStream.HandleAsync)
+           .WithTags("Data");
         app.MapGet("/api/options/stream", OptionsChangedStream.HandleAsync)
            .WithTags("Options");
         return app;

--- a/tools/Typhon.Workbench/Middleware/RequireApiVersionAttribute.cs
+++ b/tools/Typhon.Workbench/Middleware/RequireApiVersionAttribute.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Typhon.Workbench.Middleware;
+
+/// <summary>
+/// Validates the optional <c>X-Workbench-Api</c> request header and enforces API version compatibility.
+/// Missing header soft-launches as v1. A present, parseable, matching version continues. Any other
+/// case short-circuits with a structured ProblemDetails response.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class RequireApiVersionAttribute : Attribute, IAsyncActionFilter
+{
+    private const string HeaderName = "X-Workbench-Api";
+    private const int SupportedVersion = 1;
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        if (!context.HttpContext.Request.Headers.TryGetValue(HeaderName, out var raw))
+        {
+            // Soft-launch: missing header defaults to v1.
+            context.HttpContext.Items["ApiVersion"] = SupportedVersion;
+            await next();
+            return;
+        }
+
+        if (!int.TryParse(raw, out var version))
+        {
+            context.Result = new ObjectResult(new ProblemDetails
+            {
+                Type = "invalid-api-version",
+                Title = "Invalid API version",
+                Detail = $"The {HeaderName} header value '{raw}' is not a valid integer.",
+                Status = StatusCodes.Status400BadRequest,
+            })
+            { StatusCode = StatusCodes.Status400BadRequest };
+            return;
+        }
+
+        if (version != SupportedVersion)
+        {
+            context.Result = new ObjectResult(new ProblemDetails
+            {
+                Type = "api-version-mismatch",
+                Title = "API version mismatch",
+                Detail = $"This endpoint requires API version {SupportedVersion}; client sent version {version}.",
+                Status = StatusCodes.Status426UpgradeRequired,
+            })
+            { StatusCode = StatusCodes.Status426UpgradeRequired };
+            return;
+        }
+
+        context.HttpContext.Items["ApiVersion"] = SupportedVersion;
+        await next();
+    }
+}

--- a/tools/Typhon.Workbench/Program.cs
+++ b/tools/Typhon.Workbench/Program.cs
@@ -26,6 +26,14 @@ builder.Services
         // Without this, PATCH /api/options/editor 400s because the server can't deserialize "rider"
         // to the EditorKind enum.
         o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        // Cache-format structs (`SystemTickSummary`, `QueueTickSummary`, `PostTickSummary`) are
+        // packed `struct`s with public **fields** — System.Text.Json ignores fields by default and
+        // would emit `[{}, {}, ...]` for them inside `/profiler/metadata`. The aggregation /
+        // per-track endpoints already project to record DTOs (properties) and are unaffected, but
+        // the metadata endpoint hands the raw struct arrays to the client for the CP tape + skip-
+        // rate / CP-rate algorithms. Enable field serialization globally so those arrays are
+        // populated. Localhost dev tool — the "leak unintended fields" risk is bounded.
+        o.JsonSerializerOptions.IncludeFields = true;
     });
 
 builder.Services.AddOpenApi();

--- a/tools/Typhon.Workbench/Services/AggregationService.cs
+++ b/tools/Typhon.Workbench/Services/AggregationService.cs
@@ -1,0 +1,715 @@
+using System.Buffers;
+using Typhon.Profiler;
+using Typhon.Workbench.Dtos.Data;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Sessions;
+
+namespace Typhon.Workbench.Services;
+
+/// <summary>
+/// Computes Tier 1 (mean/sum/count/min/max/stddev/variance/percentiles) and Tier 2
+/// (histogram/topk/cdf) aggregation operators over v1 and v2 track families:
+/// <c>tick/summary</c>, <c>metronome/wait</c>, <c>system/&lt;name&gt;</c>, <c>queue/&lt;name&gt;</c>,
+/// <c>posttick/&lt;phase&gt;</c>.
+/// </summary>
+public static class AggregationService
+{
+    private const int StackallocThreshold = 1024;
+
+    // Allowed posttick phase names (must match DataController.GetPostTickTrackData).
+    private static readonly HashSet<string> PostTickPhases = new(StringComparer.Ordinal)
+    {
+        "walFlush", "writeTickFence", "tierBudget", "subscriptionOutput", "tierIndexRebuild", "dormancySweep",
+    };
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Public entry points
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>v2 entry — supports all track families. Used by the controller.</summary>
+    public static AggregationResultDto[] Compute(ProfilerMetadataDto metadata, AggregationQueryDto[] queries)
+        => ComputeAll(metadata.TickSummaries, queries, metadata);
+
+    /// <summary>
+    /// Legacy v1 entry. Only <c>tick/summary</c> and <c>metronome/wait</c> tracks are valid.
+    /// Throws <see cref="WorkbenchException"/> if a v2 track family is requested.
+    /// </summary>
+    public static AggregationResultDto[] Compute(TickSummaryDto[] ticks, AggregationQueryDto[] queries)
+        => ComputeAll(ticks, queries, metadata: null);
+
+    private static AggregationResultDto[] ComputeAll(
+        TickSummaryDto[] ticks,
+        AggregationQueryDto[] queries,
+        ProfilerMetadataDto metadata)
+    {
+        var results = new AggregationResultDto[queries.Length];
+        for (var i = 0; i < queries.Length; i++)
+        {
+            results[i] = ComputeOne(ticks, queries[i], metadata);
+        }
+
+        return results;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Single-query evaluation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static AggregationResultDto ComputeOne(
+        TickSummaryDto[] ticks,
+        AggregationQueryDto query,
+        ProfilerMetadataDto metadata)
+    {
+        ValidateQuery(query, metadata);
+
+        // topk needs parallel (value, tickNumber) arrays — dedicated path.
+        if (query.Op == "topk")
+        {
+            return ComputeTopK(ticks, query, metadata);
+        }
+
+        var count = CountMatching(ticks, query, metadata);
+        if (count == 0)
+        {
+            return new AggregationResultDto();
+        }
+
+        if (count <= StackallocThreshold)
+        {
+            Span<double> buf = stackalloc double[count];
+            FillValues(buf, ticks, query, metadata);
+            return RunScalarOrShape(query, buf);
+        }
+
+        var rented = ArrayPool<double>.Shared.Rent(count);
+        try
+        {
+            var span = rented.AsSpan(0, count);
+            FillValues(span, ticks, query, metadata);
+            return RunScalarOrShape(query, span);
+        }
+        finally
+        {
+            ArrayPool<double>.Shared.Return(rented);
+        }
+    }
+
+    private static AggregationResultDto RunScalarOrShape(AggregationQueryDto query, Span<double> values)
+    {
+        return query.Op switch
+        {
+            "mean"      => new AggregationResultDto(Mean(values)),
+            "sum"       => new AggregationResultDto(Sum(values)),
+            "count"     => new AggregationResultDto(values.Length),
+            "min"       => new AggregationResultDto(Min(values)),
+            "max"       => new AggregationResultDto(Max(values)),
+            "stddev"    => new AggregationResultDto(StdDev(values, out _)),
+            "variance"  => new AggregationResultDto(VarianceOnly(values)),
+            "median"    => new AggregationResultDto(Percentile(values, 50)),
+            "p50"       => new AggregationResultDto(Percentile(values, 50)),
+            "p75"       => new AggregationResultDto(Percentile(values, 75)),
+            "p90"       => new AggregationResultDto(Percentile(values, 90)),
+            "p95"       => new AggregationResultDto(Percentile(values, 95)),
+            "p99"       => new AggregationResultDto(Percentile(values, 99)),
+            "histogram" => new AggregationResultDto(Histogram: ComputeHistogram(values, query.Buckets!.Value)),
+            "cdf"       => new AggregationResultDto(Cdf: ComputeCdf(values, query.Samples!.Value)),
+            _           => new AggregationResultDto(),
+        };
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Validation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static readonly HashSet<string> ValidOps = new(StringComparer.Ordinal)
+    {
+        "mean", "min", "max", "sum", "count",
+        "median", "p50", "p75", "p90", "p95", "p99",
+        "stddev", "variance",
+        // Tier 2 (#312)
+        "histogram", "topk", "cdf",
+    };
+
+    private static readonly HashSet<string> TickSummaryFields = new(StringComparer.Ordinal)
+    {
+        "durationUs", "eventCount", "maxSystemDurationUs", "startUs", "overloadLevel",
+        "tickMultiplier", "consecutiveOverrun", "consecutiveUnderrun",
+    };
+
+    private static readonly HashSet<string> MetronomeFields = new(StringComparer.Ordinal)
+    {
+        "waitUs", "intentClass",
+    };
+
+    private static readonly HashSet<string> SystemFields = new(StringComparer.Ordinal)
+    {
+        "durationUs", "startUs", "endUs", "readyUs",
+        "entitiesProcessed", "workersTouched", "chunksProcessed", "skipReason",
+    };
+
+    private static readonly HashSet<string> QueueFields = new(StringComparer.Ordinal)
+    {
+        "peakDepth", "endOfTickDepth", "overflowCount", "produced", "consumed",
+    };
+
+    private static void ValidateQuery(AggregationQueryDto query, ProfilerMetadataDto metadata)
+    {
+        if (query.Range == null || query.Range.Length != 2)
+        {
+            throw new WorkbenchException(400, "bad-range", "Range must be an array of exactly 2 elements [t0, t1]");
+        }
+        if (query.Range[0] > query.Range[1])
+        {
+            throw new WorkbenchException(400, "bad-range", $"Range start ({query.Range[0]}) must not exceed range end ({query.Range[1]})");
+        }
+
+        ValidateTrackAndField(query, metadata);
+
+        if (!ValidOps.Contains(query.Op))
+        {
+            throw new WorkbenchException(400, "unknown-op", $"Unknown operator: '{query.Op}'.");
+        }
+
+        ValidateOpParams(query);
+    }
+
+    private static void ValidateTrackAndField(AggregationQueryDto query, ProfilerMetadataDto metadata)
+    {
+        var trackId = query.TrackId;
+
+        if (trackId == "tick/summary")
+        {
+            if (!TickSummaryFields.Contains(query.Field))
+            {
+                throw new WorkbenchException(400, "unknown-field", $"Unknown field '{query.Field}' for track '{trackId}'");
+            }
+            return;
+        }
+        if (trackId == "metronome/wait")
+        {
+            if (!MetronomeFields.Contains(query.Field))
+            {
+                throw new WorkbenchException(400, "unknown-field", $"Unknown field '{query.Field}' for track '{trackId}'");
+            }
+            return;
+        }
+
+        // v2 tracks all need metadata.
+        if (metadata == null)
+        {
+            throw new WorkbenchException(400, "unknown-track", $"Unknown track ID: '{trackId}' (or v2 tracks unavailable in this context).");
+        }
+
+        if (trackId.StartsWith("system/", StringComparison.Ordinal))
+        {
+            var name = trackId["system/".Length..];
+            if (!TryFindSystemIndex(metadata, name, out _))
+            {
+                throw new WorkbenchException(400, "unknown-system", $"No system named '{name}' in topology.");
+            }
+            if (!SystemFields.Contains(query.Field))
+            {
+                throw new WorkbenchException(400, "unknown-field", $"Unknown field '{query.Field}' for track '{trackId}'");
+            }
+            return;
+        }
+        if (trackId.StartsWith("queue/", StringComparison.Ordinal))
+        {
+            var name = trackId["queue/".Length..];
+            if (!TryFindQueueId(metadata, name, out _))
+            {
+                throw new WorkbenchException(400, "unknown-queue", $"No queue named '{name}' in topology.");
+            }
+            if (!QueueFields.Contains(query.Field))
+            {
+                throw new WorkbenchException(400, "unknown-field", $"Unknown field '{query.Field}' for track '{trackId}'");
+            }
+            return;
+        }
+        if (trackId.StartsWith("posttick/", StringComparison.Ordinal))
+        {
+            var phase = trackId["posttick/".Length..];
+            if (!PostTickPhases.Contains(phase))
+            {
+                throw new WorkbenchException(400, "unknown-posttick-phase",
+                    $"Unknown post-tick phase '{phase}'. Available: walFlush, writeTickFence, tierBudget, subscriptionOutput, tierIndexRebuild, dormancySweep.");
+            }
+            if (query.Field != "durationUs")
+            {
+                throw new WorkbenchException(400, "unknown-field", $"Unknown field '{query.Field}' for track '{trackId}' (only 'durationUs' is supported).");
+            }
+            return;
+        }
+
+        throw new WorkbenchException(400, "unknown-track", $"Unknown track ID: '{trackId}'");
+    }
+
+    private static void ValidateOpParams(AggregationQueryDto query)
+    {
+        switch (query.Op)
+        {
+            case "histogram":
+                if (query.Buckets == null || query.Buckets.Value <= 0)
+                {
+                    throw new WorkbenchException(400, "missing-param", "histogram requires 'buckets' > 0.");
+                }
+                break;
+            case "topk":
+                if (query.N == null || query.N.Value <= 0)
+                {
+                    throw new WorkbenchException(400, "missing-param", "topk requires 'n' > 0.");
+                }
+                break;
+            case "cdf":
+                if (query.Samples == null || query.Samples.Value < 2)
+                {
+                    throw new WorkbenchException(400, "missing-param", "cdf requires 'samples' >= 2.");
+                }
+                break;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Track-family lookups
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static bool TryFindSystemIndex(ProfilerMetadataDto metadata, string name, out ushort sysIdx)
+    {
+        for (var i = 0; i < metadata.Systems.Length; i++)
+        {
+            if (metadata.Systems[i].Name == name)
+            {
+                sysIdx = metadata.Systems[i].Index;
+                return true;
+            }
+        }
+        sysIdx = 0;
+        return false;
+    }
+
+    private static bool TryFindQueueId(ProfilerMetadataDto metadata, string name, out ushort queueId)
+    {
+        foreach (var (id, n) in metadata.QueueIdToName)
+        {
+            if (n == name)
+            {
+                queueId = id;
+                return true;
+            }
+        }
+        queueId = 0;
+        return false;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Count + fill — track-family dispatch
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static int CountMatching(TickSummaryDto[] ticks, AggregationQueryDto query, ProfilerMetadataDto metadata)
+    {
+        var t0 = query.Range[0];
+        var t1 = query.Range[1];
+        var trackId = query.TrackId;
+
+        if (trackId == "tick/summary" || trackId == "metronome/wait")
+        {
+            var n = 0;
+            for (var i = 0; i < ticks.Length; i++)
+            {
+                var no = ticks[i].TickNumber;
+                if (no >= t0 && no <= t1) { n++; }
+                else if (no > t1) { break; }
+            }
+            return n;
+        }
+
+        if (trackId.StartsWith("system/", StringComparison.Ordinal))
+        {
+            TryFindSystemIndex(metadata, trackId["system/".Length..], out var sysIdx);
+            var rows = metadata.SystemTickSummaries;
+            var n = 0;
+            for (var i = 0; i < rows.Length; i++)
+            {
+                ref readonly var r = ref rows[i];
+                if (r.SystemIndex == sysIdx && r.TickNumber >= t0 && r.TickNumber <= t1) { n++; }
+            }
+            return n;
+        }
+
+        if (trackId.StartsWith("queue/", StringComparison.Ordinal))
+        {
+            TryFindQueueId(metadata, trackId["queue/".Length..], out var qid);
+            var rows = metadata.QueueTickSummaries;
+            var n = 0;
+            for (var i = 0; i < rows.Length; i++)
+            {
+                ref readonly var r = ref rows[i];
+                if (r.QueueId == qid && r.TickNumber >= t0 && r.TickNumber <= t1) { n++; }
+            }
+            return n;
+        }
+
+        // posttick/<phase>
+        var prows = metadata.PostTickSummaries;
+        var pn = 0;
+        for (var i = 0; i < prows.Length; i++)
+        {
+            ref readonly var r = ref prows[i];
+            if (r.TickNumber >= t0 && r.TickNumber <= t1) { pn++; }
+        }
+        return pn;
+    }
+
+    private static void FillValues(Span<double> dest, TickSummaryDto[] ticks, AggregationQueryDto query, ProfilerMetadataDto metadata)
+    {
+        var t0 = query.Range[0];
+        var t1 = query.Range[1];
+        var trackId = query.TrackId;
+        var field = query.Field;
+        var idx = 0;
+
+        if (trackId == "tick/summary")
+        {
+            for (var i = 0; i < ticks.Length && idx < dest.Length; i++)
+            {
+                var t = ticks[i];
+                if (t.TickNumber < t0 || t.TickNumber > t1) { if (t.TickNumber > t1) break; continue; }
+                dest[idx++] = ExtractTickSummaryField(t, field);
+            }
+            return;
+        }
+        if (trackId == "metronome/wait")
+        {
+            for (var i = 0; i < ticks.Length && idx < dest.Length; i++)
+            {
+                var t = ticks[i];
+                if (t.TickNumber < t0 || t.TickNumber > t1) { if (t.TickNumber > t1) break; continue; }
+                dest[idx++] = field == "waitUs" ? t.MetronomeWaitUs : t.MetronomeIntentClass;
+            }
+            return;
+        }
+
+        if (trackId.StartsWith("system/", StringComparison.Ordinal))
+        {
+            TryFindSystemIndex(metadata, trackId["system/".Length..], out var sysIdx);
+            var rows = metadata.SystemTickSummaries;
+            for (var i = 0; i < rows.Length && idx < dest.Length; i++)
+            {
+                ref readonly var r = ref rows[i];
+                if (r.SystemIndex != sysIdx || r.TickNumber < t0 || r.TickNumber > t1) { continue; }
+                dest[idx++] = ExtractSystemField(in r, field);
+            }
+            return;
+        }
+        if (trackId.StartsWith("queue/", StringComparison.Ordinal))
+        {
+            TryFindQueueId(metadata, trackId["queue/".Length..], out var qid);
+            var rows = metadata.QueueTickSummaries;
+            for (var i = 0; i < rows.Length && idx < dest.Length; i++)
+            {
+                ref readonly var r = ref rows[i];
+                if (r.QueueId != qid || r.TickNumber < t0 || r.TickNumber > t1) { continue; }
+                dest[idx++] = ExtractQueueField(in r, field);
+            }
+            return;
+        }
+
+        // posttick/<phase>
+        var phase = trackId["posttick/".Length..];
+        var prows = metadata.PostTickSummaries;
+        for (var i = 0; i < prows.Length && idx < dest.Length; i++)
+        {
+            ref readonly var r = ref prows[i];
+            if (r.TickNumber < t0 || r.TickNumber > t1) { continue; }
+            dest[idx++] = ExtractPostTickField(in r, phase);
+        }
+    }
+
+    /// <summary>Same as FillValues but also captures the source tick number for each value (used by topk).</summary>
+    private static void FillValuesAndTicks(
+        Span<double> values,
+        Span<uint> tickNumbers,
+        TickSummaryDto[] ticks,
+        AggregationQueryDto query,
+        ProfilerMetadataDto metadata)
+    {
+        var t0 = query.Range[0];
+        var t1 = query.Range[1];
+        var trackId = query.TrackId;
+        var field = query.Field;
+        var idx = 0;
+
+        if (trackId == "tick/summary")
+        {
+            for (var i = 0; i < ticks.Length && idx < values.Length; i++)
+            {
+                var t = ticks[i];
+                if (t.TickNumber < t0 || t.TickNumber > t1) { if (t.TickNumber > t1) break; continue; }
+                values[idx] = ExtractTickSummaryField(t, field);
+                tickNumbers[idx] = t.TickNumber;
+                idx++;
+            }
+            return;
+        }
+        if (trackId == "metronome/wait")
+        {
+            for (var i = 0; i < ticks.Length && idx < values.Length; i++)
+            {
+                var t = ticks[i];
+                if (t.TickNumber < t0 || t.TickNumber > t1) { if (t.TickNumber > t1) break; continue; }
+                values[idx] = field == "waitUs" ? t.MetronomeWaitUs : t.MetronomeIntentClass;
+                tickNumbers[idx] = t.TickNumber;
+                idx++;
+            }
+            return;
+        }
+
+        if (trackId.StartsWith("system/", StringComparison.Ordinal))
+        {
+            TryFindSystemIndex(metadata, trackId["system/".Length..], out var sysIdx);
+            var rows = metadata.SystemTickSummaries;
+            for (var i = 0; i < rows.Length && idx < values.Length; i++)
+            {
+                ref readonly var r = ref rows[i];
+                if (r.SystemIndex != sysIdx || r.TickNumber < t0 || r.TickNumber > t1) { continue; }
+                values[idx] = ExtractSystemField(in r, field);
+                tickNumbers[idx] = r.TickNumber;
+                idx++;
+            }
+            return;
+        }
+        if (trackId.StartsWith("queue/", StringComparison.Ordinal))
+        {
+            TryFindQueueId(metadata, trackId["queue/".Length..], out var qid);
+            var rows = metadata.QueueTickSummaries;
+            for (var i = 0; i < rows.Length && idx < values.Length; i++)
+            {
+                ref readonly var r = ref rows[i];
+                if (r.QueueId != qid || r.TickNumber < t0 || r.TickNumber > t1) { continue; }
+                values[idx] = ExtractQueueField(in r, field);
+                tickNumbers[idx] = r.TickNumber;
+                idx++;
+            }
+            return;
+        }
+
+        var phase = trackId["posttick/".Length..];
+        var prows = metadata.PostTickSummaries;
+        for (var i = 0; i < prows.Length && idx < values.Length; i++)
+        {
+            ref readonly var r = ref prows[i];
+            if (r.TickNumber < t0 || r.TickNumber > t1) { continue; }
+            values[idx] = ExtractPostTickField(in r, phase);
+            tickNumbers[idx] = r.TickNumber;
+            idx++;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Per-row field extractors
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static double ExtractTickSummaryField(TickSummaryDto t, string field) => field switch
+    {
+        "durationUs"          => t.DurationUs,
+        "eventCount"          => t.EventCount,
+        "maxSystemDurationUs" => t.MaxSystemDurationUs,
+        "startUs"             => t.StartUs,
+        "overloadLevel"       => t.OverloadLevel,
+        "tickMultiplier"      => t.TickMultiplier,
+        "consecutiveOverrun"  => t.ConsecutiveOverrun,
+        "consecutiveUnderrun" => t.ConsecutiveUnderrun,
+        _                     => 0.0, // unreachable: validated.
+    };
+
+    private static double ExtractSystemField(in SystemTickSummary r, string field) => field switch
+    {
+        "durationUs"        => r.DurationUs,
+        "startUs"           => r.StartUs,
+        "endUs"             => r.EndUs,
+        "readyUs"           => r.ReadyUs,
+        "entitiesProcessed" => r.EntitiesProcessed,
+        "workersTouched"    => r.WorkersTouched,
+        "chunksProcessed"   => r.ChunksProcessed,
+        "skipReason"        => r.SkipReasonCode,
+        _                   => 0.0,
+    };
+
+    private static double ExtractQueueField(in QueueTickSummary r, string field) => field switch
+    {
+        "peakDepth"      => r.PeakDepth,
+        "endOfTickDepth" => r.EndOfTickDepth,
+        "overflowCount"  => r.OverflowCount,
+        "produced"       => r.Produced,
+        "consumed"       => r.Consumed,
+        _                => 0.0,
+    };
+
+    private static double ExtractPostTickField(in PostTickSummary r, string phase) => phase switch
+    {
+        "walFlush"           => r.WalFlushUs,
+        "writeTickFence"     => r.WriteTickFenceUs,
+        "tierBudget"         => r.TierBudgetUs,
+        "subscriptionOutput" => r.SubscriptionOutputUs,
+        "tierIndexRebuild"   => r.TierIndexRebuildUs,
+        "dormancySweep"      => r.DormancySweepUs,
+        _                    => 0.0,
+    };
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Tier 1 operators — single-pass (no allocation beyond the input span)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static double Sum(Span<double> values)
+    {
+        var sum = 0.0;
+        for (var i = 0; i < values.Length; i++) { sum += values[i]; }
+        return sum;
+    }
+
+    private static double Mean(Span<double> values) => Sum(values) / values.Length;
+
+    private static double Min(Span<double> values)
+    {
+        var m = double.MaxValue;
+        for (var i = 0; i < values.Length; i++) { if (values[i] < m) m = values[i]; }
+        return m;
+    }
+
+    private static double Max(Span<double> values)
+    {
+        var m = double.MinValue;
+        for (var i = 0; i < values.Length; i++) { if (values[i] > m) m = values[i]; }
+        return m;
+    }
+
+    /// <summary>Welford's online algorithm. <paramref name="varianceOut"/> is population variance.</summary>
+    private static double StdDev(Span<double> values, out double varianceOut)
+    {
+        var n = 0;
+        var mean = 0.0;
+        var m2 = 0.0;
+        for (var i = 0; i < values.Length; i++)
+        {
+            n++;
+            var v = values[i];
+            var delta = v - mean;
+            mean += delta / n;
+            m2 += delta * (v - mean);
+        }
+        varianceOut = n < 2 ? 0.0 : m2 / n;
+        return Math.Sqrt(varianceOut);
+    }
+
+    private static double VarianceOnly(Span<double> values)
+    {
+        StdDev(values, out var v);
+        return v;
+    }
+
+    /// <summary>Sorts a copy of <paramref name="values"/> and returns the value at the requested percentile (nearest-rank floor).</summary>
+    private static double Percentile(Span<double> values, int percentile)
+    {
+        // values is ours to mutate (caller copy).
+        values.Sort();
+        var index = (int)Math.Floor(percentile / 100.0 * (values.Length - 1));
+        return values[index];
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Tier 2 — histogram / topk / cdf
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Equal-width buckets across [min, max]. Last bucket includes max. Values may be mutated.</summary>
+    private static HistogramBucketDto[] ComputeHistogram(Span<double> values, int buckets)
+    {
+        var min = Min(values);
+        var max = Max(values);
+        var result = new HistogramBucketDto[buckets];
+
+        // Degenerate range — single value (or all equal): one full bucket, others empty.
+        if (max <= min)
+        {
+            for (var b = 0; b < buckets; b++)
+            {
+                result[b] = new HistogramBucketDto(min, min, b == 0 ? values.Length : 0);
+            }
+            return result;
+        }
+
+        var width = (max - min) / buckets;
+        var counts = new int[buckets];
+        for (var i = 0; i < values.Length; i++)
+        {
+            var idx = (int)Math.Floor((values[i] - min) / width);
+            if (idx < 0) idx = 0;
+            else if (idx >= buckets) idx = buckets - 1;
+            counts[idx]++;
+        }
+        for (var b = 0; b < buckets; b++)
+        {
+            var lo = min + b * width;
+            var hi = b == buckets - 1 ? max : min + (b + 1) * width;
+            result[b] = new HistogramBucketDto(lo, hi, counts[b]);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Sample the empirical CDF at <paramref name="samples"/> evenly-spaced quantiles in [0, 1].
+    /// Quantile <c>q</c> maps to the value at index <c>round(q * (n-1))</c> of the sorted set.
+    /// </summary>
+    private static CdfSampleDto[] ComputeCdf(Span<double> values, int samples)
+    {
+        values.Sort();
+        var n = values.Length;
+        var result = new CdfSampleDto[samples];
+        for (var i = 0; i < samples; i++)
+        {
+            var q = (double)i / (samples - 1);
+            var idx = (int)Math.Round(q * (n - 1));
+            if (idx < 0) idx = 0;
+            else if (idx >= n) idx = n - 1;
+            result[i] = new CdfSampleDto(q, values[idx]);
+        }
+        return result;
+    }
+
+    private static AggregationResultDto ComputeTopK(
+        TickSummaryDto[] ticks,
+        AggregationQueryDto query,
+        ProfilerMetadataDto metadata)
+    {
+        var n = query.N!.Value;
+        var count = CountMatching(ticks, query, metadata);
+        if (count == 0)
+        {
+            return new AggregationResultDto(TopK: System.Array.Empty<TopKEntryDto>());
+        }
+
+        // Need parallel sort on (value, tickNumber) — Array.Sort(keys, items) only operates on arrays.
+        // Negate then ascending-sort to get descending; restore sign before reading.
+        var valuesRent = ArrayPool<double>.Shared.Rent(count);
+        var ticksRent = ArrayPool<uint>.Shared.Rent(count);
+        try
+        {
+            FillValuesAndTicks(valuesRent.AsSpan(0, count), ticksRent.AsSpan(0, count), ticks, query, metadata);
+            for (var i = 0; i < count; i++) { valuesRent[i] = -valuesRent[i]; }
+            System.Array.Sort(valuesRent, ticksRent, 0, count);
+            for (var i = 0; i < count; i++) { valuesRent[i] = -valuesRent[i]; }
+
+            var take = Math.Min(n, count);
+            var entries = new TopKEntryDto[take];
+            for (var i = 0; i < take; i++)
+            {
+                entries[i] = new TopKEntryDto(ticksRent[i], valuesRent[i]);
+            }
+            return new AggregationResultDto(TopK: entries);
+        }
+        finally
+        {
+            ArrayPool<double>.Shared.Return(valuesRent);
+            ArrayPool<uint>.Shared.Return(ticksRent);
+        }
+    }
+}

--- a/tools/Typhon.Workbench/Services/StreamSubscriptionRegistry.cs
+++ b/tools/Typhon.Workbench/Services/StreamSubscriptionRegistry.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+
+namespace Typhon.Workbench.Services;
+
+/// <summary>
+/// Tracks per-connection event subscriptions for the unified data stream (#308 Phase C). Each
+/// connection registers under a server-assigned <c>streamId</c> on connect; clients then call
+/// <see cref="Subscribe"/> / <see cref="Unsubscribe"/> via the JSON API to grow / shrink the set
+/// of event types they want delivered. The unified-stream multiplexer consults
+/// <see cref="IsSubscribed"/> before serialising each delta.
+/// </summary>
+/// <remarks>
+/// <para><b>Default policy.</b> A freshly registered connection has an empty subscription set —
+/// only the connection-bootstrap events (<c>stream-id</c>, <c>metadata</c>, <c>session-state</c>,
+/// <c>heartbeat</c>, <c>shutdown</c>) bypass the filter; everything else (<c>tick</c>, <c>log</c>,
+/// <c>topology-changed</c>, <c>error</c>) requires explicit subscription. This avoids accidental
+/// fanout to panels that don't need the data and keeps the wire tight.</para>
+/// <para><b>Lifetime.</b> Entries are removed on connection disconnect via <see cref="Unregister"/>
+/// (called from the stream handler's <c>finally</c> block). The registry never times entries out
+/// on its own — connection liveness is the source of truth.</para>
+/// <para><b>Concurrency.</b> Backed by <see cref="ConcurrentDictionary{TKey, TValue}"/>; safe for
+/// the multiplexer to read from one thread while the controller writes from another. The inner
+/// per-stream set is also concurrent so partial subscribe calls don't tear.</para>
+/// </remarks>
+public sealed class StreamSubscriptionRegistry
+{
+    private readonly ConcurrentDictionary<Guid, ConcurrentDictionary<string, byte>> _entries = new();
+
+    /// <summary>
+    /// Registers a fresh connection under <paramref name="streamId"/> with an empty subscription
+    /// set. Returns silently if the streamId is already registered (idempotent — guards against
+    /// the multiplexer race where bootstrap events fire before the controller observes the
+    /// register call).
+    /// </summary>
+    public void Register(Guid streamId)
+    {
+        _entries.TryAdd(streamId, new ConcurrentDictionary<string, byte>());
+    }
+
+    /// <summary>
+    /// Removes the connection's subscription state. Idempotent — safe to call from the stream
+    /// handler's <c>finally</c> even if the connection died before <see cref="Register"/> ran.
+    /// </summary>
+    public void Unregister(Guid streamId)
+    {
+        _entries.TryRemove(streamId, out _);
+    }
+
+    /// <summary>
+    /// Adds <paramref name="events"/> to the subscription set for <paramref name="streamId"/>.
+    /// Unknown streamIds are silently ignored — clients racing the connection close don't get a
+    /// 4xx for what is effectively no-op cleanup.
+    /// </summary>
+    /// <returns><see langword="true"/> if the streamId is registered (regardless of which events
+    /// were already in the set); <see langword="false"/> if it was unknown.</returns>
+    public bool Subscribe(Guid streamId, IReadOnlyList<string> events)
+    {
+        if (!_entries.TryGetValue(streamId, out var set))
+        {
+            return false;
+        }
+        for (var i = 0; i < events.Count; i++)
+        {
+            set.TryAdd(events[i], 0);
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Removes <paramref name="events"/> from the subscription set for <paramref name="streamId"/>.
+    /// Unknown streamIds are silently ignored.
+    /// </summary>
+    public bool Unsubscribe(Guid streamId, IReadOnlyList<string> events)
+    {
+        if (!_entries.TryGetValue(streamId, out var set))
+        {
+            return false;
+        }
+        for (var i = 0; i < events.Count; i++)
+        {
+            set.TryRemove(events[i], out _);
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="streamId"/>'s subscription set contains
+    /// <paramref name="eventType"/>. Unknown streamIds return <see langword="false"/> — events
+    /// destined for a vanished connection are dropped silently. The multiplexer consults this
+    /// once per delta on the hot path; the dictionary lookups are O(1) average.
+    /// </summary>
+    public bool IsSubscribed(Guid streamId, string eventType)
+    {
+        return _entries.TryGetValue(streamId, out var set) && set.ContainsKey(eventType);
+    }
+
+    /// <summary>
+    /// Snapshots the subscription set for diagnostics / tests. Allocates — not for hot-path use.
+    /// </summary>
+    public string[] Snapshot(Guid streamId)
+    {
+        if (!_entries.TryGetValue(streamId, out var set))
+        {
+            return [];
+        }
+        return [.. set.Keys];
+    }
+}

--- a/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.cs
+++ b/tools/Typhon.Workbench/Sessions/AttachSessionRuntime.cs
@@ -77,6 +77,7 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
     private SystemDefinitionDto[] _initialSystems = [];
     private ArchetypeDto[] _initialArchetypes = [];
     private ComponentTypeDto[] _initialComponentTypes = [];
+    private string[] _initialPhases = [];
     private string _initialSignature;
 
     /// <summary>
@@ -517,7 +518,13 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
                     relocatedManifest,
                     spanNames,
                     _initialMetadataBytes,
-                    cacheHeader);
+                    cacheHeader,
+                    // v12 (#311): live save flow — the in-memory builder owns the per-(tick, system/queue)/post-tick rollup lists.
+                    // Snapshot them at the same point as the manifest so the saved cache reads identically to a freshly-built one.
+                    systemTickSummaries: _builder?.SystemTickSummaries ?? Array.Empty<Typhon.Profiler.SystemTickSummary>(),
+                    queueTickSummaries: _builder?.QueueTickSummaries ?? Array.Empty<Typhon.Profiler.QueueTickSummary>(),
+                    postTickSummaries: _builder?.PostTickSummaries ?? Array.Empty<Typhon.Profiler.PostTickSummary>(),
+                    queueIdToName: _builder?.QueueIdToName ?? new System.Collections.Generic.Dictionary<ushort, string>());
             }
             finally
             {
@@ -687,11 +694,13 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
         reader.ReadSystemDefinitions();
         reader.ReadArchetypes();
         reader.ReadComponentTypes();
+        reader.ReadPhases();
 
         var headerDto = ProjectHeader(reader);
         var systems = ProjectSystems(reader);
         var archetypes = ProjectArchetypes(reader);
         var componentTypes = ProjectComponentTypes(reader);
+        var phases = reader.Phases.ToArray();
 
         var newSignature = ComputeInitSignature(headerDto, systems, archetypes, componentTypes);
 
@@ -702,6 +711,7 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
             _initialSystems = systems;
             _initialArchetypes = archetypes;
             _initialComponentTypes = componentTypes;
+            _initialPhases = phases;
             _initialSignature = newSignature;
             _timestampFrequency = headerDto.TimestampFrequency;
             // Capture the raw Init payload bytes — needed verbatim for the SourceMetadata section if the user later saves the live session
@@ -1031,6 +1041,13 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
             chunkManifestArr = _chunkManifest.ToArray();
             metrics = _globalMetrics;
         }
+        // v12 (#311) — snapshot the live builder's per-(tick, system/queue) and post-tick rollups so tracks endpoints serve them
+        // immediately. Builder is null on welcome screen / disconnected sessions.
+        var sysTicks = _builder?.SystemTickSummaries is { Count: > 0 } st ? ((List<Typhon.Profiler.SystemTickSummary>)st).ToArray() : [];
+        var qTicks = _builder?.QueueTickSummaries is { Count: > 0 } qt ? ((List<Typhon.Profiler.QueueTickSummary>)qt).ToArray() : [];
+        var postTicks = _builder?.PostTickSummaries is { Count: > 0 } pt ? ((List<Typhon.Profiler.PostTickSummary>)pt).ToArray() : [];
+        var qNames = _builder?.QueueIdToName is { Count: > 0 } qn ? new Dictionary<ushort, string>(qn) : new Dictionary<ushort, string>();
+
         var snap = new ProfilerMetadataDto(
             Fingerprint: string.Empty,
             Header: _initialHeader ?? new ProfilerHeaderDto(0, 0, 0, 0, 0, 0, 0, 0, 0),
@@ -1041,7 +1058,12 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
             GlobalMetrics: metrics,
             TickSummaries: tickSummariesArr,
             ChunkManifest: chunkManifestArr,
-            GcSuspensions: []);
+            GcSuspensions: [],
+            Phases: _initialPhases ?? [],
+            SystemTickSummaries: sysTicks,
+            QueueTickSummaries: qTicks,
+            PostTickSummaries: postTicks,
+            QueueIdToName: qNames);
         _metadataSnapshot = snap;
         return snap;
     }
@@ -1168,7 +1190,21 @@ public sealed partial class AttachSessionRuntime : IDisposable, IChunkProvider
                 IsParallel: sr.IsParallel,
                 TierFilter: sr.TierFilter,
                 Predecessors: sr.Predecessors,
-                Successors: sr.Successors);
+                Successors: sr.Successors,
+                PhaseName: sr.PhaseName,
+                IsExclusivePhase: sr.IsExclusivePhase,
+                Reads: sr.Reads,
+                ReadsFresh: sr.ReadsFresh,
+                ReadsSnapshot: sr.ReadsSnapshot,
+                AdditionalReads: sr.AdditionalReads,
+                Writes: sr.Writes,
+                SideWrites: sr.SideWrites,
+                WritesEvents: sr.WritesEvents,
+                ReadsEvents: sr.ReadsEvents,
+                WritesResources: sr.WritesResources,
+                ReadsResources: sr.ReadsResources,
+                ExplicitAfter: sr.ExplicitAfter,
+                ExplicitBefore: sr.ExplicitBefore);
         }
         return arr;
     }

--- a/tools/Typhon.Workbench/Sessions/TraceSessionRuntime.cs
+++ b/tools/Typhon.Workbench/Sessions/TraceSessionRuntime.cs
@@ -339,10 +339,10 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
     }
 
     /// <summary>
-    /// Walks a <see cref="TraceFileReader"/> positioned at offset 0 (header + 3 tables) and projects each into the wire DTO shape. Shared
-    /// between the source-file path and the embedded-metadata path so both produce byte-identical metadata DTOs.
+    /// Walks a <see cref="TraceFileReader"/> positioned at offset 0 (header + 3 tables + optional v6 phases table) and projects each into the
+    /// wire DTO shape. Shared between the source-file path and the embedded-metadata path so both produce byte-identical metadata DTOs.
     /// </summary>
-    private static (ProfilerHeaderDto, SystemDefinitionDto[], ArchetypeDto[], ComponentTypeDto[]) ProjectHeaderAndTables(TraceFileReader traceReader)
+    private static (ProfilerHeaderDto, SystemDefinitionDto[], ArchetypeDto[], ComponentTypeDto[], string[]) ProjectHeaderAndTables(TraceFileReader traceReader)
     {
         var h = traceReader.ReadHeader();
         var headerDto = new ProfilerHeaderDto(
@@ -369,7 +369,21 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
                 IsParallel: sr.IsParallel,
                 TierFilter: sr.TierFilter,
                 Predecessors: sr.Predecessors,
-                Successors: sr.Successors);
+                Successors: sr.Successors,
+                PhaseName: sr.PhaseName,
+                IsExclusivePhase: sr.IsExclusivePhase,
+                Reads: sr.Reads,
+                ReadsFresh: sr.ReadsFresh,
+                ReadsSnapshot: sr.ReadsSnapshot,
+                AdditionalReads: sr.AdditionalReads,
+                Writes: sr.Writes,
+                SideWrites: sr.SideWrites,
+                WritesEvents: sr.WritesEvents,
+                ReadsEvents: sr.ReadsEvents,
+                WritesResources: sr.WritesResources,
+                ReadsResources: sr.ReadsResources,
+                ExplicitAfter: sr.ExplicitAfter,
+                ExplicitBefore: sr.ExplicitBefore);
         }
 
         var archetypeRecords = traceReader.ReadArchetypes();
@@ -386,7 +400,10 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
             componentTypes[i] = new ComponentTypeDto(componentRecords[i].ComponentTypeId, componentRecords[i].Name);
         }
 
-        return (headerDto, systems, archetypes, componentTypes);
+        // Phases section — present in v6+ traces only; reader returns empty for v5.
+        var phases = traceReader.ReadPhases().ToArray();
+
+        return (headerDto, systems, archetypes, componentTypes, phases);
     }
 
     /// <summary>
@@ -424,6 +441,7 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
         SystemDefinitionDto[] systems;
         ArchetypeDto[] archetypes;
         ComponentTypeDto[] componentTypes;
+        string[] phases;
 
         if (isReplayFile)
         {
@@ -432,14 +450,14 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
             var metaCopy = reader.SourceMetadataBytes.ToArray();
             using var ms = new MemoryStream(metaCopy, writable: false);
             using var traceReader = new TraceFileReader(ms);
-            (headerDto, systems, archetypes, componentTypes) = ProjectHeaderAndTables(traceReader);
+            (headerDto, systems, archetypes, componentTypes, phases) = ProjectHeaderAndTables(traceReader);
         }
         else
         {
             // Read source tables (header is already read by ReadSourceTimestampFrequency, but we need the tables — re-open and walk).
             using var fs = File.OpenRead(sourcePath);
             using var traceReader = new TraceFileReader(fs);
-            (headerDto, systems, archetypes, componentTypes) = ProjectHeaderAndTables(traceReader);
+            (headerDto, systems, archetypes, componentTypes, phases) = ProjectHeaderAndTables(traceReader);
         }
 
         // Tick summaries, manifest, metrics, aggregates all come from the cache reader (already in memory).
@@ -498,6 +516,12 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
 
         var fingerprintHex = Convert.ToHexString(fingerprint);
 
+        // v12 (#311) — pull per-tick rollups directly off the cache reader. v11-or-older caches return empty lists.
+        var sysTicks = reader.SystemTickSummaries is { Count: > 0 } st ? ((List<Typhon.Profiler.SystemTickSummary>)st).ToArray() : [];
+        var qTicks = reader.QueueTickSummaries is { Count: > 0 } qt ? ((List<Typhon.Profiler.QueueTickSummary>)qt).ToArray() : [];
+        var postTicks = reader.PostTickSummaries is { Count: > 0 } pt ? ((List<Typhon.Profiler.PostTickSummary>)pt).ToArray() : [];
+        var qNames = reader.QueueIdToName is { Count: > 0 } qn ? new Dictionary<ushort, string>(qn) : new Dictionary<ushort, string>();
+
         return new ProfilerMetadataDto(
             Fingerprint: fingerprintHex,
             Header: headerDto,
@@ -508,7 +532,12 @@ public sealed partial class TraceSessionRuntime : IDisposable, IChunkProvider
             GlobalMetrics: globalMetrics,
             TickSummaries: tickSummaries,
             ChunkManifest: manifest,
-            GcSuspensions: gcSuspensions);
+            GcSuspensions: gcSuspensions,
+            Phases: phases,
+            SystemTickSummaries: sysTicks,
+            QueueTickSummaries: qTicks,
+            PostTickSummaries: postTicks,
+            QueueIdToName: qNames);
     }
 
     /// <summary>

--- a/tools/Typhon.Workbench/Streams/HeartbeatStream.cs
+++ b/tools/Typhon.Workbench/Streams/HeartbeatStream.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Typhon.Workbench.Sessions;
 using WbSession = Typhon.Workbench.Sessions.ISession;
 
@@ -7,6 +6,9 @@ namespace Typhon.Workbench.Streams;
 public static class HeartbeatStream
 {
     private static readonly TimeSpan Interval = TimeSpan.FromSeconds(10);
+
+    /// <summary>SSE event type. Clients listen via <c>addEventListener('heartbeat', ...)</c>.</summary>
+    public const string EventType = "heartbeat";
 
     public static async Task HandleAsync(
         Guid sessionId,
@@ -36,7 +38,7 @@ public static class HeartbeatStream
             return;
         }
 
-        if (session is not OpenSession open)
+        if (session is not OpenSession)
         {
             // Attach/Trace sessions have no heartbeat semantics yet — refuse rather than silently
             // serve zeroed payloads that misrepresent the session state to the UI.
@@ -44,15 +46,13 @@ public static class HeartbeatStream
             return;
         }
 
-        ctx.Response.Headers.ContentType = "text/event-stream";
-        ctx.Response.Headers.CacheControl = "no-cache";
-        ctx.Response.Headers.Connection = "keep-alive";
+        await SseExtensions.WriteSseHeadersAsync(ctx, ct);
 
         try
         {
             while (!ct.IsCancellationRequested)
             {
-                var payload = JsonSerializer.Serialize(new
+                var payload = new
                 {
                     timestamp = DateTimeOffset.UtcNow,
                     // revision: still a placeholder — DatabaseEngine doesn't expose a global monotonic revision yet.
@@ -62,10 +62,9 @@ public static class HeartbeatStream
                     memoryMb = GC.GetTotalMemory(forceFullCollection: false) / 1_000_000,
                     tickRate = (int?)null,
                     activeTransactionCount = (int?)null,
-                    lastTickDurationMs = (float?)null
-                });
-                await ctx.Response.WriteAsync($"data: {payload}\n\n", ct);
-                await ctx.Response.Body.FlushAsync(ct);
+                    lastTickDurationMs = (float?)null,
+                };
+                await SseExtensions.WriteEventAsync(ctx, EventType, payload, ct);
                 await Task.Delay(Interval, ct);
             }
         }

--- a/tools/Typhon.Workbench/Streams/OptionsChangedStream.cs
+++ b/tools/Typhon.Workbench/Streams/OptionsChangedStream.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Channels;
 using Typhon.Workbench.Hosting;
 
@@ -10,7 +8,7 @@ namespace Typhon.Workbench.Streams;
 /// The browser opens an <c>EventSource</c> at <c>GET /api/options/stream</c> on app start and stays
 /// connected for the session — when the on-disk options file changes (out-of-band edit, or another
 /// Workbench window <c>PATCH</c>ing) the store's <c>OptionsChanged</c> event fires and we serialize
-/// the new document into a single <c>data:</c> frame.
+/// the new document into a single <c>options-changed</c> typed event (#308).
 /// </summary>
 /// <remarks>
 /// Bootstrap-token-gated via the URL prefix; <c>EventSource</c> can't send custom headers, so the
@@ -22,20 +20,15 @@ public static class OptionsChangedStream
 {
     private static readonly TimeSpan KeepaliveInterval = TimeSpan.FromSeconds(30);
 
-    private static readonly JsonSerializerOptions JsonOpts = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-    };
+    /// <summary>SSE event type. Clients listen via <c>addEventListener('options-changed', ...)</c>.</summary>
+    public const string EventType = "options-changed";
 
     public static async Task HandleAsync(
         HttpContext ctx,
         OptionsStore store,
         CancellationToken ct)
     {
-        ctx.Response.Headers.ContentType = "text/event-stream";
-        ctx.Response.Headers.CacheControl = "no-cache";
-        ctx.Response.Headers.Connection = "keep-alive";
+        await SseExtensions.WriteSseHeadersAsync(ctx, ct);
 
         // Buffer changes via a bounded channel — handler awaits ReadAsync and writes one SSE frame
         // per options snapshot. Bounded(1, DropOldest) coalesces bursts: if two PATCHes fire while
@@ -68,15 +61,11 @@ public static class OptionsChangedStream
                 if (winner == readTask)
                 {
                     var snapshot = await readTask;
-                    var payload = JsonSerializer.Serialize(snapshot, JsonOpts);
-                    await ctx.Response.WriteAsync($"data: {payload}\n\n", ct);
-                    await ctx.Response.Body.FlushAsync(ct);
+                    await SseExtensions.WriteEventAsync(ctx, EventType, snapshot, ct);
                 }
                 else
                 {
-                    // Comment-only frame keeps idle proxies from harvesting the connection.
-                    await ctx.Response.WriteAsync(": keepalive\n\n", ct);
-                    await ctx.Response.Body.FlushAsync(ct);
+                    await SseExtensions.WriteCommentAsync(ctx, "keepalive", ct);
                 }
             }
         }

--- a/tools/Typhon.Workbench/Streams/ProfilerBuildProgressStream.cs
+++ b/tools/Typhon.Workbench/Streams/ProfilerBuildProgressStream.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Threading.Channels;
 using Typhon.Workbench.Dtos.Profiler;
 using Typhon.Workbench.Sessions;
@@ -7,12 +6,27 @@ using WbSession = Typhon.Workbench.Sessions.ISession;
 namespace Typhon.Workbench.Streams;
 
 /// <summary>
-/// SSE stream of <see cref="BuildProgressDto"/> frames while a Trace session's sidecar cache is being built.
-/// Emits <c>progress</c> events throttled by the builder's 200 ms interval; emits a terminal <c>done</c> or
-/// <c>error</c> event when the build finishes, then closes the stream.
+/// SSE stream emitting typed events while a Trace session's sidecar cache is being built (#308):
+/// <list type="bullet">
+///   <item><c>progress</c> — throttled by the builder's 200 ms interval; carries bytes / counts.</item>
+///   <item><c>done</c> — terminal success; empty payload.</item>
+///   <item><c>error</c> — terminal failure; carries <see cref="BuildProgressDto.Message"/>.</item>
+/// </list>
+/// After the terminal <c>done</c> or <c>error</c> the server cleanly closes the stream.
 /// </summary>
 public static class ProfilerBuildProgressStream
 {
+    /// <summary>SSE event type for in-progress build frames.</summary>
+    public const string ProgressEvent = "progress";
+
+    /// <summary>SSE event type for the terminal success frame.</summary>
+    public const string DoneEvent = "done";
+
+    /// <summary>SSE event type for the terminal failure frame.</summary>
+    public const string ErrorEvent = "error";
+
+    private record struct Frame(string EventType, BuildProgressDto Payload);
+
     public static async Task HandleAsync(
         Guid sessionId,
         HttpContext ctx,
@@ -38,12 +52,9 @@ public static class ProfilerBuildProgressStream
             return;
         }
 
-        ctx.Response.Headers.ContentType = "text/event-stream";
-        ctx.Response.Headers.CacheControl = "no-cache";
-        ctx.Response.Headers.Connection = "keep-alive";
-        await ctx.Response.Body.FlushAsync(ct);
+        await SseExtensions.WriteSseHeadersAsync(ctx, ct);
 
-        var channel = Channel.CreateUnbounded<BuildProgressDto>(new UnboundedChannelOptions
+        var channel = Channel.CreateUnbounded<Frame>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = false,
@@ -51,23 +62,22 @@ public static class ProfilerBuildProgressStream
 
         Action<TraceSessionRuntime.BuildProgressEventArgs> progressHandler = args =>
         {
-            channel.Writer.TryWrite(new BuildProgressDto(
-                Phase: "building",
+            channel.Writer.TryWrite(new Frame(ProgressEvent, new BuildProgressDto(
                 BytesRead: args.BytesRead,
                 TotalBytes: args.TotalBytes,
                 TickCount: args.TickCount,
-                EventCount: args.EventCount));
+                EventCount: args.EventCount)));
         };
 
         Action<ProfilerMetadataDto> completedHandler = _ =>
         {
-            channel.Writer.TryWrite(new BuildProgressDto(Phase: "done"));
+            channel.Writer.TryWrite(new Frame(DoneEvent, new BuildProgressDto()));
             channel.Writer.TryComplete();
         };
 
         Action<string> failedHandler = msg =>
         {
-            channel.Writer.TryWrite(new BuildProgressDto(Phase: "error", Message: msg));
+            channel.Writer.TryWrite(new Frame(ErrorEvent, new BuildProgressDto(Message: msg)));
             channel.Writer.TryComplete();
         };
 
@@ -91,11 +101,11 @@ public static class ProfilerBuildProgressStream
             {
                 if (trace.Runtime.Metadata != null)
                 {
-                    channel.Writer.TryWrite(new BuildProgressDto(Phase: "done"));
+                    channel.Writer.TryWrite(new Frame(DoneEvent, new BuildProgressDto()));
                 }
                 else
                 {
-                    channel.Writer.TryWrite(new BuildProgressDto(Phase: "error", Message: "Build failed before stream connected."));
+                    channel.Writer.TryWrite(new Frame(ErrorEvent, new BuildProgressDto(Message: "Build failed before stream connected.")));
                 }
                 channel.Writer.TryComplete();
             }
@@ -121,29 +131,21 @@ public static class ProfilerBuildProgressStream
 
     private static async Task FlushLoop(
         HttpContext ctx,
-        ChannelReader<BuildProgressDto> reader,
+        ChannelReader<Frame> reader,
         CancellationToken ct)
     {
-        // All frames ship as default `message` events — the Workbench's generic useEventSource hook only listens to
-        // onmessage. Terminal-state signal lives in the payload's `phase` field, which the client switches on.
+        // Each frame ships as a typed SSE event — clients install one addEventListener per type
+        // (progress / done / error) and narrow the payload by event-type at compile time.
         while (await reader.WaitToReadAsync(ct))
         {
-            while (reader.TryRead(out var evt))
+            while (reader.TryRead(out var frame))
             {
-                var payload = JsonSerializer.Serialize(evt, SseJsonOptions.Web);
-                await WriteDataAsync(ctx, payload, ct);
-                if (evt.Phase is "done" or "error")
+                await SseExtensions.WriteEventAsync(ctx, frame.EventType, frame.Payload, ct);
+                if (frame.EventType is DoneEvent or ErrorEvent)
                 {
                     return;
                 }
             }
-            await ctx.Response.Body.FlushAsync(ct);
         }
-    }
-
-    private static async Task WriteDataAsync(HttpContext ctx, string data, CancellationToken ct)
-    {
-        await ctx.Response.WriteAsync($"data: {data}\n\n", ct);
-        await ctx.Response.Body.FlushAsync(ct);
     }
 }

--- a/tools/Typhon.Workbench/Streams/ProfilerLiveStream.cs
+++ b/tools/Typhon.Workbench/Streams/ProfilerLiveStream.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Threading.Channels;
 using Typhon.Workbench.Dtos.Profiler;
 using Typhon.Workbench.Sessions;
@@ -7,15 +6,16 @@ using WbSession = Typhon.Workbench.Sessions.ISession;
 namespace Typhon.Workbench.Streams;
 
 /// <summary>
-/// SSE stream of <see cref="LiveStreamEventDto"/> growth-deltas for an Attach session (#289 unified pipeline).
-/// Emits a full <c>metadata</c> snapshot on connect / reconnect, then per-tick / per-chunk / 1 Hz metrics deltas as the
-/// builder grows the in-memory cache. <c>heartbeat</c> on connection-state changes and on 5 s idle timeouts;
-/// <c>shutdown</c> when the engine ends the session.
+/// SSE stream of growth-deltas for an Attach session (#289 unified pipeline; retyped for #308).
+/// Emits a full <c>metadata</c> snapshot on connect / reconnect, then per-tick / per-chunk / 1 Hz
+/// metrics deltas as the builder grows the in-memory cache. Each delta ships as a typed SSE event
+/// (<c>event: tickSummaryAdded</c> etc.) — clients install one <c>addEventListener</c> per kind for
+/// clean TypeScript narrowing instead of switching on a discriminator inside the JSON payload.
+/// <c>heartbeat</c> on connection-state changes and on 5 s idle timeouts; <c>shutdown</c> when the
+/// engine ends the session.
 /// </summary>
 public static class ProfilerLiveStream
 {
-    private static JsonSerializerOptions WireOpts => SseJsonOptions.Web;
-
     private const int HeartbeatTimeoutMs = 5000;
 
     public static async Task HandleAsync(
@@ -42,10 +42,7 @@ public static class ProfilerLiveStream
             return;
         }
 
-        ctx.Response.Headers.ContentType = "text/event-stream";
-        ctx.Response.Headers.CacheControl = "no-cache";
-        ctx.Response.Headers.Connection = "keep-alive";
-        await ctx.Response.Body.FlushAsync(ct);
+        await SseExtensions.WriteSseHeadersAsync(ctx, ct);
 
         var runtime = attach.Runtime;
         var (subscriberId, reader) = runtime.Subscribe();
@@ -123,10 +120,11 @@ public static class ProfilerLiveStream
         }
     }
 
-    private static async Task WriteEventAsync(HttpContext ctx, LiveStreamEventDto evt, CancellationToken ct)
-    {
-        var json = JsonSerializer.Serialize(evt, WireOpts);
-        await ctx.Response.WriteAsync($"data: {json}\n\n", ct);
-        await ctx.Response.Body.FlushAsync(ct);
-    }
+    /// <summary>
+    /// Emits one <see cref="LiveStreamEventDto"/> as a typed SSE event. The <see cref="LiveStreamEventDto.Kind"/>
+    /// becomes the <c>event:</c> line; <see cref="JsonIgnoreAttribute"/> on <c>Kind</c> keeps it out of the
+    /// payload so the wire stays clean.
+    /// </summary>
+    private static Task WriteEventAsync(HttpContext ctx, LiveStreamEventDto evt, CancellationToken ct)
+        => SseExtensions.WriteEventAsync(ctx, evt.Kind, evt, ct);
 }

--- a/tools/Typhon.Workbench/Streams/ResourceGraphStream.cs
+++ b/tools/Typhon.Workbench/Streams/ResourceGraphStream.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Threading.Channels;
 using Typhon.Engine;
 using Typhon.Workbench.Dtos.Resources;
@@ -11,11 +10,14 @@ namespace Typhon.Workbench.Streams;
 /// SSE stream pushing <see cref="ResourceGraphEventDto"/> frames whenever the session's engine
 /// reports an <see cref="IResourceRegistry.NodeMutated"/> event. Rate-limited to ~10 frames per
 /// second per session via a 100 ms flush interval that coalesces duplicate (Kind, NodeId) events
-/// inside each window.
+/// inside each window. Each event ships as a typed SSE <c>resource-mutation</c> event (#308).
 /// </summary>
 public static class ResourceGraphStream
 {
     private static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>SSE event type. Clients listen via <c>addEventListener('resource-mutation', ...)</c>.</summary>
+    public const string EventType = "resource-mutation";
 
     public static async Task HandleAsync(
         Guid sessionId,
@@ -48,12 +50,7 @@ public static class ResourceGraphStream
             return;
         }
 
-        ctx.Response.Headers.ContentType = "text/event-stream";
-        ctx.Response.Headers.CacheControl = "no-cache";
-        ctx.Response.Headers.Connection = "keep-alive";
-
-        // Force headers to flush now so clients don't block awaiting the first event frame.
-        await ctx.Response.Body.FlushAsync(ct);
+        await SseExtensions.WriteSseHeadersAsync(ctx, ct);
 
         var channel = Channel.CreateUnbounded<ResourceMutationEventArgs>(new UnboundedChannelOptions
         {
@@ -113,15 +110,14 @@ public static class ResourceGraphStream
 
             foreach (var evt in pending.Values)
             {
-                var payload = JsonSerializer.Serialize(new ResourceGraphEventDto(
+                var payload = new ResourceGraphEventDto(
                     Kind: evt.Kind.ToString(),
                     NodeId: evt.NodeId,
                     ParentId: evt.ParentId,
                     Type: evt.Type.ToString(),
-                    Timestamp: new DateTimeOffset(evt.Timestamp, TimeSpan.Zero)));
-                await ctx.Response.WriteAsync($"data: {payload}\n\n", ct);
+                    Timestamp: new DateTimeOffset(evt.Timestamp, TimeSpan.Zero));
+                await SseExtensions.WriteEventAsync(ctx, EventType, payload, ct);
             }
-            await ctx.Response.Body.FlushAsync(ct);
             pending.Clear();
 
             // Coalescing window — subsequent events during this delay batch into the next frame.

--- a/tools/Typhon.Workbench/Streams/SseExtensions.cs
+++ b/tools/Typhon.Workbench/Streams/SseExtensions.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+
+namespace Typhon.Workbench.Streams;
+
+/// <summary>
+/// Shared SSE writer helpers used by every Workbench stream (#308). Centralises the wire format so
+/// every stream emits typed <c>event:</c> + <c>data:</c> frames identically — clients can use
+/// <c>addEventListener('&lt;event-type&gt;', ...)</c> for clean TypeScript narrowing instead of
+/// switching on a discriminator inside the JSON payload.
+/// </summary>
+public static class SseExtensions
+{
+    /// <summary>
+    /// Sets the three SSE response headers (<c>Content-Type</c>, <c>Cache-Control</c>,
+    /// <c>Connection</c>) and flushes them so the client unblocks before the first event arrives.
+    /// Call once at the top of every stream handler after auth succeeds.
+    /// </summary>
+    public static async Task WriteSseHeadersAsync(HttpContext ctx, CancellationToken ct)
+    {
+        ctx.Response.Headers.ContentType = "text/event-stream";
+        ctx.Response.Headers.CacheControl = "no-cache";
+        ctx.Response.Headers.Connection = "keep-alive";
+        await ctx.Response.Body.FlushAsync(ct);
+    }
+
+    /// <summary>
+    /// Writes one typed SSE frame: <c>event: &lt;eventType&gt;\ndata: &lt;json&gt;\n\n</c>, then
+    /// flushes. The payload is serialised with <see cref="SseJsonOptions.Web"/> for consistent
+    /// camelCase wire format — never call <see cref="JsonSerializer.Serialize{T}(T, JsonSerializerOptions)"/>
+    /// directly inside a stream.
+    /// </summary>
+    public static async Task WriteEventAsync<T>(
+        HttpContext ctx,
+        string eventType,
+        T payload,
+        CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(payload, SseJsonOptions.Web);
+        await ctx.Response.WriteAsync($"event: {eventType}\ndata: {json}\n\n", ct);
+        await ctx.Response.Body.FlushAsync(ct);
+    }
+
+    /// <summary>
+    /// Writes one typed SSE frame using a pre-serialised JSON string. Useful when the caller has
+    /// custom serialisation needs (e.g., <see cref="JsonDocument"/> reuse) and wants to avoid the
+    /// double-serialisation cost.
+    /// </summary>
+    public static async Task WriteEventRawAsync(
+        HttpContext ctx,
+        string eventType,
+        string json,
+        CancellationToken ct)
+    {
+        await ctx.Response.WriteAsync($"event: {eventType}\ndata: {json}\n\n", ct);
+        await ctx.Response.Body.FlushAsync(ct);
+    }
+
+    /// <summary>
+    /// Writes a comment-only SSE frame (<c>: &lt;text&gt;\n\n</c>) for keepalives. EventSource
+    /// clients ignore comment frames but proxies and NAT idle-timeout watchers see them as live
+    /// traffic, preventing connection harvesting on otherwise-quiet streams.
+    /// </summary>
+    public static async Task WriteCommentAsync(HttpContext ctx, string text, CancellationToken ct)
+    {
+        await ctx.Response.WriteAsync($": {text}\n\n", ct);
+        await ctx.Response.Body.FlushAsync(ct);
+    }
+}

--- a/tools/Typhon.Workbench/Streams/UnifiedDataStream.cs
+++ b/tools/Typhon.Workbench/Streams/UnifiedDataStream.cs
@@ -1,0 +1,338 @@
+using System.Threading.Channels;
+using Typhon.Workbench.Dtos.Profiler;
+using Typhon.Workbench.Services;
+using Typhon.Workbench.Sessions;
+using WbSession = Typhon.Workbench.Sessions.ISession;
+
+namespace Typhon.Workbench.Streams;
+
+/// <summary>
+/// Unified Data API SSE endpoint at <c>GET /api/sessions/{id}/stream</c> (#308 Phase B). Replaces
+/// the disparate <c>profiler/stream</c> + ad-hoc per-panel SSE consumers with a single multiplexed
+/// channel of typed events:
+/// <list type="bullet">
+///   <item><b>Bootstrap (always sent, bypasses subscription filter):</b>
+///     <c>stream-id</c> → <c>metadata</c> → <c>session-state</c>.</item>
+///   <item><b>Live deltas (filtered through <see cref="StreamSubscriptionRegistry"/>):</b>
+///     <c>tick</c>, <c>log</c>, <c>topology-changed</c>, <c>error</c>.</item>
+///   <item><b>Heartbeat &amp; lifecycle (always sent):</b>
+///     <c>heartbeat</c> every 5 s, <c>shutdown</c> when the session ends.</item>
+/// </list>
+/// Tick events use a 1-slot DropOldest channel so a slow consumer drops intermediate ticks but
+/// always sees the most recent one — matching the coalescing semantics of <c>OptionsChangedStream</c>
+/// but applied per-event-type so non-coalescing event classes (logs, errors) are not affected.
+/// </summary>
+/// <remarks>
+/// <para><b>Auth.</b> EventSource cannot send custom headers, so the URL sessionId is the
+/// auth boundary (per ADR-048; the bootstrap-token gate is enforced at the proxy layer for
+/// browser clients, and server-to-server clients can additionally send <c>X-Session-Token</c>).</para>
+/// <para><b>Subscription state.</b> A <c>streamId</c> is generated server-side and emitted on
+/// the very first frame so clients can target subsequent <c>POST /subscribe</c> /
+/// <c>POST /unsubscribe</c> calls at this connection rather than the session — multi-tab clients
+/// thus maintain independent subscription sets without coordination.</para>
+/// </remarks>
+public static class UnifiedDataStream
+{
+    /// <summary>Heartbeat cadence (also used as the multiplexer's idle timeout).</summary>
+    private const int HeartbeatTimeoutMs = 5000;
+
+    /// <summary>Bootstrap events bypass the subscription filter — clients always need them.</summary>
+    private static readonly HashSet<string> BootstrapEvents = new(StringComparer.Ordinal)
+    {
+        "stream-id",
+        "metadata",
+        "session-state",
+        "heartbeat",
+        "shutdown",
+        "error",
+    };
+
+    public static async Task HandleAsync(
+        Guid sessionId,
+        HttpContext ctx,
+        SessionManager sessions,
+        StreamSubscriptionRegistry registry,
+        CancellationToken ct)
+    {
+        WbSession session = null;
+        if (ctx.Request.Headers.TryGetValue("X-Session-Token", out var rawToken)
+            && Guid.TryParse(rawToken, out var token)
+            && sessions.TryGet(token, out var s))
+        {
+            session = s;
+        }
+        else if (sessions.TryGet(sessionId, out var s2))
+        {
+            session = s2;
+        }
+
+        if (session == null)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return;
+        }
+
+        // The unified stream is a profiler-data surface (per design §10). Database-open sessions
+        // expose their state via /api/sessions/{id}/state polling; carrying their lifecycle
+        // through this channel adds complexity for no consumer in v1.
+        if (session is not (AttachSession or TraceSession))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+            return;
+        }
+
+        var streamId = Guid.NewGuid();
+        registry.Register(streamId);
+        await SseExtensions.WriteSseHeadersAsync(ctx, ct);
+
+        try
+        {
+            // ── Bootstrap ───────────────────────────────────────────────────────────────────────
+            await SseExtensions.WriteEventAsync(ctx, "stream-id", new { streamId }, ct);
+
+            var initialMetadata = ResolveMetadata(session);
+            if (initialMetadata != null)
+            {
+                await SseExtensions.WriteEventAsync(ctx, "metadata", new { metadata = initialMetadata }, ct);
+            }
+
+            await SseExtensions.WriteEventAsync(ctx, "session-state", BuildSessionState(session), ct);
+
+            // ── Per-session-kind delta loop ────────────────────────────────────────────────────
+            if (session is AttachSession attach)
+            {
+                await DispatchAttachAsync(ctx, attach.Runtime, streamId, registry, ct);
+            }
+            else
+            {
+                // Trace: no live deltas; just heartbeat. The client still needs reconnect /
+                // disconnect detection, and may listen for late `topology-changed` if engine
+                // reattach lands in a future v2.
+                await HeartbeatOnlyLoopAsync(ctx, ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal client disconnect.
+        }
+        catch (IOException)
+        {
+            // Kestrel can surface forcible disconnect as IOException before ct fires.
+        }
+        finally
+        {
+            registry.Unregister(streamId);
+        }
+    }
+
+    /// <summary>
+    /// Drains the AttachSessionRuntime subscriber channel and writes filtered, classified events to
+    /// the SSE response. Runtime kinds map to unified event types as follows:
+    /// <list type="bullet">
+    ///   <item><c>metadata</c> → <c>metadata</c> (bypasses filter)</item>
+    ///   <item><c>tickSummaryAdded</c> → <c>tick</c> (filtered, coalescing)</item>
+    ///   <item><c>heartbeat</c> → <c>heartbeat</c> (bypasses filter)</item>
+    ///   <item><c>shutdown</c> → <c>shutdown</c> (bypasses filter)</item>
+    ///   <item><c>chunkAdded</c> / <c>globalMetricsUpdated</c> / <c>threadInfoAdded</c> → <i>dropped</i> (not on the v1 unified surface — clients still get them via the existing <c>/profiler/stream</c>)</item>
+    /// </list>
+    /// </summary>
+    private static async Task DispatchAttachAsync(
+        HttpContext ctx,
+        AttachSessionRuntime runtime,
+        Guid streamId,
+        StreamSubscriptionRegistry registry,
+        CancellationToken ct)
+    {
+        var (subscriberId, reader) = runtime.Subscribe();
+
+        // Per-event-type internal channels (D2). Ticks coalesce to latest-only; everything else
+        // is unbounded (these classes are low-frequency or already coalesced upstream).
+        var tickChannel = Channel.CreateBounded<TickSummaryDto>(
+            new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropOldest, SingleReader = true, SingleWriter = true });
+        var passthroughChannel = Channel.CreateUnbounded<UnifiedFrame>(
+            new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+
+        // Background classifier task — reads from the runtime, dispatches to the per-class
+        // channels. Decoupled from the writer so a slow writer back-pressures via the runtime's
+        // existing 1000-entry subscriber buffer instead of blocking the classifier.
+        var classifierCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var classifier = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var evt in reader.ReadAllAsync(classifierCts.Token))
+                {
+                    switch (evt.Kind)
+                    {
+                        case "metadata" when evt.Metadata != null:
+                            passthroughChannel.Writer.TryWrite(new UnifiedFrame("metadata", new { metadata = evt.Metadata }));
+                            break;
+                        case "tickSummaryAdded" when evt.TickSummary != null:
+                            tickChannel.Writer.TryWrite(evt.TickSummary);
+                            break;
+                        case "heartbeat":
+                            passthroughChannel.Writer.TryWrite(new UnifiedFrame("heartbeat", new { status = evt.Status }));
+                            break;
+                        case "shutdown":
+                            passthroughChannel.Writer.TryWrite(new UnifiedFrame("shutdown", new { status = evt.Status ?? "disconnected" }));
+                            break;
+                        // Other kinds (chunkAdded / globalMetricsUpdated / threadInfoAdded) are
+                        // intentionally not surfaced on the unified stream in v1.
+                    }
+                }
+            }
+            catch (OperationCanceledException) { /* expected on disconnect */ }
+            finally
+            {
+                tickChannel.Writer.TryComplete();
+                passthroughChannel.Writer.TryComplete();
+            }
+        }, CancellationToken.None);
+
+        try
+        {
+            // Multiplex pass-through frames + latest-tick + heartbeat onto the wire.
+            while (!ct.IsCancellationRequested)
+            {
+                using var heartbeat = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                heartbeat.CancelAfter(HeartbeatTimeoutMs);
+
+                var passReady = passthroughChannel.Reader.WaitToReadAsync(heartbeat.Token).AsTask();
+                var tickReady = tickChannel.Reader.WaitToReadAsync(heartbeat.Token).AsTask();
+
+                Task winner;
+                try
+                {
+                    winner = await Task.WhenAny(passReady, tickReady);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    // Heartbeat fallback — neither channel produced anything in HeartbeatTimeoutMs.
+                    await SseExtensions.WriteEventAsync(ctx, "heartbeat", new { status = "idle" }, ct);
+                    continue;
+                }
+
+                if (winner == passReady)
+                {
+                    if (passReady.IsCompletedSuccessfully && passReady.Result)
+                    {
+                        while (passthroughChannel.Reader.TryRead(out var frame))
+                        {
+                            await EmitAsync(ctx, streamId, registry, frame.EventType, frame.Payload, ct);
+                        }
+                    }
+                    else if (passReady.IsCompletedSuccessfully && !passReady.Result)
+                    {
+                        // Channel completed — classifier exited; bail out so we hit the heartbeat
+                        // path or terminate.
+                        return;
+                    }
+                }
+                else if (winner == tickReady && tickReady.IsCompletedSuccessfully && tickReady.Result)
+                {
+                    if (tickChannel.Reader.TryRead(out var tick))
+                    {
+                        await EmitAsync(ctx, streamId, registry, "tick", new { tickSummary = tick }, ct);
+                    }
+                }
+
+                // Drain any tick that landed while we were writing — keeps the wire fresh under load.
+                if (tickChannel.Reader.TryRead(out var pending))
+                {
+                    await EmitAsync(ctx, streamId, registry, "tick", new { tickSummary = pending }, ct);
+                }
+            }
+        }
+        finally
+        {
+            classifierCts.Cancel();
+            try { await classifier; } catch { /* swallow */ }
+            runtime.Unsubscribe(subscriberId);
+        }
+    }
+
+    /// <summary>
+    /// Idle loop for sessions that don't produce live deltas (Trace today). Emits a heartbeat
+    /// frame every <see cref="HeartbeatTimeoutMs"/> until the client disconnects.
+    /// </summary>
+    private static async Task HeartbeatOnlyLoopAsync(HttpContext ctx, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(HeartbeatTimeoutMs, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            await SseExtensions.WriteEventAsync(ctx, "heartbeat", new { status = "idle" }, ct);
+        }
+    }
+
+    /// <summary>
+    /// Writes one event to the wire, applying the subscription filter for non-bootstrap event
+    /// types. Bootstrap events (<see cref="BootstrapEvents"/>) bypass the filter — clients always
+    /// need them to drive UI lifecycle and reconnect logic.
+    /// </summary>
+    private static Task EmitAsync(
+        HttpContext ctx,
+        Guid streamId,
+        StreamSubscriptionRegistry registry,
+        string eventType,
+        object payload,
+        CancellationToken ct)
+    {
+        if (!BootstrapEvents.Contains(eventType) && !registry.IsSubscribed(streamId, eventType))
+        {
+            return Task.CompletedTask;
+        }
+        return SseExtensions.WriteEventAsync(ctx, eventType, payload, ct);
+    }
+
+    private static ProfilerMetadataDto ResolveMetadata(WbSession session) => session switch
+    {
+        AttachSession a => a.Runtime.Metadata,
+        TraceSession t => t.Runtime.Metadata,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Builds the <c>session-state</c> payload from the current session lifecycle. The shape
+    /// matches <c>SessionStateDto</c> minus the kind field — clients already know the kind from
+    /// the session-create response.
+    /// </summary>
+    private static object BuildSessionState(WbSession session)
+    {
+        if (session is AttachSession attach)
+        {
+            var ready = attach.Runtime.Metadata != null;
+            return new
+            {
+                lifecycle = ready ? "Ready" : "Loading",
+                isStreaming = ready,
+                isPaused = false,
+                isReattaching = false,
+            };
+        }
+        if (session is TraceSession trace)
+        {
+            var lifecycle = !trace.Runtime.IsBuildComplete ? "Loading"
+                : trace.Runtime.Metadata != null ? "Ready"
+                : "Closed";
+            return new
+            {
+                lifecycle,
+                isStreaming = false,
+                isPaused = false,
+                isReattaching = false,
+                reason = lifecycle == "Closed" ? "build-failed" : null,
+            };
+        }
+        return new { lifecycle = "Ready", isStreaming = false, isPaused = false, isReattaching = false };
+    }
+
+    /// <summary>Internal multiplexer envelope — pairs an event type with its payload.</summary>
+    private readonly record struct UnifiedFrame(string EventType, object Payload);
+}


### PR DESCRIPTION
## Summary

One PR covering both umbrella issues:
- **#306** — Workbench Internal Data API (v1 + v2 phases 2.1–2.6).
- **#314** — Workbench System DAG view (Phases 1, 2, 3 — sub-issues #315, #316, #317).

Both umbrellas closed with detailed summaries on the issues themselves; remaining sub-issues (#318 polish, #320 compound expand, #321 visual regression) tracked separately.

The DAG view sits on top of the new Internal Data API — the data plumbing and the consumer were built together on this branch, and the DAG view's three implementation phases are the API's first major consumer beyond the existing profiler. Single PR keeps the two halves reviewable as one unit.

## What landed — Internal Data API (#306)

**v1**
- New endpoints: `/api/sessions/{id}/topology`, `/track/...`, `/aggregate`. JSON wire.
- Header-based versioning (`X-Workbench-Api`, `X-Workbench-Wire`) with soft-launch tolerance.
- Cross-panel state: `useSelectionStore` (typed dimension slots + URL sync), `useHoverStore` (volatile, cross-panel hover for system + phase).
- SSE typed-event refactor across the existing 5 streams + new `/stream` unified endpoint with selective subscription.
- `SessionLifecycle` field migration (`Loading / Ready / Closed`).

**v2 — engine instrumentation phases that landed**
- 2.1 RFC 07 access declarations on the topology endpoint (incl. engine-built `predecessors` / `successors`).
- 2.2 Per-system tracks — `SystemTickSummary[]` cache section (v12+) with `(durationUs, startUs, endUs, readyUs, entitiesProcessed, workersTouched, chunksProcessed, skipReasonCode, flags)`.
- 2.3 Per-system `readyUs` capture (folded into the same section).
- 2.4 Per-queue tracks via `QueueTickEnd` instant event (kind 244) → `QueueTickSummaries` cache section.
- 2.5 Post-tick serial markers via `PostTickSummary` cache section.
- 2.6 Critical-path computation — pure client-side per the design's §9.3 decision (zero engine cost when the workbench isn't attached).

## What landed — System DAG view (#314)

- **Phase 1 (#315)** — topology view. Four layout modes (horizontal-lanes / vertical-lanes / compact / circular). xyflow + dagre. Edge derivation from RFC 07 declarations.
- **Phase 2 (#316)** — stats overlay. Heat-coloured node borders, queue backpressure on dashed edges, snapshot button, cross-panel binding to TimeArea.
- **Phase 3 (#317)** — Critical-Path tape, reshaped from "in-DAG column" to its own dockable panel:
  - Single-tick + aggregate + full-Gantt + linear/log + auto/horizontal/vertical orientations + lock-zoom + optional metronome stripe.
  - Three wait classes with click-throughs (phase-fence → straggler, worker-claim → waiting system).
  - Post-tick serial block.
  - CP badges on DAG nodes (★ + dominant-tick red outline).
  - Cross-panel selection + hover sync (system + phase).
  - Performance test: 1024 ticks × 200 systems < 200 ms.
- **Bonus polish.** `?` help overlays on both panels. Phase-flow arrows in lanes layouts. Phase-coloured backdrop in compact/circular layouts. Theme-aware hover indicators. `ViewportPortal` integration so all lane decorations pan/zoom with nodes.

## Bug fixes during the work

- **Engine — `DagScheduler` chunk-exception wedge.** A throwing chunk left the scheduler in a tight CPU spin (`FindReadySystem` kept returning the failed system; workers walked into `ProcessPipeline → break → repeat`). Fixed via `DrainFailedSystemChunks` — failure path drains remaining chunks atomically so `OnSystemComplete` fires.
- **Workbench — `QueueTickEnd` (kind 244) misclassified as a span.** Decoder was reading 25 payload bytes as a fake span header → garbage timings → ~30 phantom nested spans on the TickDriver track per tick. Fixed via `IsSpan` carve-out (C# + TS mirror), proper instant decoder, missing label entries.

## Design doc updates

- [`claude/design/workbench/modules/09-system-dag.md`](https://github.com/nockawa/Typhon/blob/main/claude/design/workbench/modules/09-system-dag.md) — new "Implementation status" block, every section reconciled with shipped state, architecture diagram redrawn to show CP as its own panel.
- [`claude/design/workbench/10-internal-data-api.md`](https://github.com/nockawa/Typhon/blob/main/claude/design/workbench/10-internal-data-api.md) — every v2 phase + missing-data row marked with current status.

## Test plan

- [x] Full engine suite: `dotnet test test/Typhon.Engine.Tests/Typhon.Engine.Tests.csproj -c Debug` — should pass 3,786 (the new `ParallelQueryException_TickCompletes_NoFullCpuWedge` test in `ExceptionHandlingTests.cs` covers the chunk-exception wedge fix; without the fix it times out at 2 s).
- [x] Workbench server tests: `dotnet test test/Typhon.Workbench.Tests/Typhon.Workbench.Tests.csproj`.
- [x] Workbench client tests: `cd tools/Typhon.Workbench/ClientApp && npx vitest run` — should pass 381 (24 in `criticalPath.test.ts` including the 1024×200 perf test).
- [x] Manual: `/wb-dev start`, open an AntHill trace, verify the DAG renders in all four layouts, snapshot the last 600 ticks, open the Critical Path panel, exercise single ↔ aggregate ↔ full-Gantt ↔ metronome toggles, hover a phase stripe to confirm cross-panel highlight, click a phase-fence wait to confirm straggler jump.
- [x] Manual: re-open the AntHill trace and confirm no phantom "Kind[244]" spans on the TickDriver track (the QueueTickEnd misclassification fix).
- [x] Manual: run AntHill ProfileRunner, force a chunk to throw, confirm the engine doesn't wedge in a full-CPU spin (the `DrainFailedSystemChunks` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)