### PR TITLE
SkyPilot AWS automation — bench/aws/ task files (#362)

### DIFF
--- a/bench/aws/README.md
+++ b/bench/aws/README.md
@@ -1,0 +1,83 @@
+# AntHill AWS Benchmark — Operator Runbook
+
+SkyPilot automation that runs `AntHill.Harness` on ephemeral AWS bare-metal
+instances and retrieves the `.typhon-trace` output via S3.
+
+Full design and one-time operator setup: see
+`design/Infrastructure/skypilot-aws-automation.md` in the `typhon-claude` docs repo.
+
+## Prerequisites (one-time)
+
+WSL + AWS CLI + SkyPilot installed, a dedicated `skypilot-bot` IAM user, the
+`typhon-traces` S3 bucket in `eu-west-1`, and a 128-vCPU service-quota increase.
+Work through the design doc's **Operator Setup Guide**, then confirm:
+
+```bash
+sky check aws        # must report: AWS: enabled
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `anthill-bench.sky.yaml`  | Production task — `m6idn.metal`, the 500K-ant scenario |
+| `anthill-dryrun.sky.yaml` | Dry-run task — `c5d.metal`, a small trace-on scenario |
+| `run.sh`                  | Thin wrapper — launches the production task with `--down` |
+
+## 1. Dry run — do this first
+
+Validates provisioning, NVMe mount, build, harness run, and trace→S3 retrieval
+cheaply on `c5d.metal` before spending on a production run:
+
+```bash
+sky launch bench/aws/anthill-dryrun.sky.yaml --down -y
+```
+
+Then verify:
+
+```bash
+aws s3 ls s3://typhon-traces/   # expect the dry-run .typhon-trace + JSON report
+sky status                      # expect no active cluster
+```
+
+A green dry run is the gate to the production run.
+
+## 2. Production run
+
+```bash
+./bench/aws/run.sh
+# equivalently: sky launch bench/aws/anthill-bench.sky.yaml --down -y
+```
+
+Runs the 500K-ant scenario across the 16/32/64/128 worker sweep. Each run emits
+a `.typhon-trace`; all are copied to `s3://typhon-traces/` with the JSON report.
+`--down` terminates the instance when finished.
+
+## 3. Retrieve traces
+
+```bash
+aws s3 ls s3://typhon-traces/
+aws s3 cp s3://typhon-traces/<file>.typhon-trace .
+```
+
+Open the trace in the Typhon Workbench profiler.
+
+## If an instance gets stuck
+
+`--down` should always terminate the instance. If `sky status` still shows a
+cluster, force it down:
+
+```bash
+sky down <cluster-name>
+```
+
+Cross-check the AWS EC2 console (`eu-west-1`) — a leaked `m6idn.metal` bills
+~$10/hr. The account budget alarm is the backstop.
+
+## Notes
+
+- SkyPilot `workdir: .` syncs the local repo — the benchmark runs whatever is
+  checked out. Launch from the Typhon repo root.
+- Bare-metal boot takes 5–7 min, teardown 10–20 min — all billed per-second.
+- The harness exits non-zero if any run fails; the task propagates that, so a
+  failed benchmark surfaces as a failed SkyPilot task.

--- a/bench/aws/anthill-bench.sky.yaml
+++ b/bench/aws/anthill-bench.sky.yaml
@@ -1,0 +1,41 @@
+# Production benchmark — drives AntHill.Harness at 500K ants on a bare-metal
+# m6idn.metal instance and retrieves the per-run .typhon-trace files via S3.
+# Design + one-time operator setup: design/Infrastructure/skypilot-aws-automation.md
+# Launch (from the Typhon repo root):  sky launch bench/aws/anthill-bench.sky.yaml --down -y
+name: anthill-bench
+
+resources:
+  cloud: aws
+  instance_type: m6idn.metal
+  region: eu-west-1            # MUST match the S3 bucket's region
+
+workdir: .                     # the repo root — synced to ~/sky_workdir on the instance
+
+file_mounts:
+  /outputs:
+    source: s3://typhon-traces # pre-created bucket in eu-west-1
+    mode: MOUNT                # writes to /outputs replicate to the bucket
+
+setup: |
+  set -euo pipefail
+  # Local instance-store NVMe is ephemeral and not auto-mounted — format + mount it.
+  DEV=$(lsblk -dno NAME,MODEL | grep -i 'Instance Storage' | head -1 | awk '{print $1}')
+  sudo mkfs.ext4 -F "/dev/$DEV"
+  sudo mkdir -p /nvme && sudo mount "/dev/$DEV" /nvme
+  sudo chown "$(whoami)" /nvme
+  # .NET 10 SDK + build the harness (pulls in AntHill.Core + Typhon.Engine).
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+  export PATH="$HOME/.dotnet:$PATH"
+  dotnet build demo/AntHill/AntHill.Harness/AntHill.Harness.csproj -c Release
+
+run: |
+  export PATH="$HOME/.dotnet:$PATH"
+  # Profile on fast LOCAL NVMe — cd there so traces + report land on local disk.
+  cd /nvme
+  HARNESS=~/sky_workdir/demo/AntHill/AntHill.Harness
+  dotnet "$HARNESS/bin/Release/net10.0/AntHill.Harness.dll" \
+    --scenario "$HARNESS/scenarios/anthill-500k-stress.yaml"
+  RC=$?
+  # Always retrieve whatever artifacts exist — even a failed run's partial traces.
+  cp /nvme/*.typhon-trace /nvme/anthill-500k-stress-report.json /outputs/ || true
+  exit $RC

--- a/bench/aws/anthill-dryrun.sky.yaml
+++ b/bench/aws/anthill-dryrun.sky.yaml
@@ -1,0 +1,39 @@
+# Dry-run task — validates the whole pipeline (provisioning, NVMe mount, build,
+# harness run, trace -> S3, teardown) on a cheap bare-metal c5d.metal instance
+# before committing to a production m6idn.metal run. Identical to
+# anthill-bench.sky.yaml except the instance type and the (small) scenario.
+# Launch (from the Typhon repo root):  sky launch bench/aws/anthill-dryrun.sky.yaml --down -y
+name: anthill-dryrun
+
+resources:
+  cloud: aws
+  instance_type: c5d.metal     # bare metal + local NVMe — exercises the real path, cheaply
+  region: eu-west-1            # MUST match the S3 bucket's region
+
+workdir: .                     # the repo root — synced to ~/sky_workdir on the instance
+
+file_mounts:
+  /outputs:
+    source: s3://typhon-traces # pre-created bucket in eu-west-1
+    mode: MOUNT
+
+setup: |
+  set -euo pipefail
+  # Local instance-store NVMe is ephemeral and not auto-mounted — format + mount it.
+  DEV=$(lsblk -dno NAME,MODEL | grep -i 'Instance Storage' | head -1 | awk '{print $1}')
+  sudo mkfs.ext4 -F "/dev/$DEV"
+  sudo mkdir -p /nvme && sudo mount "/dev/$DEV" /nvme
+  sudo chown "$(whoami)" /nvme
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+  export PATH="$HOME/.dotnet:$PATH"
+  dotnet build demo/AntHill/AntHill.Harness/AntHill.Harness.csproj -c Release
+
+run: |
+  export PATH="$HOME/.dotnet:$PATH"
+  cd /nvme
+  HARNESS=~/sky_workdir/demo/AntHill/AntHill.Harness
+  dotnet "$HARNESS/bin/Release/net10.0/AntHill.Harness.dll" \
+    --scenario "$HARNESS/scenarios/anthill-dryrun.yaml"
+  RC=$?
+  cp /nvme/*.typhon-trace /nvme/anthill-dryrun-report.json /outputs/ || true
+  exit $RC

--- a/bench/aws/run.sh
+++ b/bench/aws/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Launch the production AntHill benchmark on AWS. --down terminates the instance
+# when the run finishes; -y skips the confirmation prompt. Run from the repo root.
+#
+# For the cheap c5d.metal dry run, use bench/aws/anthill-dryrun.sky.yaml instead:
+#   sky launch bench/aws/anthill-dryrun.sky.yaml --down -y
+sky launch bench/aws/anthill-bench.sky.yaml --down -y "$@"

--- a/demo/AntHill/AntHill.Harness/.gitignore
+++ b/demo/AntHill/AntHill.Harness/.gitignore
@@ -1,3 +1,4 @@
 # Harness run artifacts — generated per run, never committed.
 *.typhon-trace
+*.nettrace
 *-report.json

--- a/demo/AntHill/AntHill.Harness/scenarios/anthill-dryrun.yaml
+++ b/demo/AntHill/AntHill.Harness/scenarios/anthill-dryrun.yaml
@@ -1,0 +1,15 @@
+# AntHill dry-run scenario — small and trace-enabled, for validating the AWS
+# pipeline on c5d.metal before a production run. See the SkyPilot design doc
+# (design/Infrastructure/skypilot-aws-automation.md, "First Launch").
+name: anthill-dryrun
+seed: 42
+world: 20000
+ants: 5000
+workers: [4, 8]
+duration: 3             # seconds, per worker-count run
+simulation:
+  tierMode: uniform-t0
+trace: true             # on — the dry run validates the trace -> S3 path
+assertions:
+  exceptions: { max: 0 }
+  antCount: { invariant: true }


### PR DESCRIPTION
Lands the SkyPilot task files for on-demand, ephemeral AWS bare-metal benchmark runs of `AntHill.Harness` — see #362.

## Changes

`bench/aws/`:
| File | Purpose |
|------|---------|
| `anthill-bench.sky.yaml`  | Production task — `m6idn.metal`, the 500K-ant scenario |
| `anthill-dryrun.sky.yaml` | Dry-run task — `c5d.metal`, small trace-on scenario |
| `run.sh`                  | Wrapper — launches the production task with `--down` |
| `README.md`               | Operator runbook |

Also:
- `demo/AntHill/AntHill.Harness/scenarios/anthill-dryrun.yaml` — the cheap pipeline-validation scenario.
- `demo/AntHill/AntHill.Harness/.gitignore` — ignores per-run trace artifacts.

## Validation

- ✅ Dry run on `c5d.metal` — provisioning, NVMe mount, build, harness run, trace→S3, teardown all green.
- ✅ Production run on `m6idn.metal` — 500K-ant `uniform-t0` scenario across the 16/32/64/128 worker sweep; all four runs passed.

## Related

- Tracking issue: #362
- Depends on: #353 (scriptable `AntHill.Harness`)
- Operator setup & design: `typhon-claude` repo → `design/Infrastructure/skypilot-aws-automation.md` (companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)