### PR TITLE
Committed storage discipline (#392) + cluster crash durability (#395)

### DIFF
--- a/src/Typhon.Engine/Durability/internals/CheckpointManager.cs
+++ b/src/Typhon.Engine/Durability/internals/CheckpointManager.cs
@@ -77,8 +77,17 @@ internal sealed partial class CheckpointManager : ResourceNode, IMetricSource
     /// background checkpoint thread, off every hot path.</summary>
     internal Action CycleFaultInjector { get; set; }
 
-    /// <summary>Max passes per cycle to retry pages skipped because a writer was active, before the coverage gate blocks the LSN advance (CK-03). Skip windows are
-    /// accessor-scoped (~µs), so the second pass almost always clears them.</summary>
+    /// <summary>
+    /// Wired by <see cref="DatabaseEngine"/> to <c>PersistArchetypeState</c>. Invoked at the START of every checkpoint cycle (before the durability
+    /// barrier) so the per-archetype segment pointers (EntityMap / cluster-segment SPIs in the <c>ArchetypeR1</c> table, plus NextEntityKey + EntityMap
+    /// meta) are updated and ride THIS cycle's barrier + dirty-page flush. Without this a checkpoint consolidates a cluster/EntityMap's DATA pages into
+    /// the data file but leaves the durable ArchetypeR1 still pointing at 0/stale — so a hard crash after the checkpoint reopens an orphaned
+    /// (unreachable) base and loses the entities (#395). Null until the engine wires it (early/test cycles no-op).
+    /// </summary>
+    internal Action PersistDurableMetadataHook { get; set; }
+
+    /// <summary>Max passes per cycle to retry pages skipped because a writer was active, before the coverage gate blocks the LSN advance (CK-03). Skip windows
+    /// are accessor-scoped (~µs), so the second pass almost always clears them.</summary>
     private const int MaxCoveragePasses = 3;
 
     // ═══════════════════════════════════════════════════════════════
@@ -347,6 +356,12 @@ internal sealed partial class CheckpointManager : ResourceNode, IMetricSource
             // classification. Null in production — one negligible null-check on the background thread.
             CycleFaultInjector?.Invoke();
 
+            // Persist per-archetype durable metadata (segment SPIs, NextEntityKey, EntityMap meta) into the ArchetypeR1 table BEFORE the barrier, so
+            // its WAL records and dirty pages are flushed by THIS cycle. This makes the consolidated cluster/EntityMap base reachable on reopen after a
+            // hard crash (CK-09 family / #395) — the checkpoint already writes the data pages; this records the pointers to them. Idempotent and cheap
+            // (skips archetypes whose state is unchanged).
+            PersistDurableMetadataHook?.Invoke();
+
             // Step 1: Durability barrier (CK-01/CK-02). Flush the WAL through everything appended so far, then take the
             // post-flush DurableLsn as the cycle's authoritative high-water (barrierLsn). The checkpoint advances to
             // THIS — not the stale loop-sampled targetLsn — so any records appended since the loop's trigger are now
@@ -401,7 +416,7 @@ internal sealed partial class CheckpointManager : ResourceNode, IMetricSource
                             _walManager.RequestFlush();
                             _walManager.WaitForDurable(_walManager.LastAppendedLsn, ref ctx);
 
-                            using (var fsyncScope = TyphonEvent.BeginCheckpointFsync())
+                            using (TyphonEvent.BeginCheckpointFsync())
                             {
                                 _mmf.FlushToDisk();
                             }

--- a/src/Typhon.Engine/Durability/internals/DurabilityWatermarks.cs
+++ b/src/Typhon.Engine/Durability/internals/DurabilityWatermarks.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Typhon.Engine.Internals;
 
 /// <summary>

--- a/src/Typhon.Engine/Durability/internals/RecoveryApplier.cs
+++ b/src/Typhon.Engine/Durability/internals/RecoveryApplier.cs
@@ -4,13 +4,14 @@ using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Internals;
 
-// Applies committed WAL v2 records back into engine state during crash recovery, reusing the engine's own write primitives
-// (the design's "one write path"). P1.2: rebuilds a committed spawned entity — the EntityRecord plus, per spawn-init Slot, a
-// committed revision-chain root holding the component value — by BUILDING the full record then InsertNew once, mirroring the
-// live FinalizeSpawns (approach B; the live engine has no in-place location update — a Versioned location is written once at
-// spawn and stays fixed, revisions append within the chain). Flat (non-cluster) path. Destroy / SetEnabledBits / component-
-// update Slots / cluster path / collections follow in later increments. Runs single-threaded under one epoch scope with a
-// dedicated ChangeSet (so applied page mutations are captured by the sealing checkpoint). See 03-recovery.md §3.
+// Applies committed WAL v2 records back into engine state during crash recovery, reusing the engine's own write primitives (the design's "one write path").
+// P1.2: rebuilds a committed spawned entity — the EntityRecord plus, per spawn-init Slot, a committed revision-chain root holding the component value — by
+// BUILDING the full record then InsertNew once, mirroring the live FinalizeSpawns (approach B; the live engine has no in-place location update — a Versioned
+// location is written once at spawn and stays fixed, revisions append within the chain). Both the flat (non-cluster) path and the cluster path are wired:
+// a cluster-eligible archetype reconstructs the entity into a CLUSTER slot (ClaimSlot + SoA value write + ClusterEntityRecord), mirroring the live
+// FinalizeSpawns cluster branch — this is what makes Commit-discipline SingleVersion values WAL-recoverable (#392 AC-2/AC-7). Destroy / SetEnabledBits /
+// collections follow in later increments. Runs single-threaded under one epoch scope with a dedicated ChangeSet (so applied page mutations are captured by the
+// sealing checkpoint). See 03-recovery.md §3.
 
 internal sealed unsafe class RecoveryApplier : IDisposable
 {
@@ -33,6 +34,10 @@ internal sealed unsafe class RecoveryApplier : IDisposable
     private ArchetypeMetadata _metadata;
     private int _componentCount;
     private ChunkAccessor<PersistentStore> _mapAccessor;
+
+    // Per-archetype cluster SoA accessor (set only when the current archetype is cluster-eligible with a PersistentStore ClusterSegment).
+    private bool _hasClusterAccessor;
+    private ChunkAccessor<PersistentStore> _clusterAccessor;
 
     // Per-ComponentTable recovery ComponentInfo (content + revision-table accessors bound to the recovery ChangeSet). Mirrors
     // EntityAccessor.GetComponentInfo's Versioned/SingleVersion setup, but threaded through THIS ChangeSet. Flushed at Dispose.
@@ -67,6 +72,12 @@ internal sealed unsafe class RecoveryApplier : IDisposable
     {
         Track(bornTsn);
         EnsureArchetype(archetypeId);
+
+        if (_hasClusterAccessor)
+        {
+            ApplySpawnedEntityToCluster(entityIdRaw, enabledBits, bornTsn, slots);
+            return;
+        }
 
         var key = EntityId.FromRaw(entityIdRaw).EntityKey;
 
@@ -106,6 +117,83 @@ internal sealed unsafe class RecoveryApplier : IDisposable
                     StorageMode.SingleVersion => CreateSingleVersionContent(table, slot.Payload),
                     _ => 0, // Transient values are never logged
                 };
+            }
+        }
+
+        _engineState.EntityMap.InsertNew(key, recordPtr, ref _mapAccessor, _changeSet);
+    }
+
+    /// <summary>
+    /// Cluster counterpart of <see cref="ApplySpawnedEntity"/>: reconstructs a committed spawned entity into a CLUSTER slot — claims a slot, writes each
+    /// committed component value into the cluster SoA (the HEAD; for Versioned it also builds the revision-chain root and records its chunkId), writes the
+    /// EntityId + per-slot EnabledBits into the cluster, and inserts the ClusterEntityRecord. Mirrors the live FinalizeSpawns cluster branch. Spatial
+    /// cell-routing and AABBs are rebuilt wholesale on reopen, so a plain (non-spatial) ClaimSlot is used. RB-01: secondary indexes are NOT populated here
+    /// — they are rebuilt from final HEAD data at open. Idempotent (AP-12): a re-applied entity already in the loaded map is skipped.
+    /// </summary>
+    private void ApplySpawnedEntityToCluster(long entityIdRaw, ushort enabledBits, long bornTsn, IReadOnlyCollection<SlotData> slots)
+    {
+        var key = EntityId.FromRaw(entityIdRaw).EntityKey;
+        byte* recordPtr = stackalloc byte[EntityRecordAccessor.MaxRecordSize];
+
+        if (_engineState.EntityMap.TryGet(key, recordPtr, ref _mapAccessor))
+        {
+            return; // idempotent re-apply
+        }
+
+        var clusterState = _engineState.ClusterState;
+        var layout = clusterState.Layout;
+
+        var (clusterChunkId, slotIdx) = clusterState.ClaimSlot(ref _clusterAccessor, _changeSet);
+        byte* clusterBase = _clusterAccessor.GetChunkAddress(clusterChunkId, true);
+
+        // Build the ClusterEntityRecord (19 bytes base + 4 bytes per Versioned slot).
+        ClusterEntityRecordAccessor.InitializeRecord(recordPtr, _metadata.VersionedSlotCount);
+        ref var header = ref ClusterEntityRecordAccessor.GetHeader(recordPtr);
+        header.BornTSN = bornTsn;
+        header.EnabledBits = enabledBits;
+        ClusterEntityRecordAccessor.SetClusterChunkId(recordPtr, clusterChunkId);
+        ClusterEntityRecordAccessor.SetSlotIndex(recordPtr, (byte)slotIdx);
+
+        if (slots != null)
+        {
+            foreach (var slot in slots)
+            {
+                if (!_metadata.TryGetSlot(slot.ComponentTypeId, out var slotIndex))
+                {
+                    continue; // foreign / malformed record — tolerate
+                }
+
+                var table = _engineState.SlotToComponentTable[slotIndex];
+                if (table.StorageMode == StorageMode.Transient)
+                {
+                    continue; // Transient values are never logged
+                }
+
+                // Write the committed value into the cluster SoA HEAD slot (payload is value-only; its length is the component storage size == ComponentSize).
+                int compSize = layout.ComponentSize(slotIndex);
+                byte* dst = clusterBase + layout.ComponentOffset(slotIndex) + slotIdx * compSize;
+                slot.Payload.AsSpan().CopyTo(new Span<byte>(dst, compSize));
+
+                // Versioned: also rebuild the revision-chain root and record its chunkId (the cluster slot is the HEAD cache over the chain).
+                if (table.StorageMode == StorageMode.Versioned)
+                {
+                    int vi = layout.SlotToVersionedIndex[slotIndex];
+                    if (vi >= 0)
+                    {
+                        var chainRoot = CreateVersionedChainRoot(table, entityIdRaw, slot.Tsn, slot.Payload);
+                        ClusterEntityRecordAccessor.SetCompRevFirstChunkId(recordPtr, vi, chainRoot);
+                    }
+                }
+            }
+        }
+
+        // Write the full EntityId and per-slot EnabledBits into the cluster SoA (occupancy bit was set by ClaimSlot).
+        *(long*)(clusterBase + layout.EntityIdsOffset + slotIdx * 8) = entityIdRaw;
+        for (int slot = 0; slot < _componentCount; slot++)
+        {
+            if ((enabledBits & (1 << slot)) != 0)
+            {
+                *(ulong*)(clusterBase + layout.EnabledBitsOffset(slot)) |= 1UL << slotIdx;
             }
         }
 
@@ -225,6 +313,12 @@ internal sealed unsafe class RecoveryApplier : IDisposable
             _mapAccessor.CommitChanges();
             _mapAccessor.Dispose();
         }
+        if (_hasClusterAccessor)
+        {
+            _clusterAccessor.CommitChanges();
+            _clusterAccessor.Dispose();
+            _hasClusterAccessor = false;
+        }
 
         _engineState = _dbe._archetypeStates[archId];
         _metadata = ArchetypeRegistry.GetMetadata(archId);
@@ -232,6 +326,15 @@ internal sealed unsafe class RecoveryApplier : IDisposable
         _mapAccessor = _engineState.EntityMap.Segment.CreateChunkAccessor(_changeSet);
         _hasAccessor = true;
         _lastArchId = archId;
+
+        // Cluster-eligible archetypes reconstruct into the cluster SoA (ClusterSegment is the PersistentStore primary for SV/Versioned/mixed; a
+        // pure-Transient cluster has no ClusterSegment and is never durable, so it stays on the flat no-op path).
+        var clusterState = _engineState.ClusterState;
+        if (_metadata.IsClusterEligible && clusterState?.ClusterSegment != null)
+        {
+            _clusterAccessor = clusterState.ClusterSegment.CreateChunkAccessor(_changeSet);
+            _hasClusterAccessor = true;
+        }
     }
 
     public void Dispose()
@@ -241,6 +344,12 @@ internal sealed unsafe class RecoveryApplier : IDisposable
             _mapAccessor.CommitChanges();
             _mapAccessor.Dispose();
             _hasAccessor = false;
+        }
+        if (_hasClusterAccessor)
+        {
+            _clusterAccessor.CommitChanges();
+            _clusterAccessor.Dispose();
+            _hasClusterAccessor = false;
         }
 
         foreach (var info in _infoByTable.Values)

--- a/src/Typhon.Engine/Ecs/public/ComponentTable.cs
+++ b/src/Typhon.Engine/Ecs/public/ComponentTable.cs
@@ -176,6 +176,13 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IDebugProperti
     // ── Storage mode (immutable after construction) ──
     public StorageMode StorageMode { get; private set; }
 
+    /// <summary>
+    /// Default durability discipline for this component, resolved from <c>[Component(DefaultDiscipline=…)]</c>.
+    /// Only consulted for <see cref="StorageMode.SingleVersion"/>; a transaction writing a
+    /// <see cref="DurabilityDiscipline.Commit"/> component is committed-durable for all of its writes (CM-02).
+    /// </summary>
+    public DurabilityDiscipline Discipline { get; private set; }
+
     // ── Persistent segments (Versioned & SingleVersion) ──
     public ChunkBasedSegment<PersistentStore> ComponentSegment { get; private set; }
     public ChunkBasedSegment<PersistentStore> CompRevTableSegment { get; private set; }
@@ -411,6 +418,7 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IDebugProperti
         DBE = dbe;
         Definition = definition;
         StorageMode = storageMode;
+        Discipline = definition.DefaultDiscipline;
 
         if (storageMode == StorageMode.Transient)
         {
@@ -473,6 +481,7 @@ public unsafe class ComponentTable : ResourceNode, IMetricSource, IDebugProperti
         DBE = dbe;
         Definition = definition;
         StorageMode = storageMode;
+        Discipline = definition.DefaultDiscipline;
 
         // Transient data doesn't survive restart — create a fresh empty table
         if (storageMode == StorageMode.Transient)

--- a/src/Typhon.Engine/Ecs/public/DatabaseEngine.cs
+++ b/src/Typhon.Engine/Ecs/public/DatabaseEngine.cs
@@ -316,6 +316,11 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
     /// leave indexes empty). Distinct from <see cref="_headsTrusted"/>, which can be false on a clean migration reopen with no WAL window (indexes load normally).</summary>
     internal bool WalFilesPresentAtOpen { get; private set; }
 
+    /// <summary>Gates the checkpoint-time <c>PersistArchetypeState</c> hook (#395 / CK-10). False during open + recovery (so the recovery seal — a
+    /// ForceCheckpoint — does NOT persist segment SPIs mid-rebuild); set true at the end of <c>InitializeArchetypes</c> so every steady-state
+    /// checkpoint records them.</summary>
+    private volatile bool _archetypeSpiPersistArmed;
+
     /// <summary>Test-only: when set, <see cref="Dispose"/> skips <c>MarkCleanShutdown</c>, reproducing an unclean shutdown
     /// (a real crash also never writes the marker). Unit tests cannot abort the process — same convention as the
     /// <c>BulkLoadRecoveryTests</c> incomplete-bulk path.</summary>
@@ -819,6 +824,18 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
         CheckpointManager = new CheckpointManager(MMF, UowRegistry, WalManager, _options.Resources, EpochManager, StagingBufferPool, _durabilityNode,
             initialCheckpointLsn, () => _lastTickFenceLSN);
         CheckpointManager.Logger = Logger;
+        // Persist per-archetype segment SPIs at every checkpoint so a consolidated cluster/EntityMap base is reachable on reopen after a hard crash
+        // (#395). Idempotent and skip-unchanged, so a steady-state cycle is nearly free. Runs at cycle start (before the barrier) so its WAL records +
+        // dirty pages ride the same cycle. Armed only AFTER InitializeArchetypes completes (incl. the recovery seal), so the seal — itself a
+        // ForceCheckpoint — keeps its original behaviour and does NOT persist SPIs mid-recovery (the rebuilt segments are sealed first; the first
+        // steady-state checkpoint then records them). #395.
+        CheckpointManager.PersistDurableMetadataHook = () =>
+        {
+            if (_archetypeSpiPersistArmed)
+            {
+                PersistArchetypeState();
+            }
+        };
         CheckpointManager.Start();
 
         // Wire demand-driven flush: when page cache backpressure fires, immediately wake
@@ -3645,9 +3662,20 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
             }
 
             var arch = persisted.Arch;
-            arch.EntityMapSPI = state.EntityMap.Segment.RootPageIndex;
-            arch.ClusterSegmentSPI = state.ClusterState?.ClusterSegment?.RootPageIndex ?? 0;
-            arch.NextEntityKey = Interlocked.Read(ref state.NextEntityKey);
+            var newEntityMapSpi = state.EntityMap.Segment.RootPageIndex;
+            var newClusterSpi = state.ClusterState?.ClusterSegment?.RootPageIndex ?? 0;
+            var newNextKey = Interlocked.Read(ref state.NextEntityKey);
+
+            // Skip archetypes whose persisted state is already current. The segment SPIs are stable once allocated, so a steady-state checkpoint with no
+            // spawns persists nothing — this is what makes it cheap enough to run at EVERY checkpoint (#395), not just at clean shutdown.
+            if (arch.EntityMapSPI == newEntityMapSpi && arch.ClusterSegmentSPI == newClusterSpi && arch.NextEntityKey == newNextKey)
+            {
+                continue;
+            }
+
+            arch.EntityMapSPI = newEntityMapSpi;
+            arch.ClusterSegmentSPI = newClusterSpi;
+            arch.NextEntityKey = newNextKey;
 
             // EntityMap's meta chunk tracks the total entry count, but FlushMetaToChunk is otherwise only called during a bucket split. For append-only
             // workloads that never split (e.g. a session with fewer entries than n0 × 0.75 × bucketCapacity), the persisted meta count stays at 0 from
@@ -3665,6 +3693,8 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
             // rebuilt from cluster data at startup by RebuildCellState + RebuildClusterAabbs.
 
             SystemCrud.Update(archetypesTable, persisted.ChunkId, ref arch, EpochManager, cs);
+            // refresh the cache so the next checkpoint's skip-check sees the persisted values
+            _persistedArchetypes[meta.ArchetypeId] = (persisted.ChunkId, arch);
             anyUpdated = true;
         }
 
@@ -4320,7 +4350,7 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
 
             bool isFreshAllocation;
             if (!hasMigratedSlot && _persistedArchetypes.TryGetValue(meta.ArchetypeId, out var persisted) && persisted.Arch.EntityMapSPI > 0
-                && MMF.TryLoadChunkBasedSegment(persisted.Arch.EntityMapSPI, stride, out var loadedSegment))
+                && MMF.TryLoadChunkBasedSegment(persisted.Arch.EntityMapSPI, stride, out var loadedSegment, WalFilesPresentAtOpen))
             {
                 // Reload existing EntityMap from persisted segment (O(1) reopen)
                 var em = RawValuePagedHashMap<long, PersistentStore>.Open(loadedSegment, 256, meta._entityRecordSize);
@@ -4383,7 +4413,7 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
                 {
                     ChunkBasedSegment<PersistentStore> loadedCluster = null;
                     var loaded = !isPureTransient && MMF.TryLoadChunkBasedSegment(
-                        clusterPersisted.Arch.ClusterSegmentSPI, meta.ClusterLayout.ClusterStride, out loadedCluster);
+                        clusterPersisted.Arch.ClusterSegmentSPI, meta.ClusterLayout.ClusterStride, out loadedCluster, WalFilesPresentAtOpen);
 
                     // TransientStore segment always created fresh on reopen (Transient data doesn't survive restart)
                     ChunkBasedSegment<TransientStore> transientClusterSegment = default;
@@ -4611,6 +4641,10 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
         {
             MMF.SetPageChecksumVerification(_options.Resources.PageChecksumVerification);
         }
+
+        // Open + recovery (incl. the seal) are done — arm the checkpoint-time SPI persistence (#395 / CK-10). From here every steady-state checkpoint
+        // records the per-archetype segment SPIs so a consolidated cluster/EntityMap base is reachable on reopen after a hard crash.
+        _archetypeSpiPersistArmed = true;
     }
 
     /// <summary>
@@ -5596,6 +5630,11 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
 
     [LoggerMessage(LogLevel.Debug, "CreateQuickTransaction: Tx #{tsn} created")]
     internal partial void LogQuickTxCreated(long tsn);
+
+    [LoggerMessage(LogLevel.Information,
+        "Tx #{tsn} escalated to Commit discipline by component '{componentName}' (DefaultDiscipline=Commit) — all writes in this " +
+        "transaction are now commit-durable (CM-02)")]
+    internal partial void LogDisciplineEscalated(long tsn, string componentName);
 
     [LoggerMessage(LogLevel.Debug, "Tx #{tsn} commit: CreateComponent<{componentName}> pk={pk}: {step}")]
     internal partial void LogCommitCreateComponent(long tsn, string componentName, long pk, string step);

--- a/src/Typhon.Engine/Ecs/public/EntityAccessor.ECS.cs
+++ b/src/Typhon.Engine/Ecs/public/EntityAccessor.ECS.cs
@@ -2,7 +2,10 @@
 // These are the methods EntityRef delegates to for Read/Write operations.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Typhon.Schema.Definition;
 
 namespace Typhon.Engine;
@@ -334,6 +337,13 @@ public unsafe partial class EntityAccessor
     {
         var info = GetComponentInfo(typeof(T));
         byte* ptr = table.StorageMode == StorageMode.Transient ? info.TransientCompContentAccessor.GetChunkAddress(chunkId) : info.CompContentAccessor.GetChunkAddress(chunkId);
+        // Commit-discipline read-your-own-writes: return this tx's staged value if it has staged this (component, entity). The chunk's inline
+        // entityPK (offset 0 for SV/Transient) keys the staging map.
+        if (_discipline == DurabilityDiscipline.Commit && table.StorageMode == StorageMode.SingleVersion
+            && info.CommitStaged != null && info.CommitStaged.TryGetValue(*(long*)ptr, out var slot))
+        {
+            return ref Unsafe.AsRef<T>(_commitStagingBuffer + slot.Offset);
+        }
         return ref Unsafe.AsRef<T>(ptr + info.ComponentOverhead);
     }
 
@@ -356,6 +366,23 @@ public unsafe partial class EntityAccessor
     internal ref T WriteEcsComponentData<T>(ComponentTable table, int chunkId) where T : unmanaged
     {
         var info = GetComponentInfo(typeof(T));
+
+        // Commit discipline (SingleVersion, Variant A): stage the write — leave the chunk HEAD untouched and unmarked (CM-01). The HEAD still holds the
+        // pre-write value, so seed the staging slot from it for partial-write correctness. CM-02 escalation first (so DefaultDiscipline=Commit applies).
+        if (table.StorageMode == StorageMode.SingleVersion)
+        {
+            if (table.Discipline == DurabilityDiscipline.Commit)
+            {
+                ResolveCommitDiscipline(table);
+            }
+            if (_discipline == DurabilityDiscipline.Commit)
+            {
+                byte* head = info.CompContentAccessor.GetChunkAddress(chunkId);
+                // Flat location is the content chunkId (captured for the no-re-lookup publish).
+                return ref StageCommitWriteCore<T>(info, *(long*)head, chunkId, head + info.ComponentOverhead);
+            }
+        }
+
         byte* ptr;
         if (table.StorageMode == StorageMode.Transient)
         {
@@ -364,6 +391,7 @@ public unsafe partial class EntityAccessor
         else
         {
             ptr = info.CompContentAccessor.GetChunkAddress(chunkId, true);
+            _didInPlaceSvWrite = true;   // CM-02: a TickFence in-place SingleVersion write happened — blocks late escalation to Commit
         }
         table.DirtyBitmap?.Set(chunkId);
         return ref Unsafe.AsRef<T>(ptr + info.ComponentOverhead);
@@ -394,6 +422,136 @@ public unsafe partial class EntityAccessor
             var oldKey = KeyBytes8.FromPointer(ptr + ifi.OffsetToField, ifi.Size);
             buffers[i].Append(chunkId, pk, oldKey);
         }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Committed durability discipline — Variant A staging (issue #392)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private const int InitialCommitStagingCapacity = 4096;
+
+    /// <summary>
+    /// CM-02 discipline resolution, invoked from the write path for a <see cref="DurabilityDiscipline.Commit"/>-defaulted
+    /// <see cref="StorageMode.SingleVersion"/> component. Escalates this accessor's whole transaction to Commit on first touch (so
+    /// every subsequent write is commit-durable), and rejects escalation if a TickFence in-place write has already happened (we cannot
+    /// retroactively make an applied write atomic). Idempotent and cheap once escalated. Callers gate on
+    /// <c>table.Discipline == Commit</c> so the TickFence hot path never reaches here for a non-Commit component.
+    /// </summary>
+    internal void ResolveCommitDiscipline(ComponentTable table)
+    {
+        if (_discipline == DurabilityDiscipline.Commit)
+        {
+            return;
+        }
+
+        if (_didInPlaceSvWrite)
+        {
+            throw new InvalidOperationException(
+                $"Component '{table.Name}' is declared DefaultDiscipline=Commit, but this transaction has already performed a TickFence " +
+                "in-place write. Create the transaction with discipline: DurabilityDiscipline.Commit before writing any component so the " +
+                "whole transaction is commit-durable (CM-02 uniformity).");
+        }
+
+        _discipline = DurabilityDiscipline.Commit;
+        _dbe?.LogDisciplineEscalated(TSN, table.Name);
+    }
+
+    /// <summary>
+    /// Native staging buffer for Commit-discipline SingleVersion writes (Variant A). Lazily allocated on the first staged write and
+    /// freed by <see cref="FreeCommitStaging"/> on transaction reset. Native (not a managed <c>byte[]</c>) so a staged write can return a
+    /// stable <c>ref T</c> into it. A staged ref is invalidated by the next staging allocation that grows the buffer
+    /// (the same contract as a <c>ref</c> into a <c>List&lt;T&gt;</c> via CollectionsMarshal); the common write-then-commit idiom is always safe.
+    /// </summary>
+    private protected byte* _commitStagingBuffer;
+    private protected int _commitStagingCapacity;
+    private protected int _commitStagingUsed;
+
+    /// <summary>Reserve <paramref name="size"/> bytes in the native staging buffer; returns the 0-based offset.</summary>
+    private int StageAlloc(int size)
+    {
+        var off = _commitStagingUsed;
+        var need = off + size;
+        if (need > _commitStagingCapacity)
+        {
+            var newCap = _commitStagingCapacity == 0 ? InitialCommitStagingCapacity : _commitStagingCapacity;
+            while (newCap < need)
+            {
+                newCap *= 2;
+            }
+            _commitStagingBuffer = (byte*)NativeMemory.Realloc(_commitStagingBuffer, (nuint)newCap);
+            _commitStagingCapacity = newCap;
+        }
+        _commitStagingUsed = need;
+        return off;
+    }
+
+    /// <summary>Free the native staging buffer (idempotent) and reset its bump pointer. Called from the transaction reset path.</summary>
+    private protected void FreeCommitStaging()
+    {
+        if (_commitStagingBuffer != null)
+        {
+            NativeMemory.Free(_commitStagingBuffer);
+            _commitStagingBuffer = null;
+        }
+        _commitStagingCapacity = 0;
+        _commitStagingUsed = 0;
+    }
+
+    /// <summary>
+    /// Variant-A staging core: on the first Commit-discipline write to (component, entity) this transaction, reserve a staging slot and seed it
+    /// with the current HEAD value (so partial writes are correct), then return a mutable ref into the staging buffer. The cluster/chunk HEAD is
+    /// NOT touched until commit publish (CM-01).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref T StageCommitWriteCore<T>(ComponentInfo info, long pk, int location, byte* headDataPtr) where T : unmanaged
+    {
+        var size = info.ComponentTable.ComponentStorageSize;
+        Debug.Assert(sizeof(T) == size, "Commit-discipline staging assumes the component IS T (SingleVersion layout)");
+        info.CommitStaged ??= new Dictionary<long, ComponentInfo.StagedSlot>();
+        ref var slot = ref CollectionsMarshal.GetValueRefOrAddDefault(info.CommitStaged, pk, out var exists);
+        if (!exists)
+        {
+            slot.Offset = StageAlloc(size);
+            slot.Location = location;                           // captured at stage time — publish uses it, no EntityMap re-lookup
+            Unsafe.CopyBlockUnaligned(_commitStagingBuffer + slot.Offset, headDataPtr, (uint)size);   // seed from HEAD (partial-write correctness)
+        }
+        return ref Unsafe.AsRef<T>(_commitStagingBuffer + slot.Offset);
+    }
+
+    /// <summary>
+    /// Records that a TickFence in-place SingleVersion write has happened (called from the cluster write path, the counterpart of the flag set inline by
+    /// <see cref="WriteEcsComponentData{T}"/> for the non-cluster path). Blocks a later CM-02 auto-escalation to Commit, which could no longer make the
+    /// already-applied write atomic. One bool store — negligible beside the cluster <c>SetDirty</c> on the same path.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void NoteSvInPlaceWrite() => _didInPlaceSvWrite = true;
+
+    /// <summary>
+    /// Cluster-path entry point for Commit-discipline staging — resolves the ComponentInfo, then stages (see <see cref="StageCommitWriteCore{T}"/>).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal ref T StageClusterCommitWrite<T>(ComponentTable table, int componentTypeId, long pk, int clusterLocation, byte* clusterHeadPtr) where T : unmanaged
+    {
+        var info = GetComponentInfoByTypeId(componentTypeId, typeof(T));
+        return ref StageCommitWriteCore<T>(info, pk, clusterLocation, clusterHeadPtr);
+    }
+
+    /// <summary>
+    /// Read-your-own-writes: returns a pointer to this transaction's staged value for (component, entity), or null if not staged. Consulted only
+    /// when <see cref="Discipline"/> is Commit (a per-tx constant), and never creates a ComponentInfo.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal byte* TryGetStagedPtr(Type componentType, long pk)
+    {
+        if (_commitStagingBuffer == null || !_componentInfos.TryGetValue(componentType, out var info) || info.CommitStaged == null)
+        {
+            return null;
+        }
+        if (!info.CommitStaged.TryGetValue(pk, out var slot))
+        {
+            return null;
+        }
+        return _commitStagingBuffer + slot.Offset;
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/Typhon.Engine/Ecs/public/EntityAccessor.cs
+++ b/src/Typhon.Engine/Ecs/public/EntityAccessor.cs
@@ -63,6 +63,19 @@ public partial class EntityAccessor : IDisposable
     private protected int _entityOperationCount;
     private protected ChangeSet _changeSet;
 
+    /// <summary>
+    /// Effective durability discipline for <see cref="StorageMode.SingleVersion"/> writes in this accessor's scope.
+    /// Always <see cref="DurabilityDiscipline.TickFence"/> for a bare <see cref="EntityAccessor"/> (parallel workers never stage); a <see cref="Transaction"/>
+    /// resolves it from the explicit argument or escalates on first touch of a <see cref="DurabilityDiscipline.Commit"/> component (CM-02).
+    /// </summary>
+    private protected DurabilityDiscipline _discipline;
+
+    /// <summary>Effective durability discipline for SingleVersion writes (see <see cref="_discipline"/>).</summary>
+    internal DurabilityDiscipline Discipline => _discipline;
+
+    /// <summary>True once any in-place (TickFence) SingleVersion write has been applied — blocks late escalation to Commit (CM-02).</summary>
+    private protected bool _didInPlaceSvWrite;
+
     public long TSN { get; private protected set; }
 
     /// <summary>
@@ -347,6 +360,10 @@ public partial class EntityAccessor : IDisposable
         }
 
         Array.Clear(_componentInfosByTypeId);
+
+        FreeCommitStaging();
+        _discipline = DurabilityDiscipline.TickFence;
+        _didInPlaceSvWrite = false;
 
         TSN = 0;
         _changeSet = null;

--- a/src/Typhon.Engine/Ecs/public/EntityRef.cs
+++ b/src/Typhon.Engine/Ecs/public/EntityRef.cs
@@ -118,6 +118,15 @@ public unsafe ref struct EntityRef
                 var table = _engineState.SlotToComponentTable[slot];
                 return ref _accessor.ReadEcsComponentData<T>(table, chunkId);
             }
+            // Commit-discipline read-your-own-writes: see this tx's staged value (point reads only; bulk spans read HEAD).
+            if (_accessor.Discipline == DurabilityDiscipline.Commit)
+            {
+                byte* stagedPtr = _accessor.TryGetStagedPtr(typeof(T), (long)_id.RawValue);
+                if (stagedPtr != null)
+                {
+                    return ref Unsafe.AsRef<T>(stagedPtr);
+                }
+            }
             return ref Unsafe.AsRef<T>(_clusterBase + _clusterLayout.ComponentOffset(slot) + _clusterSlotIndex * _clusterLayout.ComponentSize(slot));
         }
 
@@ -169,6 +178,23 @@ public unsafe ref struct EntityRef
 
             // SV cluster fast path: direct pointer arithmetic into SoA array.
             // Page was already marked dirty at resolve time (OpenMut → GetChunkAddress(dirty:true)).
+            byte* svHeadPtr = _clusterBase + _clusterLayout.ComponentOffset(slot) + _clusterSlotIndex * _clusterLayout.ComponentSize(slot);
+            var svTable = _engineState.SlotToComponentTable[slot];
+
+            // CM-02: a DefaultDiscipline=Commit component escalates the whole transaction to Commit on first touch.
+            if (svTable.Discipline == DurabilityDiscipline.Commit)
+            {
+                _accessor.ResolveCommitDiscipline(svTable);
+            }
+
+            // Commit discipline (Variant A): stage the write — leave the cluster HEAD untouched, no dirty bit, no shadow capture (CM-01).
+            // The exact B+Tree index is reconciled at commit (read old key from HEAD, new from the staged slot).
+            if (_accessor.Discipline == DurabilityDiscipline.Commit)
+            {
+                return ref _accessor.StageClusterCommitWrite<T>(
+                    svTable, comp._componentTypeId, (long)_id.RawValue, _clusterChunkId * 64 + _clusterSlotIndex, svHeadPtr);
+            }
+
             // Shadow capture for per-archetype B+Tree index maintenance (first write per entity per tick)
             if (clusterState.IndexSlots != null)
             {
@@ -179,8 +205,9 @@ public unsafe ref struct EntityRef
                 }
             }
 
+            _accessor.NoteSvInPlaceWrite();   // CM-02: an in-place TickFence write happened — blocks late auto-escalation to Commit
             clusterState.SetDirty(_clusterChunkId, _clusterSlotIndex);
-            return ref Unsafe.AsRef<T>(_clusterBase + _clusterLayout.ComponentOffset(slot) + _clusterSlotIndex * _clusterLayout.ComponentSize(slot));
+            return ref Unsafe.AsRef<T>(svHeadPtr);
         }
 
         {
@@ -194,7 +221,14 @@ public unsafe ref struct EntityRef
                 return ref Unsafe.AsRef<T>((byte*)rawPtr + table.ComponentOverhead);
             }
 
-            if (table.HasShadowableIndexes)
+            // CM-02: a DefaultDiscipline=Commit component escalates the whole tx to Commit before the (skipped) shadow capture below.
+            if (table.StorageMode == StorageMode.SingleVersion && table.Discipline == DurabilityDiscipline.Commit)
+            {
+                _accessor.ResolveCommitDiscipline(table);
+            }
+
+            // Commit discipline stages and reconciles indexes at commit — skip the per-tick shadow capture (which feeds the fence-time Move).
+            if (table.HasShadowableIndexes && _accessor.Discipline != DurabilityDiscipline.Commit)
             {
                 _accessor.ShadowIndexedFields<T>(table, chunkId, _id);
             }
@@ -223,6 +257,15 @@ public unsafe ref struct EntityRef
                 int chunkId = _locations[slot];
                 var table = _engineState.SlotToComponentTable[slot];
                 return ref _accessor.ReadEcsComponentData<T>(table, chunkId);
+            }
+            // Commit-discipline read-your-own-writes: see this tx's staged value (point reads only; bulk spans read HEAD).
+            if (_accessor.Discipline == DurabilityDiscipline.Commit)
+            {
+                byte* stagedPtr = _accessor.TryGetStagedPtr(typeof(T), (long)_id.RawValue);
+                if (stagedPtr != null)
+                {
+                    return ref Unsafe.AsRef<T>(stagedPtr);
+                }
             }
             return ref Unsafe.AsRef<T>(_clusterBase + _clusterLayout.ComponentOffset(slot) + _clusterSlotIndex * _clusterLayout.ComponentSize(slot));
         }
@@ -257,6 +300,20 @@ public unsafe ref struct EntityRef
 
             // SV cluster fast path
             var clusterState = _engineState.ClusterState;
+            byte* svHeadPtr = _clusterBase + _clusterLayout.ComponentOffset(slot) + _clusterSlotIndex * _clusterLayout.ComponentSize(slot);
+            var svTable = _engineState.SlotToComponentTable[slot];
+
+            // CM-02: a DefaultDiscipline=Commit component escalates the whole transaction to Commit on first touch.
+            if (svTable.Discipline == DurabilityDiscipline.Commit)
+            {
+                _accessor.ResolveCommitDiscipline(svTable);
+            }
+
+            // Commit discipline (Variant A): stage the write — HEAD untouched, no dirty/shadow (CM-01). Index reconciled at commit.
+            if (_accessor.Discipline == DurabilityDiscipline.Commit)
+            {
+                return ref _accessor.StageClusterCommitWrite<T>(svTable, typeId, (long)_id.RawValue, _clusterChunkId * 64 + _clusterSlotIndex, svHeadPtr);
+            }
 
             // Shadow capture for per-archetype B+Tree index maintenance (first write per entity per tick)
             if (clusterState.IndexSlots != null)
@@ -268,8 +325,9 @@ public unsafe ref struct EntityRef
                 }
             }
 
+            _accessor.NoteSvInPlaceWrite();   // CM-02: an in-place TickFence write happened — blocks late auto-escalation to Commit
             clusterState.SetDirty(_clusterChunkId, _clusterSlotIndex);
-            return ref Unsafe.AsRef<T>(_clusterBase + _clusterLayout.ComponentOffset(slot) + _clusterSlotIndex * _clusterLayout.ComponentSize(slot));
+            return ref Unsafe.AsRef<T>(svHeadPtr);
         }
 
         {
@@ -283,7 +341,14 @@ public unsafe ref struct EntityRef
                 return ref Unsafe.AsRef<T>((byte*)rawPtr + table.ComponentOverhead);
             }
 
-            if (table.HasShadowableIndexes)
+            // CM-02: a DefaultDiscipline=Commit component escalates the whole tx to Commit before the (skipped) shadow capture below.
+            if (table.StorageMode == StorageMode.SingleVersion && table.Discipline == DurabilityDiscipline.Commit)
+            {
+                _accessor.ResolveCommitDiscipline(table);
+            }
+
+            // Commit discipline stages and reconciles indexes at commit — skip the per-tick shadow capture (which feeds the fence-time Move).
+            if (table.HasShadowableIndexes && _accessor.Discipline != DurabilityDiscipline.Commit)
             {
                 _accessor.ShadowIndexedFields<T>(table, chunkId, _id);
             }

--- a/src/Typhon.Engine/Runtime/public/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/public/DagScheduler.cs
@@ -259,13 +259,28 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             return;
         }
 
-        if (_workerCount == 1)
+        // Outer safety net — this runs on the timer thread (HighResolutionTimerServiceBase.TimerLoop), a RAW thread with no catch of its own. An
+        // exception escaping a tick here would propagate unhandled and ABORT THE PROCESS (a "Test host process crashed" / production host crash) —
+        // strictly worse than a dropped tick. The single-threaded path (ExecuteTickSingleThreaded) runs the whole tick inline on this thread, so it has
+        // no other net; the multi-threaded path's worker exceptions are already netted in WorkerLoop, but its coordination code runs here too. Mirror
+        // the WorkerLoop net: log loudly, surface via the hook, drop this tick. (A persistently-throwing tick keeps being surfaced every tick rather
+        // than silently — the hook can escalate to graceful shutdown.)
+        try
         {
-            ExecuteTickSingleThreaded(actualTick);
+            if (_workerCount == 1)
+            {
+                ExecuteTickSingleThreaded(actualTick);
+            }
+            else
+            {
+                ExecuteTickMultiThreaded(actualTick);
+            }
         }
-        else
+        catch (Exception ex)
         {
-            ExecuteTickMultiThreaded(actualTick);
+            LogSystemException(-1, "<tick driver>", ex);
+            try { UnhandledExceptionCallback?.Invoke(-1, "<tick driver>", ex); }
+            catch { /* swallow — the callback itself threw; we are the last line of defense before the host aborts */ }
         }
     }
 

--- a/src/Typhon.Engine/Runtime/public/RuntimeSchedule.cs
+++ b/src/Typhon.Engine/Runtime/public/RuntimeSchedule.cs
@@ -2,6 +2,8 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine;
 
@@ -320,6 +322,27 @@ public sealed class RuntimeSchedule
             {
                 ValidateSameDag(reg.Before, reg.Name, dag, nameToDagId);
                 explicitEdges.Add((reg.Name, reg.Before));
+            }
+        }
+
+        // Phase 2a.5 — CM-04 (runtime-scheduling AC-05, issue #392): ReadsSnapshot requires MVCC history to freeze to, which only the Versioned layout has.
+        // Reject ReadsSnapshot on any non-Versioned component at Build() (SingleVersion under either durability discipline, or Transient).
+        foreach (var (reg, _) in allRegs)
+        {
+            if (reg.Access?.ReadsSnapshot == null)
+            {
+                continue; // engine-internal / access-less systems carry no declarations to validate
+            }
+            foreach (var snapType in reg.Access.ReadsSnapshot)
+            {
+                var attr = snapType.GetCustomAttribute<ComponentAttribute>();
+                if (attr != null && attr.StorageMode != StorageMode.Versioned)
+                {
+                    throw new InvalidOperationException(
+                        $"System '{reg.Name}' declares ReadsSnapshot<{snapType.Name}>, but '{snapType.Name}' is a {attr.StorageMode} component. " +
+                        "Snapshot reads require MVCC history — only Versioned components have it. Use Reads/ReadsFresh, or make the component Versioned " +
+                        "(CM-04 / runtime-scheduling.md AC-05).");
+                }
             }
         }
 

--- a/src/Typhon.Engine/Runtime/public/TickContext.cs
+++ b/src/Typhon.Engine/Runtime/public/TickContext.cs
@@ -1,8 +1,16 @@
 using JetBrains.Annotations;
-using System;
 using System.Collections.Generic;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine;
+
+/// <summary>
+/// Factory for side-transactions created from a <see cref="TickContext"/>. The <paramref name="discipline"/> selects the
+/// durability discipline for SingleVersion-layout writes (<see cref="DurabilityDiscipline.TickFence"/> default, or
+/// <see cref="DurabilityDiscipline.Commit"/> for zero-loss, atomic, commit-scoped writes).
+/// </summary>
+[PublicAPI]
+public delegate Transaction SideTransactionFactory(DurabilityMode mode, DurabilityDiscipline discipline = DurabilityDiscipline.TickFence);
 
 /// <summary>
 /// Context passed to CallbackSystem and QuerySystem delegates during tick execution.
@@ -68,9 +76,10 @@ public struct TickContext
     /// </summary>
     /// <remarks>
     /// Use for economy-critical operations (trades, purchases, progression) that must be durable immediately, independent of the main tick's commit.
+    /// Pass <see cref="DurabilityDiscipline.Commit"/> to make SingleVersion-layout writes zero-loss, atomic and commit-scoped (no revision chain).
     /// Null when running without a DatabaseEngine.
     /// </remarks>
-    public Func<DurabilityMode, Transaction> CreateSideTransaction { get; init; }
+    public SideTransactionFactory CreateSideTransaction { get; init; }
 
     /// <summary>
     /// Inclusive start index into <see cref="ClusterIds"/> for this worker's assigned cluster range. Used by cluster-native systems that iterate

--- a/src/Typhon.Engine/Runtime/public/TyphonRuntime.cs
+++ b/src/Typhon.Engine/Runtime/public/TyphonRuntime.cs
@@ -8,6 +8,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using Typhon.Engine.internals;
 using Typhon.Profiler;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine;
 
@@ -84,7 +85,7 @@ public sealed partial class TyphonRuntime : IDisposable
     private readonly int[] _checkerboardBlackCount;
 
     // Cached delegate — avoids per-TickContext allocation from method group conversion
-    private readonly Func<DurabilityMode, Transaction> _createSideTxDelegate;
+    private readonly SideTransactionFactory _createSideTxDelegate;
 
     // First-tick flag
     private bool _firstTickExecuted;
@@ -423,9 +424,11 @@ public sealed partial class TyphonRuntime : IDisposable
     /// The caller owns the returned Transaction and must Commit + Dispose it.
     /// Side-transactions are NOT visible to the current tick's main Transactions (snapshot isolation).
     /// </summary>
-    public Transaction CreateSideTransaction(DurabilityMode durability = DurabilityMode.Immediate) => Engine.CreateQuickTransaction(durability);
+    public Transaction CreateSideTransaction(DurabilityMode durability = DurabilityMode.Immediate,
+        DurabilityDiscipline discipline = DurabilityDiscipline.TickFence) => Engine.CreateQuickTransaction(durability, discipline);
 
-    private Transaction CreateSideTransactionInternal(DurabilityMode durability) => Engine.CreateQuickTransaction(durability);
+    private Transaction CreateSideTransactionInternal(DurabilityMode durability, DurabilityDiscipline discipline)
+        => Engine.CreateQuickTransaction(durability, discipline);
 
     // ═══════════════════════════════════════════════════════════════
     // #197: Change filter resolution

--- a/src/Typhon.Engine/Schema/public/DBComponentDefinition.cs
+++ b/src/Typhon.Engine/Schema/public/DBComponentDefinition.cs
@@ -41,6 +41,12 @@ public class DBComponentDefinition
 
     public StorageMode StorageMode { get; internal set; }
 
+    /// <summary>
+    /// Default durability discipline (from <c>[Component(DefaultDiscipline=…)]</c>). Only meaningful for
+    /// <see cref="StorageMode.SingleVersion"/>; <see cref="DurabilityDiscipline.TickFence"/> otherwise.
+    /// </summary>
+    public DurabilityDiscipline DefaultDiscipline { get; internal set; }
+
     public int ComponentStorageSize { get; private set; }
 
     /// <summary>
@@ -135,11 +141,13 @@ public class DBComponentDefinition
         public bool DoesFieldTypeSupportIndex() => (Type >= FieldType.Byte) && ((FieldType)((int)Type&0xFF) <= FieldType.String64);
     }
 
-    internal DBComponentDefinition(string name, int revision, StorageMode storageMode = StorageMode.Versioned)
+    internal DBComponentDefinition(string name, int revision, StorageMode storageMode = StorageMode.Versioned,
+        DurabilityDiscipline defaultDiscipline = DurabilityDiscipline.TickFence)
     {
         Name = name;
         Revision = revision;
         StorageMode = storageMode;
+        DefaultDiscipline = defaultDiscipline;
         _fieldsByName = new Dictionary<string, Field>();
     }
 

--- a/src/Typhon.Engine/Schema/public/DatabaseDefinitions.cs
+++ b/src/Typhon.Engine/Schema/public/DatabaseDefinitions.cs
@@ -130,7 +130,7 @@ public class DatabaseDefinitions
             throw new InvalidOperationException($"Missing the ComponentAttribute on the type {t} declaration");
         }
 
-        var compDef = new DBComponentDefinition(ca.Name ?? t.Name, ca.Revision, ca.StorageMode) { POCOType = t };
+        var compDef = new DBComponentDefinition(ca.Name ?? t.Name, ca.Revision, ca.StorageMode, ca.DefaultDiscipline) { POCOType = t };
 
         lock (_componentLock)
         {

--- a/src/Typhon.Engine/Storage/internals/ManagedPagedMMF.cs
+++ b/src/Typhon.Engine/Storage/internals/ManagedPagedMMF.cs
@@ -668,8 +668,14 @@ public partial class ManagedPagedMMF : PagedMMF, IMetricSource, IDebugProperties
         return segment;
     }
 
-    /// <summary>Try to load a segment. Returns false (instead of asserting) if the root page is already registered.</summary>
-    public bool TryLoadChunkBasedSegment(int filePageIndex, int stride, out ChunkBasedSegment<PersistentStore> result)
+    /// <summary>
+    /// Try to load a segment. Returns false (instead of asserting) if the root page is already registered. When
+    /// <paramref name="tolerateTornForRebuild"/> is set (the crash-recovery path), a structurally-incomplete segment — one a prior aborted checkpoint left
+    /// with a torn directory↔chain or an uninitialized root — also returns false (after un-registering the partial load) rather than throwing, so the
+    /// caller can fall back to a fresh allocation that WAL replay rebuilds (RB-01 / 03 §7: the persisted SPI is a hint on the crash path, not trusted). On
+    /// the clean path it stays strict — a torn segment with no WAL to recover from is genuine, loud-worthy corruption.
+    /// </summary>
+    public bool TryLoadChunkBasedSegment(int filePageIndex, int stride, out ChunkBasedSegment<PersistentStore> result, bool tolerateTornForRebuild = false)
     {
         result = null;
         var dic = _segments;
@@ -685,8 +691,20 @@ public partial class ManagedPagedMMF : PagedMMF, IMetricSource, IDebugProperties
         }
 
         ResolveDirectoryPairsForLoad(filePageIndex);   // CK-05 (C2): register directory-page slot state before the load walks them
-        if (!segment.Load(filePageIndex))
+        try
         {
+            if (!segment.Load(filePageIndex))
+            {
+                dic.TryRemove(filePageIndex, out _);
+                return false;
+            }
+        }
+        catch (InvalidOperationException) when (tolerateTornForRebuild)
+        {
+            // The persisted SPI points at a segment a prior aborted checkpoint left structurally incomplete (it wrote the ArchetypeR1 SPI page but not
+            // all of the segment's pages; CK-03's coverage gate held CheckpointLSN back, so the full WAL window is intact). Discard the partial load
+            // and let the caller fresh-allocate + WAL-replay instead of trusting it (#395 / RB-01).
+            dic.TryRemove(filePageIndex, out _);
             return false;
         }
 

--- a/src/Typhon.Engine/Transactions/internals/ComponentInfo.cs
+++ b/src/Typhon.Engine/Transactions/internals/ComponentInfo.cs
@@ -79,6 +79,24 @@ internal sealed class ComponentInfo
     /// <summary>Per-entity (primary key → component-revision info) working set for this transaction.</summary>
     internal Dictionary<long, CompRevInfo> SingleCache;
 
+    /// <summary>One Commit-discipline staged write: where the value lives in the tx staging buffer, plus the HEAD location captured at write time.</summary>
+    public struct StagedSlot
+    {
+        /// <summary>0-based offset into the transaction's native staging buffer (presence in <see cref="CommitStaged"/> means "staged").</summary>
+        public int Offset;
+
+        /// <summary>HEAD location captured at stage time so publish needs no EntityMap re-lookup: cluster ⇒ clusterChunkId*64+slotIndex; flat ⇒ content
+        /// chunkId.</summary>
+        public int Location;
+    }
+
+    /// <summary>
+    /// Commit-discipline (SingleVersion) staging map for this transaction: entity primary key → <see cref="StagedSlot"/>. Lazily allocated on the first
+    /// Commit-discipline write to this component. Kept separate from <see cref="SingleCache"/> so staging entries never collide with the Versioned
+    /// revision-chain consumers (rollback iteration, cluster resolution). See <c>claude/design/Ecs/committed-storage-mode.md</c> (issue #392).
+    /// </summary>
+    internal Dictionary<long, StagedSlot> CommitStaged;
+
     public void AddNew(long pk, CompRevInfo entry) => SingleCache.Add(pk, entry);
 
     /// <summary>

--- a/src/Typhon.Engine/Transactions/internals/TransactionChain.cs
+++ b/src/Typhon.Engine/Transactions/internals/TransactionChain.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Internals;
 
@@ -216,7 +217,7 @@ internal class TransactionChain : ResourceNode, IDebugPropertiesProvider
     /// Lock-free transaction creation. No lock acquired — uses ConcurrentQueue for pooling, atomic TSN increment, and CAS-based PushHead.
     /// </summary>
     [return: TransfersOwnership]
-    public Transaction CreateTransaction(DatabaseEngine dbe, UnitOfWork uow = null, bool readOnly = false)
+    public Transaction CreateTransaction(DatabaseEngine dbe, UnitOfWork uow = null, bool readOnly = false, DurabilityDiscipline discipline = DurabilityDiscipline.TickFence)
     {
         if (_activeCount >= _maxActiveTransactions)
         {
@@ -228,7 +229,7 @@ internal class TransactionChain : ResourceNode, IDebugPropertiesProvider
             t = new Transaction();
         }
 
-        t.Init(dbe, Interlocked.Increment(ref _nextFreeId), uow, readOnly);
+        t.Init(dbe, Interlocked.Increment(ref _nextFreeId), uow, readOnly, discipline);
 
         // Gauge: cumulative "transactions created" counter. Single convergence point — every call path (UnitOfWork.CreateTransaction,
         // DatabaseEngine.CreateQuickTransaction, DatabaseEngine.CreateReadOnlyTransaction) funnels through this method, so one

--- a/src/Typhon.Engine/Transactions/public/DatabaseEngineExtensions.cs
+++ b/src/Typhon.Engine/Transactions/public/DatabaseEngineExtensions.cs
@@ -1,4 +1,5 @@
 using JetBrains.Annotations;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine;
 
@@ -13,6 +14,10 @@ public static class DatabaseEngineExtensions
     /// </summary>
     /// <param name="dbe">The database engine.</param>
     /// <param name="durabilityMode">Controls when WAL records become crash-safe. Default is <see cref="DurabilityMode.Deferred"/>.</param>
+    /// <param name="discipline">
+    /// Durability discipline for SingleVersion-layout writes (<see cref="DurabilityDiscipline.TickFence"/> default, or
+    /// <see cref="DurabilityDiscipline.Commit"/> for zero-loss, atomic, commit-scoped writes). Fixed for the transaction.
+    /// </param>
     /// <returns>A transaction whose <see cref="System.IDisposable.Dispose"/> also disposes the owning UoW.</returns>
     /// <remarks>
     /// This is a convenience wrapper for the common single-transaction pattern:
@@ -24,11 +29,12 @@ public static class DatabaseEngineExtensions
     /// </code>
     /// </remarks>
     [return: TransfersOwnership]
-    public static Transaction CreateQuickTransaction(this DatabaseEngine dbe, DurabilityMode durabilityMode = DurabilityMode.Deferred)
+    public static Transaction CreateQuickTransaction(this DatabaseEngine dbe, DurabilityMode durabilityMode = DurabilityMode.Deferred,
+        DurabilityDiscipline discipline = DurabilityDiscipline.TickFence)
     {
         var uow = dbe.CreateUnitOfWork(durabilityMode);
         dbe.LogUowLifecycle("CreateQuickTransaction: UoW created, calling CreateTransaction");
-        var tx = uow.CreateTransaction();
+        var tx = uow.CreateTransaction(discipline);
         dbe.LogQuickTxCreated(tx.TSN);
         tx.OwnsUnitOfWork = true;
         return tx;

--- a/src/Typhon.Engine/Transactions/public/Transaction.cs
+++ b/src/Typhon.Engine/Transactions/public/Transaction.cs
@@ -127,7 +127,7 @@ public unsafe partial class Transaction : EntityAccessor
         }
     }
 
-    public void Init(DatabaseEngine dbe, long tsn, UnitOfWork uow = null, bool readOnly = false)
+    public void Init(DatabaseEngine dbe, long tsn, UnitOfWork uow = null, bool readOnly = false, DurabilityDiscipline discipline = DurabilityDiscipline.TickFence)
     {
         // Residual risk: _dbe.MMF.CreateChangeSet allocates and could throw OOM in extreme conditions, dropping the span.
         // Per project policy this is acceptable for a hot per-tx path.
@@ -148,6 +148,10 @@ public unsafe partial class Transaction : EntityAccessor
         _committedOperationCount = null;
         _deletedComponentCount = 0;
         _entityOperationCount = 0;
+        // Durability discipline (SingleVersion layout only). Explicit Commit is final; TickFence (explicit or default)
+        // stays open so a DefaultDiscipline=Commit component can escalate the whole tx on first touch (CM-02).
+        _discipline = discipline;
+        _didInPlaceSvWrite = false;
         _changeSet = readOnly ? null : (uow?.ChangeSet ?? _dbe.MMF.CreateChangeSet());
         State = TransactionState.Created;
         TSN = tsn;
@@ -1238,7 +1242,7 @@ public unsafe partial class Transaction : EntityAccessor
 
         // LCRI / CommitSequence bookkeeping — header field writes (under the retained handler lock when LockHeld).
         ref var header = ref compRevTableAccessor.GetChunk<CompRevStorageHeader>(e.FirstChunkId, true);
-        header.LastCommitRevisionIndex = (short)Math.Max(e.LastCommitRevisionIndex, e.CurRevisionIndex);
+        header.LastCommitRevisionIndex = Math.Max(e.LastCommitRevisionIndex, e.CurRevisionIndex);
         if (!e.Created)
         {
             header.CommitSequence++;
@@ -1381,90 +1385,12 @@ public unsafe partial class Transaction : EntityAccessor
         if (hasIndexes)
         {
             // Read new and old field values from CONTENT CHUNKS (not cluster slot — cluster hasn't been updated yet).
-            byte* newComp = compRevInfo.CurCompContentChunkId != 0 ? 
+            byte* newComp = compRevInfo.CurCompContentChunkId != 0 ?
                 _clusterCommitContentAccessor.GetChunkAddress(compRevInfo.CurCompContentChunkId) + table.ComponentOverhead : null;
-            byte* oldComp = readCompChunkId != 0 ? 
+            byte* oldComp = readCompChunkId != 0 ?
                 _clusterCommitContentAccessor.GetChunkAddress(readCompChunkId) + table.ComponentOverhead : null;
 
-            // Find the index slot for this component
-            for (int ixs = 0; ixs < clusterState.IndexSlots.Length; ixs++)
-            {
-                ref var ixSlot = ref clusterState.IndexSlots[ixs];
-                if (ixSlot.Slot != compSlot)
-                {
-                    continue;
-                }
-
-                for (int fi = 0; fi < ixSlot.Fields.Length; fi++)
-                {
-                    ref var field = ref ixSlot.Fields[fi];
-                    var idxAccessor = field.Index.Segment.CreateChunkAccessor(_changeSet);
-                    try
-                    {
-                        if (newComp != null && oldComp != null)
-                        {
-                            // Update: move from old key to new key
-                            field.Index.Move(oldComp + field.FieldOffset, newComp + field.FieldOffset, clusterLocation, ref idxAccessor);
-                        }
-                        else if (newComp != null)
-                        {
-                            // Insert (first commit after spawn)
-                            field.Index.Add(newComp + field.FieldOffset, clusterLocation, ref idxAccessor);
-                        }
-                        else if (oldComp != null)
-                        {
-                            // Delete
-                            field.Index.Remove(oldComp + field.FieldOffset, out _, ref idxAccessor);
-                        }
-
-                        // Widen zone map with new value
-                        if (newComp != null)
-                        {
-                            field.ZoneMap?.Widen(clusterChunkId, newComp + field.FieldOffset);
-                        }
-
-                        // Notify views of index change (delta buffer for incremental views)
-                        var viewTable = es.SlotToComponentTable[ixSlot.Slot];
-                        var views = viewTable.ViewRegistry.GetViewsForField(fi);
-                        for (int v = 0; v < views.Length; v++)
-                        {
-                            var reg = views[v];
-                            if (reg.View.IsDisposed)
-                            {
-                                continue;
-                            }
-
-                            if (newComp != null && oldComp != null)
-                            {
-                                // Move: emit old and new keys
-                                var oldKey = KeyBytes8.FromPointer(oldComp + field.FieldOffset, field.FieldSize);
-                                var newKey = KeyBytes8.FromPointer(newComp + field.FieldOffset, field.FieldSize);
-                                byte flags = (byte)(fi & 0x3F);
-                                reg.DeltaBuffer.TryAppend(entityKey, oldKey, newKey, TSN, flags, reg.ComponentTag);
-                            }
-                            else if (newComp != null)
-                            {
-                                // Add: isCreation flag
-                                var newKey = KeyBytes8.FromPointer(newComp + field.FieldOffset, field.FieldSize);
-                                byte flags = (byte)((fi & 0x3F) | 0x40); // isCreation
-                                reg.DeltaBuffer.TryAppend(entityKey, default, newKey, TSN, flags, reg.ComponentTag);
-                            }
-                            else if (oldComp != null)
-                            {
-                                // Remove: isDeletion flag
-                                var oldKey = KeyBytes8.FromPointer(oldComp + field.FieldOffset, field.FieldSize);
-                                byte flags = (byte)((fi & 0x3F) | 0x80); // isDeletion
-                                reg.DeltaBuffer.TryAppend(entityKey, oldKey, default, TSN, flags, reg.ComponentTag);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        idxAccessor.Dispose();
-                    }
-                }
-                break; // Found the matching index slot
-            }
+            ReconcileClusterIndexAndViews(es, clusterState, compSlot, clusterChunkId, clusterLocation, entityKey, oldComp, newComp);
         }
 
         // Phase B (HEAD→cluster slot copy) is deferred to PublishClusterVersionedSlot (AP-01). The cluster dirty bit it sets is what later drives
@@ -1513,6 +1439,275 @@ public unsafe partial class Transaction : EntityAccessor
             _clusterCommitContentAccessor.Dispose();
             _clusterCommitClusterAccessor.Dispose();
             _hasClusterCommitAccessors = false;
+        }
+    }
+
+    /// <summary>
+    /// Reconciles the per-archetype B+Tree index(es) and view delta buffers for one component slot of one cluster entity, given the field-value
+    /// base pointers BEFORE (<paramref name="oldComp"/>) and AFTER (<paramref name="newComp"/>) the change (each already past the component overhead;
+    /// null means absent). Move when both are present, Add on insert, Remove on delete. Shared by the Versioned cluster commit
+    /// (<see cref="PrepareClusterVersionedSlot"/>, value pointers into content chunks) and the Commit-discipline staged publish
+    /// (<see cref="PublishStagedCommitWrites"/>, old = cluster HEAD, new = staging buffer).
+    /// </summary>
+    private void ReconcileClusterIndexAndViews(ArchetypeEngineState es, ArchetypeClusterState clusterState, int compSlot, int clusterChunkId,
+        int clusterLocation, long entityKey, byte* oldComp, byte* newComp)
+    {
+        for (int ixs = 0; ixs < clusterState.IndexSlots.Length; ixs++)
+        {
+            ref var ixSlot = ref clusterState.IndexSlots[ixs];
+            if (ixSlot.Slot != compSlot)
+            {
+                continue;
+            }
+
+            for (int fi = 0; fi < ixSlot.Fields.Length; fi++)
+            {
+                ref var field = ref ixSlot.Fields[fi];
+                var idxAccessor = field.Index.Segment.CreateChunkAccessor(_changeSet);
+                try
+                {
+                    if (newComp != null && oldComp != null)
+                    {
+                        // Update: move from old key to new key
+                        field.Index.Move(oldComp + field.FieldOffset, newComp + field.FieldOffset, clusterLocation, ref idxAccessor);
+                    }
+                    else if (newComp != null)
+                    {
+                        // Insert (first commit after spawn)
+                        field.Index.Add(newComp + field.FieldOffset, clusterLocation, ref idxAccessor);
+                    }
+                    else if (oldComp != null)
+                    {
+                        // Delete
+                        field.Index.Remove(oldComp + field.FieldOffset, out _, ref idxAccessor);
+                    }
+
+                    // Widen zone map with new value
+                    if (newComp != null)
+                    {
+                        field.ZoneMap?.Widen(clusterChunkId, newComp + field.FieldOffset);
+                    }
+
+                    // Notify views of index change (delta buffer for incremental views)
+                    var viewTable = es.SlotToComponentTable[ixSlot.Slot];
+                    var views = viewTable.ViewRegistry.GetViewsForField(fi);
+                    for (int v = 0; v < views.Length; v++)
+                    {
+                        var reg = views[v];
+                        if (reg.View.IsDisposed)
+                        {
+                            continue;
+                        }
+
+                        if (newComp != null && oldComp != null)
+                        {
+                            // Move: emit old and new keys
+                            var oldKey = KeyBytes8.FromPointer(oldComp + field.FieldOffset, field.FieldSize);
+                            var newKey = KeyBytes8.FromPointer(newComp + field.FieldOffset, field.FieldSize);
+                            byte flags = (byte)(fi & 0x3F);
+                            reg.DeltaBuffer.TryAppend(entityKey, oldKey, newKey, TSN, flags, reg.ComponentTag);
+                        }
+                        else if (newComp != null)
+                        {
+                            // Add: isCreation flag
+                            var newKey = KeyBytes8.FromPointer(newComp + field.FieldOffset, field.FieldSize);
+                            byte flags = (byte)((fi & 0x3F) | 0x40); // isCreation
+                            reg.DeltaBuffer.TryAppend(entityKey, default, newKey, TSN, flags, reg.ComponentTag);
+                        }
+                        else if (oldComp != null)
+                        {
+                            // Remove: isDeletion flag
+                            var oldKey = KeyBytes8.FromPointer(oldComp + field.FieldOffset, field.FieldSize);
+                            byte flags = (byte)((fi & 0x3F) | 0x80); // isDeletion
+                            reg.DeltaBuffer.TryAppend(entityKey, oldKey, default, TSN, flags, reg.ComponentTag);
+                        }
+                    }
+                }
+                finally
+                {
+                    idxAccessor.Dispose();
+                }
+            }
+            break; // Found the matching index slot
+        }
+    }
+
+    /// <summary>
+    /// PUBLISH pass for Commit-discipline (SingleVersion) staged writes (issue #392, Variant A). Runs AFTER the WAL Append (AP-01). For each staged
+    /// (component, entity): re-resolves the cluster slot, reconciles the exact B+Tree index (old key from the still-unpublished HEAD, new key from the
+    /// staged slot — matching Versioned, CM-05/AC-11) and notifies views, copies the staged bytes into the cluster HEAD (the visibility act), then marks
+    /// the slot dirty (drives spatial migration at the fence and a benign last-writer-wins fence re-emit — CM-03). Spatial / zone maps stay fence-batched
+    /// for all modes (decision #31). No-op when nothing was staged. Commit discipline currently targets cluster-eligible archetypes only.
+    /// </summary>
+    /// <summary>Benchmark-only hook (#392 AC-5): runs just the staged-commit PUBLISH pass on an already-staged, not-yet-committed transaction, so the
+    /// per-component publish cost can be measured in isolation from BUILD/APPEND/WAIT. Idempotent for non-indexed components (re-memcpy +
+    /// re-SetDirty).</summary>
+    internal void PublishStagedForBenchmark() => PublishStagedCommitWrites();
+
+    private void PublishStagedCommitWrites()
+    {
+        if (_commitStagingBuffer == null)
+        {
+            return;
+        }
+
+        foreach (var kvp in _componentInfos)
+        {
+            var info = kvp.Value;
+            if (info.CommitStaged == null || info.ComponentTable.StorageMode != StorageMode.SingleVersion)
+            {
+                continue;
+            }
+
+            foreach (var staged in info.CommitStaged)
+            {
+                PublishStagedEntry(info, staged.Key, staged.Value);
+            }
+        }
+
+        DisposeClusterCommitAccessors();
+    }
+
+    /// <summary>Publishes one Commit-discipline staged write to its HEAD (index reconcile → HEAD memcpy → dirty mark), dispatching to the cluster SoA
+    /// slot or, for a non-cluster archetype, the entity's content chunk. Uses the HEAD location captured at stage time (<see cref="ComponentInfo.StagedSlot"/>)
+    /// — no EntityMap re-lookup (the writing tx never relocates the entity it is writing). See <see cref="PublishStagedCommitWrites"/>.</summary>
+    private void PublishStagedEntry(ComponentInfo info, long pk, ComponentInfo.StagedSlot stagedSlot)
+    {
+        var componentTypeId = info.ComponentTypeId;
+        var entityId = EntityId.FromRaw(pk);
+        var archId = entityId.ArchetypeId;
+        var meta = ArchetypeRegistry.GetMetadata(archId);
+        var es = _dbe._archetypeStates[archId];
+        if (!meta.TryGetSlot(componentTypeId, out byte compSlotByte))
+        {
+            return;
+        }
+        int compSlot = compSlotByte;
+        byte* staged = _commitStagingBuffer + stagedSlot.Offset;
+        var clusterState = es?.ClusterState;
+
+        // Non-cluster (flat) archetype: publish to the entity's content chunk HEAD instead of a cluster SoA slot (Location = content chunkId).
+        if (clusterState == null || !meta.IsClusterEligible)
+        {
+            PublishStagedFlatEntry(info, stagedSlot.Location, entityId.EntityKey, staged);
+            return;
+        }
+
+        // Lazy-cache the per-archetype cluster accessor (reused across consecutive same-archetype staged entries; map/content accessors kept for parity
+        // with the Versioned publish that shares these fields).
+        if (!_hasClusterCommitAccessors || _clusterCommitArchId != archId)
+        {
+            DisposeClusterCommitAccessors();
+            _clusterCommitMapAccessor = es.EntityMap.Segment.CreateChunkAccessor();
+            _clusterCommitContentAccessor = es.SlotToComponentTable[compSlot].ComponentSegment.CreateChunkAccessor();
+            _clusterCommitClusterAccessor = clusterState.ClusterSegment.CreateChunkAccessor();
+            _clusterCommitArchId = archId;
+            _hasClusterCommitAccessors = true;
+        }
+
+        // Coords captured at stage time — no per-component EntityMap re-lookup (Location = clusterChunkId*64 + slotIndex).
+        int clusterLocation = stagedSlot.Location;
+        int clusterChunkId = clusterLocation >> 6;
+        byte slotIndex = (byte)(clusterLocation & 63);
+
+        var layout = clusterState.Layout;
+        byte* clusterBase = _clusterCommitClusterAccessor.GetChunkAddress(clusterChunkId, true);
+        int compSize = layout.ComponentSize(compSlot);
+        byte* headPtr = clusterBase + layout.ComponentOffset(compSlot) + slotIndex * compSize;
+
+        // Exact-index reconcile BEFORE the HEAD memcpy: old key still lives in the HEAD slot, new key in the staged slot (CM-05/AC-11).
+        if (clusterState.IndexSlots != null)
+        {
+            ReconcileClusterIndexAndViews(es, clusterState, compSlot, clusterChunkId, clusterLocation, entityId.EntityKey, headPtr, staged);
+        }
+
+        // Visibility act: publish the staged value to the cluster HEAD, then mark dirty (CM-03: memcpy THEN dirty).
+        Unsafe.CopyBlockUnaligned(headPtr, staged, (uint)compSize);
+        clusterState.SetDirty(clusterChunkId, slotIndex);
+    }
+
+    /// <summary>
+    /// Publishes one Commit-discipline staged write to a non-cluster entity's content chunk HEAD using the chunkId captured at stage time (no EntityMap
+    /// re-lookup): reconciles the table's exact B+Tree index(es) (old key from the still-unpublished HEAD, new key from the staged slot — CM-05/AC-11),
+    /// copies the staged value into the chunk HEAD (the visibility act), then marks the chunk dirty for the tick fence.
+    /// </summary>
+    private void PublishStagedFlatEntry(ComponentInfo info, int chunkId, long entityKey, byte* staged)
+    {
+        if (chunkId == 0)
+        {
+            return;
+        }
+
+        var table = info.ComponentTable;
+        byte* headPtr = info.CompContentAccessor.GetChunkAddress(chunkId, true) + info.ComponentOverhead;
+
+        // Exact-index reconcile BEFORE the HEAD memcpy: old key still lives in the chunk HEAD, new key in the staged slot.
+        if (table.HasShadowableIndexes)
+        {
+            ReconcileFlatIndexAndViews(table, chunkId, entityKey, headPtr, staged);
+        }
+
+        // Visibility act: publish the staged value to the chunk HEAD, then mark dirty (CM-03: memcpy THEN dirty).
+        Unsafe.CopyBlockUnaligned(headPtr, staged, (uint)table.ComponentStorageSize);
+        table.DirtyBitmap?.Set(chunkId);
+    }
+
+    /// <summary>
+    /// Flat (non-cluster) counterpart of <see cref="ReconcileClusterIndexAndViews"/>: updates each indexed field's table B+Tree from <paramref name="oldComp"/>
+    /// (the chunk HEAD field base, pre-publish) to <paramref name="newComp"/> (the staged slot) and notifies views. Mirrors the fence-time
+    /// <c>ProcessShadowFieldEntries</c> Move branch, but runs at commit (the Commit-discipline write skips shadow capture). The B+Tree value is the entity's
+    /// content chunkId; for an AllowMultiple index the element id (in the chunk overhead, untouched by the value memcpy) is moved and written back.
+    /// </summary>
+    private void ReconcileFlatIndexAndViews(ComponentTable table, int chunkId, long entityKey, byte* oldComp, byte* newComp)
+    {
+        var fields = table.IndexedFieldInfos;
+        for (int fi = 0; fi < fields.Length; fi++)
+        {
+            ref var ifi = ref fields[fi];
+            // oldComp/newComp point at the component DATA (the chunk HEAD past its overhead, and the staging slot — both
+            // data-relative). IndexedFieldInfo.OffsetToField, however, is measured from the CHUNK BASE so it INCLUDES the
+            // overhead (matching the fence path ProcessShadowFieldEntries, which reads at GetChunkAddress(chunkId) + OffsetToField).
+            // Rebase to a data-relative offset before indexing into the two data pointers — adding the chunk-base OffsetToField
+            // directly would double-count ComponentOverhead and read the key from the wrong location.
+            int dataFieldOffset = ifi.OffsetToField - table.ComponentOverhead;
+            var oldKey = KeyBytes8.FromPointer(oldComp + dataFieldOffset, ifi.Size);
+            byte* newFieldPtr = newComp + dataFieldOffset;
+            var newKey = KeyBytes8.FromPointer(newFieldPtr, ifi.Size);
+            if (oldKey.RawValue == newKey.RawValue)
+            {
+                continue;
+            }
+
+            var index = ifi.PersistentIndex;
+            var idxAccessor = index.Segment.CreateChunkAccessor(_changeSet);
+            try
+            {
+                if (index.AllowMultiple)
+                {
+                    // Element id lives in the chunk overhead (chunk base = HEAD field base − ComponentOverhead); the value memcpy never touches it.
+                    int* elementIdPtr = (int*)(oldComp - table.ComponentOverhead + ifi.OffsetToIndexElementId);
+                    *elementIdPtr = index.MoveValue(&oldKey, newFieldPtr, *elementIdPtr, chunkId, ref idxAccessor, out _, out _);
+                }
+                else
+                {
+                    index.Move(&oldKey, newFieldPtr, chunkId, ref idxAccessor);
+                }
+
+                var views = table.ViewRegistry.GetViewsForField(fi);
+                for (int v = 0; v < views.Length; v++)
+                {
+                    var reg = views[v];
+                    if (reg.View.IsDisposed)
+                    {
+                        continue;
+                    }
+                    reg.DeltaBuffer.TryAppend(entityKey, oldKey, newKey, TSN, (byte)(fi & 0x3F), reg.ComponentTag);
+                }
+            }
+            finally
+            {
+                idxAccessor.Dispose();
+            }
         }
     }
 
@@ -1646,6 +1841,46 @@ public unsafe partial class Transaction : EntityAccessor
                 var s = _spawnedEntities[i];
                 batch.AddSpawn((long)s.Id.RawValue, s.Id.ArchetypeId, s.EnabledBits);
             }
+
+            // #395 Face B (design D5): under Commit discipline a spawn must be ATOMICALLY durable — also WAL-log its SingleVersion component VALUES
+            // (one Slot upsert each). Without this the spawn lifecycle is logged but the SV values are not (they only ride the cluster SoA / content
+            // chunk, persisted by the next checkpoint), so a hard crash before that checkpoint recovers the entity alive-but-default — a phantom.
+            // Recovery aggregates the Spawn + these Slots by EntityId and applies them together (ApplySpawnedEntity → cluster slot claim + SoA value
+            // write), so the entity recovers with its values. TickFence spawns stay checkpoint-durable by design (no per-commit SV WAL). Versioned
+            // spawn values are already logged via their revision chains (SingleCache loop below); Transient is never logged. Read from the
+            // spawn-staging content chunk (entry.Loc[slot]) — FinalizeSpawns runs later (PUBLISH), so the cluster SoA is not populated yet, but the
+            // value already sits at ComponentOverhead in the staging chunk.
+            if (_discipline == DurabilityDiscipline.Commit)
+            {
+                for (int i = 0; i < _spawnedEntities.Count; i++)
+                {
+                    var s = _spawnedEntities[i];
+                    if (_pendingDestroys != null && _pendingDestroys.Contains(s.Id))
+                    {
+                        continue;   // spawned and destroyed in the same tx — nothing to restore
+                    }
+
+                    var slotTables = _dbe._archetypeStates[s.Id.ArchetypeId].SlotToComponentTable;
+                    for (int slot = 0; slot < slotTables.Length; slot++)
+                    {
+                        var table = slotTables[slot];
+                        if (table == null || table.StorageMode != StorageMode.SingleVersion)
+                        {
+                            continue;   // Versioned already logged (chains); Transient never logged
+                        }
+
+                        int locChunkId = s.Loc[slot];
+                        if (locChunkId <= 0)
+                        {
+                            continue;   // component not provided at spawn
+                        }
+
+                        var info = GetComponentInfo(table.Definition.POCOType);
+                        var payload = info.CompContentAccessor.GetChunkAsReadOnlySpan(locChunkId);
+                        batch.AddSlot((long)s.Id.RawValue, (ushort)info.ComponentTypeId, payload.Slice(info.ComponentOverhead, table.ComponentStorageSize));
+                    }
+                }
+            }
         }
 
         // Component values: one Slot upsert per modified component (skip reads and deletes — deletes ride the entity-destroy record).
@@ -1673,6 +1908,17 @@ public unsafe partial class Transaction : EntityAccessor
                 var overhead = info.ComponentTable.ComponentOverhead;
                 var payload = info.CompContentAccessor.GetChunkAsReadOnlySpan(cri.CurCompContentChunkId);
                 batch.AddSlot(cacheEntry.Key, componentTypeId, payload.Slice(overhead, storageSize));
+            }
+
+            // Commit-discipline (SingleVersion) staged writes: the value lives in the native staging buffer (offset is 1-based), already sliced past
+            // the component overhead. Logged as an ordinary Slot record; the batch's Committed flag is telemetry (recovery applies it like any
+            // tick-fence slot record — last-writer-wins by LSN, AC-7).
+            if (info.CommitStaged != null)
+            {
+                foreach (var staged in info.CommitStaged)
+                {
+                    batch.AddSlot(staged.Key, componentTypeId, new ReadOnlySpan<byte>(_commitStagingBuffer + staged.Value.Offset, storageSize));
+                }
             }
         }
 
@@ -1711,7 +1957,7 @@ public unsafe partial class Transaction : EntityAccessor
             {
                 _commitBatchArena ??= new CommitBatchArena();
                 _commitBatchArena.Reset();
-                var batch = new CommitBatchBuilder(_commitBatchArena, TSN, UowId);
+                var batch = new CommitBatchBuilder(_commitBatchArena, TSN, UowId, committedDiscipline: _discipline == DurabilityDiscipline.Commit);
                 BuildCommitBatch(ref batch);
                 if (!batch.IsEmpty)
                 {
@@ -1962,6 +2208,9 @@ public unsafe partial class Transaction : EntityAccessor
             _dbe.LogCommitPhase(TSN, "Publish");
             PublishPreparedComponents();
             FlushEcsPendingOperations();
+            // Commit-discipline (SingleVersion) staged writes: publish to cluster HEAD + reconcile exact indexes (after FinalizeSpawns so a staged
+            // write to a same-tx-spawned entity resolves in the EntityMap). Variant A / issue #392.
+            PublishStagedCommitWrites();
 
             // ── WAIT (Immediate) + transition to Committed. Publish already ran and released handler locks, so the durability wait never spans a held
             //    lock; a wait timeout here means durability-uncertain, not rollback (AP-02). ──

--- a/src/Typhon.Engine/Transactions/public/UnitOfWork.cs
+++ b/src/Typhon.Engine/Transactions/public/UnitOfWork.cs
@@ -2,6 +2,7 @@ using JetBrains.Annotations;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine;
 
@@ -104,8 +105,12 @@ public sealed class UnitOfWork : IDisposable
     /// </summary>
     /// <exception cref="ObjectDisposedException">The UoW has been disposed.</exception>
     /// <exception cref="InvalidOperationException">The UoW is not in <see cref="UnitOfWorkState.Pending"/> state.</exception>
+    /// <param name="discipline">
+    /// Durability discipline for SingleVersion-layout writes (<see cref="DurabilityDiscipline.TickFence"/> default, or
+    /// <see cref="DurabilityDiscipline.Commit"/> for zero-loss, atomic, commit-scoped writes). Fixed for the transaction.
+    /// </param>
     [return: TransfersOwnership]
-    public Transaction CreateTransaction()
+    public Transaction CreateTransaction(DurabilityDiscipline discipline = DurabilityDiscipline.TickFence)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (_state != UnitOfWorkState.Pending)
@@ -115,7 +120,7 @@ public sealed class UnitOfWork : IDisposable
 
         Interlocked.Increment(ref _transactionCount);
         _dbe.RecordTransactionCreated();
-        return _dbe.TransactionChain.CreateTransaction(_dbe, this);
+        return _dbe.TransactionChain.CreateTransaction(_dbe, this, discipline: discipline);
     }
 
     /// <summary>

--- a/src/Typhon.Schema.Definition/Attributes.cs
+++ b/src/Typhon.Schema.Definition/Attributes.cs
@@ -20,6 +20,14 @@ public sealed class ComponentAttribute : Attribute
     /// <summary>Storage mode for this component. Default is <see cref="StorageMode.Versioned"/> (full MVCC).</summary>
     public StorageMode StorageMode { get; set; } = StorageMode.Versioned;
 
+    /// <summary>
+    /// Default durability discipline for this component when its <see cref="StorageMode"/> is <see cref="StorageMode.SingleVersion"/>.
+    /// Default is <see cref="DurabilityDiscipline.TickFence"/> (batched, ≤1-tick loss).
+    /// Set to <see cref="DurabilityDiscipline.Commit"/> to make any transaction that writes this component commit-durable (zero-loss, atomic) for all of its
+    /// writes (CM-02 uniformity). Ignored for <see cref="StorageMode.Versioned"/> (always commit-scoped) and <see cref="StorageMode.Transient"/> (never durable).
+    /// </summary>
+    public DurabilityDiscipline DefaultDiscipline { get; set; } = DurabilityDiscipline.TickFence;
+
     public ComponentAttribute(string name, int revision)
     {
         Name = name;

--- a/src/Typhon.Schema.Definition/DurabilityDiscipline.cs
+++ b/src/Typhon.Schema.Definition/DurabilityDiscipline.cs
@@ -1,0 +1,34 @@
+using JetBrains.Annotations;
+
+namespace Typhon.Schema.Definition;
+
+/// <summary>
+/// Runtime durability discipline for a <see cref="StorageMode.SingleVersion"/>-layout component — selected per transaction, orthogonal to the design-time
+/// <see cref="StorageMode"/> (which fixes the cluster layout) and to the per-UoW <c>DurabilityMode</c> (which fixes flush timing).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The discipline is a transaction-time knob on the existing per-UoW durability axis; it does NOT change a component's storage layout and is NOT a new
+/// <see cref="StorageMode"/> value. It only applies to the <see cref="StorageMode.SingleVersion"/> layout — <see cref="StorageMode.Versioned"/> is always
+/// commit-scoped and <see cref="StorageMode.Transient"/> is never durable.
+/// </para>
+/// <para>
+/// See <c>claude/design/Ecs/committed-storage-mode.md</c> (the authoritative feature spec).
+/// </para>
+/// </remarks>
+[PublicAPI]
+public enum DurabilityDiscipline : byte
+{
+    /// <summary>
+    /// Default. In-place writes, last-writer-wins, durability batched at the tick fence (≤1-tick loss). Maximum throughput for high-frequency, loss-tolerant
+    /// data (position, velocity, health).
+    /// </summary>
+    TickFence = 0,
+
+    /// <summary>
+    /// Writes are staged per transaction and made atomic + zero-loss durable at <c>Transaction.Commit</c> via a logical-redo WAL record, then published in
+    /// place — read-committed isolation, O(1) rollback, no revision chain.
+    /// For writes that must not be lost and must be all-or-nothing (teleport, item pickup) without paying for MVCC.
+    /// </summary>
+    Commit = 1,
+}

--- a/test/Typhon.Benchmark/CommittedDisciplineBenchmarks.cs
+++ b/test/Typhon.Benchmark/CommittedDisciplineBenchmarks.cs
@@ -1,0 +1,186 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Typhon.Engine;
+using Typhon.Schema.Definition;
+
+namespace Typhon.Benchmark;
+
+// ═══════════════════════════════════════════════════════════════════════
+// Committed durability discipline write/commit benchmarks (#392 AC-5).
+// Targets (Zen 4): Commit-discipline write ≤ 25 ns; commit publish ≤ 60 ns/component; ≥ 8× faster than a Versioned write;
+// the SV TickFence in-place path (~3 ns) unregressed.
+//
+// Reuses the cluster archetypes from ArchetypeAccessorBenchmark.cs:
+//   AaBenchAnt (510):          SV Position + SV Movement
+//   AaBenchMixedCluster (516): SV Position + SV Movement + Versioned Health
+//
+// Each benchmark drives N entities through one transaction and reports per-component time via OperationsPerInvoke = N
+// (the per-transaction create/dispose overhead amortizes away). Write benchmarks roll back (isolate the write); the commit
+// benchmark commits (Deferred, so no fsync dominates the in-memory publish cost).
+// ═══════════════════════════════════════════════════════════════════════
+
+[SimpleJob(warmupCount: 3, iterationCount: 7)]
+[MemoryDiagnoser]
+[BenchmarkCategory("Committed", "Durability")]
+public class CommittedDisciplineBenchmarks : IDisposable
+{
+    private const int N = 1000;
+
+    private ServiceProvider _serviceProvider;
+    private DatabaseEngine _dbe;
+    private EntityId[] _svIds;       // AaBenchAnt — SV Position
+    private EntityId[] _mixedIds;    // AaBenchMixedCluster — Versioned Health
+    private Transaction _stagedTx;   // Publish_Only: a Commit tx with N staged writes, not yet committed
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Archetype<AaBenchAnt>.Touch();
+        Archetype<AaBenchMixedCluster>.Touch();
+
+        var name = $"CommittedBench_{Environment.ProcessId}";
+        var sc = new ServiceCollection();
+        sc.AddLogging(b => b.SetMinimumLevel(LogLevel.Critical))
+          .AddResourceRegistry()
+          .AddMemoryAllocator()
+          .AddEpochManager()
+          .AddHighResolutionSharedTimer()
+          .AddDeadlineWatchdog()
+          .AddScopedManagedPagedMemoryMappedFile(o =>
+          {
+              o.DatabaseName = name;
+              o.DatabaseCacheSize = (ulong)(200 * 1024 * PagedMMF.PageSize);
+              o.PagesDebugPattern = false;
+          })
+          .AddInMemoryWalEngine();
+
+        _serviceProvider = sc.BuildServiceProvider();
+        _serviceProvider.EnsureFileDeleted<ManagedPagedMMFOptions>();
+        _dbe = _serviceProvider.GetRequiredService<DatabaseEngine>();
+
+        _dbe.RegisterComponentFromAccessor<AaBenchPosition>();
+        _dbe.RegisterComponentFromAccessor<AaBenchMovement>();
+        _dbe.RegisterComponentFromAccessor<AaVcHealth>();
+        _dbe.InitializeArchetypes();
+
+        _svIds = new EntityId[N];
+        _mixedIds = new EntityId[N];
+        using (var tx = _dbe.CreateQuickTransaction())
+        {
+            for (int i = 0; i < N; i++)
+            {
+                var pos = new AaBenchPosition(i, i);
+                var mov = new AaBenchMovement(1, 1);
+                _svIds[i] = tx.Spawn<AaBenchAnt>(AaBenchAnt.Position.Set(in pos), AaBenchAnt.Movement.Set(in mov));
+            }
+            tx.Commit();
+        }
+        using (var tx = _dbe.CreateQuickTransaction())
+        {
+            for (int i = 0; i < N; i++)
+            {
+                var pos = new AaBenchPosition(i, i);
+                var mov = new AaBenchMovement(1, 1);
+                var health = new AaVcHealth { Current = 100, Max = 100 };
+                _mixedIds[i] = tx.Spawn<AaBenchMixedCluster>(
+                    AaBenchMixedCluster.Position.Set(in pos), AaBenchMixedCluster.Movement.Set(in mov), AaBenchMixedCluster.Health.Set(in health));
+            }
+            tx.Commit();
+        }
+    }
+
+    // ── Resolution-only baseline (OpenMut, no write). The AC-5 write/stage cost is the DELTA of the write benchmarks over this. ──
+    [Benchmark(OperationsPerInvoke = N, Baseline = true)]
+    public void Resolve_Only()
+    {
+        using var tx = _dbe.CreateQuickTransaction(DurabilityMode.Deferred);
+        ulong sink = 0;
+        for (int i = 0; i < N; i++)
+        {
+            sink += tx.OpenMut(_svIds[i]).Id.RawValue;
+        }
+        tx.Rollback();
+        GC.KeepAlive(sink);
+    }
+
+    // ── Write cost: SV TickFence in-place (baseline ~3 ns over resolution) ──────────────
+    [Benchmark(OperationsPerInvoke = N)]
+    public void Write_Sv_TickFence()
+    {
+        using var tx = _dbe.CreateQuickTransaction(DurabilityMode.Deferred);
+        for (int i = 0; i < N; i++)
+        {
+            tx.OpenMut(_svIds[i]).Write(AaBenchAnt.Position).X = i;
+        }
+        tx.Rollback();
+    }
+
+    // ── Write cost: Commit discipline (Variant-A staging, target ≤ 25 ns) ───────────────
+    [Benchmark(OperationsPerInvoke = N)]
+    public void Write_Sv_Commit()
+    {
+        using var tx = _dbe.CreateQuickTransaction(DurabilityMode.Deferred, DurabilityDiscipline.Commit);
+        for (int i = 0; i < N; i++)
+        {
+            tx.OpenMut(_svIds[i]).Write(AaBenchAnt.Position).X = i;
+        }
+        tx.Rollback();
+    }
+
+    // ── Write cost: Versioned COW (the path Committed replaces, ~146–170 ns) ────────────
+    [Benchmark(OperationsPerInvoke = N)]
+    public void Write_Versioned()
+    {
+        using var tx = _dbe.CreateQuickTransaction(DurabilityMode.Deferred);
+        for (int i = 0; i < N; i++)
+        {
+            tx.OpenMut(_mixedIds[i]).Write(AaBenchMixedCluster.Health).Current = i;
+        }
+        tx.Rollback();
+    }
+
+    // ── Commit cost: full Commit-discipline transaction (stage + BUILD + APPEND + publish per component) ──
+    [Benchmark(OperationsPerInvoke = N)]
+    public void Commit_Sv_Commit()
+    {
+        using var tx = _dbe.CreateQuickTransaction(DurabilityMode.Deferred, DurabilityDiscipline.Commit);
+        for (int i = 0; i < N; i++)
+        {
+            tx.OpenMut(_svIds[i]).Write(AaBenchAnt.Position).X = i;
+        }
+        tx.Commit();
+    }
+
+    // ── Publish cost in ISOLATION (target ≤ 60 ns/component): just the PUBLISH pass (re-resolve + memcpy→HEAD + SetDirty),
+    //    excluding BUILD/APPEND/WAIT. Staged once per iteration in IterationSetup; the measured body re-runs the publish pass. ──
+    [IterationSetup(Target = nameof(Publish_Only))]
+    public void StagePublishTx()
+    {
+        _stagedTx = _dbe.CreateQuickTransaction(DurabilityMode.Deferred, DurabilityDiscipline.Commit);
+        for (int i = 0; i < N; i++)
+        {
+            _stagedTx.OpenMut(_svIds[i]).Write(AaBenchAnt.Position).X = i; // stage only — not committed
+        }
+    }
+
+    [IterationCleanup(Target = nameof(Publish_Only))]
+    public void DisposePublishTx()
+    {
+        _stagedTx?.Rollback();
+        _stagedTx?.Dispose();
+        _stagedTx = null;
+    }
+
+    [Benchmark(OperationsPerInvoke = N)]
+    public void Publish_Only() => _stagedTx.PublishStagedForBenchmark();
+
+    public void Dispose()
+    {
+        _stagedTx?.Dispose();
+        _stagedTx = null;
+        _serviceProvider?.Dispose();
+        _serviceProvider = null;
+    }
+}

--- a/test/Typhon.Engine.Tests/Data/ECS/CommittedDisciplineTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/CommittedDisciplineTests.cs
@@ -1,0 +1,350 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Typhon.Schema.Definition;
+
+namespace Typhon.Engine.Tests;
+
+// ── Test components for the Committed durability discipline (issue #392) ──────────────────
+[Component("Typhon.Test.Committed.CmPosition", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+struct CmPosition
+{
+    public float X, Y;
+    public CmPosition(float x, float y) { X = x; Y = y; }
+}
+
+// DefaultDiscipline=Commit — any tx that writes this component is escalated to Commit (CM-02).
+[Component("Typhon.Test.Committed.CmWallet", 1, StorageMode = StorageMode.SingleVersion, DefaultDiscipline = DurabilityDiscipline.Commit)]
+[StructLayout(LayoutKind.Sequential)]
+struct CmWallet
+{
+    public long Gold;
+    public CmWallet(long gold) { Gold = gold; }
+}
+
+[Archetype(530)]
+partial class CmEntity : Archetype<CmEntity>
+{
+    public static readonly Comp<CmPosition> Position = Register<CmPosition>();
+    public static readonly Comp<CmWallet> Wallet = Register<CmWallet>();
+}
+
+// Indexed SV component — for the exact-index-at-commit test (AC-11 / CM-05).
+[Component("Typhon.Test.Committed.CmTeam", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+struct CmTeam
+{
+    [Index]
+    public int TeamId;
+    public int Rank;
+}
+
+[Archetype(531)]
+partial class CmIdxEntity : Archetype<CmIdxEntity>
+{
+    public static readonly Comp<CmPosition> Position = Register<CmPosition>();
+    public static readonly Comp<CmTeam> Team = Register<CmTeam>();
+}
+
+// Indexed SV component written under Commit on the FLAT (non-cluster) path. The archetype is forced non-cluster-eligible by pairing it with a
+// Transient+indexed component (engine rule: a Transient indexed field keeps the whole archetype on the legacy per-entity path).
+[Component("Typhon.Test.Committed.CmFlatVal", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+struct CmFlatVal
+{
+    [Index]
+    public int Tag;
+    public int Other;
+}
+
+[Component("Typhon.Test.Committed.CmTransIdx", 1, StorageMode = StorageMode.Transient)]
+[StructLayout(LayoutKind.Sequential)]
+struct CmTransIdx
+{
+    [Index]
+    public int Key;
+}
+
+[Archetype(532)]
+partial class CmFlatEntity : Archetype<CmFlatEntity>
+{
+    public static readonly Comp<CmFlatVal> Val = Register<CmFlatVal>();
+    public static readonly Comp<CmTransIdx> Idx = Register<CmTransIdx>();
+}
+
+[TestFixture]
+[NonParallelizable]
+class CommittedDisciplineTests : TestBase<CommittedDisciplineTests>
+{
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        Archetype<CmEntity>.Touch();
+        Archetype<CmIdxEntity>.Touch();
+        Archetype<CmFlatEntity>.Touch();
+    }
+
+    private DatabaseEngine SetupEngine()
+    {
+        var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        dbe.RegisterComponentFromAccessor<CmPosition>();
+        dbe.RegisterComponentFromAccessor<CmWallet>();
+        dbe.RegisterComponentFromAccessor<CmTeam>();
+        dbe.RegisterComponentFromAccessor<CmFlatVal>();
+        dbe.RegisterComponentFromAccessor<CmTransIdx>();
+        dbe.InitializeArchetypes();
+        return dbe;
+    }
+
+    private static EntityId SpawnAnt(DatabaseEngine dbe, float x, float y, long gold)
+    {
+        using var tx = dbe.CreateQuickTransaction();
+        var pos = new CmPosition(x, y);
+        var wallet = new CmWallet(gold);
+        var id = tx.Spawn<CmEntity>(CmEntity.Position.Set(in pos), CmEntity.Wallet.Set(in wallet));
+        tx.Commit();
+        return id;
+    }
+
+    // ── AC-1 / AC-2 (path): a Commit-discipline write publishes to HEAD at commit ──────────
+    [Test]
+    public void CommitDiscipline_Write_PublishesAtCommit()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnAnt(dbe, 10, 20, 0);
+
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+        {
+            var e = tx.OpenMut(id);
+            ref var p = ref e.Write(CmEntity.Position);
+            p.X = 99;
+            p.Y = 88;
+            tx.Commit();
+        }
+
+        using var read = dbe.CreateQuickTransaction();
+        ref readonly var rp = ref read.Open(id).Read(CmEntity.Position);
+        Assert.That(rp.X, Is.EqualTo(99f));
+        Assert.That(rp.Y, Is.EqualTo(88f));
+    }
+
+    // ── CM-01: staged writes never touch HEAD before commit (a concurrent reader sees the old value) ──
+    [Test]
+    public void CommitDiscipline_StagedWrite_NotVisibleBeforeCommit()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnAnt(dbe, 1, 2, 0);
+
+        using var writeTx = dbe.CreateQuickTransaction(DurabilityMode.Deferred, DurabilityDiscipline.Commit);
+        var e = writeTx.OpenMut(id);
+        e.Write(CmEntity.Position).X = 777;   // staged — HEAD must remain (1,2)
+
+        // A separate transaction reads HEAD: read-committed ⇒ still sees the pre-write value.
+        using (var peek = dbe.CreateQuickTransaction())
+        {
+            ref readonly var pk = ref peek.Open(id).Read(CmEntity.Position);
+            Assert.That(pk.X, Is.EqualTo(1f), "staged value leaked to HEAD before commit (CM-01 violation)");
+        }
+
+        writeTx.Commit();
+
+        using var after = dbe.CreateQuickTransaction();
+        Assert.That(after.Open(id).Read(CmEntity.Position).X, Is.EqualTo(777f), "value not published at commit");
+    }
+
+    // ── AC-4: read-your-own-writes within the writing Commit-discipline tx ─────────────────
+    [Test]
+    public void CommitDiscipline_ReadYourOwnWrites()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnAnt(dbe, 5, 6, 0);
+
+        using var tx = dbe.CreateQuickTransaction(DurabilityMode.Deferred, DurabilityDiscipline.Commit);
+        var e = tx.OpenMut(id);
+        e.Write(CmEntity.Position).X = 42;
+        ref readonly var rp = ref e.Read(CmEntity.Position);
+        Assert.That(rp.X, Is.EqualTo(42f), "writer did not see its own staged value (RYOW)");
+        Assert.That(rp.Y, Is.EqualTo(6f), "partial write lost the unwritten field (seed missing)");
+    }
+
+    // ── AC-3: rollback discards staged values; HEAD never changed ──────────────────────────
+    [Test]
+    public void CommitDiscipline_Rollback_DiscardsStaged()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnAnt(dbe, 3, 4, 0);
+
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Deferred, DurabilityDiscipline.Commit))
+        {
+            tx.OpenMut(id).Write(CmEntity.Position).X = 1234;
+            tx.Rollback();
+        }
+
+        using var read = dbe.CreateQuickTransaction();
+        Assert.That(read.Open(id).Read(CmEntity.Position).X, Is.EqualTo(3f), "rollback did not discard the staged write");
+    }
+
+    // ── AC-3: all writes of a Commit-discipline tx become visible together ─────────────────
+    [Test]
+    public void CommitDiscipline_MultiWrite_Atomic()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnAnt(dbe, 0, 0, 100);
+
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+        {
+            var e = tx.OpenMut(id);
+            e.Write(CmEntity.Position) = new CmPosition(7, 8);
+            e.Write(CmEntity.Wallet) = new CmWallet(500);
+            tx.Commit();
+        }
+
+        using var read = dbe.CreateQuickTransaction();
+        var e2 = read.Open(id);
+        Assert.That(e2.Read(CmEntity.Position).X, Is.EqualTo(7f));
+        Assert.That(e2.Read(CmEntity.Wallet).Gold, Is.EqualTo(500L));
+    }
+
+    // ── AC-1: DefaultDiscipline=Commit escalates a default-discipline tx (CM-02) ────────────
+    [Test]
+    public void DefaultDiscipline_Commit_EscalatesTransaction()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnAnt(dbe, 0, 0, 10);
+
+        // No explicit discipline → escalates to Commit on first touch of CmWallet (DefaultDiscipline=Commit).
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate))
+        {
+            tx.OpenMut(id).Write(CmEntity.Wallet).Gold = 9999;
+            Assert.That(tx.Discipline, Is.EqualTo(DurabilityDiscipline.Commit), "tx was not escalated by DefaultDiscipline=Commit");
+            tx.Commit();
+        }
+
+        using var read = dbe.CreateQuickTransaction();
+        Assert.That(read.Open(id).Read(CmEntity.Wallet).Gold, Is.EqualTo(9999L));
+    }
+
+    // ── AC-11 / CM-05: the exact B+Tree index reflects a Commit-discipline write AT COMMIT (no tick fence) ──
+    [Test]
+    public void CommitDiscipline_IndexedWrite_FreshAtCommit_NoFence()
+    {
+        using var dbe = SetupEngine();
+
+        EntityId id;
+        using (var tx = dbe.CreateQuickTransaction())
+        {
+            id = tx.Spawn<CmIdxEntity>(CmIdxEntity.Position.Set(new CmPosition(0, 0)), CmIdxEntity.Team.Set(new CmTeam { TeamId = 1, Rank = 5 }));
+            tx.Spawn<CmIdxEntity>(CmIdxEntity.Position.Set(new CmPosition(1, 1)), CmIdxEntity.Team.Set(new CmTeam { TeamId = 2, Rank = 5 }));
+            tx.Commit();
+        }
+        dbe.WriteTickFence(1); // index the spawned values
+
+        // Move entity from TeamId 1 → 7 under Commit discipline, then commit. Deliberately NO WriteTickFence afterward:
+        // the exact index must already reflect TeamId=7, the same as Versioned (CM-05/AC-11 — Move done at commit).
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+        {
+            tx.OpenMut(id).Write(CmIdxEntity.Team).TeamId = 7;
+            tx.Commit();
+        }
+
+        using var q = dbe.CreateQuickTransaction();
+        Assert.That(q.Query<CmIdxEntity>().WhereField<CmTeam>(t => t.TeamId == 1).Count(), Is.EqualTo(0),
+            "old key still present in the exact index after a committed write (AC-11 false-negative)");
+        Assert.That(q.Query<CmIdxEntity>().WhereField<CmTeam>(t => t.TeamId == 7).Count(), Is.EqualTo(1),
+            "new key not visible in the exact index at commit — index lagged to the fence (AC-11/CM-05)");
+        Assert.That(q.Query<CmIdxEntity>().WhereField<CmTeam>(t => t.TeamId == 2).Count(), Is.EqualTo(1),
+            "untouched entity disappeared from the index");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Non-cluster (flat) Commit path — large component ⇒ not cluster-eligible
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void NonCluster_ArchetypeIsFlat()
+    {
+        using var dbe = SetupEngine();
+        Assert.That(Archetype<CmFlatEntity>.Metadata.IsClusterEligible, Is.False,
+            "CmFlatEntity must NOT be cluster-eligible for these tests to exercise the flat Commit path");
+    }
+
+    private static EntityId SpawnFlat(DatabaseEngine dbe, int tag)
+    {
+        using var tx = dbe.CreateQuickTransaction();
+        // CmTransIdx is a unique Transient index — its Key must be distinct per entity. Derive it from tag.
+        var id = tx.Spawn<CmFlatEntity>(CmFlatEntity.Val.Set(new CmFlatVal { Tag = tag }), CmFlatEntity.Idx.Set(new CmTransIdx { Key = tag + 1000 }));
+        tx.Commit();
+        return id;
+    }
+
+    [Test]
+    public void NonCluster_CommitDiscipline_Write_PublishesAtCommit()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnFlat(dbe, 10);
+
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+        {
+            var e = tx.OpenMut(id);
+            // Staged write — HEAD untouched until commit; a peek tx sees the old value.
+            e.Write(CmFlatEntity.Val).Tag = 55;
+            Assert.That(e.Read(CmFlatEntity.Val).Tag, Is.EqualTo(55), "flat read-your-own-writes failed");
+            using (var peek = dbe.CreateQuickTransaction())
+            {
+                Assert.That(peek.Open(id).Read(CmFlatEntity.Val).Tag, Is.EqualTo(10), "staged flat write leaked to HEAD pre-commit (CM-01)");
+            }
+            tx.Commit();
+        }
+
+        using var read = dbe.CreateQuickTransaction();
+        Assert.That(read.Open(id).Read(CmFlatEntity.Val).Tag, Is.EqualTo(55), "flat Commit write not published at commit");
+    }
+
+    [Test]
+    public void NonCluster_CommitDiscipline_Rollback_DiscardsStaged()
+    {
+        using var dbe = SetupEngine();
+        var id = SpawnFlat(dbe, 7);
+
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Deferred, DurabilityDiscipline.Commit))
+        {
+            tx.OpenMut(id).Write(CmFlatEntity.Val).Tag = 999;
+            tx.Rollback();
+        }
+
+        using var read = dbe.CreateQuickTransaction();
+        Assert.That(read.Open(id).Read(CmFlatEntity.Val).Tag, Is.EqualTo(7), "flat rollback did not discard the staged write");
+    }
+
+    // ── AC-11 on the flat path: the table B+Tree reflects a Commit write at commit (no tick fence). Fixed by rebasing the
+    // ReconcileFlatIndexAndViews field offset (OffsetToField is chunk-base-relative; the data pointers are data-relative). ──
+    [Test]
+    public void NonCluster_CommitDiscipline_IndexedWrite_FreshAtCommit_NoFence()
+    {
+        using var dbe = SetupEngine();
+
+        EntityId id;
+        using (var tx = dbe.CreateQuickTransaction())
+        {
+            id = tx.Spawn<CmFlatEntity>(CmFlatEntity.Val.Set(new CmFlatVal { Tag = 1 }), CmFlatEntity.Idx.Set(new CmTransIdx { Key = 1001 }));
+            tx.Spawn<CmFlatEntity>(CmFlatEntity.Val.Set(new CmFlatVal { Tag = 2 }), CmFlatEntity.Idx.Set(new CmTransIdx { Key = 1002 }));
+            tx.Commit();
+        }
+        dbe.WriteTickFence(1);
+
+        using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+        {
+            tx.OpenMut(id).Write(CmFlatEntity.Val).Tag = 7;
+            tx.Commit();
+        }
+
+        using var q = dbe.CreateQuickTransaction();
+        Assert.That(q.Query<CmFlatEntity>().WhereField<CmFlatVal>(b => b.Tag == 1).Count(), Is.EqualTo(0),
+            "old key still in the flat index after a committed write (AC-11)");
+        Assert.That(q.Query<CmFlatEntity>().WhereField<CmFlatVal>(b => b.Tag == 7).Count(), Is.EqualTo(1),
+            "new key not in the flat index at commit (AC-11 / CM-05)");
+        Assert.That(q.Query<CmFlatEntity>().WhereField<CmFlatVal>(b => b.Tag == 2).Count(), Is.EqualTo(1),
+            "untouched flat entity disappeared from the index");
+    }
+}

--- a/test/Typhon.Engine.Tests/Durability/CrashRecovery/CommittedDisciplineRecoveryTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/CrashRecovery/CommittedDisciplineRecoveryTests.cs
@@ -1,0 +1,302 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using Typhon.Schema.Definition;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// Crash-recovery proof for the Committed durability discipline (issue #392, AC-2 / AC-7). A SingleVersion-layout component written under
+/// <see cref="DurabilityDiscipline.Commit"/> with <see cref="DurabilityMode.Immediate"/> is fsynced to the WAL as an ordinary Slot record (Committed
+/// flag = telemetry only). After a hard crash (managed page cache discarded, no checkpoint), reopen must replay the record through the same
+/// <c>RecoveryDriver</c> path tick-fence and Versioned records use — last-writer-wins by LSN — and restore the exact committed value (AC-7: zero
+/// Committed-specific recovery code). Uses the <see cref="CmEntity"/> cluster archetype from <c>CommittedDisciplineTests</c>.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+internal sealed class CommittedDisciplineRecoveryTests
+{
+    private string _dbDir;
+    private string _walDir;
+    private ServiceProvider _serviceProvider;
+
+    private static string CurrentDatabaseName
+    {
+        get
+        {
+            var name = TestContext.CurrentContext.Test.Name;
+            foreach (var c in new[] { '(', ')', ',', ' ', '"' })
+            {
+                name = name.Replace(c, '_');
+            }
+
+            const int max = 63;
+            const string prefix = "Cdr_";
+            if (prefix.Length + name.Length > max)
+            {
+                name = name[^(max - prefix.Length)..];
+            }
+            return prefix + name;
+        }
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        Archetype<CmEntity>.Touch();
+        Archetype<CmIdxEntity>.Touch();
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Typhon.Tests", nameof(CommittedDisciplineRecoveryTests));
+        _dbDir = Path.Combine(root, CurrentDatabaseName, "db");
+        _walDir = Path.Combine(root, CurrentDatabaseName, "wal");
+        Directory.CreateDirectory(_dbDir);
+        Directory.CreateDirectory(_walDir);
+
+        var services = new ServiceCollection();
+        services
+            .AddLogging(b => b.SetMinimumLevel(LogLevel.Warning))
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddHighResolutionSharedTimer()
+            .AddDeadlineWatchdog()
+            .AddScopedManagedPagedMemoryMappedFile(opts =>
+            {
+                opts.DatabaseName = CurrentDatabaseName;
+                opts.DatabaseDirectory = _dbDir;
+                opts.DatabaseCacheSize = (ulong)PagedMMF.MinimumCacheSize * 4;
+            })
+            .AddScopedDatabaseEngine(opts =>
+            {
+                opts.Wal = new WalWriterOptions
+                {
+                    WalDirectory = _walDir,
+                    GroupCommitIntervalMs = 5,
+                    UseFUA = false,
+                    SegmentSize = 4 * 1024 * 1024,
+                    PreAllocateSegments = 1,
+                };
+            });
+
+        _serviceProvider = services.BuildServiceProvider();
+        _serviceProvider.EnsureFileDeleted<ManagedPagedMMFOptions>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _serviceProvider?.Dispose();
+        _serviceProvider = null;
+
+        var testRoot = Directory.GetParent(_dbDir)?.FullName;
+        try
+        {
+            if (testRoot != null && Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Test]
+    [CancelAfter(15_000)]
+    public void CommitDiscipline_Write_SurvivesHardCrash()
+    {
+        EntityId id;
+
+        // Phase 1: spawn (Immediate), then overwrite Position under Commit discipline (Immediate ⇒ fsynced), then hard-crash with no checkpoint.
+        using (var scope1 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope1.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            dbe.RegisterComponentFromAccessor<CmPosition>();
+            dbe.RegisterComponentFromAccessor<CmWallet>();
+            dbe.InitializeArchetypes();
+
+            using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate))
+            {
+                id = tx.Spawn<CmEntity>(CmEntity.Position.Set(new CmPosition(1, 1)), CmEntity.Wallet.Set(new CmWallet(50)));
+                tx.Commit();
+            }
+
+            using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+            {
+                tx.OpenMut(id).Write(CmEntity.Position) = new CmPosition(99, 88);
+                tx.Commit();
+            }
+
+            // Power cut: managed page cache discarded, no checkpoint / clean-shutdown marker. The committed value lives ONLY in the fsynced WAL.
+            dbe.SimulateHardCrash();
+        }
+
+        // Phase 2: reopen the same directory — WAL replay must restore the Commit-discipline value (last-writer-wins over the spawn value).
+        using (var scope2 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            dbe.RegisterComponentFromAccessor<CmPosition>();
+            dbe.RegisterComponentFromAccessor<CmWallet>();
+            dbe.InitializeArchetypes();
+
+            using var tx = dbe.CreateQuickTransaction();
+            Assert.That(tx.IsAlive(id), Is.True, "Commit-discipline entity must survive a hard crash via WAL replay");
+
+            var e = tx.Open(id);
+            ref readonly var pos = ref e.Read(CmEntity.Position);
+            // Position was written under Commit discipline (Immediate) ⇒ a fsynced WAL Slot record ⇒ recovered exactly (AC-2).
+            Assert.That(pos.X, Is.EqualTo(99f), "Commit-discipline write must be recovered (AC-2) — got the pre-write value, durability lost");
+            Assert.That(pos.Y, Is.EqualTo(88f), "Commit-discipline write Y must be recovered");
+            // NB: the spawn-init Wallet value (SingleVersion, TickFence) is NOT asserted — without a checkpoint/tick fence it is not WAL-durable
+            // (≤1-tick-loss by design). Only the Commit-discipline write carries the zero-loss guarantee under test here.
+        }
+    }
+
+    /// <summary>
+    /// MixedDiscipline crash sweep (issue #392, AC-10 workload from 08 §T-6): a single session interleaves TickFence (default) and Commit-discipline
+    /// transactions across distinct entities, then hard-crashes with no checkpoint. The contract under test is that the Commit-discipline writes are
+    /// recovered EXACTLY (zero-loss, last-writer-wins by LSN) regardless of the interleaved TickFence churn — i.e. mixing disciplines never weakens the
+    /// Commit guarantee. The TickFence-only entity is intentionally NOT asserted: without a checkpoint/fence its writes are ≤1-tick-loss by design.
+    /// </summary>
+    [Test]
+    [CancelAfter(15_000)]
+    public void MixedDiscipline_CommitWritesSurviveCrash_AmidTickFenceChurn()
+    {
+        EntityId e1, e2;
+
+        // Phase 1: spawn two entities, then alternate TickFence (on e2) and Commit (on e1) transactions, ending on a Commit. Hard-crash, no checkpoint.
+        using (var scope1 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope1.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            dbe.RegisterComponentFromAccessor<CmPosition>();
+            dbe.RegisterComponentFromAccessor<CmWallet>();
+            dbe.InitializeArchetypes();
+
+            using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate))
+            {
+                e1 = tx.Spawn<CmEntity>(CmEntity.Position.Set(new CmPosition(1, 1)), CmEntity.Wallet.Set(new CmWallet(10)));
+                e2 = tx.Spawn<CmEntity>(CmEntity.Position.Set(new CmPosition(2, 2)), CmEntity.Wallet.Set(new CmWallet(20)));
+                tx.Commit();
+            }
+
+            // TickFence churn on e2 (interleaved "noise" — may be lost across the crash).
+            using (var tf = dbe.CreateQuickTransaction(DurabilityMode.Immediate))
+            {
+                tf.OpenMut(e2).Write(CmEntity.Position) = new CmPosition(222, 222);
+                tf.Commit();
+            }
+
+            // Commit-discipline write on e1 (zero-loss).
+            using (var cm = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+            {
+                cm.OpenMut(e1).Write(CmEntity.Position) = new CmPosition(11, 11);
+                cm.Commit();
+            }
+
+            // More TickFence churn on e2.
+            using (var tf = dbe.CreateQuickTransaction(DurabilityMode.Immediate))
+            {
+                tf.OpenMut(e2).Write(CmEntity.Position) = new CmPosition(444, 444);
+                tf.Commit();
+            }
+
+            // Final Commit-discipline transaction on e1 — overwrites Position (last writer) and sets Wallet (CmWallet is DefaultDiscipline=Commit).
+            using (var cm = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+            {
+                var e = cm.OpenMut(e1);
+                e.Write(CmEntity.Position) = new CmPosition(33, 33);
+                e.Write(CmEntity.Wallet) = new CmWallet(777);
+                cm.Commit();
+            }
+
+            dbe.SimulateHardCrash();
+        }
+
+        // Phase 2: reopen — the Commit-discipline writes on e1 must be recovered exactly; the TickFence-only e2 is not asserted.
+        using (var scope2 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            dbe.RegisterComponentFromAccessor<CmPosition>();
+            dbe.RegisterComponentFromAccessor<CmWallet>();
+            dbe.InitializeArchetypes();
+
+            using var tx = dbe.CreateQuickTransaction();
+            Assert.That(tx.IsAlive(e1), Is.True, "e1 must survive — its Commit-discipline writes were fsynced (mixed-discipline zero-loss)");
+
+            var e = tx.Open(e1);
+            // Last Commit-discipline write to e1 wins on recovery (LSN last-writer-wins), despite the interleaved TickFence churn on e2.
+            Assert.That(
+                e.Read(CmEntity.Position).X,
+                Is.EqualTo(33f),
+                "last Commit write to e1.Position lost across the crash (mixed-discipline zero-loss violated)");
+            Assert.That(e.Read(CmEntity.Position).Y, Is.EqualTo(33f));
+            Assert.That(e.Read(CmEntity.Wallet).Gold, Is.EqualTo(777L), "Commit-discipline Wallet write lost across the crash");
+        }
+    }
+
+    /// <summary>
+    /// #395 capstone — an INDEXED cluster archetype spawned under Commit discipline survives a CONSOLIDATING checkpoint + hard crash, with both its
+    /// values and its secondary index intact. This is the cell that exercises all three durability fixes composing at once: CK-10 (the checkpoint
+    /// persists the cluster/EntityMap segment SPIs so the consolidated base is reachable on reopen), Face B / CM-06 (the Commit-discipline spawn
+    /// WAL-logs its SV values), and RB-01 (the secondary B+Tree is never trusted post-crash — rebuilt from the recovered cluster data). The earlier
+    /// sweep cells covered non-indexed cluster (MixedDiscipline) and the no-checkpoint indexed path (CmIdxEntity unit tests); this closes the indexed ×
+    /// consolidation × crash gap.
+    /// </summary>
+    [Test]
+    [CancelAfter(15_000)]
+    public void CommitDiscipline_IndexedClusterSpawn_SurvivesConsolidatingCheckpointCrash()
+    {
+        EntityId id1, id2;
+
+        using (var scope1 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope1.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            dbe.RegisterComponentFromAccessor<CmPosition>();
+            dbe.RegisterComponentFromAccessor<CmTeam>();
+            dbe.InitializeArchetypes();
+
+            using (var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit))
+            {
+                id1 = tx.Spawn<CmIdxEntity>(CmIdxEntity.Position.Set(new CmPosition(1, 1)), CmIdxEntity.Team.Set(new CmTeam { TeamId = 7, Rank = 1 }));
+                id2 = tx.Spawn<CmIdxEntity>(CmIdxEntity.Position.Set(new CmPosition(2, 2)), CmIdxEntity.Team.Set(new CmTeam { TeamId = 9, Rank = 2 }));
+                tx.Commit();
+            }
+
+            // Consolidate the Commit-discipline spawns into the data file (CheckpointLSN advances past their LSNs), then hard-crash with an empty WAL window —
+            // recovery must restore the cluster SV state + rebuild the index from the persisted base alone.
+            dbe.ForceCheckpoint();
+            dbe.CheckpointManager.WaitForCheckpoint(TimeSpan.FromSeconds(10));
+            dbe.SimulateHardCrash();
+        }
+
+        using (var scope2 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            dbe.RegisterComponentFromAccessor<CmPosition>();
+            dbe.RegisterComponentFromAccessor<CmTeam>();
+            dbe.InitializeArchetypes();
+
+            using var tx = dbe.CreateQuickTransaction();
+
+            // Values: the Commit-discipline spawn values survive consolidation + crash (Face B / CM-06 + CK-10).
+            Assert.That(tx.IsAlive(id1), Is.True, "indexed cluster entity lost through a consolidating checkpoint + crash (CK-10)");
+            Assert.That(tx.Open(id1).Read(CmIdxEntity.Team).TeamId, Is.EqualTo(7), "Commit-discipline spawn value lost through consolidation (Face B)");
+            Assert.That(tx.Open(id2).Read(CmIdxEntity.Team).TeamId, Is.EqualTo(9));
+
+            // Index: the secondary B+Tree, never trusted post-crash, is rebuilt from the recovered cluster data and is exact (RB-01).
+            Assert.That(
+                tx.Query<CmIdxEntity>().WhereField<CmTeam>(t => t.TeamId == 7).Count(),
+                Is.EqualTo(1),
+                "secondary index not rebuilt/exact after recovery (RB-01)");
+            Assert.That(tx.Query<CmIdxEntity>().WhereField<CmTeam>(t => t.TeamId == 9).Count(), Is.EqualTo(1));
+            Assert.That(tx.Query<CmIdxEntity>().WhereField<CmTeam>(t => t.TeamId == 1).Count(), Is.EqualTo(0), "phantom index entry after recovery");
+        }
+    }
+}

--- a/test/Typhon.Engine.Tests/Durability/CrashRecovery/DifferentialRecoveryOracleTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/CrashRecovery/DifferentialRecoveryOracleTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.IO;
 using System.Linq;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Tests;
 
@@ -11,14 +12,15 @@ namespace Typhon.Engine.Tests;
 /// The T-5 differential recovery oracle (design 03 §4.2, 08 T-5) exercised at one crash point. Each test runs a workload to durability, hard-crashes
 /// (<see cref="DatabaseEngine.SimulateHardCrash"/>), reopens to drive WAL v2 recovery, then asserts the recovered engine reproduces a <see cref="RecoveryShadowModel"/>
 /// captured just before the crash. This is the differential regression lock for the P1.2 flat-path recovery (increments 1–8 generalized from hand-picked asserts into a
-/// property) and the evidence generator that adjudicates the two remaining gaps:
+/// property) and the evidence generator that adjudicated the two gaps it originally surfaced — both now FIXED and green:
 /// <list type="bullet">
-/// <item><b>index axis</b> (<see cref="IndexedFlat_IndexAxis_MatchesBroadScan"/>) — a recovered <i>indexed</i> archetype whose secondary B+Tree is not rebuilt.</item>
-/// <item><b>cluster axis</b> (<see cref="ClusterAllSv_PrimaryAxis_SurvivesCrash"/>) — a recovered all-SingleVersion (cluster-eligible) archetype the flat-only applier
-/// does not restore.</item>
+/// <item><b>index axis</b> (<see cref="IndexedFlat_IndexAxis_MatchesBroadScan"/>) — a recovered <i>indexed</i> archetype's secondary B+Tree, now
+/// rebuilt at recovery (RB-01).</item>
+/// <item><b>cluster axis</b> (<see cref="ClusterAllSv_PrimaryAxis_SurvivesCrash"/>) — a recovered all-SingleVersion (cluster-eligible) archetype:
+/// spawned under the Commit discipline its SV values are now WAL-logged per-commit and restored exactly (#395 Face B / design D5).</item>
 /// </list>
-/// Both are quarantined RED (<c>KnownIssue-395-*</c>): the test asserts the desired post-fix behaviour and goes green when the corresponding increment lands, exactly as
-/// the One True Crash Test gated P1.2. The harness mirrors <see cref="TrueCrashE2ETests"/>; the full crash sweep (A1.2) is P1.5 and reuses this oracle over many crash points.
+/// The harness mirrors <see cref="TrueCrashE2ETests"/>; the full crash sweep (A1.2, <see cref="WalCrashSweepTests"/>) reuses this oracle over many
+/// crash points.
 /// </summary>
 [TestFixture]
 internal sealed class DifferentialRecoveryOracleTests
@@ -265,16 +267,18 @@ internal sealed class DifferentialRecoveryOracleTests
         });
     }
 
-    // ── AC6 — cluster-axis measurement: P2-gated, NOT a P1 recovery-routing bug ──
-    // The oracle established (record-kind counts: spawns=10, slots=0, with and without a tick-fence) that cluster/SingleVersion spawn VALUES are checkpoint-durable,
-    // not WAL-durable per-commit: the spawn path deliberately does not set the cluster fence dirty bitmap (Transaction.ECS.cs:1522), so neither the per-commit log nor
-    // the tick-fence carries the value. An Immediate commit makes an SV value durable only at the next checkpoint; per-commit SV WAL durability is the Committed
-    // discipline (P2 / design D5). So a window cluster/SV spawn recovers alive-but-default — a phantom — until P2. (Spawn IS logged but its value is not: an atomicity
-    // nuance flagged for P2.) This is therefore not a RecoveryApplier routing fix; it goes green when P2 makes SV values WAL-durable.
+    // ── AC6 — cluster-axis recovery under the Commit discipline (#395 Face B — FIXED) ──
+    // The oracle originally established (record-kind counts: spawns=10, slots=0) that a TickFence cluster/SingleVersion spawn logs its lifecycle but
+    // NOT its values — the spawn copies them into the cluster SoA (checkpoint-durable) without emitting Slot records, so a hard crash before a
+    // checkpoint recovered the entity alive-but-default (a phantom). That was #395 Face B, deferred to "the Committed discipline makes per-commit SV
+    // WAL durability" (design D5). It is now FIXED: BuildCommitBatch emits a Slot upsert per SingleVersion spawn value when the tx is
+    // Commit-discipline, and recovery aggregates the Spawn + Slots and applies them together (ApplySpawnedEntity → cluster slot claim + SoA write). So
+    // an all-SV cluster archetype spawned under Commit discipline recovers EXACTLY across a hard crash with NO checkpoint. (A plain TickFence spawn is
+    // still checkpoint-durable only — the documented non-guarantee, not a bug.)
     [Test]
     [CancelAfter(15_000)]
-    [Category("KnownIssue-395-sv-durability-p2")]
-    public void ClusterAllSv_PrimaryAxis_SurvivesCrash() => RecoverWith(new ClusterAllSvWorkload(10), RecoveryOracle.AssertPrimaryAxis);
+    public void ClusterAllSv_PrimaryAxis_SurvivesCrash()
+        => RecoverWith(new ClusterAllSvWorkload(10, DurabilityDiscipline.Commit), RecoveryOracle.AssertPrimaryAxis);
 
     // ── Scale: a large indexed workload forces the recovery index rebuild to split the B+Tree across many nodes — stresses the apply loop + RB-01 (index.Add) at scale ──
     [Test]

--- a/test/Typhon.Engine.Tests/Durability/CrashRecovery/RecoveryWorkloads.cs
+++ b/test/Typhon.Engine.Tests/Durability/CrashRecovery/RecoveryWorkloads.cs
@@ -224,8 +224,16 @@ internal sealed class MultiValueDupKeyWorkload : IRecoveryWorkload
 internal sealed class ClusterAllSvWorkload : IRecoveryWorkload
 {
     private readonly int _count;
+    private readonly DurabilityDiscipline _discipline;
 
-    public ClusterAllSvWorkload(int count = 10) => _count = count;
+    // discipline TickFence (default): the SV spawn values are checkpoint-durable only (a hard crash before a checkpoint recovers them alive-but-default
+    // — by design, #395 Face B's "non-guarantee"). discipline Commit: the spawn WAL-logs its SV values per-commit (#395 Face B fix / D5), so they
+    // survive a hard crash with NO checkpoint — the per-commit-durable mode the differential oracle's "SurvivesCrash" assertion needs.
+    public ClusterAllSvWorkload(int count = 10, DurabilityDiscipline discipline = DurabilityDiscipline.TickFence)
+    {
+        _count = count;
+        _discipline = discipline;
+    }
 
     public string Name => "ClusterAllSv";
 
@@ -237,7 +245,7 @@ internal sealed class ClusterAllSvWorkload : IRecoveryWorkload
 
     public void Execute(UnitOfWork uow, RecoveryShadowModel shadow)
     {
-        using var tx = uow.CreateTransaction();
+        using var tx = uow.CreateTransaction(_discipline);
         for (int i = 0; i < _count; i++)
         {
             var s = new SvIndexed(i * 7, i);
@@ -247,6 +255,103 @@ internal sealed class ClusterAllSvWorkload : IRecoveryWorkload
 
         tx.Commit();
     }
+}
+
+/// <summary>
+/// The P2 <b>MixedDiscipline</b> workload (design 08 §5 / §T-6): a cluster-eligible all-SingleVersion archetype written under a MIX of durability
+/// disciplines in interleaved transactions — a TickFence (default, ≤1-tick-loss) noise write followed by a <see cref="DurabilityDiscipline.Commit"/>
+/// write that overwrites BOTH components with their final values. Because the differential oracle asserts every recorded entity's exact post-recovery
+/// state, the workload makes the asserted state entirely Commit-durable: the Commit write is the last writer on every component, so each captured value
+/// is the zero-loss Commit value (the spawn + TickFence values are deliberately transient and overwritten). This proves Commit-discipline WRITES
+/// survive every crash boundary despite interleaved TickFence churn. (Commit-discipline SPAWNS — the value carried by the spawn itself rather than a
+/// later write — are #395 Face B, covered by <see cref="ClusterAllSvWorkload"/> under <see cref="DurabilityDiscipline.Commit"/>; a plain TickFence
+/// <see cref="ClusterAllSvWorkload"/> remains checkpoint-durable only, the documented non-guarantee.)
+/// </summary>
+internal sealed class MixedDisciplineWorkload : IRecoveryWorkload
+{
+    private readonly int _count;
+
+    public MixedDisciplineWorkload(int count = 8) => _count = count;
+
+    public string Name => "MixedDiscipline";
+
+    public void Register(DatabaseEngine dbe)
+    {
+        dbe.RegisterComponentFromAccessor<MixA>();
+        dbe.RegisterComponentFromAccessor<MixB>();
+        Archetype<MixArch>.Touch();
+    }
+
+    public void Execute(UnitOfWork uow, RecoveryShadowModel shadow)
+    {
+        var ids = new List<EntityId>(_count);
+
+        // Phase 1: spawn with placeholder values (default/TickFence discipline). The cluster SV spawn values are not WAL-durable on their own; the
+        // Commit writes below carry the entity into durability.
+        using (var tx = uow.CreateTransaction())
+        {
+            for (int i = 0; i < _count; i++)
+            {
+                var id = tx.Spawn<MixArch>(MixArch.A.Set(new MixA(-1)), MixArch.B.Set(new MixB(-1)));
+                shadow.RecordSpawn(id);
+                ids.Add(id);
+            }
+
+            tx.Commit();
+        }
+
+        // Phase 2: TickFence (default discipline) noise write on A — NOT WAL-durable; the Phase-3 Commit write is the last writer on A, so the
+        // captured/recovered value is the Commit value, never this noise.
+        using (var tx = uow.CreateTransaction())
+        {
+            foreach (var id in ids)
+            {
+                tx.OpenMut(id).Write(MixArch.A).X = unchecked((int)0xBADBAD);
+            }
+
+            tx.Commit();
+        }
+
+        // Phase 3: Commit discipline — overwrite BOTH components with their final, zero-loss values (last writer on every asserted field).
+        using (var tx = uow.CreateTransaction(DurabilityDiscipline.Commit))
+        {
+            for (int i = 0; i < ids.Count; i++)
+            {
+                var e = tx.OpenMut(ids[i]);
+                e.Write(MixArch.A).X = i + 1_000;
+                e.Write(MixArch.B).Y = i + 2_000;
+            }
+
+            tx.Commit();
+        }
+    }
+}
+
+// ── MixedDiscipline workload archetype: all-SingleVersion, non-indexed ⇒ cluster-eligible (DatabaseEngine.InitializeArchetypes). Id 952 is unused. ──
+
+[Component("Typhon.Schema.UnitTest.MixA", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+public struct MixA
+{
+    public int X;
+
+    public MixA(int x) => X = x;
+}
+
+[Component("Typhon.Schema.UnitTest.MixB", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+public struct MixB
+{
+    public int Y;
+
+    public MixB(int y) => Y = y;
+}
+
+[Archetype(952)]
+internal class MixArch : Archetype<MixArch>
+{
+    public static readonly Comp<MixA> A = Register<MixA>();
+    public static readonly Comp<MixB> B = Register<MixB>();
 }
 
 // ── An all-SingleVersion, indexed component + archetype: all-SV + a non-Transient indexed field ⇒ cluster-eligible (DatabaseEngine.InitializeArchetypes), the cluster

--- a/test/Typhon.Engine.Tests/Durability/CrashRecovery/WalCrashSweepTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/CrashRecovery/WalCrashSweepTests.cs
@@ -20,8 +20,11 @@ namespace Typhon.Engine.Tests;
 ///   the entities in the WAL window, with and without a consolidating mid-workload checkpoint.</item>
 /// </list>
 /// Page <i>corruption</i> (torn/zero) is exercised in <c>SuspectPageTests</c> (A1.11), where the damaged page's segment kind is known and the
-/// heal-vs-RB-04-loud-fail outcome can be asserted precisely. <c>ClusterAllSv</c> is excluded (P2 SV-durability unimplemented — the known
-/// <c>KnownIssue-395-sv-durability-p2</c> red). Category <c>CrashSweep</c> so the boundary fan-out can be sampled in PR CI / run full nightly.
+/// heal-vs-RB-04-loud-fail outcome can be asserted precisely. The cluster axis is covered by the <c>MixedDiscipline</c> cells below (Commit-discipline
+/// writes over every boundary) and by <c>DifferentialRecoveryOracleTests.ClusterAllSv_PrimaryAxis_SurvivesCrash</c> (Commit-discipline SV spawns, #395 Face B,
+/// at the no-checkpoint crash point — the recovery path is identical Slot-record application at every boundary the MixedDiscipline cells already sweep). Both
+/// now green (#395 SV-durability is implemented: Face A = checkpoint persists segment SPIs, CK-10; Face B = Commit-discipline spawns WAL-log SV values, D5).
+/// Category <c>CrashSweep</c> so the boundary fan-out can be sampled in PR CI / run full nightly.
 /// </summary>
 [TestFixture]
 [Category("CrashSweep")]
@@ -43,6 +46,7 @@ internal sealed class WalCrashSweepTests
         "LifecycleChurn" => new LifecycleChurnWorkload(1234, 24),
         "IndexedFlat" => new IndexedFlatWorkload(10),
         "MultiValueDupKey" => new MultiValueDupKeyWorkload(12, 3),
+        "MixedDiscipline" => new MixedDisciplineWorkload(8),
         _ => throw new ArgumentException($"unknown workload '{name}'", nameof(name)),
     };
 
@@ -259,6 +263,138 @@ internal sealed class WalCrashSweepTests
 
             // Crash the synchronous checkpoint at the Nth page write. RunCheckpointCycle swallows the ChaosSimulatedCrashException (CK-06) and
             // returns WITHOUT advancing CheckpointLSN — pages 1..N-1 may be on disk, but the coverage gate keeps the whole WAL window live.
+            var chaos = new ChaosPageIO();
+            chaos.WireTo(mmf);
+            chaos.SetCrashAtPageWrite(crashAtWrite);
+            dbe.CheckpointManager.RunCheckpointCycle(dbe.WalManager.DurableLsn);
+            chaos.Unwire(mmf);
+
+            dbe.SimulateHardCrash();
+        }
+
+        using (var scope2 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            workload.Register(dbe);
+            dbe.InitializeArchetypes();
+            RecoveryOracle.AssertPrimaryAxis(dbe, shadow);
+        }
+    }
+
+    // ── P2: MixedDiscipline (08 §5) joins the sweep ─────────────────────────────────────────────────────────────────
+    // A cluster-eligible all-SV archetype written under interleaved TickFence + Commit transactions. The asserted state is the Commit-durable
+    // last-writer values, so the oracle proves recovery reproduces them at every boundary despite the TickFence churn. Cluster + Commit-write means the
+    // entity rides the Commit slot records through RecoveryApplier's cluster reconstruction (the path #392 built), not the pure-SV-spawn path that
+    // excludes ClusterAllSv.
+
+    private static IEnumerable<TestCaseData> MixedDisciplinePageAxisCases()
+    {
+        foreach (var n in CrashBoundaries)
+        {
+            yield return new TestCaseData(n).SetName($"PageAxis_MixedDiscipline_N{n}");
+        }
+    }
+
+    [Test]
+    [CancelAfter(20_000)]
+    [VerifiesRule("AP-12")]
+    public void MixedDiscipline_WalWindow_Recover_OracleHolds()
+    {
+        var workload = new MixedDisciplineWorkload(8);
+        var shadow = new RecoveryShadowModel();
+
+        using (var scope1 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope1.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            workload.Register(dbe);
+            dbe.InitializeArchetypes();
+            using (var uow = dbe.CreateUnitOfWork(DurabilityMode.Immediate))
+            {
+                workload.Execute(uow, shadow);
+                uow.Flush();
+            }
+
+            shadow.CaptureValues(dbe);
+            dbe.SimulateHardCrash();
+        }
+
+        using (var scope2 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            workload.Register(dbe);
+            dbe.InitializeArchetypes();
+            RecoveryOracle.AssertPrimaryAxis(dbe, shadow);
+        }
+    }
+
+    // #395 Face A (consolidation-orphan) — FIXED. A consolidating checkpoint followed by a hard crash used to LOSE the cluster entities entirely: the
+    // checkpoint wrote the cluster DATA pages (OccupancyBits / EntityKeys / SoA) to the data file but the per-archetype segment SPIs in the durable
+    // ArchetypeR1 table were recorded only at clean shutdown, so reopen found ArchetypeR1.ClusterSegmentSPI == 0, took the fresh-allocation path, and
+    // rebuilt from an empty cluster (ActiveClusterCount == 0). The fix persists the SPIs at every checkpoint
+    // (CheckpointManager.PersistDurableMetadataHook → DatabaseEngine.PersistArchetypeState, run before the cycle's barrier), so the consolidated base
+    // is reachable on reopen and the EntityMap rebuild re-derives the entities from the cluster occupancy. (NB: this is distinct from #395 Face B — a
+    // plain SV cluster *spawn* value is not WAL-durable per-commit, so ClusterAllSv, which never checkpoints and never Commit-writes, stays red; that
+    // is the Committed discipline's job.)
+    [Test]
+    [CancelAfter(20_000)]
+    [VerifiesRule("AP-12")]
+    public void MixedDiscipline_WalWindow_MidCheckpoint_OracleHolds()
+    {
+        var workload = new MixedDisciplineWorkload(8);
+        var shadow = new RecoveryShadowModel();
+
+        using (var scope1 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope1.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            workload.Register(dbe);
+            dbe.InitializeArchetypes();
+            using (var uow = dbe.CreateUnitOfWork(DurabilityMode.Immediate))
+            {
+                workload.Execute(uow, shadow);
+                uow.Flush();
+            }
+
+            // Consolidate the Commit-discipline writes into the data file (CheckpointLSN advances past their LSNs), then hard-crash with an empty WAL
+            // window — recovery must restore the cluster SV state from the persisted base alone.
+            dbe.ForceCheckpoint();
+            dbe.CheckpointManager.WaitForCheckpoint(TimeSpan.FromSeconds(10));
+
+            shadow.CaptureValues(dbe);
+            dbe.SimulateHardCrash();
+        }
+
+        using (var scope2 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            workload.Register(dbe);
+            dbe.InitializeArchetypes();
+            RecoveryOracle.AssertPrimaryAxis(dbe, shadow);
+        }
+    }
+
+    [Test]
+    [CancelAfter(20_000)]
+    [TestCaseSource(nameof(MixedDisciplinePageAxisCases))]
+    [VerifiesRule("CK-03")]
+    public void MixedDiscipline_PageAxis_CheckpointCrashAtBoundary_OracleHolds(int crashAtWrite)
+    {
+        var workload = new MixedDisciplineWorkload(8);
+        var shadow = new RecoveryShadowModel();
+
+        using (var scope1 = _serviceProvider.CreateScope())
+        {
+            var dbe = scope1.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            var mmf = scope1.ServiceProvider.GetRequiredService<ManagedPagedMMF>();
+            workload.Register(dbe);
+            dbe.InitializeArchetypes();
+            using (var uow = dbe.CreateUnitOfWork(DurabilityMode.Immediate))
+            {
+                workload.Execute(uow, shadow);
+                uow.Flush();
+            }
+
+            shadow.CaptureValues(dbe);
+
             var chaos = new ChaosPageIO();
             chaos.WireTo(mmf);
             chaos.SetCrashAtPageWrite(crashAtWrite);

--- a/test/Typhon.Engine.Tests/Runtime/AccessDagDerivationTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/AccessDagDerivationTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using System.Linq;
+using Typhon.Schema.Definition;
 
 namespace Typhon.Engine.Tests.Runtime;
 
@@ -26,6 +27,10 @@ public class AccessDagDerivationTests
     private struct CompA { public int V; }
     private struct CompB { public int V; }
     private struct CompC { public int V; }
+
+    // SingleVersion component for the CM-04 / AC-05 rejection test (issue #392).
+    [Component("Typhon.Test.Cm04.SvComp", 1, StorageMode = StorageMode.SingleVersion)]
+    private struct Cm04SvComp { public int V; }
 
     private class Sys : CallbackSystem
     {
@@ -105,6 +110,22 @@ public class AccessDagDerivationTests
     }
 
     // ── R×W plain detection ───────────────────────────────────────────
+
+    // ── CM-04 / AC-05: ReadsSnapshot requires a Versioned component (issue #392) ──
+    [Test]
+    public void ReadsSnapshot_OnSingleVersionComponent_ThrowsAtBuild()
+    {
+        var schedule = RuntimeSchedule.Create(Options())
+            .PublicTrack.DeclareDag("Test")
+            .Phases(Phase.Input, Phase.Simulation, Phase.Output, Phase.Cleanup)
+            .DefaultPhase(Phase.Simulation)
+            .Add(new Sys { ConfigureAction = b => b.Name("Reader").Phase(Phase.Simulation).ReadsSnapshot<Cm04SvComp>() });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => schedule.Build(_registry.Runtime));
+        Assert.That(ex.Message, Does.Contain("'Reader'"));
+        Assert.That(ex.Message, Does.Contain("ReadsSnapshot"));
+        Assert.That(ex.Message, Does.Contain("Versioned"));
+    }
 
     [Test]
     public void RW_PlainReadWithSamePhaseWriter_Throws()

--- a/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
@@ -94,6 +94,29 @@ public class DagSchedulerTests
         Assert.That(executed, Does.Contain("D"));
     }
 
+    // ── Host-crash guard (#395 follow-up). The tick runs on the timer thread — a raw Thread. An exception escaping the inner per-system handlers (e.g.
+    //    from the tick-start hook, or the entity-set prepare phase — the `ViewBase` teardown-race NullReferenceException that aborted the test host
+    //    under load) MUST be caught by ExecuteCallbacks's outer safety net and surfaced via UnhandledExceptionCallback, NOT propagate out of TimerLoop
+    //    and ABORT THE PROCESS. Without the net this test would crash the test host instead of failing. ──
+    [Test]
+    public void TickThread_UnhandledOrchestrationException_SurfacedNotHostCrash()
+    {
+        Exception captured = null;
+        using var scheduler = NewDag(workerCount: 1)
+            .CallbackSystem("S", _ => { })
+            .Build(_registry.Runtime);
+        scheduler.UnhandledExceptionCallback = (_, _, ex) => Interlocked.CompareExchange(ref captured, ex, null);
+        scheduler.TickStartCallback = _ => throw new InvalidOperationException("simulated tick-orchestration fault");
+
+        scheduler.Start();
+        SpinWait.SpinUntil(() => captured != null, TimeSpan.FromSeconds(5));
+        scheduler.Shutdown();
+
+        Assert.That(captured, Is.Not.Null,
+            "tick-thread outer safety net did not fire — an orchestration exception escaped ExecuteCallbacks and would have aborted the host");
+        Assert.That(captured, Is.TypeOf<InvalidOperationException>());
+    }
+
     // ═══════════════════════════════════════════════════════════════
     // Correctness: Multi-threaded mode
     // ═══════════════════════════════════════════════════════════════

--- a/test/Typhon.Engine.Tests/Runtime/SideTransactionTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/SideTransactionTests.cs
@@ -138,7 +138,7 @@ class SideTransactionTests : TestBase<SideTransactionTests>
     public void SideTransaction_CreateSideTransaction_Available()
     {
         using var dbe = SetupEngine();
-        Func<DurabilityMode, Transaction> capturedFactory = null;
+        SideTransactionFactory capturedFactory = null;
         var captured = 0;
 
         using var runtime = TyphonRuntime.Create(dbe, schedule =>


### PR DESCRIPTION
Implements **#392** (Committed durability discipline) and the two **#395** cluster crash-durability fixes, plus a host-crash hardening found under load.

Design doc: `claude/design/Ecs/committed-storage-mode.md` (rev 3). Docs PR: nockawa/typhon-claude#52.

## #392 — Committed durability discipline
Runtime `DurabilityDiscipline { TickFence (default) | Commit }` knob on the `SingleVersion` layout (not a new `StorageMode`). Commit-discipline writes are **staged per-tx** (Variant A — native arena), made **atomic + zero-loss durable at `Transaction.Commit`** via the unified `SlotRecord`, then **published in place** to the cluster/flat HEAD. Read-committed, O(1) rollback, no revision chain. Exact B+Tree index reconciled at commit (spatial stays fence-batched for all modes).

## #395 — cluster crash durability
- **Face A (CK-10):** every checkpoint persists the per-archetype segment SPIs it consolidates, so a consolidated cluster/EntityMap base is reachable on reopen after a hard crash (was orphaned → total archetype loss).
- **Face B (CM-06):** a Commit-discipline spawn WAL-logs its `SingleVersion` component values per-commit, so a crash before the next checkpoint recovers the entity with its values (was alive-but-default). Cluster `RecoveryApplier` increment added.

## Host-crash hardening (top-priority, found under load)
`DagScheduler.ExecuteCallbacks` runs the tick on the raw timer thread; an unhandled tick exception aborted the process. Added an outer safety net mirroring `WorkerLoop` (log + surface via `UnhandledExceptionCallback`, drop the tick). Root teardown race (view-dispose vs in-flight tick) documented as a separate follow-up; benign with this net in place.

## Acceptance criteria
- [x] AC-1 shared layout / runtime discipline
- [x] AC-2 commit durability (crash/recovery)
- [x] AC-3 atomicity + rollback
- [x] AC-4 read path unchanged (per-tx-constant `Discipline` branch only)
- [~] **AC-5 write ~SV-class** — write **23.25 ns** (≤25 ✓), **22.6×** faster than Versioned (≥8× ✓), TickFence unregressed (+7 ns, within noise). **Publish 65 ns vs ≤60 ns target** — ~9% over, but BDN flagged the measurement unreliable (57 µs iteration, ±19 ns). See the benchmark comment on #392.
- [x] AC-6 no revision chain allocated (staging dict = 104 B/op, 3× under Versioned's 288 B)
- [x] AC-7 recovery reuse (LSN-ordered `SlotRecord`, no Committed-specific recovery code)
- [x] AC-8 scheduler rejects `ReadsSnapshot` on non-Versioned at `Build()` (CM-04)
- [x] AC-9 Versioned & TickFence untouched
- [x] AC-10 tests + TLA⁺ S3 green + `MixedDiscipline` crash sweep (benchmarks now recorded — see AC-5)
- [x] AC-11 exact index at commit (flat + cluster)

## Tests
Full suite: **3940 passed, 18 failed, 34 skipped — zero new reds** (all 18 failures proven pre-existing baseline: spatial BulkLoad timeouts, OlcBTree #133 backpressure, lock-timeout-leak, CollectibleAlc, and the stale `RunCheckpointCycle_NoDirtyPages` which fails identically on `main`). No host crash across two full runs. New tests: `CommittedDisciplineTests` (AC unit), `CommittedDisciplineRecoveryTests` (AC-2/7 + #395 capstone), `ReadsSnapshot_OnSingleVersionComponent_ThrowsAtBuild` (CM-04), `TickThread_UnhandledOrchestrationException_SurfacedNotHostCrash` (host-crash regression), `MixedDiscipline` crash-sweep cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)