### PR TITLE
doc/feature-set: cross-category dedup + navigation pass

### DIFF
--- a/doc/feature-set/Durability/README.md
+++ b/doc/feature-set/Durability/README.md
@@ -1,0 +1,27 @@
+# Durability
+> Crash-safe persistence for Typhon: a logical Write-Ahead Log (WAL v2) backs an append-before-publish commit pipeline and per-transaction durability controls, while a checkpoint pipeline consolidates dirty pages under CRC32C + seqlock protection and a recovery driver rebuilds — never repairs — derived structures from the durably-committed prefix. Every protocol claim is backed by invariant rules and TLA+ models, not tests alone; BulkLoad (throughput) and point-in-time backup (external recovery points) are opt-in paths layered on the same WAL.
+
+> 🔬 **Recommended:** read [in-depth-overview/11-durability.md](../../in-depth-overview/11-durability.md) (Chapter 11: Durability) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Durability Modes](durability-modes/README.md) | Per-Unit-of-Work control over when WAL records become crash-safe — pick latency vs. data-at-risk per workload | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Committed Durability Discipline](durability-modes/committed-discipline.md) | Zero-loss, atomic writes on Typhon's cheapest component layout (`SingleVersion`) without paying for an MVCC revision chain | ✅ Implemented | 🟣 Advanced |
+| [Write-Ahead Log (WAL v2 logical records)](wal-v2.md) | The single source of durability truth: logical `(EntityId, ComponentTypeId)` records, one codec, a sequential CRC-chained log | ✅ Implemented | 🟣 Advanced |
+| [Commit Pipeline (append-before-publish)](commit-pipeline.md) | `Transaction.Commit`'s VALIDATE→PREPARE→BUILD→APPEND→PUBLISH→WAIT ordering guarantees nothing is visible before its WAL record is appended, and publish never rolls back | ✅ Implemented | 🟣 Advanced |
+| [Checkpoint v2 (SnapshotStore pipeline)](checkpoint-v2/README.md) | Background pipeline that consolidates dirty data pages into the data file, advances `CheckpointLSN` only over pages it actually wrote, and recycles WAL segments | ✅ Implemented | 🟣 Advanced |
+| [Crash Recovery (RecoveryDriver)](crash-recovery/README.md) | On open, scans the WAL's durably-committed prefix and replays it idempotently, in strict LSN order, through the engine's own write primitives | ✅ Implemented | 🟣 Advanced |
+| [Page Checksums & Seqlock Snapshots](page-checksums-seqlock.md) | CRC32C torn-page detection on every page, paired with a lock-free seqlock so checkpoints snapshot live pages without blocking writers | ✅ Implemented | 🟣 Advanced |
+| [BulkLoad Write Path](bulk-load.md) | An opt-in, exclusive, throughput-first session API that skips per-row WAL and brackets the whole bulk with a `BulkBegin`/`BulkEnd` manifest pair plus a synchronous checkpoint barrier | 🚧 Partial | 🟣 Advanced |
+| [Durability Health & Introspection](durability-introspection.md) | `DurabilityHealth` (Ok/Degraded/Fatal) and checkpoint/WAL-writer cycle counters via the Resource Graph let an operator observe the subsystem without reaching into internals | ✅ Implemented | 🟣 Advanced |
+| [Point-in-Time Incremental Backup](pit-backup.md) | Forward-incremental `.pack` backups scoped to changed pages; restore reassembles a base and heals it through crash recovery's `RecoveryDriver` | 📋 Planned | 🟣 Advanced |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [A/B Protected-Page Slot-Pairing](checkpoint-v2/protected-page-pairing.md) (part of [Checkpoint v2](checkpoint-v2/README.md)) | Doublewrite-free torn-write protection for the meta page and segment-directory pages that crash recovery can't re-derive | ✅ Implemented |
+| [Rebuild of Derived Structures](crash-recovery/rebuild-derived-structures.md) (part of [Crash Recovery (RecoveryDriver)](crash-recovery/README.md)) | Indexes, EntityMap, and occupancy are never repaired after a crash — they're discarded and rebuilt wholesale from the recovered primary data | ✅ Implemented |
+| [Formal Proofs & Invariant Rules](correctness-proofs.md) | Durability correctness is gated on falsifiable artifacts — invariant rules, TLA+ specs, and a crash-simulation sweep — enforced in CI | ✅ Implemented |

--- a/doc/feature-set/Durability/bulk-load.md
+++ b/doc/feature-set/Durability/bulk-load.md
@@ -1,0 +1,81 @@
+# BulkLoad Write Path
+> Skip per-row WAL for mass loads — one checkpoint-backed manifest pair makes the whole load atomic, not each row.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](./README.md)
+**Assumes:** [Durability Modes](durability-modes/README.md)
+
+## 🎯 What it solves
+
+Typhon's default write path is latency-critical: every spawn/update/destroy emits a per-row WAL record and dirties
+pages that only the background checkpoint can drain, throwing a backpressure timeout if it can't keep up. That's
+the right trade-off for OLTP traffic; it's the wrong one for seeding a multi-million-entity world, importing a
+dataset, or rebuilding a fixture. Every mature engine ships a second, throughput-first path for exactly this case
+(SQL Server `BULK_LOGGED`, Postgres `pg_bulkload`) — BulkLoad is Typhon's.
+
+## ⚙️ How it works (in brief)
+
+`BeginBulkLoad` opens an exclusive session that writes spawned/updated/destroyed entities straight to pages,
+skipping per-row WAL entirely. The session is bracketed by two manifest records: `BulkBegin` at open, `BulkEnd` at
+`CompleteBulkLoad`. `CompleteBulkLoad` is the durability barrier — it drains every dirty page, forces a checkpoint
+and waits for it, emits `BulkEnd`, and waits for that record to be durable before returning. Only then are the
+session's entities visible to other transactions. Closing the session any other way (`Dispose` without
+`CompleteBulkLoad`, or a crash) discards the entire session as if it never ran — there is no partial result.
+
+## 💻 Usage
+
+```csharp
+using var session = engine.BeginBulkLoad(new BulkLoadOptions
+{
+    ProgressReporter = p => Console.WriteLine($"{p.EntitiesSpawned:N0} spawned ({p.ElapsedMilliseconds} ms)"),
+    ProgressBatchSize = 50_000,
+    CheckpointTimeout = TimeSpan.FromMinutes(10),
+});
+
+for (int i = 0; i < 4_000_000; i++)
+{
+    var id = session.Spawn<ParticleArchetype>();
+    session.Update(id, new Position { X = i, Y = 0, Z = 0 });
+}
+
+try
+{
+    session.CompleteBulkLoad();   // synchronous: drain + checkpoint + BulkEnd barrier before returning
+}
+catch (BulkLoadCheckpointTimeoutException)
+{
+    session.CompleteBulkLoad();  // session is still open — retry, or Dispose() to discard
+}
+// 4M entities now durable and visible to subsequent transactions.
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `ProgressReporter` | `null` | Callback invoked every `ProgressBatchSize` operations |
+| `ProgressBatchSize` | `10_000` | Operations between progress callbacks |
+| `CheckpointTimeout` | 5 min | Max wait in `CompleteBulkLoad` for the forced checkpoint; throws `BulkLoadCheckpointTimeoutException` and leaves the session open on expiry |
+
+## ⚠️ Guarantees & limits
+
+- **Exclusive** — only one `BulkLoadSession` per engine; a second `BeginBulkLoad` while one is open throws `BulkSessionAlreadyActiveException`.
+- **Thread-affine** — only the thread that called `BeginBulkLoad` may call methods on the returned session.
+- **No per-row WAL** — the only WAL traffic for the session is the `BulkBegin`/`BulkEnd` manifest pair (plus unrelated TickFence activity); `DurabilityMode`/`DurabilityOverride` don't apply inside a session.
+- **Session-granularity atomicity, not per-row** — `CompleteBulkLoad` returning is the only success signal: every spawn/update/destroy in the session becomes durable and visible together, or (on `Dispose` without `CompleteBulkLoad`, or a crash) none of them do.
+- **Concurrent readers unaffected** — regular `UnitOfWork`s keep running during the session and see the pre-bulk MVCC snapshot; bulk-spawned entities aren't visible to them until `CompleteBulkLoad` returns.
+- **Update/Destroy scope** — only target entities spawned earlier in the *same* session; mutating pre-existing entities requires the standard `UnitOfWork` path.
+- **No latency budget** — `CompleteBulkLoad` blocks on a real checkpoint cycle; `CheckpointTimeout` only guards against it never finishing, it doesn't bound how long the call takes.
+- **Partial status** — discarded-session page reclamation isn't wired yet: pages allocated by a session that's `Dispose`d without `CompleteBulkLoad` (or that crashes) stay marked occupied — not user-visible, but not freed — until a future recovery increment adds allocation tracking and explicit free.
+
+## 🧪 Tests
+
+- [BulkLoadApiSurfaceTests](../../../test/Typhon.Engine.Tests/Durability/BulkLoadApiSurfaceTests.cs) — session exclusivity/lifecycle, `BeginBulkLoad`/`Dispose`/`CompleteBulkLoad` API surface
+- [BulkLoadWriteTests](../../../test/Typhon.Engine.Tests/Durability/BulkLoadWriteTests.cs) — no per-row WAL, exactly one `BulkBegin`/`BulkEnd` pair, entities invisible until `CompleteBulkLoad`
+- [BulkLoadRecoveryTests](../../../test/Typhon.Engine.Tests/Durability/BulkLoadRecoveryTests.cs) — crash after `BulkBegin` discards the session; crash after `CompleteBulkLoad` survives reopen
+
+## 🔗 Related
+
+- Sibling entry: [TyphonException Hierarchy & Catalog](../Errors/exception-hierarchy.md)
+
+<!-- Deep dive: claude/overview/06-durability.md §6.8 -->
+<!-- Design: claude/design/Durability/BulkLoad/README.md (01-api, 02-write-path, 03-recovery, 04-manifest-format, 05-invariants) -->
+<!-- ADR: 053-bulk-load-write-path (claude/adr/053-bulk-load-write-path.md) -->
+<!-- Rules: claude/rules/durability.md — module BulkLoad (BL-01..04) -->

--- a/doc/feature-set/Durability/checkpoint-v2/README.md
+++ b/doc/feature-set/Durability/checkpoint-v2/README.md
@@ -1,0 +1,62 @@
+# Checkpoint v2 (SnapshotStore pipeline)
+> Background pipeline that consolidates dirty pages into the data file and advances CheckpointLSN only over pages it actually wrote.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](../README.md)
+
+## 🎯 What it solves
+
+The WAL grows without bound, and crash-recovery replay time grows with it, unless committed changes are periodically consolidated from the log into the data file. A naive "just write the dirty pages" approach risks two failure modes: persisting bytes whose WAL record isn't durable yet (phantom data after a crash) or advancing the recovery watermark past a page an active writer hadn't finished mutating (the data silently vanishes once its WAL segment is reclaimed). Applications need WAL disk usage and recovery time bounded automatically, without trading away crash correctness or stalling commits to get it.
+
+## ⚙️ How it works (in brief)
+
+Each cycle starts with a durability barrier — the WAL is flushed through everything appended so far — then every dirty page is snapshotted through a lock-free, seqlock-protected copy; a page an active writer is mid-mutation on is simply skipped this cycle. The WAL is flushed a second time through the high-water LSN the captured copies can reflect, *before* those copies are fsynced to the data file, so the data file can never hold bytes whose WAL record could still be lost. `CheckpointLSN` — the watermark that bounds recovery replay and gates WAL segment recycling — only advances if every page collected at cycle start was actually captured this cycle (the coverage gate); a page skipped for an in-flight writer holds the watermark back, not the correctness, until a later cycle catches it. Cycles run automatically on a timer or a dirty-page threshold, or can be triggered on demand.
+
+## 💻 Usage
+
+```csharp
+services
+    .AddScopedManagedPagedMemoryMappedFile(o =>
+    {
+        o.DatabaseName = "skirmish";
+        o.DatabaseDirectory = ".";
+    })
+    .AddScopedDatabaseEngine(o =>
+    {
+        o.Resources.CheckpointIntervalMs = 30_000;        // background cadence when idle
+        o.Resources.CheckpointMaxDirtyPages = 10_000;      // force an early cycle past this many dirty pages
+        o.Resources.CheckpointBarrierTimeoutMs = 30_000;   // bound on the per-cycle WAL durability-barrier wait
+    });
+
+// Checkpointing runs automatically — call ForceCheckpoint() only when you need to push a cycle now,
+// e.g. before a planned shutdown or right after a large bulk import.
+dbe.ForceCheckpoint();
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `CheckpointIntervalMs` | 30000 | Background cycle cadence while idle |
+| `CheckpointMaxDirtyPages` | 10000 | Dirty-page count that forces an earlier cycle |
+| `CheckpointBarrierTimeoutMs` | 30000 | Timeout for a cycle's WAL durability-barrier waits; on expiry the cycle is classified transient and retried next tick |
+
+## ⚠️ Guarantees & limits
+
+- **Captured ⊆ durable** — the WAL is always flushed through a captured page's high-water LSN before that page's bytes reach the data file; the data file can never contain a change whose WAL record could still be lost.
+- **Never advances past unwritten data** — `CheckpointLSN` only moves forward when every page collected that cycle was captured; WAL segments are only ever recycled below the persisted `CheckpointLSN`, so recovery replay window and WAL disk usage are both bounded by the last successful cycle.
+- **Failure-isolated** — a transient I/O or back-pressure failure degrades health and retries next cycle; it never silently and permanently disables checkpointing. A non-transient failure halts periodic cycles, but shutdown still attempts one last-chance flush.
+- **`ForceCheckpoint()` doesn't block** — it wakes the background cycle and returns immediately; pair it with the [Metric Reporting](../../Resources/metric-reporting.md) snapshot (`ResourceGraph.GetSnapshot()`, node `"Durability/CheckpointManager"`) if the caller needs to confirm a cycle completed.
+- **Cadence is a throughput/recovery-time trade-off** — a shorter `CheckpointIntervalMs` bounds crash-recovery replay tighter at the cost of more frequent page writes; a longer one amortizes I/O but lengthens the post-crash recovery window.
+- A page with an unusually long-lived active writer can repeatedly miss the coverage gate; this only delays `CheckpointLSN` advancement for that page, it never advances incorrectly.
+
+## 🧪 Tests
+
+- [CheckpointManagerTests](../../../../test/Typhon.Engine.Tests/Durability/CheckpointManagerTests.cs) — coverage gate (skipped vs. released pages), `CheckpointLSN` advancement, timer/force-cycle triggering, WAL segment reclaim
+- [CheckpointResilienceTests](../../../../test/Typhon.Engine.Tests/Durability/CheckpointResilienceTests.cs) — transient-fault retry vs. fatal-fault halt, last-chance flush at shutdown
+
+## 🔗 Related
+
+- Sub-features: [A/B Protected-Page Slot-Pairing](./protected-page-pairing.md)
+- Sibling: [Memory-Mapped Page Cache & Clock-Sweep Eviction](../../Storage/page-cache.md) — checkpoint copies pages straight out of the page cache it consolidates
+
+<!-- Deep dive: claude/overview/06-durability.md §6.4, claude/design/Durability/MinimalWal/04-checkpoint.md -->
+<!-- ADR: claude/adr/025-checkpoint-manager-sole-fsync-owner.md -->
+<!-- Rules: claude/rules/durability.md — module CK -->

--- a/doc/feature-set/Durability/checkpoint-v2/protected-page-pairing.md
+++ b/doc/feature-set/Durability/checkpoint-v2/protected-page-pairing.md
@@ -1,0 +1,55 @@
+# A/B Protected-Page Slot-Pairing
+> Doublewrite-free torn-write protection for the meta page and segment-directory pages that crash recovery can't re-derive.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Durability](../README.md)
+
+## 🎯 What it solves
+
+Most data pages survive a torn write because they're either rebuilt from primary data on the next crash recovery, or detected as corrupt and the open fails loudly. Two kinds of page are neither: the database's root metadata and each segment's page directory describe *where everything else lives* — there's no "primary data" to rebuild them from. A power cut mid-write to the only copy of such a page would corrupt structure recovery depends on, with nothing to recover it from. The earlier fix (a before-image written on every checkpoint cycle) protected these pages but cost an extra write per protected page on every single cycle, whether or not the page had changed.
+
+## ⚙️ How it works (in brief)
+
+Every protected page — the meta page and each segment's directory pages — is backed by two physical slots. A write always lands on whichever slot isn't the currently-trusted one, tagged with a higher generation number and its own checksum; only after that write is confirmed durable does Typhon start treating it as current. The previously-current slot is never touched by the write, so a crash can tear at most the *other* copy. At open, or whenever a torn write is suspected, both slots are read and the highest-generation one that passes its checksum is trusted; if neither does, the open fails loudly rather than risk silently serving corrupt structure.
+
+## 💻 Usage
+
+Entirely automatic — there is no API to opt into. It engages whenever the engine writes the meta page (schema/bootstrap changes) or grows a segment's directory (an archetype acquiring more storage), both ordinary side effects of normal writes and of every checkpoint cycle:
+
+```csharp
+services
+    .AddScopedManagedPagedMemoryMappedFile(o =>
+    {
+        o.DatabaseName = "skirmish";
+        o.DatabaseDirectory = ".";
+    })
+    .AddScopedDatabaseEngine();
+
+// Nothing extra to call — spawning enough entities to grow an archetype's segment, or any
+// schema mutation, is already protected the moment the engine persists it.
+using var t = dbe.CreateQuickTransaction();
+var id = t.Spawn<Soldier>(Unit.Health.Set(new Health { Current = 100 }));
+t.Commit();
+```
+
+## ⚠️ Guarantees & limits
+
+- **At least one valid copy always exists** — the trusted slot is never overwritten by a protected-page write, so torn-write exposure is limited to the alternate slot only.
+- **Both-slots-corrupt is a loud failure, never a silent fallback** — unlike ordinary data pages, these have no primary data to rebuild from; a confirmed double failure means restoring from backup.
+- **Doublewrite-free** — unlike the retired Full-Page-Image mechanism, this costs one extra page write only when a protected page actually changes (segment creation/growth, schema mutation) — not on every checkpoint cycle regardless of change.
+- **Cold path only** — segment-directory writes happen at segment create/grow time, not on steady-state entity reads/writes, so normal-operation hot paths pay zero extra cost from this mechanism.
+- **Generation is monotonic** — selection at open/recovery is unambiguous: the highest valid generation number wins, never a heuristic or timestamp comparison.
+- **Tied to the on-disk format version** — a database file written before this mechanism cannot be opened by an engine that expects it; older files are refused outright, not auto-migrated.
+
+## 🧪 Tests
+
+- [MetaPairTests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/MetaPairTests.cs) — meta-page A/B slot alternation, torn-slot recovery, generation monotonicity
+- [DirectoryPairTests](../../../../test/Typhon.Engine.Tests/Storage/DirectoryPairTests.cs) — segment-directory twin slot-pairing, same corruption/reopen style for directory pages
+- [ProtectedPairTests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/ProtectedPairTests.cs) — falsifiable proof via a write-log that the current-valid slot is never physically written
+
+## 🔗 Related
+
+- Parent feature: [Checkpoint v2](./README.md)
+- Sibling: [Page Integrity — CRC32C, Seqlock Snapshots & A/B Page Pairing](../../Storage/page-integrity.md) — storage-layer description of the same A/B slot-pairing mechanism
+
+<!-- Deep dive: claude/design/Durability/MinimalWal/04-checkpoint.md §4, claude/overview/06-durability.md §6.4 -->
+<!-- Rules: claude/rules/durability.md — rule CK-05 -->

--- a/doc/feature-set/Durability/commit-pipeline.md
+++ b/doc/feature-set/Durability/commit-pipeline.md
@@ -1,0 +1,57 @@
+# Commit Pipeline (append-before-publish)
+> Transaction.Commit's VALIDATE→PREPARE→BUILD→APPEND→PUBLISH→WAIT ordering guarantees nothing is visible before its WAL record is appended, and publish never rolls back.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](./README.md)
+
+## 🎯 What it solves
+
+A commit has to update many things at once — entity visibility, indexes, the WAL — and a crash can land between any two of them. If a change became visible (readable by other transactions, or capturable by a checkpoint) before its WAL record existed, a crash would leave readers having seen data that recovery can never reproduce: phantom state. Conversely, if "did it commit?" depended on multiple independent writes succeeding, a partial failure would leave the transaction in an undefined state — neither cleanly committed nor cleanly rolled back. The commit pipeline removes both failure modes by fixing one strict order and one irreversible step.
+
+## ⚙️ How it works (in brief)
+
+`Transaction.Commit` runs six phases in order: **VALIDATE** (conflict checks), **PREPARE** (all fallible work — allocation, index-key extraction — without touching visibility), **BUILD** (assemble the WAL batch from the prepared values), **APPEND** (write the batch to the WAL — the point of no return), **PUBLISH** (flip visibility — clear isolation, copy values to their committed slot, update indexes and the entity map), **WAIT** (only for `DurabilityMode.Immediate`: block until the appended batch is fsync'd). APPEND is the point of no return: once it succeeds, the transaction *is* committed and PUBLISH never rolls back. PUBLISH itself does no fallible allocation, so it cannot fail partway — it either runs to completion or the process is already going down for unrelated reasons. WAIT runs last and only for `Immediate` commits, specifically so the durability fsync is never on the critical path of any lock PUBLISH might still be holding.
+
+## 💻 Usage
+
+This pipeline runs on every `Commit()` — there is no separate API to invoke it. The only place it surfaces to application code is the outcome of an `Immediate`-mode commit whose post-append durability wait didn't confirm in time:
+
+```csharp
+using var uow = db.CreateUnitOfWork(DurabilityMode.Immediate);
+using var tx = uow.CreateTransaction();
+
+UpdateAccountBalance(tx, accountId, newBalance);
+
+try
+{
+    tx.Commit();   // VALIDATE→PREPARE→BUILD→APPEND→PUBLISH→WAIT; returns once durable
+}
+catch (CommitDurabilityUncertainException ex)
+{
+    // The transaction is committed and visible (APPEND succeeded, PUBLISH ran) — this is
+    // NOT a rollback. The WAL fsync that confirms it survives a crash didn't finish in time.
+    // Do not retry the transaction. Optionally poll ex.HighLsn against the durability watermark.
+    LogDurabilityUncertain(ex.HighLsn);
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Append before publish** — no other transaction, index, or checkpoint can ever observe a change before its WAL record exists; a checkpoint can never persist never-durable data.
+- **Append is the point of no return** — all conflict validation happens before APPEND; after APPEND, the transaction reaches `Committed` and is never rolled back, even if the subsequent durability wait fails.
+- **A failed durability wait is not a failed commit** — `CommitDurabilityUncertainException` means "committed, durability unconfirmed," not "rolled back." Never re-run the transaction in response to it.
+- **Publish is (mostly) non-throwing** — the per-component publish step is provably allocation-free. Spawning new entities retains a residual allocation-throw risk under page-cache backpressure (tracked separately; not a correctness gap, just an unclosed edge case).
+- **No cost beyond the mode you chose** — the ordering itself adds no latency: `Deferred`/`GroupCommit` commits stay ~1–2 µs; `Immediate` pays exactly one FUA round-trip (~15–85 µs), same as without this pipeline.
+- Concurrent commits on entities with conflicting writes resolve against the *published* value of the entity, not an intermediate state — the per-entity lock spans PREPARE through PUBLISH for that reason.
+
+## 🧪 Tests
+
+- [AppendBeforePublishTests](../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/AppendBeforePublishTests.cs) — proves visible-implies-appended (AP-01) and that a concurrent reader never observes a value ahead of its WAL append, on the real WAL pipeline
+
+## 🔗 Related
+
+- Sibling: [Write-Ahead Log (WAL v2 logical records)](./wal-v2.md) — APPEND writes the assembled commit batch straight into this log
+- Sibling: [Commit / Rollback Pipeline (ACID Commit Path)](../Transactions/commit-rollback-pipeline.md) — the Transaction-level view of this same PREPARE→append→PUBLISH ordering
+
+<!-- Deep dive: claude/overview/06-durability.md §6.2 -->
+<!-- Design: claude/design/Durability/MinimalWal/01-architecture.md §5 -->
+<!-- Rules: claude/rules/durability.md — module AP -->

--- a/doc/feature-set/Durability/correctness-proofs.md
+++ b/doc/feature-set/Durability/correctness-proofs.md
@@ -1,0 +1,95 @@
+# Formal Proofs & Invariant Rules
+> Typhon's crash-safety claims are gated on falsifiable proofs — invariant rules, TLA+ models, and a crash-simulation sweep — not on tests happening to pass.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Durability](./README.md)
+
+## 🎯 What it solves
+
+"We tested it and it passed" is not the same claim as "we proved it can't happen." Durability bugs are exactly
+the class of defect that green tests are worst at catching — they live in rare interleavings (crash mid-checkpoint,
+torn write straddling an I/O boundary, a reopen whose LSN allocator restarts) that a hand-written test suite is
+unlikely to ever construct, let alone construct deliberately. Typhon's durability program treats every WAL,
+checkpoint, and recovery protocol as a claim that must be falsifiable: a named, numbered invariant, a model
+that's mechanically checked against every reachable state in its (small) universe, and a test that's confirmed
+to fail before the fix and pass after. This is what backs the engine's crash-recovery guarantees with evidence
+an application developer (or their auditor) can actually go read.
+
+## ⚙️ How it works (in brief)
+
+Three artifacts, each covering a different failure mode. **Invariant rules** (`claude/rules/durability.md`) are a
+curated, numbered database of pseudo-code predicates grouped by module — `LOG` (log format/append), `AP` (commit
+pipeline / apply), `CK` (checkpoint), `RB` (rebuild), `CM` (Committed discipline) — each naming the source files
+that enforce it and the test(s) that verify it. **TLA+ specifications** (`claude/rules/tla/`) model the checkpoint protocol, the commit/recovery protocol, and
+Committed discipline's stage/append/publish race against checkpoint as state machines (S1–S3) and exhaustively
+check them with TLC over every crash-at-any-step interleaving within small bounds; each spec ships a
+deliberately-broken "mutant" variant that TLC must report as a violation, so a vacuously-green spec can't hide. **The crash-simulation sweep**
+(`WalCrashSweepTests` + the differential recovery oracle) actually runs workloads against a fault-injecting I/O
+layer, crashes at every WAL/checkpoint boundary, reopens through the real recovery path, and compares the result
+byte-for-byte against an independent in-memory shadow model of what should have survived. All three run in CI on
+every change — a regression in any of them fails the build, not just a future bug report.
+
+## 💻 Usage
+
+There's no API to call — this is a property of the engine, not a feature you invoke. What it means for your code
+is that the exceptions Typhon raises around durability are themselves the proven, named behaviors — not ad hoc
+error handling:
+
+```csharp
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.Immediate);
+using var tx = uow.CreateTransaction();
+var trade = tx.OpenMut(tradeId);
+trade.Write(Trade.Status).Current = TradeStatus.Settled;
+
+try
+{
+    tx.Commit();   // AP-02: once Commit() returns, the change is published and irreversible —
+                    // proven in TLA+ spec S2 (CommitRecovery.tla) and rule AP-02.
+}
+catch (CommitDurabilityUncertainException ex)
+{
+    // The transaction WAS published (do not retry it) — only the FUA confirmation timed out.
+    // ex.HighLsn names exactly the LSN to poll for; this exception shape IS rule AP-02's contract.
+    _logger.LogWarning(ex, "Trade {Id} committed, durability unconfirmed at LSN {Lsn}", tradeId, ex.HighLsn);
+}
+
+// On reopen after a crash, rule RB-04 guarantees this never silently serves torn data:
+var engine = serviceProvider.GetRequiredService<DatabaseEngine>();   // throws CorruptionException, not a silent open, if an
+                                                                       // unhealable primary page exists (RB-04, proven via the
+                                                                       // crash sweep's torn-page gates).
+```
+
+## ⚠️ Guarantees & limits
+
+- **Every `[fatal]`/`[silent]` rule has a named, live test** — the rule database and the test suite are
+  cross-referenced; a rule with no verifying test is a tracked gap, not an assumption.
+- **TLA+ specs are exhaustive within their bounds, not sampled** — `CheckpointProtocol.tla` (S1),
+  `CommitRecovery.tla` (S2), and `CommittedDiscipline.tla` (S3) each check every reachable state of the modeled
+  protocol (≤3 pages, ≤2 transactions, crash-at-any-step), including crash-during-recovery and re-run scenarios a
+  hand-written test would rarely hit.
+- **Genuineness is checked, not assumed** — every spec ships a mutant variant with one guard deliberately broken;
+  CI confirms TLC actually flags it, so a spec that would pass regardless of the protocol's correctness is itself
+  a failure.
+- **The crash sweep is differential, not assertion-only** — it compares full post-recovery engine state against
+  an independent shadow model restricted to the durably-committed prefix, catching divergence a fixed set of
+  hand-picked assertions would miss.
+- **This proves the protocols, not your schema or query logic** — the scope is WAL append, checkpoint
+  consolidation, and recovery; it does not model your application's transaction logic or business invariants.
+- **Bounded model sizes are a deliberate trade-off** — TLA+ state spaces are capped (state-space budget < 10⁷) to
+  keep CI runs fast; this proves correctness within the modeled bounds, not at arbitrary scale (the crash sweep
+  and production usage are the scale-side evidence).
+- **A PR touching a covered protocol must update its spec in the same PR** — enforced in review, not just CI,
+  so the proofs can't silently drift from the code they describe.
+
+## 🧪 Tests
+
+- [WalCrashSweepTests](../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/WalCrashSweepTests.cs) — the full crash sweep: page-axis (checkpoint crash at every write boundary) and WAL-window axis, oracle-verified at each boundary
+- [DifferentialRecoveryOracleTests](../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/DifferentialRecoveryOracleTests.cs) — the T-5 differential oracle itself: recovered state vs. an independent shadow model at one crash point
+
+## 🔗 Related
+
+- Related features: [Crash Recovery (RecoveryDriver)](./crash-recovery/README.md), [Checkpoint v2](./checkpoint-v2/README.md)
+
+<!-- Deep dive: claude/overview/06-durability.md §6.9 — Formal Proofs & Rules -->
+<!-- Rules database: claude/rules/durability.md, conventions in claude/rules/README.md -->
+<!-- TLA+ specs: claude/rules/tla/README.md -->
+<!-- Proof plan / acceptance criteria: claude/design/Durability/MinimalWal/08-test-plan.md -->

--- a/doc/feature-set/Durability/crash-recovery/README.md
+++ b/doc/feature-set/Durability/crash-recovery/README.md
@@ -1,0 +1,94 @@
+# Crash Recovery (RecoveryDriver)
+> Scans the WAL's durably-committed prefix and replays it, in strict LSN order, through the engine's own write primitives.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](../README.md)
+
+## 🎯 What it solves
+
+A process crash, OS panic, or power loss can land mid-write — there is no guarantee about what made it to disk
+at that instant. Without an automatic, deterministic recovery step, every application would need to reason
+about partial writes itself, or risk silently opening a database that's missing committed data or carrying
+phantom uncommitted data. Crash Recovery reconstructs the database to exactly the durably-committed prefix of
+what the application wrote before the crash — no more, no less — on every open, with zero application code
+involved.
+
+## ⚙️ How it works (in brief)
+
+On open, the engine scans its retained WAL segments and CRC-validates the chunk chain, stopping at the first
+torn chunk. A transaction's records are applied only if its commit marker falls inside that valid prefix —
+everything else (partial writes, never-committed transactions) is discarded. Applicable records replay in
+strict ascending LSN order through the same write primitives live transactions use (spawn-if-absent,
+destroy-if-present, value-overwrite), so re-running any prefix twice converges to the same state — a crash
+*during* recovery is itself safe. The engine accepts no transactions until recovery, scrub, and rebuild all
+complete.
+
+## 💻 Usage
+
+```csharp
+using Typhon.Engine;
+
+var services = new ServiceCollection();
+services
+    .AddResourceRegistry()
+    .AddMemoryAllocator()
+    .AddEpochManager()
+    .AddHighResolutionSharedTimer()
+    .AddDeadlineWatchdog()
+    .AddManagedPagedMMF(opts =>
+    {
+        opts.DatabaseName      = "skirmish";
+        opts.DatabaseDirectory = @"C:\data\skirmish";
+    })
+    .AddDatabaseEngine(engineOpts => engineOpts.Wal = new WalWriterOptions { WalDirectory = @"C:\data\skirmish\wal" });
+
+var serviceProvider = services.BuildServiceProvider();
+
+try
+{
+    // If the prior session crashed, recovery runs here — before this call returns.
+    // There is no separate "recover" step, flag, or API to invoke.
+    var engine = serviceProvider.GetRequiredService<DatabaseEngine>();
+}
+catch (CorruptionException ex)
+{
+    // An unhealable torn primary page (RB-04) — the open fails loudly rather than
+    // silently serving partial data. Needs human intervention / restore from backup.
+    _logger.LogCritical(ex, "Recovery could not open '{Component}' page {Page}", ex.ComponentName, ex.PageIndex);
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Fully automatic** — no recovery API, flag, or manual step; it runs on every open and is effectively free on
+  a clean reopen (the WAL window since the last checkpoint is empty).
+- **Transaction is the atomicity unit** (LOG-04) — a `Deferred`/`GroupCommit` UoW recovers as exactly its
+  durably-marked transactions, each whole, the set possibly a true prefix of what you committed. A crash never
+  yields a half-applied transaction.
+- **Idempotent by construction** (AP-12) — every record kind applies as spawn-if-absent / destroy-if-present /
+  absolute-overwrite / value-overwrite, so re-running any prefix (including a crash during recovery itself)
+  converges to the same result.
+- **One write path** (AP-10) — recovery has no parallel apply routine that can drift from the live commit path;
+  it reuses the engine's own primitives.
+- **Loud failure over silent corruption** — an unrecoverable torn primary page throws `CorruptionException` and
+  aborts the open; it never serves corrupted data. (What counts as "unrecoverable" is the Rebuild sub-feature's
+  concern.)
+- **Typical recovery time ~15–60 ms**, dominated by the apply phase (scan + fate < 5 ms; apply 10–50 ms for the
+  WAL window since the last checkpoint, 30 s by default).
+- **No inspection API today** — recovery's record/transaction counters exist for internal testing, not as a
+  public surface; an application can't query "how much was replayed" after open.
+
+## 🧪 Tests
+
+- [TrueCrashE2ETests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/TrueCrashE2ETests.cs) — the "One True Crash Test": hard-crash via `SimulateHardCrash` with data only in the WAL, reopen replays it byte-for-byte
+- [WalRecoveryTests](../../../../test/Typhon.Engine.Tests/Durability/WalRecoveryTests.cs) — the recovery orchestrator: commit-marker fate resolution, promoting committed UoWs and voiding pending ones
+- [DifferentialRecoveryOracleTests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/DifferentialRecoveryOracleTests.cs) — recovered state compared byte-for-byte against a pre-crash shadow model
+
+## 🔗 Related
+
+- Sub-features: [Rebuild of Derived Structures (scrub + rebuild, no FPI)](./rebuild-derived-structures.md)
+- Sibling: [Crash-Recovery Chain Scrub & Orphan Sweep](../../Revision/crash-recovery-chain-scrub.md) — ECS-level revision-chain scrub that runs in the same recovery sequence, one layer up
+
+<!-- Deep dive: claude/overview/06-durability.md §6.5 -->
+<!-- Design: claude/design/Durability/MinimalWal/03-recovery.md -->
+<!-- Testing strategy: claude/design/Durability/crash-recovery-testing.md (recovery *model* section is historical — see its banner; the deterministic fault-injection *approach* shipped) -->
+<!-- Rules: claude/rules/durability.md — modules LOG, AP -->

--- a/doc/feature-set/Durability/crash-recovery/rebuild-derived-structures.md
+++ b/doc/feature-set/Durability/crash-recovery/rebuild-derived-structures.md
@@ -1,0 +1,83 @@
+# Rebuild of Derived Structures (scrub + rebuild, no FPI)
+> Derived structures — indexes, EntityMap, occupancy — are never repaired after a crash; they're discarded and rebuilt from primary data.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Durability](../README.md)
+
+## 🎯 What it solves
+
+A torn index page or a torn EntityMap page can't be patched byte-for-byte the way a per-page repair scheme
+would patch a torn data page — an index is wholly redundant with the data it indexes, and a half-repaired
+EntityMap (a hash directory of raw chunk-id pointers) is worse than no map at all: dereferencing a torn pointer
+crashes the process before any safety check can catch it. Typhon doesn't attempt to repair these structures.
+Every derived structure is rebuilt wholesale from the data it derives from, so a torn on-disk copy is simply
+replaced rather than trusted, patched, or guessed at.
+
+## ⚙️ How it works (in brief)
+
+After the WAL window is applied and every Versioned revision chain is collapsed to its single committed value,
+the engine clears each derived structure — secondary B+Tree indexes (and their multi-value buffers), the
+EntityMap, the page-occupancy bitmap — and repopulates it by scanning the now-final primary data: indexes from
+each table's committed values, the EntityMap from cluster occupancy slots (or revision-chain heads for flat
+archetypes), occupancy from actual page ownership. A torn page that happened to belong to one of these
+structures needs no special handling — it's simply part of what gets discarded. Primary data (component
+content, cluster slots, and the rare EntityMap that has no cluster/chain source to rebuild from) follows a
+different rule: heal silently if no longer referenced by anything live, or fail the open loudly if it still
+backs live data. There is no Full-Page-Image repair anywhere in the engine — that mechanism was retired in
+favor of this rebuild-or-loud-fail net.
+
+## 💻 Usage
+
+```csharp
+// Same DI-resolved open as Crash Recovery — rebuild is an internal recovery phase,
+// there's nothing to call. What distinguishes it from the application's point of view:
+// a torn INDEX, EntityMap, or occupancy page never surfaces an exception — it's silently
+// rebuilt. Only a torn PRIMARY page that still backs live data does.
+try
+{
+    var engine = serviceProvider.GetRequiredService<DatabaseEngine>();
+    // No exception ⇒ indexes/EntityMap/occupancy are guaranteed consistent with the
+    // recovered primary data, even if their on-disk copies were torn before the crash.
+}
+catch (CorruptionException ex)
+{
+    // RB-04: a PRIMARY page the rebuild net could not heal — never a derived
+    // (index/EntityMap/occupancy) page; those are always rebuilt, never reported.
+    _logger.LogCritical(ex, "Unrecoverable primary page in '{Component}' at page {Page}", ex.ComponentName, ex.PageIndex);
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Always rebuilt, never repaired** — secondary B+Tree indexes, the page-occupancy bitmap, and the EntityMap of
+  any "rebuildable" archetype (cluster-eligible, or every non-`Transient` slot `Versioned`) are unconditionally
+  cleared and rebuilt after every crash recovery; a CRC-clean derived page on disk is not even consulted.
+- **Ordering is load-bearing** — rebuild runs after the WAL window is applied and Versioned chains are scrubbed
+  to their single committed HEAD, so indexes are built from final values, never from pre-crash MVCC history.
+  The occupancy bitmap rebuild specifically runs after recovery's own seal checkpoint, since that checkpoint can
+  still grow segments — page ownership is only final afterward.
+- **Heal-or-loud-fail is reserved for primary data** — component/revision content, collections, cluster slots,
+  and the rare non-rebuildable EntityMap (a non-cluster archetype still holding a `SingleVersion` slot with no
+  persisted source to rebuild from). A torn primary page heals only if it no longer backs any live chunk (the
+  entity was re-created within the recovery window); otherwise the open fails with `CorruptionException` rather
+  than silently opening over corrupt data.
+- **No Full-Page-Image anywhere** — the mechanism that historically repaired pages byte-for-byte (a before-image
+  written per dirty page per checkpoint cycle) has been removed entirely; this rebuild net is the sole torn-page
+  protection for derived structures, at zero steady-state cost — a clean reopen never enters the rebuild phase.
+- **Cost scales with live data, not WAL size** — rebuild is a full scan of the post-recovery primary data (a few
+  ms for typical entity/index counts), not an incremental repair of only the torn pages.
+
+## 🧪 Tests
+
+- [DifferentialRecoveryOracleTests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/DifferentialRecoveryOracleTests.cs) — index axis (RB-01: secondary B+Tree rebuilt at recovery) and cluster axis (EntityMap/SV rebuild) proofs
+- [WalIntegrationTests](../../../../test/Typhon.Engine.Tests/Durability/WalIntegrationTests.cs) — `WAL_Destroy_TombstonedEntitiesExcludedFromEntityMapRebuild`: EntityMap rebuild on reopen correctly excludes tombstoned entities
+- [RawValueHashMapTests](../../../../test/Typhon.Engine.Tests/Data/ECS/RawValueHashMapTests.cs) — `ClearForRebuild`/`InsertDuringRebuild` on the hash map backing the EntityMap, the primitive the rebuild phase drives
+
+## 🔗 Related
+
+- Parent feature: [Crash Recovery (RecoveryDriver)](./README.md)
+- Sibling: [Crash-Recovery Chain Scrub & Orphan Sweep](../../Revision/crash-recovery-chain-scrub.md) — this rebuild runs after chain scrub collapses every Versioned chain to its committed HEAD
+
+<!-- Deep dive: claude/overview/06-durability.md §6.6 — Torn-Page Safety (no FPI) -->
+<!-- Design: claude/design/Durability/MinimalWal/03-recovery.md §6–7 -->
+<!-- Historical (superseded): claude/design/Durability/fpi-durability.md -->
+<!-- Rules: claude/rules/durability.md — module RB (RB-01..05), CK-09 -->

--- a/doc/feature-set/Durability/durability-introspection.md
+++ b/doc/feature-set/Durability/durability-introspection.md
@@ -1,0 +1,57 @@
+# Durability Health & Introspection
+> See whether WAL/checkpoint durability is keeping up — health state, cycle stats, honest watermarks — without reaching into engine internals.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](./README.md)
+
+## 🎯 What it solves
+
+"Are commits actually becoming durable, or is checkpoint stuck?" needs an answer operators and tooling (Workbench) can get without parsing WAL segment files or holding a reference to the engine's internal types. A transient I/O stall, a writer pinning a dirty page past the coverage gate, and a fatal disk error each call for a different operator response, but look identical from the outside unless the engine classifies and reports them as they happen.
+
+## ⚙️ How it works (in brief)
+
+Every checkpoint cycle ends in one of three `DurabilityHealth` states: `Ok`; `Degraded` — a transient stall (back-pressure, lock, or I/O timeout) that retries next cycle, no data at risk; or `Fatal` — a non-transient error that halts periodic checkpointing (shutdown still attempts one last-chance flush). State transitions are reported through the engine's own `ILogger`, so they land wherever the host application already routes its logs — no separate sink to wire up. Underneath, the engine continuously holds three watermarks in strict order — `CheckpointLSN ≤ DurableLsn ≤ LastAppendedLsn` — the basis both the health classification and the checkpoint coverage gate reason from; `DurableLsn` is derived from per-slot LSNs recorded at WAL publish time, not a coarse "highest claimed" guess, so it never claims a record durable before it is actually fsynced. Checkpoint-cycle counters (cycles run, pages written, segments recycled, cycle duration) and WAL-writer counters (bytes written, flushes, flush latency) are reported as nodes in the engine's Resource Graph, queryable the same way as any other subsystem.
+
+## 💻 Usage
+
+```csharp
+// 1. Health transitions ride the engine's own logger — wire it once at startup, nothing durability-specific to opt into.
+var builder = Host.CreateApplicationBuilder();
+builder.Logging.AddConsole();
+builder.Services
+    .AddScopedManagedPagedMemoryMappedFile(o => { o.DatabaseName = "skirmish"; o.DatabaseDirectory = "."; })
+    .AddScopedDatabaseEngine();
+// A transient stall logs: "Checkpoint cycle hit a transient failure (Health=Degraded); retrying on the next cycle"
+// A non-transient failure logs Health=Fatal and halts periodic checkpointing.
+
+// 2. Checkpoint/WAL cycle counters via the Resource Graph (same pattern as any IMetricSource node).
+builder.Services.AddSingleton<IResourceGraph>(sp => new ResourceGraph(sp.GetRequiredService<IResourceRegistry>()));
+// ...
+ResourceSnapshot snapshot = resourceGraph.GetSnapshot();
+var ckpt = snapshot.Nodes["Durability/CheckpointManager"];
+long cycles = ckpt.Throughput.First(t => t.Name == "Checkpoints").Count;
+long lastCycleUs = ckpt.Duration.First(d => d.Name == "CheckpointDuration").LastUs;
+
+var walWriter = snapshot.Nodes["Durability/WalManager/WalWriter"];
+long bytesFlushed = walWriter.Throughput.First(t => t.Name == "BytesWritten").Count;
+```
+
+## ⚠️ Guarantees & limits
+
+- **Three health states, never silently stuck** — `Degraded` always retries next cycle; `Fatal` halts periodic checkpointing, but a last-chance flush still runs at shutdown (rule CK-06).
+- **Honest watermark ordering always holds** — `CheckpointLSN ≤ DurableLsn ≤ LastAppendedLsn`, continuously, not just at the moments you happen to check.
+- **Cycle/WAL-writer counters are public today** via the Resource Graph (`Durability/CheckpointManager`, `Durability/WalManager/WalWriter` nodes) — wire the [Resource Graph Metrics Bridge](../Observability/otel-metrics-export/resource-graph-metrics-bridge.md) to push them into Prometheus/OTLP instead of polling manually.
+- **Exact LSN values and commit-buffer occupancy are not yet on that public surface** — today they drive the engine's own internal retry/halt/coverage-gate decisions and are visible at session open/close via a WAL-watermarks log line; a unified snapshot exposing `CheckpointLsn`/`DurableLsn`/`LastAppendedLsn`/buffer occupancy directly in one call is designed (MinimalWal `01-architecture.md` §7) but not yet implemented.
+- **Health is per-checkpoint-cycle, not per-commit** — a single slow commit under `Immediate` durability surfaces its own `WalBackPressureTimeoutException` / `CommitDurabilityUncertainException`, not a `DurabilityHealth` transition.
+- **`DurabilityHealth` is distinct from the generic Resource Health Checks** (Healthy/Degraded/Unhealthy by capacity-utilization threshold) — checkpoint cycles don't report a `Capacity` metric, so they don't participate in that composite verdict today.
+
+## 🧪 Tests
+
+- [CheckpointResilienceTests](../../../test/Typhon.Engine.Tests/Durability/CheckpointResilienceTests.cs) — `Degraded` transient-fault retry vs. `Fatal` halt-with-last-chance-flush health transitions
+- [DurableLsnHonestyTests](../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/DurableLsnHonestyTests.cs) — `DurableLsn` never exceeds the highest LSN physically written (the honest-watermark fix, LOG-05)
+
+## 🔗 Related
+
+- Related feature: [Checkpoint v2 (SnapshotStore pipeline)](./checkpoint-v2/README.md), [Metric Reporting (IMetricSource / IMetricWriter)](../Resources/metric-reporting.md), [OpenTelemetry Metrics Export](../Observability/otel-metrics-export/README.md)
+
+<!-- Deep dive: claude/overview/06-durability.md — Honest Watermarks, claude/design/Durability/MinimalWal/01-architecture.md §7 -->
+<!-- Rules: claude/rules/durability.md — CK-06, LOG-05 -->

--- a/doc/feature-set/Durability/durability-modes/README.md
+++ b/doc/feature-set/Durability/durability-modes/README.md
@@ -1,0 +1,89 @@
+# Durability Modes
+> Per-Unit-of-Work control over when WAL records become crash-safe — pick latency vs. data-at-risk per workload.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Durability](../README.md)
+
+## 🎯 What it solves
+
+Different workloads in the same process need different durability guarantees: a game tick can tolerate losing
+the last ~16ms of work on crash, a player trade cannot lose anything, and general server requests sit somewhere
+in between. A single global durability setting forces every workload onto the slowest, most conservative choice.
+Durability Modes let each Unit of Work (UoW) pick its own commit-latency vs. data-at-risk trade-off — without
+touching the rest of the engine's guarantees: atomicity and isolation stay per-transaction in every mode.
+
+## ⚙️ How it works (in brief)
+
+`DurabilityMode` is fixed when a UoW is created and controls only *when* that UoW's WAL records are flushed
+(fsync'd) to stable media — never whether a transaction commits or becomes visible. All commits stay in-memory
+and MVCC-visible at the same ~1-2µs regardless of mode; the mode only changes how long the WAL record sits in
+the commit buffer before it's durable. The **transaction** is always the unit of crash atomicity: a crash never
+recovers a partial transaction, only a possibly-shorter prefix of the transactions you committed.
+
+## 💻 Usage
+
+```csharp
+// General server workload — bounded data-at-risk, no per-tx wait
+using var uow = db.CreateUnitOfWork(DurabilityMode.GroupCommit);
+using var tx = uow.CreateTransaction();
+UpdatePlayerState(tx, playerId);
+tx.Commit();                  // ~1-2µs — durable within WalWriterOptions.GroupCommitIntervalMs (default 5ms)
+
+// Batch import — many transactions, one flush at the end
+using var batch = db.CreateUnitOfWork(DurabilityMode.Deferred);
+foreach (var row in rows)
+{
+    using var tx = batch.CreateTransaction();
+    ImportRow(tx, row);
+    tx.Commit();               // ~1-2µs — volatile until Flush()
+}
+await batch.FlushAsync();      // one FUA for the whole batch
+
+// Financial trade — zero data-at-risk
+using var trade = db.CreateUnitOfWork(DurabilityMode.Immediate);
+using var tx2 = trade.CreateTransaction();
+ExecuteTrade(tx2, alice, bob, item, gold);
+tx2.Commit();                  // blocks ~15-85µs — durable on the data file's WAL before returning
+```
+
+| Mode | Commit latency | Data-at-risk window | Notes |
+|------|-----------------|---------------------|-------|
+| `Deferred` (default) | ~1-2µs | until `uow.Flush()` / `FlushAsync()` | best for ticks, bulk imports |
+| `GroupCommit` | ~1-2µs | ≤ `WalWriterOptions.GroupCommitIntervalMs` (default 5ms, engine-wide via `services.AddDatabaseEngine(o => o.Wal.GroupCommitIntervalMs = …)`) | best for general request handlers |
+| `Immediate` | ~15-85µs (one WAL FUA) | zero | best for trades, irreversible state |
+
+## ⚠️ Guarantees & limits
+
+- Mode is fixed for the UoW's lifetime — there is no API to change it mid-UoW; create a separate UoW for a
+  different durability need.
+- Atomicity and isolation are unaffected by mode. Only the post-crash data-loss window changes; a crash never
+  yields a half-applied transaction.
+- `GroupCommitIntervalMs` is an engine-wide WAL writer setting (`DatabaseEngineOptions.Wal`), not a per-UoW
+  property — every `GroupCommit` UoW in the engine shares the same interval.
+- Disposing a `Deferred` UoW does **not** flush — unflushed transactions stay volatile until something else
+  flushes the WAL (explicit `Flush()`/`FlushAsync()`, the GroupCommit timer, or 80%-buffer back-pressure).
+  Disposing a `GroupCommit` or `Immediate` UoW does flush.
+- `Immediate` raises `CommitDurabilityUncertainException` rather than rolling back if the post-append fsync
+  wait doesn't confirm in time — the transaction is already committed and visible; this is "durability
+  unconfirmed," never a rollback signal. See the [Commit Pipeline](../commit-pipeline.md) feature.
+- **Known gap:** the `DurabilityOverride` enum (`Default`/`Immediate`, escalating a single transaction inside an
+  otherwise `Deferred`/`GroupCommit` UoW) is declared on the public API surface (`DurabilityMode.cs`) per
+  [ADR-005](../../../../claude/adr/005-durability-mode-per-uow.md), but is not yet wired into
+  `Transaction.Commit()` — there is currently no single-call escalation path for a commit within an existing
+  UoW. Today's workaround for a critical operation inside an otherwise low-durability workload: commit it
+  through its own `DurabilityMode.Immediate` UoW (`dbe.CreateQuickTransaction(DurabilityMode.Immediate)`), or,
+  from a scheduled system, a side-transaction (`ctx.CreateSideTransaction(DurabilityMode.Immediate, …)`).
+- Max durable tx/s: ~12K-65K for `Immediate` (FUA round-trip bound) vs. millions for `GroupCommit`/`Deferred`
+  (CPU-serialization bound, amortized FUA).
+
+## 🧪 Tests
+
+- [UnitOfWorkTests](../../../../test/Typhon.Engine.Tests/Execution/UnitOfWorkTests.cs) — mode fixed per UoW, `Flush()`/`FlushAsync()` semantics, `Deferred` not flushing on dispose
+- [WalIntegrationTests](../../../../test/Typhon.Engine.Tests/Durability/WalIntegrationTests.cs) — `Deferred`/`GroupCommit`/`Immediate` exercised across dirty-page and reopen scenarios
+
+## 🔗 Related
+
+- Sub-features: [Committed Durability Discipline](./committed-discipline.md)
+- Sibling: [Unit of Work (durability boundary)](../../Transactions/unit-of-work.md) — `DurabilityMode` is fixed on the UoW at creation; the UoW is the object that owns this choice
+
+<!-- Deep dive: claude/overview/06-durability.md §6.3, claude/overview/02-execution.md §2.3, claude/adr/005-durability-mode-per-uow.md -->
+<!-- Rules: claude/rules/durability.md — module CX -->

--- a/doc/feature-set/Durability/durability-modes/committed-discipline.md
+++ b/doc/feature-set/Durability/durability-modes/committed-discipline.md
@@ -1,0 +1,88 @@
+# Committed Durability Discipline
+> Zero-loss, atomic writes on Typhon's cheapest component layout — without paying for an MVCC revision chain.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](../README.md)
+**Assumes:** [SingleVersion (Tick-Fence Durability)](../../Ecs/storage-modes/storage-mode-singleversion.md)
+
+## 🎯 What it solves
+
+`SingleVersion` components are Typhon's cheapest write path (~3ns, in-place), but by default they're only
+durable at the next tick fence — up to one tick of writes (~16ms at 60fps) can be lost on crash. A large class
+of writes (a player teleport, an item pickup, a currency debit) needs atomicity and zero data loss but not
+MVCC snapshot isolation or AS-OF queries. Forcing those onto a `Versioned` component buys zero-loss durability
+at ~6× the write cost (a revision-chain allocation plus its eventual GC) for an isolation guarantee the write
+never uses. Committed discipline gives zero-loss, atomic writes on the `SingleVersion` layout at a fraction of
+`Versioned`'s cost.
+
+## ⚙️ How it works (in brief)
+
+`DurabilityDiscipline` is a per-transaction knob (`TickFence` default, or `Commit`) — orthogonal to
+`DurabilityMode`: mode still decides *when* the WAL flushes, discipline decides *how* a `SingleVersion` write
+becomes durable. Under `Commit`, a write is staged into a per-transaction arena (the live HEAD slot is never
+touched pre-commit); at `Commit()`, the staged values are appended to the WAL as ordinary records and only then
+published in place — memcpy to HEAD plus index reconciliation. The discipline is uniform per transaction: once
+any write escalates a transaction to `Commit` — explicitly, or because a component declares
+`[Component(DefaultDiscipline = DurabilityDiscipline.Commit)]` — every `SingleVersion` write in that
+transaction is commit-staged. Rollback is O(1): discard the arena, HEAD was never touched.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Wallet", 1, StorageMode = StorageMode.SingleVersion,
+           DefaultDiscipline = DurabilityDiscipline.Commit)]   // optional: every tx touching this escalates
+struct Wallet { public long Gold; }
+
+[Archetype(42)]
+partial class Player : Archetype<Player>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+    public static readonly Comp<Wallet> Wallet = Register<Wallet>();
+}
+
+// Explicit escalation for one critical operation:
+using var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit);
+var e = tx.OpenMut(playerId);
+ref var pos = ref e.Write(Player.Pos);
+pos.X = teleportTarget.X;
+pos.Y = teleportTarget.Y;
+tx.Commit();              // staged value WAL-logged + published atomically — zero loss on crash
+
+// From inside a scheduled system, via the TickContext side-transaction idiom:
+using var side = ctx.CreateSideTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit);
+side.OpenMut(playerId).Write(Player.Wallet).Gold -= price;
+side.Commit();
+```
+
+| Discipline | Write cost (Zen 4) | Durable when | Loss window | Isolation |
+|------------|---------------------|--------------|-------------|-----------|
+| `TickFence` (default) | ~3 ns | at the next tick fence | ≤ 1 tick | tick-fence |
+| `Commit` | ~23 ns stage / ~65 ns publish | at `Commit()` | zero | read-committed |
+
+## ⚠️ Guarantees & limits
+
+- Applies only to `StorageMode.SingleVersion` components — `Versioned` is always commit-scoped already (no
+  benefit), `Transient` is never durable (discipline is meaningless there).
+- Read-your-own-writes works for point reads (`EntityRef.Read`/`Write`) inside the writing transaction. Bulk
+  span reads (`ClusterRef.GetSpan<T>`) inside that same transaction do **not** see staged values — read HEAD
+  through a side-transaction or after commit instead.
+- Isolation is **read-committed**, not snapshot — a `Commit`-discipline (or plain `SingleVersion`) component
+  used with `ReadsSnapshot` fails loudly at scheduler `Build()` time; use `Versioned` for snapshot/AS-OF reads.
+- A duplicate WAL record from a concurrent tick fence re-emitting the just-committed value is benign
+  (last-writer-wins by LSN) — at most one redundant record, never a correctness or double-durability issue.
+- No revision chain, no deferred-cleanup GC cost — rollback is an arena reset, not a chain unwind.
+- Recovery needs no discipline-specific code: a `Commit`-discipline write is an ordinary WAL slot record,
+  replayed by the same apply routine as every other write.
+
+## 🧪 Tests
+
+- [CommittedDisciplineTests](../../../../test/Typhon.Engine.Tests/Data/ECS/CommittedDisciplineTests.cs) — arena staging/publish, read-your-own-writes, rollback-discards-staged, `DefaultDiscipline` escalation, cluster and non-cluster archetypes
+- [CommittedDisciplineRecoveryTests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/CommittedDisciplineRecoveryTests.cs) — hard-crash proof: a `Commit`-discipline write survives as an ordinary Slot record with zero discipline-specific recovery code
+
+## 🔗 Related
+
+- Parent feature: [Durability Modes](./README.md)
+- Sibling: [Committed Durability Discipline](../../Ecs/storage-modes/storage-mode-committed.md) — same feature, ECS storage-mode-facing side of this durability-facing knob
+- Sibling: [SingleVersion Durability Discipline (TickFence / Commit)](../../Transactions/durability-discipline/README.md) — the Transaction-level API surface for choosing this discipline
+
+<!-- Deep dive: claude/design/Durability/MinimalWal/05-committed-mode.md, claude/adr/057-committed-durability-discipline.md, claude/design/Ecs/committed-storage-mode.md -->
+<!-- Rules: claude/design/Durability/MinimalWal/07-rules.md — module CM -->

--- a/doc/feature-set/Durability/page-checksums-seqlock.md
+++ b/doc/feature-set/Durability/page-checksums-seqlock.md
@@ -1,0 +1,71 @@
+# Page Checksums & Seqlock Snapshots
+> CRC32C torn-page detection on every page, paired with a lock-free seqlock so checkpoints snapshot live pages without blocking writers.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](./README.md)
+
+## 🎯 What it solves
+
+An 8 KB page can be physically torn by a power loss mid-write (consumer NVMe write-atomicity unit is typically smaller than 8 KB), or silently bit-rot on the storage medium. Without a checksum, that corruption is invisible until the bad bytes are interpreted as live data. Separately, the checkpoint needs to copy a page's bytes to disk while application transactions may be actively writing that same page — a snapshot taken mid-write would itself encode torn data with a checksum that looks valid. Typhon needs both corruption detection and a copy mechanism that is provably consistent, without making writers wait on the checkpoint.
+
+## ⚙️ How it works (in brief)
+
+Every page carries a CRC32C checksum (hardware-accelerated via the SSE4.2/ARMv8 CRC32 instruction) covering its contents. The checksum is recomputed whenever a page is written and verified whenever a page is read, depending on the configured mode. To let the checkpoint copy a page without locking it against writers, each page also carries a *seqlock* counter: a writer bumps it to odd before mutating the page and back to even after, under the page's exclusive latch. The checkpoint reads the counter, copies the page, then re-reads the counter — if it changed or was caught odd, the copy is discarded and retried (or the page is skipped for that cycle). A torn-page failure is never silently repaired in place: on-load mismatches throw, and a torn page reachable only through crash recovery is healed or fails the open loudly — see the Crash Recovery and Checkpoint entries.
+
+## 💻 Usage
+
+CRC verification is on by default and requires no code changes. The only knob is *when* it runs:
+
+```csharp
+services.AddScopedDatabaseEngine(o =>
+{
+    // Default: verify CRC on every page load — catches corruption at first access.
+    o.Resources.PageChecksumVerification = PageChecksumVerification.OnLoad;
+
+    // Lower overhead: skip on-load checks, verify only during crash recovery.
+    // o.Resources.PageChecksumVerification = PageChecksumVerification.RecoveryOnly;
+});
+```
+
+A mismatch under `OnLoad` surfaces as a normal exception you can catch at the call site that touched the page:
+
+```csharp
+try
+{
+    using var tx = uow.CreateTransaction();
+    var view = tx.Open(soldier);
+    _ = view.Read(Unit.Health);
+}
+catch (PageCorruptionException ex)
+{
+    // ex.PageIndex, ex.ExpectedCrc, ex.ComputedCrc — log and escalate (restore from backup).
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `PageChecksumVerification.OnLoad` | default | Verify CRC on every page load from disk; throws `PageCorruptionException` on mismatch. |
+| `PageChecksumVerification.RecoveryOnly` | opt-in | Skip CRC checks during normal operation; verify only while replaying crash recovery. |
+
+## ⚠️ Guarantees & limits
+
+- **Detection, not repair** — a CRC mismatch under `OnLoad` is reported, never silently patched; there is no in-place page repair (the old Full-Page-Image mechanism was retired — see ADR for the rationale). Recovery from a confirmed bad page means restoring from backup or letting crash recovery rebuild what it can.
+- **Whole-page coverage** — the checksum covers the entire page except the 4-byte checksum field itself; any single- or multi-bit corruption in the page is detected.
+- **Non-blocking checkpoint snapshots** — the seqlock lets the checkpoint copy a page that is concurrently being written without taking a lock writers must wait on; a page with a writer in flight for an unreasonably long time is skipped for that checkpoint cycle rather than stalling it.
+- **Hardware-accelerated** — CRC32C uses the CPU's native CRC32 instruction; cost is roughly constant per 8 KB page and negligible next to the I/O it accompanies.
+- **`RecoveryOnly` trades safety for overhead** — normal reads skip verification entirely, so a torn page introduced outside the recovery window can go undetected until it's next touched during a future recovery pass.
+- **Same mechanism backs WAL records** — WAL record framing uses the same CRC32C algorithm, so a single, consistently-tested corruption-detection primitive covers both pages and the log.
+
+## 🧪 Tests
+
+- [PageCrcVerificationTests](../../../test/Typhon.Engine.Tests/Durability/PageCrcVerificationTests.cs) — lazy CRC verification on page load (`OnLoad` mode), mismatch throws `PageCorruptionException`
+- [SeqlockProtocolTests](../../../test/Typhon.Engine.Tests/Durability/SeqlockProtocolTests.cs) — modification-counter seqlock protocol, checkpoint CRC stamping, concurrent snapshot consistency
+- [Crc32CUtilTests](../../../test/Typhon.Engine.Tests/Durability/Crc32CUtilTests.cs) — the CRC32C algorithm itself against known test vectors
+
+## 🔗 Related
+
+- Sibling: [Page Integrity — CRC32C, Seqlock Snapshots & A/B Page Pairing](../Storage/page-integrity.md) — storage-layer description of this same CRC32C + seqlock mechanism
+- Sibling: [Checkpoint v2 (SnapshotStore pipeline)](checkpoint-v2/README.md) — checkpoint is the primary consumer of the seqlock snapshot copy
+
+<!-- Deep dive: claude/overview/06-durability.md §6.7 -->
+<!-- ADR: 015-crc32c-page-checksums (claude/adr/015-crc32c-page-checksums.md) -->
+<!-- Rules: claude/rules/durability.md — modules Seqlock, Page Safety -->

--- a/doc/feature-set/Durability/pit-backup.md
+++ b/doc/feature-set/Durability/pit-backup.md
@@ -1,0 +1,80 @@
+# Point-in-Time Incremental Backup
+> Forward-incremental `.pack` backups scoped to changed pages; restore reassembles a base and heals it through crash recovery's RecoveryDriver.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](./README.md)
+**Assumes:** [Crash Recovery (RecoveryDriver)](crash-recovery/README.md)
+
+## 🎯 What it solves
+
+A database that only ever recovers to "last checkpoint plus WAL replay" has no answer for disk failure, accidental
+mass-delete, or wanting a snapshot from four hours ago — the WAL itself is recycled after each checkpoint
+([ADR-014](../../../claude/adr/014-no-point-in-time-recovery.md)), so nothing but the live data file survives past
+that point. A naive backup that copies the whole database every time doesn't scale: I/O cost is proportional to
+database size, not to how much actually changed. PIT Backup gives Typhon an external, self-contained recovery
+point whose cost tracks the change rate, without taxing the live transaction path to get it.
+
+## ⚙️ How it works (in brief)
+
+The checkpoint pipeline already iterates dirty pages every cycle; it OR's each flushed page's index into a
+**persistent dirty bitmap** at near-zero cost. A backup point forces a checkpoint, reads that bitmap as the
+changed-page set since the last backup, copies just those pages from the data file, and writes them — LZ4-compressed,
+checksummed, page-indexed — into a self-contained `.pack` file. Successive `.pack` files chain forward; restoring a
+point walks the chain **backward**, taking the newest copy of each page (first-hit-wins) to assemble a single backup
+base. That base is then handed to the **same `RecoveryDriver` used for crash recovery** — it validates pages and
+rebuilds every derived structure (indexes, EntityMap, occupancy bitmap, spatial/statistics) from scratch, exactly as
+it does after a crash. Backups therefore never capture derived-structure pages at all, and restore carries no
+backup-specific replay code. Periodic **compaction** collapses the chain into a fresh base to bound restore time; a
+**retention policy** prunes old points.
+
+> Design note: the original draft ([6-part series](../../../claude/design/Durability/PitBackup/README.md)) protected
+> the live capture window with a scoped Copy-on-Write shadow buffer. That mechanism was dropped in the 2026-06-11
+> redesign ([MinimalWal README §P3, decision D11](../../../claude/design/Durability/MinimalWal/README.md)) in favor
+> of plain post-checkpoint reads — consistency is restored at restore time by RecoveryDriver instead of guaranteed at
+> capture time, which is simpler and reuses an already-proven healing path.
+
+## 💻 Usage
+
+Not implemented — there is no API or CLI to create, restore, or manage backups today. The sketch below shows the
+*intended* shape (a CLI tool plus an in-process retention policy) for planning purposes only; none of this exists yet:
+
+```csharp
+// Illustrative only — not a real/current Typhon API.
+
+// Planned: configure automatic compaction/pruning alongside the engine.
+// var policy = new BackupRetentionPolicy
+// {
+//     MaxAge           = TimeSpan.FromDays(7),
+//     MaxTotalSize     = 20L * 1024 * 1024 * 1024,
+//     CompactThreshold = 42,   // compact after 42 incrementals (~1 week at 4h intervals)
+//     MinKeep          = 5,
+// };
+```
+
+```
+# Planned CLI surface (separate process / offline — not engine-embedded)
+typhon-backup create   --db <path> --dest <backup-dir>
+typhon-backup restore  --source <backup-dir> --target <db-path> [--point <id|datetime>]
+typhon-backup compact  --source <backup-dir>
+typhon-backup prune    --source <backup-dir> --before <id|datetime>
+typhon-backup verify   --source <backup-dir> [--point <id|datetime>]
+```
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** No code exists under `src/Typhon.Engine/Backup` today; everything above is a design sketch, subject to change.
+- **I/O proportional to change, not size** — a backup point costs O(changed pages); only periodic compaction costs O(database size), amortized over the chain (design target: ~15 GB per incremental vs. ~205 GB for a naive full-copy scheme, at 100 GB DB / 10% churn).
+- **Self-contained per chain** — each `.pack` file is independently checksummed (header, footer, and per-page CRC32C); the base point needs no live WAL to restore.
+- **Zero transaction-path overhead when idle** — the only steady-state cost is the checkpoint pipeline's one bit-OR per flushed page.
+- **Restore heals, it doesn't trust** — the assembled base is run through `RecoveryDriver`, the identical mechanism crash recovery uses; derived structures are always rebuilt, never restored byte-for-byte.
+- **One backup at a time** — compaction and pruning run offline against `.pack` files only and never touch the live engine.
+- **Fine-grained point-in-time restore is a separate, optional layer** — retaining WAL segments past checkpoint (revising [ADR-014](../../../claude/adr/014-no-point-in-time-recovery.md)) is planned but not part of the base design; without it, restore granularity is "whichever backup point you took."
+
+## 🔗 Related
+
+- Sibling: [Checkpoint v2 (SnapshotStore pipeline)](checkpoint-v2/README.md) — a backup point forces a checkpoint cycle and reads its dirty-page bitmap
+- Sibling: [Pluggable WAL I/O Backend (IWalFileIO seam)](../Hosting/wal-io-injection-seam.md) — the kind of file-system access seam backup tooling would need for its own I/O
+
+<!-- Overview: claude/overview/07-backup.md -->
+<!-- Design (original 6-part spec — file format, dirty bitmap, chain-walk reconstruction, compaction/pruning still current): claude/design/Durability/PitBackup/README.md -->
+<!-- Design (current resolution — supersedes the CoW capture mechanism, adds RecoveryDriver-based restore): claude/design/Durability/MinimalWal/README.md §P3 / Decision D11 -->
+<!-- ADRs: 014 — No PITR (claude/adr/014-no-point-in-time-recovery.md, revision planned), 028 — CoW snapshot backup (claude/adr/028-cow-snapshot-backup.md, capture mechanism superseded), 029 — Reverse-delta snapshots (claude/adr/029-reverse-delta-incremental-snapshots.md, superseded by forward incrementals), 030 — Dual-limit retention policy (claude/adr/030-dual-limit-retention-policy.md) -->

--- a/doc/feature-set/Durability/wal-v2.md
+++ b/doc/feature-set/Durability/wal-v2.md
@@ -1,0 +1,80 @@
+# Write-Ahead Log (WAL v2 logical records)
+> The single source of durability truth: logical `(EntityId, ComponentTypeId)` records, one codec, a sequential CRC-chained log.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Durability](./README.md)
+
+## 🎯 What it solves
+
+A crash must never lose a write the application was told succeeded, and recovery must never have to guess what physically changed on disk. Logging entire data pages for a small component update wastes most of the I/O and ties the log to wherever the data happened to live — a relocation or compaction breaks replay. Typhon's WAL records only the logical fact — *this entity's component now has these bytes* — so log volume tracks the size of your changes, not your page size, and replay survives a different on-disk layout than the one that produced the log.
+
+## ⚙️ How it works (in brief)
+
+Every commit assembles its changes — spawns, component upserts, collection edits, destroys — into one batch and hands it to a single codec, which serializes it as logical records into a sequential per-database log. Records are framed in CRC-chained chunks, so a torn last write is detected and the log truncates cleanly at the first invalid chunk rather than being misread. Producer threads (your transactions) claim space in a lock-free buffer; a dedicated writer thread drains it and flushes to disk, optionally with Force-Unit-Access so a confirmed write is physically durable, not just OS-buffered. No record ever names a page, chunk, or buffer — only `(EntityId, ComponentTypeId)` — so the physical placement is re-derived at apply time.
+
+## 💻 Usage
+
+The WAL is always on and runs transparently under every commit — you configure it once at engine setup and otherwise never touch it directly:
+
+```csharp
+services
+    .AddScopedManagedPagedMemoryMappedFile(o =>
+    {
+        o.DatabaseName = "skirmish";
+        o.DatabaseDirectory = ".";
+    })
+    .AddScopedDatabaseEngine(o =>
+    {
+        o.Wal = new WalWriterOptions
+        {
+            WalDirectory = "wal",
+            SegmentSize = 64 * 1024 * 1024,    // 64 MB segments
+            GroupCommitIntervalMs = 5,
+        };
+    });
+
+// Every Commit() builds a logical record batch and appends it — no separate WAL API to call.
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.GroupCommit);
+using var tx = uow.CreateTransaction();
+var e = tx.OpenMut(soldier);
+e.Write(Unit.Health).Current -= 25;
+tx.Commit();   // batch appended now; durable on the next GroupCommit flush
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `WalDirectory` | `"wal"` | Directory holding WAL segment files |
+| `SegmentSize` | 64 MB | Size of each pre-allocated segment file |
+| `PreAllocateSegments` | 4 | Segments kept pre-allocated ahead of the write position |
+| `GroupCommitIntervalMs` | 5 | Auto-flush interval consumed by `DurabilityMode.GroupCommit` |
+| `UseFUA` | `true` | Per-write Force-Unit-Access durability vs. relying on explicit flush |
+| `StagingBufferSize` | 256 KB | Aligned staging buffer size used for direct I/O writes |
+| `WriterThreadCoreAffinity` | -1 (none) | Pin the WAL writer thread to a logical core |
+
+## ⚠️ Guarantees & limits
+
+- **Mandatory, not optional** — every `DatabaseEngine` runs the WAL; it cannot be turned off (only its disk backend can be swapped for an in-process one in tests/benchmarks).
+- **Logical-only records** — never a page, chunk, or buffer ID — so replay tolerates a different allocation outcome than the run that produced the log.
+- **One codec, one format** — all record bytes are written and read by a single codec on both the commit and recovery paths; no second, divergent path can drift out of sync.
+- **Torn-tail safe** — chunks are CRC-chained; a partial last write is detected and the log truncates at the first invalid chunk instead of being misread as valid data.
+- **Honest watermarks** — `CheckpointLSN ≤ DurableLsn ≤ LastAppendedLsn` always holds; `DurableLsn` never claims a record durable before it is actually fsynced.
+- **Bounded record size** — a single record (header + payload) is capped at chunk size minus envelope (~64 KB); oversized component/collection payloads are rejected at schema registration, not at WAL-write time.
+- **Commit stays cheap** — no disk I/O on the commit path itself beyond serializing into the in-memory buffer (~1–2 µs); FUA cost (~10–80 µs) is paid only when a mode actually waits for it.
+- **Backpressure, not silent loss** — a full commit buffer surfaces as a transient `WalBackPressureTimeoutException`; a single claim larger than the buffer throws `WalClaimTooLargeException`. Append either appends every record or throws — never a partial write.
+- **Not a torn-page repair tool** — the WAL records logical changes, not page images; recovering a torn *data page* is the job of checkpoint A/B pairing and structure rebuild (see the Checkpoint and Crash Recovery entries), not the log itself.
+
+## 🧪 Tests
+
+- [WalCommitBufferTests](../../../test/Typhon.Engine.Tests/Durability/WalCommitBufferTests.cs) — producer-side lock-free claim/publish/drain/overflow semantics
+- [WalWriterTests](../../../test/Typhon.Engine.Tests/Durability/WalWriterTests.cs) — writer-thread drain/flush pipeline, FUA vs. buffered durability
+- [WalRecordHeaderTests](../../../test/Typhon.Engine.Tests/Durability/WalRecordHeaderTests.cs) — on-disk logical record/frame/chunk layout (the `(EntityId, ComponentTypeId)` format itself)
+- [WalIntegrationTests](../../../test/Typhon.Engine.Tests/Durability/WalIntegrationTests.cs) — end-to-end WAL pipeline across all three `DurabilityMode`s with real disk I/O
+
+## 🔗 Related
+
+- Sibling: [Commit Pipeline (append-before-publish)](./commit-pipeline.md) — APPEND is the pipeline's point of no return, writing straight into this log
+- Sibling: [Unit of Work (durability boundary)](../Transactions/unit-of-work.md) — the UoW's `DurabilityMode` decides when this WAL's records are flushed to stable media
+
+<!-- Deep dive: claude/overview/06-durability.md §6.1 -->
+<!-- Design: claude/design/Durability/MinimalWal/02-wal-format.md -->
+<!-- ADRs: 011 (claude/adr/011-logical-wal-records.md), 012 (claude/adr/012-mpsc-ring-buffer-wal.md), 015 (claude/adr/015-crc32c-page-checksums.md), 020 (claude/adr/020-dedicated-wal-writer-thread.md) -->
+<!-- Rules: claude/rules/durability.md — module LOG -->

--- a/doc/feature-set/Ecs/README.md
+++ b/doc/feature-set/Ecs/README.md
@@ -1,0 +1,29 @@
+# Ecs
+> Typhon's archetype-based Entity-Component-System is the primary application-facing data model and read/write path: structured 64-bit entity identity, C# archetype classes, and typed zero-copy `Comp<T>` handles resolve any entity's components in O(1). Each component type independently picks a storage mode — `Versioned` (full MVCC), `SingleVersion` (tick-fence durable), or `Transient` (heap-only) — with a `Committed` discipline escalation for atomic zero-loss writes without a revision chain, layered under a three-tier query/reactive-view system, typed entity relationships with cascade delete, and a batched cluster storage engine that turns bulk iteration into ~50x-faster sequential array scans.
+
+> 🔬 **Recommended:** read [in-depth-overview/06-ecs.md](../../in-depth-overview/06-ecs.md) (Chapter 06: ECS) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Entity & Archetype Model](entity-archetype-model.md) | Structured 64-bit `EntityId`, C# class-hierarchy archetypes, and typed `Comp<T>` handles resolving entities to component slots in O(1) | ✅ Implemented | 🟢 Start Here |
+| [Entity Lifecycle & CRUD API](entity-lifecycle-crud/README.md) | Zero-copy `EntityRef` accessor for Spawn, Open, Read, Write, Destroy, and Enable/Disable — the sole entity manipulation API | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Generated Multi-Component Accessors](entity-lifecycle-crud/generated-multi-component-accessors.md) | Source-generated zero-copy `Refs`/`MutRefs` structs reading or writing every archetype component in one call | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Batch & SoA Spawn](entity-lifecycle-crud/batch-soa-spawn.md) | Bulk entity creation — shared-value batches or per-entity SoA spans — amortizing per-call overhead across thousands of entities | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Enable/Disable Components](entity-lifecycle-crud/enable-disable-components.md) | O(1) per-component bit-flip toggle — data preserved, not freed, with its own MVCC snapshot isolation independent of the component's StorageMode | ✅ Implemented | 🔵 Core |
+| [Storage Modes](storage-modes/README.md) | Per-component-type choice of durability/performance tier (`Versioned` / `SingleVersion` / `Transient`), declared via `[Component(StorageMode = ...)]`, under one `Read<T>()`/`Write<T>()` API | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Versioned](storage-modes/storage-mode-versioned.md) | Full MVCC snapshot isolation and zero-loss durability for data that can never be lost or read torn | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [SingleVersion (Tick-Fence Durable)](storage-modes/storage-mode-singleversion.md) | In-place writes at near-zero cost, durable to the last completed game tick | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Transient (Heap-Only)](storage-modes/storage-mode-transient.md) | Heap-only component storage for scratch data that should never touch disk | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Committed Durability Discipline](storage-modes/storage-mode-committed.md) | Zero-loss, atomic commits on the `SingleVersion` layout — without paying for a `Versioned` revision chain | ✅ Implemented | 🟣 Advanced |
+| [Query System (EcsQuery)](query-system.md) | Three-tier constraint evaluation (`ArchetypeMask`, `EnabledBits`, WHERE) with planner-chosen broad or targeted scan, indexed/opaque predicates, FK joins, and spatial filters (full query/view feature set catalogued under Querying) | ✅ Implemented | 🟢 Start Here |
+| [Reactive Views (EcsView)](reactive-views.md) | Persistent, incrementally-maintained query results with ring-buffer delta tracking across Incremental, OR, and Pull refresh modes (canonical doc lives under Querying) | 🚧 Partial | 🔵 Core |
+| [Entity Relationships](entity-relationships.md) | Typed `EntityLink<T>` entity references used to build 1:1, 1:N, and N:M relationships, with declarative cascade delete and FK indexing | ✅ Implemented | 🔵 Core |
+| [Component Collections](component-collections.md) | Per-entity variable-length lists (owned data or entity-reference lists) via a shared buffer pool, in-place for `SingleVersion` and copy-on-write for `Versioned` | ✅ Implemented | 🔵 Core |
+| [Schema Versioning & Migration](schema-versioning-migration.md) | Detects struct/archetype layout drift at database open and migrates data automatically or via your own functions | 🚧 Partial | 🔵 Core |
+| [Entity Clusters (Batched SoA Storage)](entity-clusters.md) | GPU-inspired batched SoA storage that turns per-entity hashmap/page lookups into sequential array scans (~50x faster bulk iteration) | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+*No internal-only engine machinery documented separately in this category — every feature file above is directly reached from application code (`DatabaseEngine`, `Transaction`, `EntityRef`, `Comp<T>`/attributes, or `EcsQuery`/`EcsView`).*

--- a/doc/feature-set/Ecs/component-collections.md
+++ b/doc/feature-set/Ecs/component-collections.md
@@ -1,0 +1,96 @@
+# Component Collections
+> Per-entity variable-length lists — owned data or entity-reference lists — without breaking fixed-size component layout.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](./README.md)
+
+## 🎯 What it solves
+
+Components are fixed-size blittable structs stored column-major (SoA) — there's no room for a per-entity list of
+unknown length: a path's waypoints, a player's inventory slots, a parent's child-entity list. `ComponentCollection<T>`
+adds exactly that, for both owned value data (`ComponentCollection<Waypoint>`) and entity-reference lists
+(`ComponentCollection<EntityLink<TArch>>`, the "collection on parent" side of a 1:N relationship — see
+[Entity Relationships](./entity-relationships.md)), without growing the component's stride or wasting space on the
+common short case.
+
+## ⚙️ How it works (in brief)
+
+A `ComponentCollection<T>` field is 4 bytes — a buffer id, nothing else. The elements live in a separate pool, shared
+by every `ComponentCollection<T>` field across every archetype that uses that element type `T`. Mutation goes through
+`Transaction.CreateComponentCollectionAccessor` (append-only `Add`, plus `ElementCount`/`GetAllElements` for bulk
+read); read-only iteration goes through `Transaction.GetReadOnlyCollectionEnumerator` (cheap `foreach`, no write
+intent). On a `SingleVersion` component the buffer is owned in place by the one committed slot, mutated directly. On
+a `Versioned` component an overwrite duplicates the buffer id into the new revision and bumps a reference count; the
+first mutation through that still-shared buffer clones it (copy-on-write), so an older MVCC snapshot keeps observing
+the contents it originally read. `T` must be `unmanaged` — the same blittability constraint as a component field.
+
+## 💻 Usage
+
+```csharp
+public struct PathData
+{
+    public float TotalLength;
+    public ComponentCollection<Waypoint> Waypoints;   // owned value data, not entity refs
+}
+
+public struct Waypoint   // plain struct, not an archetype — no identity, no independent lifecycle
+{
+    public Vector3 Position;
+    public float Speed;
+}
+
+// Append elements
+EntityRef path = tx.OpenMut(pathId);
+ref PathData data = ref path.Write<PathData>();
+using (var cca = tx.CreateComponentCollectionAccessor(ref data.Waypoints))
+{
+    cca.Add(new Waypoint { Position = p0, Speed = 4.5f });
+    cca.Add(new Waypoint { Position = p1, Speed = 3.0f });
+}
+
+// Bulk read
+var read = tx.Open(pathId).Read<PathData>();
+using var cca2 = tx.CreateComponentCollectionAccessor(ref read.Waypoints);
+Span<Waypoint> all = stackalloc Waypoint[cca2.ElementCount];
+cca2.GetAllElements(all);
+
+// Lightweight foreach (no write intent)
+foreach (ref readonly Waypoint wp in tx.GetReadOnlyCollectionEnumerator(ref read.Waypoints))
+{
+    // process wp
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Zero cost for components without a collection field — the field is 4 bytes, and the per-table bookkeeping that
+  drives append/read/destroy is gated on the table actually declaring one.
+- `SingleVersion`: the cluster slot is the buffer's sole owner; destroying the entity frees it automatically.
+- `Versioned`: O(1) per overwrite (a reference-count bump, not an element copy) until a shared buffer is actually
+  written, then the clone is O(K) where K = element count at that point. Storage is reclaimed when the owning
+  revision is garbage-collected — a long-lived revision chain pins every distinct buffer it still references.
+- **Not supported on `Transient` components** — registering one with a `ComponentCollection<T>` field throws at
+  startup (`InvalidOperationException`). A Transient component doesn't survive restart; its collection buffer would,
+  leaving an orphaned buffer with nothing to reference it.
+- Public API is append-and-bulk-read (`Add`, `GetAllElements`, the read-only enumerator) — no per-element
+  remove/replace through `ComponentCollectionAccessor<T>`.
+- Insertion order is preserved; there is no secondary index over collection contents — finding "the entity whose
+  collection contains X" requires an application-level scan, not a query.
+- **Crash safety caveat:** collection buffer *content* reaches disk only at checkpoint, not WAL-redo-logged. A crash
+  between a collection write and the next checkpoint can lose that write (the field's buffer id is recovered; the
+  new elements are not). Collection durability is checkpoint-bounded, not commit-bounded — a known gap tracked
+  separately, distinct from the rest of the commit path.
+- `T` must be `unmanaged` (no references) — same constraint as any component field.
+
+## 🧪 Tests
+
+- [ComponentCollectionTests](../../../test/Typhon.Engine.Tests/Data/ComponentCollectionTests.cs) — `Versioned` create/read/update, reference-count bump, copy-on-write clone on shared-buffer mutation, destroy frees the buffer
+- [SvComponentCollectionTests](../../../test/Typhon.Engine.Tests/Data/ECS/SvComponentCollectionTests.cs) — `SingleVersion` in-place update (no new buffer), migrate/rollback buffer lifecycle, registering one on `Transient` throws
+- [ClusterComponentCollectionTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterComponentCollectionTests.cs) — collection field on a clustered `Versioned` archetype: spawn/update/migrate/destroy
+
+## 🔗 Related
+
+- Source: `src/Typhon.Engine/Ecs/public/ComponentCollection.cs` (`ComponentCollectionAccessor<T>`),
+  `src/Typhon.Engine/Transactions/public/Transaction.cs` (`CreateComponentCollectionAccessor`, `GetReadOnlyCollectionEnumerator`)
+- Related features: [Entity Relationships](./entity-relationships.md)
+
+<!-- Deep dive: ADR-056 (claude/adr/056-cluster-componentcollection-storage.md), overview/04-data.md §4.16 (claude/overview/04-data.md), design/Ecs/08-entity-relationships.md (claude/design/Ecs/08-entity-relationships.md) -->

--- a/doc/feature-set/Ecs/entity-archetype-model.md
+++ b/doc/feature-set/Ecs/entity-archetype-model.md
@@ -1,0 +1,87 @@
+# Entity & Archetype Model
+> Structured 64-bit entity identity, C# class-hierarchy archetypes, and typed zero-copy component handles — the schema backbone of every other ECS feature.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Ecs](./README.md)
+
+## 🎯 What it solves
+
+A flat `EntityId` with independent per-component tables gives no guarantee that a "Factory" entity actually has the components a Factory needs, and forces one B+Tree lookup per component just to read an entity's data. The Entity & Archetype Model fixes both: an archetype declares an entity's complete component set up front (engine-enforced, not caller-maintained), and a single per-archetype lookup resolves every component slot at once. It also removes a whole class of bugs around stale references — entity identity here can never collide with a previously deleted entity occupying the same slot.
+
+## ⚙️ How it works (in brief)
+
+Archetypes are plain C# classes in a single-inheritance hierarchy, each declaring its components as `static readonly Comp<T>` fields; a derived archetype (e.g. `House : Archetype<House, Building>`) inherits its parent's components at stable slot indices and adds its own. Every `EntityId` packs a 52-bit monotonic `EntityKey` and a 12-bit `ArchetypeId` into one `ulong` — the `ArchetypeId` routes to the entity's archetype, the `EntityKey` is the lookup key within it. Because keys are never recycled, a stale `EntityId` simply misses on lookup; no version/generation field is needed. Opening an entity (`Open`/`OpenMut`) pays one lookup and returns an `EntityRef` that amortizes it across all subsequent `Read`/`Write` calls for that entity. `Comp<T>` is the typed handle used both to declare a component on an archetype and to address it later — slot resolution is O(1) and type-checked by the compiler.
+
+## 💻 Usage
+
+```csharp
+// ─── Component types: plain unmanaged structs ───
+[Component("Game.Placement", 1)]
+public struct Placement
+{
+    public float X, Y, Z;
+}
+
+[Component("Game.HouseData", 1)]
+public struct HouseData
+{
+    public int Residents;
+}
+
+// ─── Archetype hierarchy ───
+[Archetype(1)]
+public class Building : Archetype<Building>
+{
+    public static readonly Comp<Placement> Placement = Register<Placement>();
+}
+
+[Archetype(2)]
+public class House : Archetype<House, Building>
+{
+    public static readonly Comp<HouseData> HouseInfo = Register<HouseData>();
+}
+
+// ─── Spawn, open, and access ───
+using var t = dbe.CreateQuickTransaction();
+
+var id = t.Spawn<House>(
+    Building.Placement.Set(new Placement { X = 1, Y = 0, Z = 2 }),
+    House.HouseInfo.Set(new HouseData { Residents = 4 }));
+
+var house = t.Open(id);
+ref readonly var placement = ref house.Read(Building.Placement); // inherited slot, zero-copy
+ref readonly var info = ref house.Read(House.HouseInfo);
+
+t.Commit();
+```
+
+| Constraint | Limit | Effect |
+|---|---|---|
+| Components per archetype | 16 | `[Archetype]` registration throws if exceeded |
+| Registered archetypes | 4,096 (12-bit `ArchetypeId`) | IDs are explicit (`[Archetype(Id = N)]`), not auto-assigned |
+| `ComponentValue` inline payload | 112 bytes | Larger components use incremental Spawn (`Spawn` + `OpenMut` + `Write`) |
+| Archetype inheritance | single parent only | No diamond inheritance — enforced at registration |
+
+## ⚠️ Guarantees & limits
+
+- **Schema enforcement at creation**: `Spawn<T>` always allocates every component slot of the archetype (omitted ones zero-initialized and disabled) — there is no "entity missing a required component" error class.
+- **O(1) entity→component routing**: one lookup per `Open`/`OpenMut` resolves all component locations for that entity; `Read`/`Write` afterward are direct, ~1-5ns for SingleVersion/Transient, ~50-100ns for Versioned (MVCC revision walk).
+- **Zero-copy access**: `Read` returns `ref readonly T`, `Write` returns `ref T` — no struct copies into or out of storage.
+- **Stale references always miss, safely**: `EntityKey` is monotonic and never recycled, so there's no version field and no ABA hazard — a held `EntityId` for a destroyed entity simply fails to resolve.
+- **Polymorphic slot stability**: a component inherited from a parent archetype sits at the same slot index in every descendant, so handles like `Building.Placement` work uniformly across `Building`, `House`, and any other subclass.
+- **`ArchetypeId` is permanent**: it's embedded in every persisted `EntityId`, so it must be assigned explicitly via the attribute and never reused for a different schema.
+- **Component removal is non-structural**: an archetype's component set is fixed after spawn — "removing" a component means disabling it (O(1) bit), not migrating the entity to a different archetype.
+
+## 🧪 Tests
+
+- [EntityIdTests](../../../test/Typhon.Engine.Tests/Data/ECS/EntityIdTests.cs) — `EntityId` 64-bit packing (`EntityKey`/`ArchetypeId`), null semantics, equality, raw-value round-trip
+- [ArchetypeRegistrationTests](../../../test/Typhon.Engine.Tests/Data/ECS/ArchetypeRegistrationTests.cs) — archetype registration, parent-first slot inheritance, component-type dedup across archetypes, subtree building
+
+## 🔗 Related
+
+- Sibling: [Entity Lifecycle & CRUD API](entity-lifecycle-crud/README.md) — `Open`/`OpenMut`/`Spawn` resolve entities through the archetype model described here
+- Sibling: [Query System (EcsQuery)](query-system.md) — Tier 1 `ArchetypeMask` constraints are built directly on this model
+
+<!-- Deep dive: claude/design/Ecs/03-entity-model.md (EntityId layout, archetype registration, resolution chain) -->
+<!-- Deep dive: claude/design/Ecs/02-design-decisions.md (decisions #1-21) -->
+<!-- Deep dive: claude/design/Ecs/01-motivation.md (why archetypes replace the flat CRUD model) -->
+<!-- ADR: 002-ecs-data-model (claude/adr/002-ecs-data-model.md) -->

--- a/doc/feature-set/Ecs/entity-clusters.md
+++ b/doc/feature-set/Ecs/entity-clusters.md
@@ -1,0 +1,79 @@
+# Entity Clusters (Batched SoA Storage)
+> GPU-inspired batched SoA storage that turns per-entity hashmap/page lookups into sequential array scans.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Ecs](./README.md)
+
+**Assumes:** [Storage Modes](./storage-modes/README.md)
+
+## 🎯 What it solves
+
+Per-entity storage pays a hash-map lookup plus a scattered page fetch for every component, on every entity, every tick. At 100K+ entities that indirection — not the actual computation — dominates iteration cost (profiling found 66% of per-entity time in lookup/fetch overhead) and blows the working set past L2/L3 cache. Entity Clusters eliminate that indirection for bulk iteration (movement systems, AI ticks, batch queries) while leaving random single-entity access, MVCC isolation, indexes, and all three storage modes working exactly as before.
+
+## ⚙️ How it works (in brief)
+
+Eligible archetypes auto-compute a cluster size N (8-64, chosen to maximize entities-per-page) and pack N same-archetype entities into one contiguous chunk: an occupancy bitmask, an enabled-bitmask per component, an entity-key array, then each component's data as a separate contiguous array (SoA) — `Component0[N], Component1[N], ...`. `ClusterEnumerator<TArch>` walks an archetype's active clusters; each `ClusterRef<TArch>` exposes `OccupancyBits` plus `GetSpan<T>`/`Get<T>` for direct, branch-free access to a component's slot array — no hash lookup, no per-component page fetch. Random access (`Open`/`OpenMut`) is unchanged at the API level: it transparently resolves through the EntityMap to the same cluster + slot. `SingleVersion` and `Versioned` components live in the cluster (Versioned stores its HEAD there, the revision chain stays separate); `Transient` components live in a parallel heap-backed segment with identical layout so the SoA pattern is uniform across all three modes. When an archetype also declares a `[SpatialIndex]` field, cluster membership gains a further constraint: [Spatially-Coherent Entity Clustering](../Spatial/spatial-coherent-clustering.md) additionally packs entities by grid cell, not just by archetype, so per-cell spatial operations (tier assignment, dormancy, broadphase) stay per-cluster instead of per-entity — this is what a "cluster migration" (mentioned in the tick fence docs) actually is: an entity crossing its cluster's cell boundary and being moved to a cluster for its new cell.
+
+## 💻 Usage
+
+```csharp
+[Archetype(100)]
+public class Ant : Archetype<Ant>
+{
+    public static readonly Comp<Position> Position = Register<Position>();
+    public static readonly Comp<Movement> Movement = Register<Movement>();
+}
+
+// Bulk iteration — the cluster-native path, ~50x faster than per-entity Open/OpenMut.
+var ants = ctx.Accessor.For<Ant>();
+using var clusters = ants.GetClusterEnumerator();
+while (clusters.MoveNext())
+{
+    var cluster = clusters.Current;
+    var positions = cluster.GetSpan(Ant.Position);
+    var movements = cluster.GetReadOnlySpan(Ant.Movement);
+
+    ulong bits = cluster.OccupancyBits;
+    while (bits != 0)
+    {
+        int idx = BitOperations.TrailingZeroCount(bits);
+        bits &= bits - 1;
+        positions[idx].X += movements[idx].VX * ctx.DeltaTime;
+        positions[idx].Y += movements[idx].VY * ctx.DeltaTime;
+    }
+    clusters.MarkCurrentDirty(); // required: flags the writes for WAL/checkpoint — the cluster path skips dirty tracking otherwise
+}
+
+// Random single-entity access — same archetype, same API, transparently cluster-backed.
+var entity = ants.OpenMut(someAntId);
+ref var pos = ref entity.Write(Ant.Position);
+pos.X += 1;
+```
+
+## ⚠️ Guarantees & limits
+
+- **Cluster size is auto-computed, not chosen by the caller**: N ∈ [8, 64] is picked per archetype to maximize entities-per-page; iteration code is identical for every N.
+- **Eligibility is automatic, not opt-in**: an archetype clusters if it has at least one `SingleVersion` or `Transient` component. Pure-`Versioned` archetypes and `Transient` components with indexed fields stay on the legacy per-entity path — there is no manual opt-out.
+- **Direct `GetSpan`/`Get` writes bypass dirty tracking**: call `MarkCurrentDirty()` (whole cluster) or `MarkSlotDirty(slot)` (single entity) after writing, or the change never reaches the WAL/checkpoint. Writing `Versioned` components through `GetSpan` is rejected by design (`Debug.Assert`) — use `OpenMut`/`Write` for those, which still goes through the revision chain.
+- **Measured impact** (100K entities, 2-component archetype): per-entity cost 134 ns → ~2.7 ns (~50x), tick time ~10x, working set 19.2 MB → 2.5 MB (L3 → L2).
+- **Random access stays correct, not just fast**: MVCC visibility (`BornTSN`/`DiedTSN`), B+Tree/spatial indexes, and `EnabledBits` are all maintained per entity; `Open`/`OpenMut` need no code changes to benefit.
+- **Trade-offs are real, not hidden**: checkpoint I/O is ~1.6x larger (bigger stride per page); highly selective queries pay a zone-map scan floor (~19 µs); schema evolution rebuilds every cluster in the archetype (~C× more expensive than per-component migration, an offline operation).
+- **`EntityId` format is unchanged** — clusters are a storage detail; entity identity, serialization, and WAL/network formats are unaffected.
+
+## 🧪 Tests
+
+- [ClusterStorageTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterStorageTests.cs) — cluster sizing/cache-line-aligned stride, `GetClusterEnumerator` bulk iteration, random-access read/write/destroy through the cluster
+- [ClusterDirtyTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterDirtyTests.cs) — `MarkCurrentDirty`/per-slot dirty-bitmap semantics, tick-fence snapshot clearing, writes lost if dirty isn't marked
+- [ClusterVersionedTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterVersionedTests.cs) — `Versioned` HEAD stored in the cluster with the revision chain kept separate, bulk iteration seeing the latest HEAD after a write
+
+## 🔗 Related
+
+- Sibling: [Storage Modes](./storage-modes/README.md) — clustered component data still splits by `Versioned`/`SingleVersion`/`Transient` mode, just batched
+- Sibling: [Spatially-Coherent Entity Clustering](../Spatial/spatial-coherent-clustering.md) — for archetypes with a `[SpatialIndex]` field, additionally constrains cluster membership to one grid cell, and defines cluster migration
+- Sibling: [Cluster Spatial Queries](../Spatial/cluster-spatial-queries.md) — indexes cluster bounding boxes instead of per-entity, exploiting this same batched layout
+- Sibling: [Spatial Tiers & Adaptive Dispatch](../Runtime/spatial-tiers-adaptive-dispatch/README.md) — per-cluster simulation tiers dispatch over this storage layer
+
+<!-- Deep dive: claude/design/Ecs/EntityClusters/README.md (overview, sizing formula, eligibility, recovery/persistence) -->
+<!-- Deep dive: claude/design/Ecs/EntityClusters/01-data-layout.md (byte layout, page geometry, occupancy/enabled bit semantics) -->
+<!-- Deep dive: claude/design/Ecs/EntityClusters/04-entity-mapping.md (EntityMap evolution, random access path, ClusterLocation encoding) -->
+<!-- Deep dive: claude/design/Ecs/EntityClusters/10-api-surface.md (public API surface, source-generated accessors) -->
+<!-- ADR: 045-entity-cluster-storage (claude/adr/045-entity-cluster-storage.md) -->

--- a/doc/feature-set/Ecs/entity-lifecycle-crud/README.md
+++ b/doc/feature-set/Ecs/entity-lifecycle-crud/README.md
@@ -1,0 +1,96 @@
+# Entity Lifecycle & CRUD API
+> Zero-copy EntityRef accessor for Spawn, Open, Read, Write, Destroy, Enable/Disable — the sole entity manipulation API.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+Every entity touchpoint — create, read, mutate, delete, toggle a component — needs to resolve "where is this
+entity's data" before doing anything useful. A naive API re-resolves that on every call; for code that reads or
+writes several components on the same entity, that's redundant hashmap work per component.
+
+## ⚙️ How it works (in brief)
+
+`tx.Open(id)` / `tx.OpenMut(id)` probe the entity's per-archetype LinearHash once, check MVCC visibility at the
+transaction's TSN, and return an `EntityRef` — a `ref struct` caching the per-slot component locations. From
+there, `Read<T>(Comp<T>)` / `Write<T>(Comp<T>)` resolve a component slot in O(1) and return a typed ref straight
+into chunk or cluster memory: `Versioned` writes copy-on-write into a new revision, `SingleVersion`/`Transient`
+writes mutate in place. `Spawn` allocates all of an archetype's components up front (omitted ones
+zero-initialized and disabled) and stages the entity invisibly until commit; `Destroy` tombstones it
+(cascade-deleting configured children) — data is freed later by deferred GC, never by the destroying
+transaction itself.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1, StorageMode = StorageMode.SingleVersion)]
+struct Position { public float X, Y, Z; }
+
+[Component("Game.UnitStats", 1, StorageMode = StorageMode.Versioned)]
+struct UnitStats { public int Health, MaxHealth; }
+
+[Archetype(42)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+    public static readonly Comp<UnitStats> Stats = Register<UnitStats>();
+}
+
+// ─── Spawn — all components provided up front; omitted ones are zero-init + disabled ───
+using var tx = dbe.CreateQuickTransaction();
+EntityId id = tx.Spawn<Unit>(
+    Unit.Pos.Set(new Position { X = 0, Y = 0, Z = 0 }),
+    Unit.Stats.Set(new UnitStats { Health = 100, MaxHealth = 100 }));
+tx.Commit();
+
+// ─── Read — one Open() amortized across every component access on `e` ───
+using var rtx = dbe.CreateQuickTransaction();
+if (rtx.TryOpen(id, out EntityRef e))             // try-pattern — no exception on a stale reference
+{
+    ref readonly Position pos = ref e.Read(Unit.Pos);
+}
+
+// ─── Write — OpenMut once, write/disable several components ───
+using var wtx = dbe.CreateQuickTransaction();
+EntityRef m = wtx.OpenMut(id);
+ref Position p = ref m.Write(Unit.Pos);
+p.X += 1f;
+m.Disable(Unit.Stats);          // O(1) bit flip — data preserved, not freed, instantly re-enable-able
+wtx.Commit();
+
+// ─── Destroy — tombstones now (cascade-deletes configured children); freed later by GC ───
+using var dtx = dbe.CreateQuickTransaction();
+dtx.Destroy(id);
+dtx.Commit();
+```
+
+## ⚠️ Guarantees & limits
+
+- One LinearHash probe per `Open`/`OpenMut` (~350ns), amortized across every subsequent `Read`/`Write` on that
+  `EntityRef` (~1-5ns per component for `SingleVersion`/`Transient`).
+- `EntityRef` is a `ref struct` — stack-only, cannot escape its creating accessor/transaction, cannot be stored
+  in a field or passed across threads.
+- `Write<T>` is the dirty boundary — marks dirty (or stages copy-on-write) the moment it's called; no separate
+  `MarkDirty` step.
+- Writing a `Versioned` component requires a full `Transaction` — a bare `EntityAccessor` or `PointInTimeAccessor`
+  worker accessor throws on `Write` to a `Versioned` slot (read-only there).
+- `Spawn`/`SpawnBatch` entities are invisible to other transactions until commit (`BornTSN = commit TSN`);
+  `Destroy` only tombstones (`DiedTSN = commit TSN`) — entries/chunks are reclaimed by deferred GC once no live
+  transaction can still see the entity.
+- Enable/Disable never frees or reallocates a chunk — data is preserved for an immediate, zero-cost re-enable.
+  Two-state only (no partial); zero overhead unless a concurrent transaction is mid-`Enable`/`Disable`.
+- There is no `tx.Read<T>(id)` shorthand — always `Open`/`OpenMut` first to obtain an `EntityRef`.
+- The old flat CRUD API (`CreateEntity`/`ReadEntity`/`UpdateEntity`/`DeleteEntity`) is gone — `EntityRef` is the
+  only entity manipulation path.
+
+## 🧪 Tests
+
+- [EntitySpawnTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EntitySpawnTests.cs) — Spawn/Open/OpenMut/Read/Write core paths, `TryOpen` on a stale id, rollback-doesn't-leak-chunks
+- [EntityDestroyTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EntityDestroyTests.cs) — Destroy tombstoning, visibility after commit vs. same-transaction, cascade through `EntityLink`
+- [EnableDisableTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EnableDisableTests.cs) — Enable/Disable bit-flip semantics, data preservation across re-enable, MVCC visibility of enabled-bits history
+
+## 🔗 Related
+
+- Sub-features: [Generated Multi-Component Accessors](./generated-multi-component-accessors.md), [Batch & SoA Spawn](./batch-soa-spawn.md), [Enable/Disable Components](./enable-disable-components.md)
+
+<!-- Deep dive: claude/design/Ecs/04-crud-api.md, claude/design/Ecs/entity-accessor-comparison.md -->

--- a/doc/feature-set/Ecs/entity-lifecycle-crud/batch-soa-spawn.md
+++ b/doc/feature-set/Ecs/entity-lifecycle-crud/batch-soa-spawn.md
@@ -1,0 +1,73 @@
+# Batch & SoA Spawn
+> Bulk entity creation — shared-value batches or per-entity SoA spans — amortizing per-call overhead across thousands of entities.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+Spawning entities one at a time pays per-call overhead (an `Interlocked.Increment` for the entity key, an
+`EnsureMutable` check, a chunk allocation per component) on every iteration of the loop — too slow for bulk
+world-load or stress-test scale (tens of thousands of entities at once). Batch & SoA Spawn amortizes that
+overhead: one key-range reservation and one mutability check for the whole batch, and — for workloads that
+supply distinct per-entity data — one slot/table/accessor resolution shared across every entity instead of one
+per entity.
+
+## ⚙️ How it works (in brief)
+
+`SpawnBatch<TArch>` reserves N entity keys in a single atomic `Interlocked.Add` and applies the same shared
+`ComponentValue`s to every entity in the batch. For per-entity data supplied as parallel SoA spans, the source
+generator emits a `SpawnBatch(tx, span1, span2, ...)` overload on `partial` archetype classes, built from two
+lower-level `Transaction` primitives: `SpawnBatchAllocate<TArch>` allocates N entities with every component
+chunk pre-allocated (`EnabledBits = 0`), and `SpawnBatchWriteAll` writes one parallel `ReadOnlySpan<T>` across
+the whole allocated range — resolving the slot, table, and accessor once, then looping with zero dictionary
+lookups per entity and setting that component's enabled bit as it writes.
+
+## 💻 Usage
+
+```csharp
+// ─── Shared values — every spawned entity gets the same component data ───
+Span<EntityId> ids = stackalloc EntityId[100];
+tx.SpawnBatch<Unit>(ids, Unit.Pos.Set(new Position { X = 0, Y = 0, Z = 0 }));
+
+// ─── Per-entity SoA — source-generated overload (archetype must be 'partial') ───
+ReadOnlySpan<Position> positions = ...;   // one value per entity, same order as velocities
+ReadOnlySpan<Velocity> velocities = ...;
+EntityId[] ids2 = Unit.SpawnBatch(tx, positions, velocities);
+
+// ─── Hand-rolled SoA — what the generator emits, for custom hot paths ───
+Span<EntityId> ids3 = new EntityId[positions.Length];
+int baseIndex = tx.SpawnBatchAllocate<Unit>(positions.Length, ids3);
+tx.SpawnBatchWriteAll(baseIndex, positions.Length, Unit.Pos, positions);
+tx.SpawnBatchWriteAll(baseIndex, positions.Length, Unit.Vel, velocities);
+tx.Commit();
+```
+
+## ⚠️ Guarantees & limits
+
+- `SpawnBatch<TArch>(Span<EntityId>, params ComponentValue[])` applies identical values to every entity in the
+  batch — for distinct per-entity data, use the SoA path instead.
+- The caller supplies the pre-sized `ids` output span (`stackalloc` for small batches) — there is no internal
+  allocation for the id list itself.
+- All component chunks for all entities are allocated up front, mirroring single `Spawn` semantics — any
+  component not covered by shared values or a `SpawnBatchWriteAll` call stays zero-initialized and disabled.
+- The generated SoA `SpawnBatch` overload requires the archetype be declared `partial`; all input spans must
+  have equal length (`Debug.Assert`-checked — not validated in a Release build).
+- Epoch refresh happens every 128 entities, not per-entity, bounding page-cache pressure during very large
+  batches.
+- Spawned entities follow the same MVCC visibility rule as single `Spawn` — invisible to other transactions
+  until commit (`BornTSN = commit TSN`).
+- `SpawnBatchAllocate`/`SpawnBatchWriteAll` are public `Transaction` members, not generator-internal-only — they
+  can be called directly for hand-written hot paths that don't fit the generated shape (e.g. non-archetype
+  bulk-load tooling).
+
+## 🧪 Tests
+
+- [BatchOperationTests](../../../../test/Typhon.Engine.Tests/Data/ECS/BatchOperationTests.cs) — shared-value and source-generated per-entity SoA `SpawnBatch`, archetype inheritance, `DestroyBatch` incl. cascade
+- [EntitySpawnTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EntitySpawnTests.cs) — shared-value `SpawnBatch` unique-key allocation, zero-value-stays-disabled semantics, commit-then-read-in-new-tx
+
+## 🔗 Related
+
+- Source: `src/Typhon.Engine/Transactions/public/Transaction.ECS.cs`
+- Parent feature: [Entity Lifecycle & CRUD API](./README.md)
+
+<!-- Deep dive: claude/design/Ecs/04-crud-api.md §Batch Spawn / §Per-Component SoA Spawn -->

--- a/doc/feature-set/Ecs/entity-lifecycle-crud/enable-disable-components.md
+++ b/doc/feature-set/Ecs/entity-lifecycle-crud/enable-disable-components.md
@@ -1,0 +1,82 @@
+# Enable/Disable Components
+> O(1) bit-flip to toggle a component's participation without freeing its data, copying it, or migrating the entity.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+Some component data needs to temporarily "not count" — a stunned unit's AI shouldn't tick, a downed unit's health
+regen shouldn't apply — without permanently removing the component. Removing and re-adding a component isn't even
+possible post-spawn (an archetype's component set is fixed for the entity's life), and reallocating storage just to
+toggle participation would be wasteful when the data needs to come right back. Enable/Disable gives every component
+slot a cheap two-state toggle that `Query`, iteration, and optional reads all respect, with the underlying storage
+untouched.
+
+## ⚙️ How it works (in brief)
+
+Each entity carries one `EnabledBits` bitmask on its `EntityRecord` — one bit per archetype component slot.
+`Enable<T>(Comp<T>)`/`Disable<T>(Comp<T>)` on a writable `EntityRef` flip that bit locally and stage the change via
+`StageEnableDisable` for commit; a read-only `EntityAccessor`/`PointInTimeAccessor` worker throws, since only a full
+`Transaction` supports staging structural changes. If the entity lives in cluster (batched SoA) storage, the
+cluster's own enabled-bit vector is updated immediately too, so bulk cluster iteration sees the change without
+waiting for commit. Because `EnabledBits` is entity-level metadata independent of each component's own
+`StorageMode`, it carries its own MVCC snapshot isolation through an engine-wide exception dictionary
+(`EnabledBitsOverrides`): a fast path (`_overrideCount == 0`, a single volatile-int read) skips it entirely when no
+concurrent transaction is mid-toggle; when one is, older transactions still resolve the pre-change bits via a
+per-entity `EnabledBitsHistory`. The query engine's `.Enabled<T>()`/`.Disabled<T>()` constraints and reactive views
+integrate for free — a per-component `hasEnabledAwareViews` flag keeps view notification at zero cost unless a view
+actually filters on enabled state.
+
+## 💻 Usage
+
+```csharp
+using var tx = dbe.CreateQuickTransaction();
+var id = tx.Spawn<Unit>(Unit.Pos.Set(new Position { X = 0, Y = 0, Z = 0 }));
+// Velocity omitted at Spawn — starts disabled, its chunk is zero-initialized
+tx.Commit();
+
+using var wtx = dbe.CreateQuickTransaction();
+EntityRef e = wtx.OpenMut(id);
+bool moving = e.IsEnabled(Unit.Vel);   // false — never set at Spawn
+e.Enable(Unit.Vel);                     // O(1) bit flip — data zero-initialized, now live
+e.Disable(Unit.Pos);                    // O(1) bit flip — data preserved, not freed
+wtx.Commit();
+
+// Safe optional read — false if disabled or absent, no exception
+using var rtx = dbe.CreateQuickTransaction();
+if (rtx.Open(id).TryRead<Velocity>(out var vel)) { /* vel is a copy, not a ref */ }
+
+// Query-side: only entities with Velocity currently enabled
+HashSet<EntityId> moving2 = rtx.Query<Unit>().Enabled<Velocity>().Execute();
+```
+
+## ⚠️ Guarantees & limits
+
+- Always O(1) — a single bit flip on the `EntityRef`'s cached bits; no chunk allocation, no data copy.
+- Disabling never frees or reallocates a component's chunk — data is preserved and immediately available on
+  re-enable; chunks are freed only when the entity itself is destroyed.
+- Two-state only (enabled/disabled) — no partial or graded state.
+- `Enable`/`Disable` require the `Comp<T>` handle overload — there is no bare-type-parameter form.
+- Requires a full `Transaction` — a read-only `EntityAccessor`/`PointInTimeAccessor` worker accessor throws
+  (`StageEnableDisable` is Transaction-only).
+- Carries its own MVCC snapshot isolation independent of the component's `StorageMode`: even a
+  `SingleVersion`/`Transient` component's enabled bit stays snapshot-consistent for concurrent readers via
+  `EnabledBitsOverrides` — zero overhead (one volatile-int check) when no transaction is mid-toggle.
+- Visible within the same transaction immediately (read-your-own-writes) — `.Enabled<T>()`/`.Disabled<T>()` query
+  filters see a pending, uncommitted toggle before that transaction commits.
+- Cluster-stored (batched SoA) entities update the cluster's own enabled-bit vector immediately on toggle, not just
+  at commit, so bulk cluster iteration reflects it right away.
+- `TryRead<T>` returns a copy, not a ref (an `out` parameter can't be `ref readonly`) — for zero-copy access, check
+  `IsEnabled` first, then call `Read` directly.
+
+## 🧪 Tests
+
+- [EnableDisableTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EnableDisableTests.cs) — enabled-bits-after-spawn (full/partial), Enable/Disable bit-flip and data preservation across re-enable, commit persistence, MVCC (older transaction still sees pre-disable bits), multiple toggles in one transaction (last state wins), disable-then-destroy, all-disabled-but-entity-still-alive, same-transaction query visibility of a pending toggle
+
+## 🔗 Related
+
+- Sibling: [Query System (EcsQuery)](../query-system.md) — `.Enabled<T>()`/`.Disabled<T>()` query constraints
+- Sibling: [Persistent Views](../../Querying/persistent-views.md) — enable/disable toggles drive view boundary-crossing notifications
+- Parent feature: [Entity Lifecycle & CRUD API](./README.md)
+
+<!-- Deep dive: claude/design/Ecs/04-crud-api.md §Disable / Enable, §MVCC Isolation, §View Notification -->

--- a/doc/feature-set/Ecs/entity-lifecycle-crud/generated-multi-component-accessors.md
+++ b/doc/feature-set/Ecs/entity-lifecycle-crud/generated-multi-component-accessors.md
@@ -1,0 +1,78 @@
+# Generated Multi-Component Accessors
+> Source-generated zero-copy Refs/MutRefs structs reading or writing every archetype component in one call.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+Reading or writing several components on the same entity through raw `EntityRef` calls needs N+1 lines — one
+`Open`/`OpenMut` plus one `Read`/`Write` per component. For archetypes with four or five components that
+clutters game-loop code with repetitive boilerplate, and a generic `out T1, out T2, ...` alternative would copy
+data instead of returning zero-copy refs. The `ArchetypeAccessorGenerator` emits named, zero-copy multi-component
+accessors directly on the archetype class so one call resolves every declared component.
+
+## ⚙️ How it works (in brief)
+
+For any `[Archetype]` class declared `partial`, the source generator emits nested `Refs` / `MutRefs` ref
+structs — one `ref readonly` (or `ref`) field per `Comp<T>` the archetype declares, named to match the field —
+plus static `ReadAll(tx, id)` / `ReadWriteAll(tx, id)` methods. Internally these call `tx.Open`/`OpenMut` exactly
+once, then `entity.Read`/`Write` by handle for every component — the same O(1)-per-component cost as hand-written
+code, just without the repetition. Child archetypes get a `Refs`/`MutRefs` that includes every inherited
+component first, routed through the declaring parent class's `Comp<T>` handle for correct slot resolution.
+
+## 💻 Usage
+
+```csharp
+[Archetype(100)]
+partial class Unit : Archetype<Unit>           // 'partial' required — non-partial archetypes are silently skipped
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+    public static readonly Comp<Velocity> Vel = Register<Velocity>();
+}
+
+[Archetype(101)]
+partial class Soldier : Archetype<Soldier, Unit>
+{
+    public static readonly Comp<Health> Health = Register<Health>();
+}
+
+// ─── Read every component in one call ───
+Unit.Refs r = Unit.ReadAll(tx, id);
+float x = r.Pos.X;
+float dx = r.Vel.Dx;
+
+// ─── Inherited archetype — parent components included, parent-first ───
+Soldier.Refs sr = Soldier.ReadAll(tx, soldierId);
+float sx = sr.Pos.X;        // from Unit
+int hp = sr.Health.Current; // own
+
+// ─── Write every component in one call ───
+Unit.MutRefs m = Unit.ReadWriteAll(tx, id);
+m.Pos.X = 999;
+m.Vel.Dx = 42;
+tx.Commit();
+```
+
+## ⚠️ Guarantees & limits
+
+- The archetype class must be declared `partial`; if it isn't, the generator silently skips it — no
+  `Refs`/`MutRefs`/`ReadAll`/`ReadWriteAll` are emitted, and no diagnostic is raised.
+- `Refs`/`MutRefs` are `ref struct` — stack-only, same lifetime constraints as `EntityRef`; cannot be stored in
+  a field, boxed, or escape the call site.
+- Cost is one `Open`/`OpenMut` (~350ns) plus N ref assignments (~1-5ns each for `SingleVersion`/`Transient`);
+  `Versioned` fields additionally pay the per-`Write` copy-on-write allocation.
+- Generated field names match the `Comp<T>` declarations exactly — there is no positional `C1`/`C2` form to
+  disambiguate.
+- `ReadWriteAll` opens the entity read-write and exposes every field mutably at once; there is no generated
+  partial-write overload — use `EntityRef.Write` directly when only a subset of components needs mutation.
+
+## 🧪 Tests
+
+- [EntitySpawnTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EntitySpawnTests.cs) — `ReadAll`/`ReadWriteAll` zero-copy round-trip, inherited-archetype field inclusion, mutate-then-verify-persisted
+
+## 🔗 Related
+
+- Source: `src/Typhon.Generators/ArchetypeAccessorGenerator.cs`
+- Parent feature: [Entity Lifecycle & CRUD API](./README.md)
+
+<!-- Deep dive: claude/design/Ecs/04-crud-api.md §Generated Multi-Component Accessors -->

--- a/doc/feature-set/Ecs/entity-relationships.md
+++ b/doc/feature-set/Ecs/entity-relationships.md
@@ -1,0 +1,97 @@
+# Entity Relationships
+> Typed `EntityLink<T>` references plus declarative cascade delete and reactive FK joins.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](./README.md)
+
+## 🎯 What it solves
+
+Entities rarely stand alone — bags own items, characters own equipment, guilds own members. An ECS needs a
+relationship model with the same guarantees as the rest of the database: type-checked endpoints (not raw
+integer IDs), indexed reverse lookups, predictable cleanup when a parent goes away, and reactive joins for views
+that must stay live as relationships change. `EntityLink<T>` plus the indexing/cascade/navigation machinery
+built on top of it covers 1:1, 1:N, and N:M relationships, and hierarchical trees, without ad-hoc bookkeeping.
+
+## ⚙️ How it works (in brief)
+
+`EntityLink<TArchetype>` is an 8-byte, archetype-checked wrapper around `EntityId` — `EntityLink<Building>`
+accepts `Building` or any descendant archetype, `EntityLink.Null` means "no reference." Marking the field
+`[Index]` gives an indexed FK: a child stores a link to its parent (1:N, "FK on child"), or a parent stores a
+`ComponentCollection<EntityLink<T>>` of children (1:N, "collection on parent"); the two compose for bidirectional
+access. `[Index(OnParentDelete = CascadeAction.Delete)]` on an FK field makes `tx.Destroy()` on the parent
+recursively destroy every child still pointing to it — validated cycle- and diamond-free at registration.
+Reactive FK joins (`NavigateField`/`NavigationView`, see [Query System](./query-system.md)) walk a plain
+`long`-typed indexed field rather than `EntityLink<T>` directly — model that field as `[Index] public long
+OwnerId;` alongside (or instead of) a typed `EntityLink<T>` field if a relationship needs one.
+
+## 💻 Usage
+
+```csharp
+public struct ItemData
+{
+    [Index(AllowMultiple = true, OnParentDelete = CascadeAction.Delete)]
+    public EntityLink<Bag> Owner;
+    public int Damage;
+}
+
+public struct BagData
+{
+    public int Capacity;
+}
+
+// FK on child — O(1) reverse lookup, no contention on the parent
+EntityId itemId = tx.Spawn<Item>(Item.Data.Set(new ItemData { Owner = bagId, Damage = 15 }));
+
+foreach (EntityRef item in tx.Query<Item>().Where(i => i.Owner == bagId))
+{
+    ref readonly ItemData data = ref item.Read<ItemData>();
+}
+
+// Safe follow of a possibly-stale link
+if (tx.TryOpen(item.Read<ItemData>().Owner, out EntityRef bag))
+{
+    // alive — use it
+}
+
+// Cascade delete — destroying the bag destroys every Item whose Owner points to it
+tx.Destroy(bagId);
+```
+
+| Relationship shape | Mechanism | Reverse lookup | Reactive join (`NavigateField`) |
+|---------------------|-----------|-----------------|-----------------|
+| 1:1 | `EntityLink<T>` field, optionally `[Index]` | Only if indexed | Needs a separate `long` `[Index]` field |
+| 1:N (FK on child) | `[Index(AllowMultiple = true)]` `EntityLink<T>` | O(1) field read | Needs a separate `long` `[Index]` field |
+| 1:N (collection on parent) | `ComponentCollection<EntityLink<T>>` | Not indexed | Not applicable |
+| N:M | Junction archetype with two indexed `EntityLink<T>` fields | Both sides indexed | Needs a separate `long` `[Index]` field |
+
+## ⚠️ Guarantees & limits
+
+- `EntityLink<T>` is 8 bytes, same layout as `EntityId` — zero overhead over a raw reference; construction
+  asserts (debug builds) that the target archetype is in `T`'s subtree.
+- A unique `[Index]` (no `AllowMultiple`) on an `EntityLink<T>` field rejects a second entity claiming the same
+  target — enforced at index-update time, at commit.
+- Cascade delete (`OnParentDelete = CascadeAction.Delete`) only follows indexed FK fields; the cascade graph is
+  validated at registration — cycles and diamonds both fail startup with a descriptive error, so cascade is
+  always a bounded tree traversal. All cascaded destroys commit atomically with the parent destroy.
+- `ComponentCollection<EntityLink<T>>` relationships are not indexed — no reverse lookup, no independent query
+  on members, and concurrent writers to the same parent collection retry on conflict (microsecond cost,
+  in-process). Cascade for these is a parent-side iterate-and-destroy, not an index scan.
+- Opening a stale (destroyed, non-cascaded) link fails the MVCC visibility check; use `tx.TryOpen` to handle it
+  without an exception.
+- `NavigateField`/`NavigationView` take an `Expression<Func<TSource, long>>` FK selector — a raw indexed `long`
+  field, not an `EntityLink<T>` field directly (no implicit conversion exists between the two). `EntityLink<T>`
+  fields work with `Where`, cascade delete, and `tx.Open`/`tx.TryOpen`, just not a reactive FK join today.
+
+## 🧪 Tests
+
+- [CascadeDeleteTests](../../../test/Typhon.Engine.Tests/Data/ECS/CascadeDeleteTests.cs) — cascade graph validation, multi-level and mixed-ownership cascade, already-dead children, same-transaction cascade
+- [EcsHardeningTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsHardeningTests.cs) — `EntityLink<T>` implicit conversion round-trip, null detection, `IsAlive`/`Open` via a link, deep cascade hierarchies
+- [EcsNavigationTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsNavigationTests.cs) — `NavigateField` reactive FK join, combined source/target predicates, incremental view over the join
+
+## 🔗 Related
+
+- Source: `src/Typhon.Engine/Ecs/public/EntityLink.cs`, `src/Typhon.Engine/Ecs/public/EcsNavigationQueryBuilder.cs`,
+  `src/Typhon.Engine/Ecs/internals/ArchetypeRegistry.cs` (cascade graph validation)
+- Related features: [Query System](./query-system.md), [Automatic Secondary Indexes](../Indexing/automatic-secondary-indexes/README.md),
+  [ECS Query API](../Querying/ecs-query-api/README.md)
+
+<!-- Deep dive: claude/design/Ecs/08-entity-relationships.md -->

--- a/doc/feature-set/Ecs/query-system.md
+++ b/doc/feature-set/Ecs/query-system.md
@@ -1,0 +1,85 @@
+# Query System (EcsQuery)
+> Three-tier constraint evaluation with planner-chosen broad or targeted scan, indexed predicates, FK joins, and spatial filters.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Ecs](./README.md)
+
+## 🎯 What it solves
+
+Application code needs to ask "which entities match these conditions" without hand-rolling a scan, choosing an index, or tracking which fields are searchable. `EcsQuery` gives a single fluent builder that covers structural filters (archetype/component presence), lightweight per-entity state (enabled/disabled), and value predicates (field comparisons, FK joins, spatial overlap) — and picks the cheapest execution strategy for you. Without it, every query site would need its own decision about scanning everything versus walking a secondary index.
+
+## ⚙️ How it works (in brief)
+
+Constraints are evaluated in three tiers, cheapest first: Tier 1 collapses all archetype/component constraints into one `ArchetypeMask` (one AND + branch per entity); Tier 2 resolves `Enabled`/`Disabled` constraints into a per-archetype bitmask checked against the entity's `EnabledBits`; Tier 3 applies WHERE predicates. `Where<T>(Func<T,bool>)` is an opaque lambda evaluated per-entity during a broad (archetype-first, linear) scan — no index, no incremental view. `WhereField<T>(Expression<Func<T,bool>>)` is parsed into indexed `FieldEvaluator`s, enabling a targeted (index-first) scan when selective, and is the only predicate form that can back a `ToView()` incremental view. The planner compares estimated index cardinality against archetype cardinality to choose broad vs. targeted; `OrderByField` forces index-first.
+
+## 💻 Usage
+
+```csharp
+// Field predicate — planner picks targeted (index-first) scan when selective
+HashSet<EntityId> rare = tx.Query<Factory>()
+    .WhereField<FactoryData>(f => f.Throughput > 50)
+    .Execute();
+
+// Structural + enabled-bit constraints — broad scan, no index needed
+int armed = tx.Query<Building>()
+    .With<Placement>()
+    .Without<FactoryData>()
+    .Enabled<Placement>()
+    .Count();
+
+// OR predicate (DNF, max 16 branches) + ordering/pagination (requires WhereField)
+List<EntityId> topFactories = tx.Query<Factory>()
+    .WhereField<FactoryData>(f => f.Throughput > 50 || f.Type == FactoryType.Steel)
+    .OrderByFieldDescending<FactoryData, float>(f => f.Throughput)
+    .Skip(20).Take(10)
+    .ExecuteOrdered();
+
+// FK navigation join — "Houses whose Owner is over 30"
+HashSet<EntityId> houses = tx.Query<House>()
+    .NavigateField<HouseData, OwnerData>(h => h.OwnerId)
+    .Where((h, o) => o.Age > 30)
+    .Execute();
+
+// Spatial predicate on a [SpatialIndex] field
+HashSet<EntityId> nearby = tx.Query<Building>()
+    .WhereNearby<Placement>(centerX: 0, centerY: 0, centerZ: 0, radius: 100)
+    .Execute();
+
+// Persistent reactive view — incremental refresh via ring buffer (WhereField only)
+using EcsView<Factory> view = tx.Query<Factory>()
+    .WhereField<FactoryData>(f => f.Throughput > 50)
+    .ToView();
+```
+
+| Constraint | Tier | Example |
+|---|---|---|
+| `Query<T>()` / `QueryExact<T>()` | T1 | Polymorphic vs. exact-archetype root |
+| `.With<T>()` / `.Without<T>()` / `.Exclude<T>()` | T1 | Archetype mask AND / AND NOT / subtree removal |
+| `.Enabled<T>()` / `.Disabled<T>()` | T2 | Max 4 each per query |
+| `.Where<T>(Func)` | T3 | Opaque, broad scan only |
+| `.WhereField<T>(Expr)` | T3 | Indexed, enables targeted scan + views |
+
+## ⚠️ Guarantees & limits
+
+- Constraints are evaluated cheapest-tier-first; a contradictory Tier 1 mask (e.g. `.With<A>().Without<A>()`) short-circuits to an empty result with zero iteration.
+- `.Enabled<T>()`/`.Disabled<T>()`: max 4 type IDs each per query — exceeding throws `InvalidOperationException`.
+- `WhereField` requires the field to carry a B+Tree index; non-indexed fields are rejected at plan-build time. `Where<T>(Func)` has no such requirement but never uses an index and never drives an incremental view.
+- OR predicates inside `WhereField` are normalized to DNF, capped at 16 branches (ANDing OR pairs multiplies branch count — five 2-way ORs already exceeds the cap).
+- `OrderByField`/`OrderByFieldDescending`/`Skip`/`Take` require a prior `WhereField` call (it identifies the component table) and an indexed field; `ExecuteOrdered()` does not support OR predicates.
+- `ToView()` rejects `OrderBy`/`Skip`/`Take` (a view is unordered) and rejects combining `WhereField` with a spatial predicate or a chained `.Where(lambda)`.
+- At most one spatial predicate (`WhereNearby`/`WhereInAABB`/`WhereRay`) per query; the target component must declare `[SpatialIndex]`.
+- `EcsQuery<TArchetype>` is a mutable struct that borrows the `Transaction` — it does not own it and must not outlive it.
+- Polymorphic queries (`Query<T>()`) match the archetype's full descendant subtree; use `QueryExact<T>()` to match only the named archetype.
+
+## 🧪 Tests
+
+- [EcsQueryTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsQueryTests.cs) — Tier1/Tier2/Tier3 broad scan (`With`/`Without`/`Exclude`/`Enabled`/`Disabled`/opaque `Where`), contradiction short-circuit, `Count`/`Any`
+- [EcsQueryTargetedScanTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsQueryTargetedScanTests.cs) — `WhereField` targeted (index-first) scan vs. broad-scan equivalence, `OrderByField`/`Skip`/`Take`, guard-throws for missing `WhereField`/`OrderBy`
+- [EcsNavigationTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsNavigationTests.cs) — `NavigateField` FK join combining source and target predicates, `Count`, incremental view over a join
+
+## 🔗 Related
+
+- Full query/view feature catalog: [Querying category](../Querying/README.md) — ordering & pagination, spatial predicates,
+  statistics infrastructure, persistent views, view pooling, and temporal queries all build on the fluent API
+  introduced here.
+
+<!-- Deep dive: claude/design/Ecs/05-query-system.md, claude/overview/05-query.md -->

--- a/doc/feature-set/Ecs/reactive-views.md
+++ b/doc/feature-set/Ecs/reactive-views.md
@@ -1,0 +1,19 @@
+# Reactive Views (EcsView)
+> Persistent, incrementally-maintained query results — documented in full under Querying, since `ToView()` is a terminal method on `EcsQuery`.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](./README.md)
+
+**Assumes:** [Query System (EcsQuery)](./query-system.md)
+
+## 🎯 What it solves
+
+Game loops and reactive systems need to repeatedly know "which entities currently match this filter" without re-running a full scan every tick. This is listed here too because `EcsQuery<TArchetype>.ToView()` is the entry point application code actually calls, and it reads naturally as an ECS capability — but the full write-up (mechanics, modes, guarantees, tests) lives in one place to avoid two docs drifting apart on the same feature.
+
+→ **See [Persistent Views — Incremental Refresh & Delta Tracking](../Querying/persistent-views.md)** in the Querying category for the complete documentation: how `Incremental`/`OR`/`Pull` modes are chosen, the ring-buffer change-capture mechanism, `Refresh`/delta semantics, config knobs, guarantees and limits (including the SingleVersion/Transient validation gap behind the Partial status), and tests.
+
+## 🔗 Related
+
+- Canonical doc: [Querying/persistent-views.md](../Querying/persistent-views.md)
+
+<!-- Deep dive: claude/design/Ecs/05-query-system.md §EcsView — Persistent Query Results -->
+<!-- ADR: 042-view-system-architecture (claude/adr/042-view-system-architecture.md) -->

--- a/doc/feature-set/Ecs/schema-versioning-migration.md
+++ b/doc/feature-set/Ecs/schema-versioning-migration.md
@@ -1,0 +1,97 @@
+# Schema Versioning & Migration
+> Detects struct/archetype layout drift at database open and migrates data automatically or via your own functions.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](./README.md)
+
+## 🎯 What it solves
+
+Component structs and archetypes evolve over an application's lifetime — fields get added, removed, widened, or
+reordered, and the set of components on an archetype changes. Without versioning, a stale on-disk layout silently
+misaligns with the runtime struct, corrupting data or crashing. Typhon persists both component and archetype
+schema metadata and validates it on every open, so layout drift is caught loudly instead of silently — then
+migrates the common cases automatically and gives you a typed escape hatch for the rest.
+
+## ⚙️ How it works (in brief)
+
+Every `[Component]` and `[Archetype]` declares a `Revision`; persisted field metadata (name, type, offset, stable
+`FieldId`) is compared against the runtime struct at `RegisterComponentFromAccessor<T>()`. Field add/remove/reorder
+and safe type widenings (`int`→`long`, `Float`→`Double`, …) are detected as **compatible** and migrated
+automatically — segments are reallocated to the new stride and every entity is copied field-by-field, eagerly, at
+open. Lossy or semantic changes (narrowing, signed↔unsigned, cross-type, field split/merge) are **breaking**: the
+engine refuses to open until you register a `MigrationFunc<TOld, TNew>` (or a byte-level fallback) that transforms
+old bytes to new; chains of single-step migrations are resolved automatically via BFS. Archetype-level changes
+(component count or archetype `Revision` mismatch) are validated the same way but only as a hard fail — there is
+no automatic add/remove-component-from-archetype migration yet.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", revision: 2)]
+public struct PlayerV2
+{
+    public int Health;
+    [Field(PreviousName = "Mana")]
+    public long Energy;          // widened + renamed — auto-migrated, no function needed
+    public float HealthRatio;    // new field — zero-initialized
+}
+
+// Breaking change: needs an explicit transform (must run before RegisterComponentFromAccessor)
+dbe.RegisterMigration<PlayerV1, PlayerV2>((ref PlayerV1 old, out PlayerV2 cur) =>
+{
+    cur = new PlayerV2
+    {
+        Health = old.Health,
+        Energy = old.Mana,
+        HealthRatio = old.HealthPercent / 100f,   // semantic conversion — why a function is required
+    };
+});
+
+dbe.RegisterComponentFromAccessor<PlayerV2>();   // validates, auto-migrates compatible fields, runs registered functions
+```
+
+```
+tsh> schema-validate
+  [green]OK[/] Game.Inventory — identical
+  [red]FAIL[/] Game.Equipment — 1 breaking field change (NO migration path!)
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `schemaValidation: SchemaValidationMode` on `RegisterComponentFromAccessor<T>` | `Enforce` | `Skip` bypasses validation entirely — unsafe, may corrupt data if the layout actually changed |
+
+## ⚠️ Guarantees & limits
+
+- Persisted vs. runtime field layout (name, type, offset, stable `FieldId`) is diffed on every open; a breaking
+  diff with no migration path throws `SchemaValidationException` before any user transaction runs.
+- Opening a database written by a newer binary (persisted revision > runtime revision) throws
+  `SchemaDowngradeException` — downgrades are never attempted.
+- Compatible changes (add/remove/reorder field, safe widening) migrate automatically, eagerly, at open — no
+  read-path branching afterward. MVCC revision chains are collapsed to HEAD only during migration (history is not
+  preserved across a stride change).
+- Breaking changes require a registered `MigrationFunc<TOld, TNew>` or byte-level function; multi-step chains
+  resolve via BFS over registered (from, to) revision pairs. A migration failure on any entity aborts before the
+  old segment is touched — the database is left exactly as it was.
+- Archetype-level schema (component count, archetype `Revision`) is validated the same way but **only as a hard
+  error** ("Run `tsh migrate`") — there is no automatic migration for adding/removing a component on an archetype
+  or for changing archetype inheritance; the database must be recreated for those cases today.
+- `tsh migrate` opens the database through the normal engine path (not raw/exclusive file access) and reports
+  per-component OK/MIGRATED/FAIL; `schema-diff`, `schema-validate`, `schema-fields`, `schema-history`, and
+  `schema-export` give pre-flight and audit visibility without mutating anything.
+
+## 🧪 Tests
+
+- [SchemaEvolutionTests](../../../test/Typhon.Engine.Tests/Data/Schema/SchemaEvolutionTests.cs) — compatible auto-migration: add/remove/reorder fields, safe int→long/float→double widening, surviving indexes
+- [MigrationFunctionTests](../../../test/Typhon.Engine.Tests/Data/Schema/MigrationFunctionTests.cs) — breaking-change `MigrationFunc`/byte-level migration, chained multi-step BFS resolution, missing-migration and duplicate-registration failures
+- [SchemaValidationIntegrationTests](../../../test/Typhon.Engine.Tests/Data/Schema/SchemaValidationIntegrationTests.cs) — `SchemaValidationException` on an unmigrated breaking change, `SchemaDowngradeException`, `Skip` validation mode
+- [SchemaVersioningTests](../../../test/Typhon.Engine.Tests/Data/ECS/SchemaVersioningTests.cs) — archetype-level schema persistence and tamper detection (component-count/revision mismatch hard-fails)
+
+## 🔗 Related
+
+- Source: `src/Typhon.Engine/Ecs/public/DatabaseEngine.cs` (`RegisterComponentFromAccessor`, `RegisterMigration`,
+  `ValidateArchetypeSchema`), `src/Typhon.Engine/Schema/internals/SchemaEvolutionEngine.cs`,
+  `src/Typhon.Engine/Schema/internals/MigrationRegistry.cs`, `src/Typhon.Engine/Schema/public/SchemaDiff.cs`,
+  `src/Typhon.Shell/Commands/CommandExecutor.cs` (`migrate`, `schema-*` commands)
+- Related features: [Entity & Archetype Model](./entity-archetype-model.md)
+- Sibling: [User-Defined Migration Functions](../Schema/migration-functions.md) — the engine-side `MigrationFunc<TOld, TNew>` mechanism breaking changes register here
+
+<!-- Deep dive: claude/design/Schema/README.md (component-level layers — Implemented), claude/design/Schema/03-compatible-evolution.md, claude/design/Schema/04-migration-functions.md, claude/design/Schema/05-operational-tooling.md, claude/design/Ecs/03-entity-model.md §Schema Versioning & Migration (archetype-level — partial) -->

--- a/doc/feature-set/Ecs/storage-modes/README.md
+++ b/doc/feature-set/Ecs/storage-modes/README.md
@@ -1,0 +1,55 @@
+# Storage Modes
+> Pick durability and write cost per component type — from microsecond ACID to nanosecond scratch memory, in one engine.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+Game and server workloads mix data with wildly different needs: a position updated every tick can tolerate
+losing a few frames, while inventory or currency can never be lost or read half-written. Forcing all of it
+through one storage tier means either paying full ACID cost for high-frequency data or risking real state on a
+fast-but-loose tier. Storage Modes let each *component type* — not the whole database — declare its own point
+on the durability/performance spectrum, so a single entity can mix a `Versioned` wallet with a `SingleVersion`
+position and a `Transient` animation cursor.
+
+## ⚙️ How it works (in brief)
+
+`StorageMode` is set via `[Component(StorageMode = ...)]` at registration and is immutable for the life of the
+database (changing it requires recreating the database). `Versioned` keeps a full MVCC revision chain
+(snapshot isolation, zero loss); `SingleVersion` stores one in-place HEAD slot with WAL tick-fence durability
+(≤1 tick loss); `Transient` is heap-only and never persisted. All three are read and written through the same
+`EntityRef.Read<T>()` / `Write<T>()` calls — only the cost and guarantees differ, not the API. A runtime
+durability discipline (`Committed`) layers commit-time, zero-loss atomicity onto the `SingleVersion` layout
+without paying for a revision chain.
+
+## Sub-features
+
+| Sub-feature | Use it for | Write cost (Zen 4)            | Durability |
+|-------------|-----------|-------------------------------|------------|
+| [Versioned](./storage-mode-versioned.md) | Inventory, economy, progression, anything needing snapshot isolation or AS-OF reads | ~150-360 ns                   | Zero loss, full ACID |
+| [SingleVersion (Tick-Fence Durability)](./storage-mode-singleversion.md) | Position, velocity, health, cooldowns — high-frequency, loss-tolerant | ~3-10 ns                      | ≤1 tick loss |
+| [Transient](./storage-mode-transient.md) | Animation state, input buffers, pathfinding scratch, targeting info | ~3-5 ns                       | None — gone on crash |
+| [Committed Durability Discipline](./storage-mode-committed.md) | A `SingleVersion` write that must be atomic and zero-loss without MVCC (teleport, item pickup, currency debit) | ~25 ns stage / ~60 ns publish | Zero loss, atomic, no chain |
+
+## ⚠️ Guarantees & limits
+
+- `StorageMode` is immutable once a component is registered — there is no in-place migration between modes.
+- An entity can freely mix component types across all three modes (`Spawn`/`Open`/`OpenMut`/`Destroy` work
+  uniformly); rollback semantics differ per mode — see each sub-feature.
+- Indexes, spatial queries, and ECS lifecycle (Spawn/Destroy/Enable) are available in all three modes, but with
+  different freshness/synchronicity guarantees — check the Storage Mode Feature Matrix (linked below) before
+  committing to a mode.
+- The mode choice is silent at the API level — picking `Versioned` for scratch data overpays, picking
+  `SingleVersion` for currency under-protects. There is no compiler or runtime guard for "wrong mode for this
+  data."
+
+## 🧪 Tests
+
+- [StorageModeReadWriteTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeReadWriteTests.cs) — an entity mixing all three modes, uniform `Read`/`Write` across them, per-mode rollback/dirty-bitmap behavior
+- [StorageModeInfrastructureTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeInfrastructureTests.cs) — `[Component(StorageMode = ...)]` attribute defaults/overrides, per-mode segment allocation differences
+
+## 🔗 Related
+
+- Sub-features: [Versioned](./storage-mode-versioned.md), [SingleVersion (Tick-Fence Durability)](./storage-mode-singleversion.md), [Transient](./storage-mode-transient.md), [Committed Durability Discipline](./storage-mode-committed.md)
+
+<!-- Deep dive: claude/design/Ecs/06-storage-modes.md, claude/design/Ecs/01-motivation.md, claude/overview/04-data.md — Storage Mode Feature Matrix -->

--- a/doc/feature-set/Ecs/storage-modes/storage-mode-committed.md
+++ b/doc/feature-set/Ecs/storage-modes/storage-mode-committed.md
@@ -1,0 +1,83 @@
+# Committed Durability Discipline
+> Zero-loss, atomic commits on the SingleVersion layout — without paying for a Versioned revision chain.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Ecs](../README.md)
+
+**Assumes:** [SingleVersion (Tick-Fence Durable)](./storage-mode-singleversion.md)
+
+## 🎯 What it solves
+
+Some writes need both `SingleVersion`'s cheap layout and `Versioned`'s commit-time guarantees: a teleport, an
+item pickup, a currency debit must be atomic and never lost, but doesn't need snapshot isolation or AS-OF
+queries. Choosing `Versioned` for these pays ~6× the write cost for a revision chain you will never read
+historically; choosing plain `SingleVersion` risks losing the write if the process crashes before the next tick
+fence. Committed discipline closes that gap **on the same `SingleVersion` component** — it's a transaction-time
+choice, not a schema change.
+
+## ⚙️ How it works (in brief)
+
+`Commit` is a runtime `DurabilityDiscipline` (`TickFence` default, or `Commit`), set per transaction or
+side-transaction — not a new `StorageMode` and not a layout change. Under `Commit`, a write stages into a
+per-transaction arena instead of touching the cluster HEAD slot; at `Transaction.Commit()` the staged values are
+WAL-appended as ordinary durable records and only then published in place (HEAD memcpy plus exact index
+reconciliation). `tx.Rollback()` just discards the arena — the HEAD was never touched, so rollback is O(1).
+Every `SingleVersion` component you write inside a `Commit`-discipline transaction is staged this way (the
+discipline is uniform per transaction).
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Wallet", 1, StorageMode = StorageMode.SingleVersion,
+           DefaultDiscipline = DurabilityDiscipline.Commit)]   // optional: any tx touching Wallet escalates
+public struct Wallet { public long Gold; }
+
+[Archetype(13)]
+partial class Player : Archetype<Player>
+{
+    public static readonly Comp<Wallet> Wallet = Register<Wallet>();
+}
+
+// Explicit escalation for one critical operation:
+using var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit);
+var e = tx.OpenMut(playerId);
+e.Write(Player.Wallet).Gold -= price;
+tx.Commit();                  // staged value WAL-logged + published atomically — zero loss on crash
+
+// From inside a scheduled system, via the side-transaction idiom:
+using var side = ctx.CreateSideTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit);
+side.OpenMut(playerId).Write(Player.Wallet).Gold += reward;
+side.Commit();
+```
+
+| Discipline | Write cost (Zen 4) | Durable when | Loss window | Isolation |
+|------------|---------------------|--------------|-------------|-----------|
+| `TickFence` (default) | ~3 ns | at the next tick fence | ≤ 1 tick | tick-fence |
+| `Commit` | ~25 ns stage / ~60 ns publish | at `Commit()` | zero | read-committed |
+
+## ⚠️ Guarantees & limits
+
+- Applies only to `StorageMode.SingleVersion` components — `Versioned` is always commit-scoped already (no
+  benefit), `Transient` is never durable (the discipline knob is meaningless there).
+- Discipline is fixed per transaction: once any write escalates a transaction to `Commit` — explicitly, or
+  because a component declares `DefaultDiscipline = DurabilityDiscipline.Commit` — every `SingleVersion` write
+  in that transaction is commit-staged.
+- Read-your-own-writes works for point reads (`EntityRef.Read`/`Write`) inside the writing transaction. Bulk
+  span reads (`ClusterRef.GetSpan<T>`) inside that same transaction do **not** see staged values — read HEAD
+  through a side-transaction or after commit instead.
+- Isolation is read-committed, not snapshot — `ReadsSnapshot` on a `Commit`-discipline (or plain
+  `SingleVersion`) component fails loudly at scheduler `Build()` time; use `Versioned` for snapshot/AS-OF reads.
+- No revision chain, no deferred-cleanup GC cost — rollback is an arena reset, not a chain unwind.
+- Recovery needs no discipline-specific code: a `Commit`-discipline write is an ordinary WAL slot record,
+  replayed through the same path as every other write.
+
+## 🧪 Tests
+
+- [CommittedDisciplineTests](../../../../test/Typhon.Engine.Tests/Data/ECS/CommittedDisciplineTests.cs) — arena staging, publish-at-commit, read-your-own-writes, rollback discards the arena, cluster and non-cluster paths
+- [CommittedDisciplineRecoveryTests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/CommittedDisciplineRecoveryTests.cs) — crash recovery of `Commit`-discipline writes through ordinary WAL replay
+
+## 🔗 Related
+
+- Also documented from the durability-mode angle: [Durability Modes — Committed Durability Discipline](../../Durability/durability-modes/committed-discipline.md)
+- Parent feature: [Storage Modes](./README.md)
+
+<!-- Deep dive: claude/design/Ecs/committed-storage-mode.md, claude/adr/057-committed-durability-discipline.md, claude/design/Durability/MinimalWal/05-committed-mode.md -->

--- a/doc/feature-set/Ecs/storage-modes/storage-mode-singleversion.md
+++ b/doc/feature-set/Ecs/storage-modes/storage-mode-singleversion.md
@@ -1,0 +1,82 @@
+# SingleVersion (Tick-Fence Durability)
+> In-place writes at near-zero cost, durable to the last completed game tick.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+High-frequency component data — position, velocity, health, cooldowns — gets rewritten every tick by every
+entity. Paying `Versioned`'s copy-on-write and revision-chain cost on every such write would dominate the frame
+budget for data that naturally tolerates losing the last few milliseconds on a crash. `SingleVersion` gives
+near-Flecs/DOTS write performance while remaining on disk and recoverable, just to a coarser durability
+boundary than `Versioned`.
+
+## ⚙️ How it works (in brief)
+
+A `SingleVersion` component has exactly one HEAD slot per entity — writes overwrite it in place, last-writer-
+wins, immediately visible to every reader (no isolation). Each write sets a bit in a per-entity dirty bitmap. At
+the end of each game tick, `DatabaseEngine.WriteTickFence(tickNumber)` serializes every dirty `SingleVersion`
+entity to the WAL as a tick-fence record, establishing a crash-recovery boundary. A crash recovers state as of
+the last completed tick fence — at most one tick of writes is lost, never corrupted (the WAL record holds
+complete post-tick values and overwrites any torn on-disk state).
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1, StorageMode = StorageMode.SingleVersion)]
+public struct Position
+{
+    [Index] public int Zone;
+    public float X, Y, Z;
+}
+
+[Archetype(11)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+var id = tx.Spawn<Unit>(Unit.Pos.Set(new Position { X = 0, Y = 0, Z = 0 }));
+tx.Commit();
+
+using var tx2 = dbe.CreateQuickTransaction();
+var e = tx2.OpenMut(id);
+ref var pos = ref e.Write(Unit.Pos);
+pos.X += dtVelocityX;          // in-place — visible to every reader immediately, no commit needed for visibility
+tx2.Commit();
+
+// Once per game tick, after all systems have run:
+dbe.WriteTickFence(tickNumber);  // batches every dirty SingleVersion component to WAL — the crash-recovery boundary
+```
+
+## ⚠️ Guarantees & limits
+
+- Write cost ~3-10 ns — an in-place store, no allocation, no revision chain.
+- Crash recovery to the last completed `WriteTickFence` call — up to one tick of writes can be lost, but state
+  is never torn or corrupted.
+- Forgetting to call `WriteTickFence` silently degrades a `SingleVersion` component to `Transient`-like
+  durability (no crash recovery) — it never corrupts data.
+- No MVCC isolation: last-writer-wins, and `tx.Rollback()` does **not** revert a `SingleVersion` write already
+  applied in-place.
+- `ReadsSnapshot` is rejected at scheduler `Build()` time for `SingleVersion` components — use `Versioned` for
+  snapshot reads.
+- Secondary B+Tree indexes and spatial structures are reconciled at the tick-fence boundary (deferred), not
+  synchronously on every write.
+- Need atomicity and zero loss for one write without paying for snapshot isolation? See
+  [Committed Durability Discipline](./storage-mode-committed.md) — it escalates a `SingleVersion` write to
+  commit-time durability, closing the ≤1-tick loss window.
+
+## 🧪 Tests
+
+- [StorageModeTickFenceTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeTickFenceTests.cs) — `WriteTickFence` dirty-bitmap serialization, Versioned/Transient correctly skipped
+- [TickFenceE2ETests](../../../../test/Typhon.Engine.Tests/Durability/TickFenceE2ETests.cs) — crash/reopen recovery to the last completed tick fence, multi-entity and multi-update recovery
+
+## 🔗 Related
+
+- Code: `src/Typhon.Engine/Ecs/internals/DirtyBitmap.cs`, `src/Typhon.Engine/Ecs/internals/DirtyBitmapRing.cs`
+- Sub-feature: [Committed Durability Discipline](./storage-mode-committed.md)
+- Sibling: [Durability Modes](../../Durability/durability-modes/README.md) — the separate UoW-level commit-durability spectrum; tick-fence durability here is a distinct, component-level mechanism
+- Parent feature: [Storage Modes](./README.md)
+
+<!-- Deep dive: claude/design/Ecs/06-storage-modes.md, claude/design/Ecs/07-durability.md — WAL Tick Fence -->

--- a/doc/feature-set/Ecs/storage-modes/storage-mode-transient.md
+++ b/doc/feature-set/Ecs/storage-modes/storage-mode-transient.md
@@ -1,0 +1,74 @@
+# Transient
+> Heap-only component storage for scratch data that should never touch disk.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+Some component data is genuinely throwaway between runs — animation state, input buffers, pathfinding scratch,
+targeting info. Paying any persistence cost (WAL, checkpoint, page-cache writeback) for data nobody needs to
+survive a crash is pure overhead. `Transient` removes that cost entirely: the data lives only in process
+memory, is structurally part of the same ECS entity as your durable components, and uses the same
+`Read<T>()`/`Write<T>()` API as every other mode.
+
+## ⚙️ How it works (in brief)
+
+A `Transient` component's chunks live in pinned heap memory rather than the memory-mapped file — there is no
+WAL record, no checkpoint participation, and no dirty tracking; the JIT eliminates the dirty-tracking branches
+entirely for this mode. Reads and writes are direct pointer arithmetic. On crash or restart, `Transient`
+component segments come back empty — the application is responsible for re-initializing any state it needs.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.AnimState", 1, StorageMode = StorageMode.Transient)]
+public struct AnimState
+{
+    public int ClipId;
+    public float Time;
+}
+
+[Archetype(12)]
+partial class Actor : Archetype<Actor>
+{
+    public static readonly Comp<AnimState> Anim = Register<AnimState>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+var id = tx.Spawn<Actor>(Actor.Anim.Set(new AnimState { ClipId = 3, Time = 0f }));
+tx.Commit();
+
+using var tx2 = dbe.CreateQuickTransaction();
+var e = tx2.OpenMut(id);
+ref var anim = ref e.Write(Actor.Anim);
+anim.Time += dt;               // ~3-5 ns, no dirty tracking, no WAL
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `TransientOptions.MaxMemoryBytes` | 256 MB | `AllocateChunk` throws once total `Transient` allocation across the engine exceeds the cap |
+
+## ⚠️ Guarantees & limits
+
+- All data is lost on crash and on every restart — there is no recovery path, by design.
+- Write/read cost ~3-5 ns — the cheapest mode in the engine, comparable to raw Flecs/DOTS arrays.
+- No locking, no torn-data protection, no isolation — "developer owns concurrency" (same model as Unity
+  DOTS/Flecs); two concurrent writes to the same component are undefined.
+- An entity can mix `Transient` components with `Versioned`/`SingleVersion` ones; on recovery only the
+  non-`Transient` components come back — the application must re-initialize `Transient` state for surviving
+  entities.
+- `ComponentCollection<T>` (variable-length) fields are supported on `Transient`.
+- `ReadsSnapshot` is rejected for `Transient` components — there is no history to freeze to.
+
+## 🧪 Tests
+
+- [StorageModeReadWriteTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeReadWriteTests.cs) — `Transient` spawn/read/write, no dirty-bitmap tracking, rollback frees chunks
+- [ClusterTransientTests](../../../../test/Typhon.Engine.Tests/Data/ECS/ClusterTransientTests.cs) — pure-`Transient` cluster has no page-cache segment (heap-only), mixed SV+Transient bulk iteration
+
+## 🔗 Related
+
+- Sibling: [Entity Clusters](../entity-clusters.md) — `Transient` components live in a parallel heap-backed cluster segment with the same SoA layout
+- Sibling: [SingleVersion (Tick-Fence Durable)](./storage-mode-singleversion.md) — same near-zero write cost, but durable to the last tick fence instead of never persisted
+- Parent feature: [Storage Modes](./README.md)
+
+<!-- Deep dive: claude/design/Ecs/06-storage-modes.md — TransientStore Memory Management, Transient Concurrency -->

--- a/doc/feature-set/Ecs/storage-modes/storage-mode-versioned.md
+++ b/doc/feature-set/Ecs/storage-modes/storage-mode-versioned.md
@@ -1,0 +1,70 @@
+# Versioned
+> Full MVCC snapshot isolation and zero-loss durability for data that can never be lost or read torn.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Ecs](../README.md)
+
+## 🎯 What it solves
+
+Some component data — inventory, currency, guild membership, progression — must never be lost on crash, must
+never be visible to a concurrent transaction in a half-written state, and sometimes needs to be read "as of" a
+prior point in time. `Versioned` is Typhon's default storage mode: every write is isolated until commit, every
+commit is WAL-durable, and concurrent readers always see a consistent value.
+
+## ⚙️ How it works (in brief)
+
+A `Versioned` component keeps a per-entity revision chain alongside its data. `EntityRef.Write<T>()` is
+copy-on-write — it allocates a new revision and copies forward rather than overwriting in place, so concurrent
+readers keep seeing the prior committed value until your transaction commits. Every transaction is WAL-logged;
+on commit the new revision becomes the visible HEAD and is durable. Reads walk the chain under transaction-
+sequence-number visibility, giving each transaction a consistent snapshot of the data.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Inventory", 1)]   // StorageMode.Versioned is the default — no need to set it explicitly
+public struct Inventory
+{
+    [Index] public int ItemId;
+    public int Quantity;
+}
+
+[Archetype(10)]
+partial class Player : Archetype<Player>
+{
+    public static readonly Comp<Inventory> Inventory = Register<Inventory>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+var id = tx.Spawn<Player>(Player.Inventory.Set(new Inventory { ItemId = 7, Quantity = 1 }));
+tx.Commit();
+
+using var tx2 = dbe.CreateQuickTransaction();
+var e = tx2.OpenMut(id);
+ref var inv = ref e.Write(Player.Inventory);
+inv.Quantity += 1;            // copy-on-write — old revision still visible to concurrent readers
+tx2.Commit();                 // new revision becomes HEAD, durable
+```
+
+## ⚠️ Guarantees & limits
+
+- Zero data loss on crash — every committed write is WAL-durable and recoverable to the exact pre-crash state.
+- Full snapshot isolation: concurrent transactions never see another transaction's uncommitted writes;
+  conflicting writes are detected at commit.
+- `tx.Rollback()` discards the staged revision entirely — the prior committed value is untouched.
+- The most expensive mode: ~150-580 ns/write versus ~3-10 ns for `SingleVersion`/`Transient` (copy-on-write
+  allocation, revision-chain append, eventual chain GC).
+- Carries per-entity chain memory overhead even when a component is rarely written.
+- Required for `ReadsSnapshot` / temporal "AS OF" reads and TAIL (committed-value) indexes — these guarantees
+  are `Versioned`-only; `SingleVersion` and `Transient` reject them.
+
+## 🧪 Tests
+
+- [EcsSpawnMvccTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EcsSpawnMvccTests.cs) — copy-on-write on `Write`, concurrent transaction still seeing old data, rollback freeing the new chunk, revision-chain creation
+
+## 🔗 Related
+
+- Sibling: [Committed Durability Discipline](./storage-mode-committed.md) — gets `Versioned`-grade commit atomicity on the cheaper `SingleVersion` layout, for writes that don't need snapshot isolation
+- Sibling: [Revision](../../Revision/README.md) — the MVCC revision-chain subsystem `Versioned` writes append into
+- Parent feature: [Storage Modes](./README.md)
+
+<!-- Deep dive: claude/design/Ecs/06-storage-modes.md, claude/overview/04-data.md §4.6 Revision Chains / MVCC Deep Dive -->

--- a/doc/feature-set/Errors/README.md
+++ b/doc/feature-set/Errors/README.md
@@ -1,0 +1,24 @@
+# Errors
+> Typhon's unified error model: a single-rooted exception hierarchy with numeric error codes and an `IsTransient` retry hint, finite per-subsystem timeouts that replace infinite hangs, `ExhaustionPolicy`-driven bounded-resource failures, and a DEBUG-only declared-access validator. For expected non-error outcomes on hot paths, a zero-allocation `Result<TValue,TStatus>` struct replaces exceptions entirely — retrying is always the caller's decision, the engine never retries on its own.
+
+> 🔬 **Recommended:** read [in-depth-overview/14-errors.md](../../in-depth-overview/14-errors.md) (Chapter 14: Errors) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [TyphonException Hierarchy & Catalog](exception-hierarchy.md) | Base `TyphonException` (`ErrorCode` + virtual `IsTransient`) rooted hierarchy giving callers three catch granularities, with a living catalog of every concrete exception type and a caller-owns-retry philosophy | ✅ Implemented | 🔵 Core |
+| [IsTransient Retry Hint](transience-hint.md) | A virtual `IsTransient` flag on every `TyphonException` hinting whether a retry might succeed, without the engine ever retrying on the caller's behalf | ✅ Implemented | 🔵 Core |
+| [Timeout Exceptions & Deadline Propagation](timeout-exceptions-deadlines.md) | Configurable, finite deadlines (`TimeoutOptions`, `WaitContext`) replace infinite-wait lock primitives, converting hangs into typed `TyphonTimeoutException` subclasses plus a bulk-load checkpoint timeout | ✅ Implemented | 🔵 Core |
+| [Error Code Classification](error-codes.md) | A numeric `TyphonErrorCode` per failure, grouped into subsystem ranges (1xxx-8xxx) for logging/metrics dashboards — the exception type, not the code, is what callers catch on | ✅ Implemented | 🟣 Advanced |
+| [Resource Exhaustion Handling](resource-exhaustion-handling.md) | `ExhaustionPolicy` metadata (FailFast/Wait/Evict/Degrade) documents how the engine reacts when a bounded resource is full — FailFast throws a structured `ResourceExhaustedException` (`IsTransient=true`), Wait resources throw a bounded `TyphonTimeoutException` subclass, never an unbounded hang or `InvalidOperationException` | ✅ Implemented | 🟣 Advanced |
+| [Storage & Corruption Exceptions](storage-corruption-exceptions.md) | Typed failures for storage I/O, CRC32C page corruption (unhealable), and another-process database-file-lock detection | ✅ Implemented | 🟣 Advanced |
+| [Durability (WAL / BulkLoad / Commit) Exceptions](durability-exceptions.md) | Typed, fail-fast failures from the WAL writer, the commit pipeline's durability wait, and BulkLoad session lifecycle | ✅ Implemented | 🟣 Advanced |
+| [Schema & Constraint Violation Exceptions](schema-constraint-exceptions.md) | Engine-refuses-to-proceed failures for the data model: breaking schema mismatch, migration failure, revision downgrade, duplicate unique key | ✅ Implemented | 🟣 Advanced |
+| [Runtime/Scheduler Declared-Access Validation](runtime-access-validation.md) | DEBUG-only `InvalidAccessException` when a system writes a component it never declared via `Writes<T>()`/`SideWrites<T>()`, compiled out in RELEASE | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Result\<TValue,TStatus\> Hot-Path Result Type](result-type.md) | Zero-allocation dual-generic result struct for hot-path lookups that expect a miss — no exceptions, no boxing, no branch on access; used internally by B+Tree/MVCC hot paths, not surfaced through `Transaction`/`Query` call sites | ✅ Implemented |

--- a/doc/feature-set/Errors/durability-exceptions.md
+++ b/doc/feature-set/Errors/durability-exceptions.md
@@ -1,0 +1,80 @@
+# Durability (WAL / BulkLoad / Commit) Exceptions
+> Typed, fail-fast failures from the WAL writer, the commit pipeline's durability wait, and BulkLoad session lifecycle.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+
+WAL and commit failures are not interchangeable: a disk write that fails outright must stop the engine from accepting further durable commits, a WAL claim that's larger than the whole ring buffer can never succeed no matter how many times it's retried, and an `Immediate`-mode commit whose post-publish fsync wait times out has *already committed* — it is not a failure to retry. Treating all of these as one generic I/O exception would force callers to parse messages to tell "restart the engine" apart from "this commit is fine, just unconfirmed." BulkLoad sessions add their own lifecycle failures (concurrent session, closed session, stuck checkpoint) that don't map to any standard transaction exception either. This feature gives each distinct outcome its own typed, catchable exception.
+
+## ⚙️ How it works (in brief)
+
+All seven types inherit `DurabilityException : TyphonException`, so `catch (DurabilityException)` is the subsystem-wide umbrella. `WalWriteException` wraps a fatal WAL writer I/O failure (ADR-020's dedicated writer thread) — not transient; the engine stops accepting durable commits and needs a restart. `WalClaimTooLargeException` and `WalSegmentException` are buffer-sizing and segment-file errors, also not transient — they're configuration problems, not contention. `CommitDurabilityUncertainException` is the **AP-02** point-of-no-return signal: by the time it's thrown, Append and Publish already succeeded and the transaction is committed and visible — only the durability *confirmation* (the post-publish FUA wait) didn't land in time. The three `BulkLoadSession` exceptions cover its own exclusivity gate, post-close calls, and the `CompleteBulkLoad` checkpoint barrier ([BulkLoad Write Path](../Durability/bulk-load.md) covers the session mechanics; this entry covers only its exceptions).
+
+## 💻 Usage
+
+```csharp
+using var uow = db.CreateUnitOfWork(DurabilityMode.Immediate);
+using var tx = uow.CreateTransaction();
+UpdateAccountBalance(tx, accountId, newBalance);
+
+try
+{
+    tx.Commit();
+}
+catch (CommitDurabilityUncertainException ex)
+{
+    // Committed and visible — APPEND + PUBLISH already ran. Do NOT retry the transaction.
+    // Poll ex.HighLsn against DurabilityLog.DurableLsn to learn when it becomes durable.
+    LogDurabilityUncertain(ex.HighLsn);
+}
+catch (WalWriteException)
+{
+    // Fatal WAL I/O — the engine will reject further durable commits. Escalate to restart.
+    InitiateEngineRestart();
+}
+
+try
+{
+    using var bulk = db.BeginBulkLoad();
+    // ... bulk.Spawn / bulk.Update ...
+    bulk.CompleteBulkLoad();
+}
+catch (BulkLoadCheckpointTimeoutException ex)
+{
+    // Session is still open — caller may retry CompleteBulkLoad() or Dispose() to discard.
+}
+```
+
+| Type | Error code | `IsTransient` | Notable properties |
+|---|---|---|---|
+| `WalWriteException` | `WalWriteFailure` (7003) | `false` | inner exception only |
+| `WalClaimTooLargeException` | `WalClaimTooLarge` (7002) | `false` | `RequestedBytes`, `BufferCapacity` |
+| `WalSegmentException` | `WalSegmentError` (7004) | `false` | `SegmentPath` |
+| `CommitDurabilityUncertainException` | `CommitDurabilityUncertain` (7008) | `false` | `HighLsn` |
+| `BulkSessionAlreadyActiveException` | `BulkSessionAlreadyActive` (7005) | `false` | `ActiveBulkSessionId` |
+| `BulkSessionClosedException` | `BulkSessionClosed` (7006) | `false` | `BulkSessionId` |
+| `BulkLoadCheckpointTimeoutException` | `BulkLoadCheckpointTimeout` (7007) | `false` | `BulkSessionId`, `Timeout` |
+
+## ⚠️ Guarantees & limits
+
+- `WalWriteException` is unconditionally fatal — there is no retry path; it signals the dedicated WAL writer thread itself failed (ADR-020), and the engine stops accepting durable commits until restarted.
+- `CommitDurabilityUncertainException` means **"committed, durability unconfirmed,"** never a rollback — `IsTransient` is `false` specifically to stop callers from auto-retrying a transaction that already happened.
+- `WalClaimTooLargeException` / `WalSegmentException` are not transient: a larger buffer or a fixed segment path is needed before the same operation can succeed.
+- The three `BulkLoadSession` exceptions are scoped to that session's own state machine — `BulkSessionAlreadyActiveException` from a second `BeginBulkLoad`, `BulkSessionClosedException` from any call after `CompleteBulkLoad`/`Dispose`, `BulkLoadCheckpointTimeoutException` only from `CompleteBulkLoad` (the session stays open afterward — retry or dispose).
+- All seven inherit `DurabilityException`, so `catch (DurabilityException)` catches the whole family uniformly for logging/alerting, while specific catches still get typed properties (`HighLsn`, `SegmentPath`, etc.).
+- None of these are part of the `TyphonTimeoutException` family, even though `BulkLoadCheckpointTimeoutException` is deadline-driven — it stays under `DurabilityException` because the BulkLoad session, unlike a lock wait, remains alive and resumable after the timeout.
+
+## 🧪 Tests
+
+- [WalCommitBufferTests](../../../test/Typhon.Engine.Tests/Durability/WalCommitBufferTests.cs) — an over-capacity claim throws `WalClaimTooLargeException`; a ring-buffer claim that outlives its deadline throws `WalBackPressureTimeoutException`.
+- [BulkLoadApiSurfaceTests](../../../test/Typhon.Engine.Tests/Durability/BulkLoadApiSurfaceTests.cs) — a second concurrent `BeginBulkLoad` throws `BulkSessionAlreadyActiveException` (`ActiveBulkSessionId`); any call after `Dispose`/`CompleteBulkLoad` throws `BulkSessionClosedException` (`CompleteBulkLoad`, `Destroy`).
+
+## 🔗 Related
+
+- Related catalog entries: [TyphonException Hierarchy & Catalog](./exception-hierarchy.md), [Commit Pipeline](../Durability/commit-pipeline.md), [BulkLoad Write Path](../Durability/bulk-load.md), [Bulk Load Session](../Transactions/bulk-load-session.md)
+
+<!-- Deep dive: claude/overview/06-durability.md §6.2 (AP-02), §6.8 (BulkLoad) -->
+<!-- Design: claude/design/Errors/05-public-exception-catalog.md, claude/design/Durability/BulkLoad/01-api.md -->
+<!-- ADR: claude/adr/020-dedicated-wal-writer-thread.md, claude/adr/053-bulk-load-write-path.md -->
+<!-- Rules: claude/rules/durability.md — modules LOG, AP, BL -->

--- a/doc/feature-set/Errors/error-codes.md
+++ b/doc/feature-set/Errors/error-codes.md
@@ -1,0 +1,64 @@
+# Error Code Classification
+> A numeric `TyphonErrorCode` per failure, grouped into subsystem ranges, for logging and metrics — not for catching.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+
+Operators need a stable, compact identifier to log, alert on, and group failures by in dashboards — a string message or a C# type name doesn't serialize cleanly into metrics labels, and message text can change without notice. `TyphonErrorCode` gives every thrown `TyphonException` a numeric code whose range alone tells you which subsystem failed (transaction, storage, schema, index, resource, durability, runtime), even before you look at the exception type.
+
+## ⚙️ How it works (in brief)
+
+`TyphonErrorCode` is a flat `enum` with codes grouped into per-subsystem ranges (`1xxx` Transaction, `2xxx` Storage, `3xxx` Component/Schema, `4xxx` Index, `6xxx` Resource, `7xxx` Durability, `8xxx` Runtime/Scheduler). Every `TyphonException` carries one via its `ErrorCode` property, set once at construction and never changed. Codes are sequential within a range with intentional numeric gaps, so new codes can be inserted later without renumbering existing ones; gaps in the range table (e.g. `5xxx` Query) are reserved for subsystems that don't throw yet. There is no separate `ErrorCategory` enum — the **exception type hierarchy** is the classification axis you `catch` on; `ErrorCode` is for logging/metrics, not control flow.
+
+## 💻 Usage
+
+```csharp
+try
+{
+    using var tx = dbe.CreateQuickTransaction();
+    var e = tx.OpenMut(soldier);
+    e.Write(Unit.Health).Current -= 25;
+    tx.Commit();
+}
+catch (TyphonException ex)
+{
+    // ErrorCode groups by subsystem range for metrics/log aggregation;
+    // the catch type (here, TyphonException) is what drives the actual handling decision.
+    _logger.LogError(ex, "Operation failed: {ErrorCode} IsTransient={IsTransient}",
+        ex.ErrorCode, ex.IsTransient);
+    throw;
+}
+```
+
+| Range | Subsystem | Example codes |
+|---|---|---|
+| 1xxx | Transaction | `TransactionTimeout` (1002) |
+| 2xxx | Storage | `DataCorruption` (2003), `PageChecksumMismatch` (2005), `DatabaseLocked` (2007) |
+| 3xxx | Component / Schema | `SchemaValidation` (3001), `SchemaMigration` (3002) |
+| 4xxx | Index | `UniqueConstraintViolation` (4001) |
+| 6xxx | Resource | `ResourceExhausted` (6001), `LockTimeout` (6003) |
+| 7xxx | Durability | `WalBackPressureTimeout` (7001), `WalWriteFailure` (7003), `CommitDurabilityUncertain` (7008) |
+| 8xxx | Runtime / Scheduler | `InvalidSystemAccess` (8001) |
+
+## ⚠️ Guarantees & limits
+
+- **Range tells you the subsystem at a glance** — no need to open the type hierarchy to know a `7xxx` code came from durability.
+- **Codes are append-only** — gaps within and between ranges are intentional headroom; existing codes never get renumbered, so logged/stored codes stay valid across engine versions.
+- **Not exhaustive of every subsystem yet** — `5xxx` (Query) has no codes defined; future subsystems will land in their reserved range as exceptions are added there.
+- **Not the catch axis** — don't `switch` on `ErrorCode` to decide control flow; `catch` the exception type instead (see the Exception Hierarchy entry in this category). `ErrorCode` is for telemetry, dashboards, and log correlation.
+- **One code per exception instance, set at construction** — it never changes after the exception is thrown.
+
+## 🧪 Tests
+
+- [TyphonExceptionTests](../../../test/Typhon.Engine.Tests/Errors/TyphonExceptionTests.cs) — `ErrorCodeUniqueness_NoDuplicateValues` guards the whole `TyphonErrorCode` enum against colliding numeric values; per-type `ErrorCode` assignment is asserted alongside each exception's other properties (e.g. `LockTimeoutException_Properties`, `CorruptionException_Properties`).
+
+## 🔗 Related
+
+- Parent feature: [Errors](./README.md)
+- Sibling: [TyphonException Hierarchy & Catalog](./exception-hierarchy.md) — `ErrorCode` is carried by every exception in this hierarchy; the type, not the code, is the catch axis
+- Sibling: [Durability (WAL / BulkLoad / Commit) Exceptions](./durability-exceptions.md) — the `7xxx` range this table cites is defined there
+- Source: `src/Typhon.Engine/Errors/public/TyphonErrorCode.cs`
+
+<!-- Deep dive: claude/overview/10-errors.md §10.2 -->
+<!-- Design: claude/design/Errors/01-exception-hierarchy.md -->

--- a/doc/feature-set/Errors/exception-hierarchy.md
+++ b/doc/feature-set/Errors/exception-hierarchy.md
@@ -1,0 +1,75 @@
+# TyphonException Hierarchy & Catalog
+> A single-rooted, typed exception tree with numeric codes, an `IsTransient` hint, and a catalog of every concrete failure type.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+
+Database failures span wildly different recovery strategies — a lock timeout wants a retry, a CRC mismatch wants an operator alert, a duplicate key wants a validation message back to the user. A flat `Exception` (or a grab-bag of unrelated custom types) forces every caller to either catch everything or maintain a brittle list of exact types. Typhon gives every failure a place in one typed tree, rooted at `TyphonException`, so application code can catch as broadly or narrowly as the situation calls for, and read a numeric `ErrorCode` plus an `IsTransient` hint without parsing message text.
+
+## ⚙️ How it works (in brief)
+
+`TyphonException : Exception` carries a `TyphonErrorCode` (numeric, grouped into per-subsystem ranges) and a virtual `IsTransient` (default `false` — subclasses opt in). `TyphonTimeoutException` is an intermediate base so `catch (TyphonTimeoutException)` handles every kind of timeout uniformly; `StorageException` and `DurabilityException` are similar subsystem-grouping intermediates. Leaf types with no sibling in their category (`UniqueConstraintViolationException`, the schema exceptions, `InvalidAccessException`) sit directly under `TyphonException` — no intermediate exists for a one-member group. The engine never retries on the caller's behalf: `IsTransient` is informational, and only the caller decides whether and how to retry.
+
+## 💻 Usage
+
+```csharp
+try
+{
+    using var tx = dbe.CreateQuickTransaction();
+    var e = tx.OpenMut(soldier);
+    e.Write(Unit.Health).Current -= 25;
+    tx.Commit();
+}
+catch (LockTimeoutException ex)
+{
+    // Narrowest: this specific failure — ex.ResourceName, ex.WaitDuration
+}
+catch (TyphonTimeoutException ex)
+{
+    // Mid: any timeout (lock, transaction, page-cache/WAL back-pressure)
+}
+catch (TyphonException ex)
+{
+    // Broadest: any engine error
+    _logger.LogError(ex, "Operation failed: {ErrorCode} IsTransient={IsTransient}", ex.ErrorCode, ex.IsTransient);
+    throw;
+}
+```
+
+## Catalog of concrete types
+
+| Type | Parent | `IsTransient` | Notable typed properties |
+|---|---|---|---|
+| `TyphonTimeoutException` | `TyphonException` | `true` | `WaitDuration` |
+| `LockTimeoutException`, `TransactionTimeoutException`, `PageCacheBackpressureTimeoutException`, `WalBackPressureTimeoutException` | `TyphonTimeoutException` | `true` | see [Timeout Exceptions & Deadlines](./timeout-exceptions-deadlines.md) |
+| `StorageException` | `TyphonException` | `false` | — |
+| `CorruptionException` / `PageCorruptionException` | `StorageException` | `false` | `ComponentName`, `PageIndex` / `ExpectedCrc`, `ComputedCrc` |
+| `DatabaseLockedException` | `StorageException` | `false` | `OwnerPid`, `OwnerMachine`, `StartedAt` |
+| `DurabilityException` | `TyphonException` | `false` | — |
+| `WalWriteException`, `WalSegmentException`, `WalClaimTooLargeException` | `DurabilityException` | `false` | `SegmentPath` / `RequestedBytes`, `BufferCapacity` |
+| `ResourceExhaustedException` | `TyphonException` | `true` | see [Resource Exhaustion Handling](./resource-exhaustion-handling.md) |
+| `SchemaValidationException`, `SchemaMigrationException`, `SchemaDowngradeException` | `TyphonException` | `false` | `Diff`, `Failures`, `PersistedRevision`/`RuntimeRevision` |
+| `UniqueConstraintViolationException` | `TyphonException` | `false` | — |
+| `InvalidAccessException` | `TyphonException` | `false` | `SystemName`, `UndeclaredType` (DEBUG-only) |
+
+## ⚠️ Guarantees & limits
+
+- Three catch granularities by construction: `catch (TyphonException)` (any engine error), `catch (TyphonTimeoutException)` / `catch (StorageException)` / `catch (DurabilityException)` (subsystem-wide), or a specific leaf type.
+- `IsTransient` defaults to `false`; only `TyphonTimeoutException` (and its subclasses) and `ResourceExhaustedException` override it to `true`. See [IsTransient Retry Hint](./transience-hint.md) for the full retry philosophy.
+- No `Context` dictionary on the base class — every subclass exposes its diagnostic data as typed, strongly-named properties, not a string-keyed bag.
+- `ErrorCode` groups every exception into a stable, gap-numbered subsystem range — see [Error Code Classification](./error-codes.md).
+- Not `[Serializable]` — pre-1.0, no cross-process/cross-AppDomain exception marshaling is supported.
+- No nullable reference type annotations anywhere in the hierarchy (project-wide convention) — `null` is a valid, unannotated argument where documented.
+- The catalog above is living — new leaf types are added under the appropriate intermediate (or directly under `TyphonException` for one-member groups) as new subsystems gain structured errors; existing types and codes are never renumbered or removed.
+
+## 🧪 Tests
+
+- [TyphonExceptionTests](../../../test/Typhon.Engine.Tests/Errors/TyphonExceptionTests.cs) — the hierarchy itself: `LockTimeoutException`/`TransactionTimeoutException` are both `TyphonTimeoutException`, every leaf is a `TyphonException`, three-granularity catch-block roundtrip (`CatchGranularity_*`), and `ErrorCode`/`IsTransient` per leaf type.
+
+## 🔗 Related
+
+- Related catalog entries: [Error Code Classification](./error-codes.md), [IsTransient Retry Hint](./transience-hint.md), [Timeout Exceptions & Deadlines](./timeout-exceptions-deadlines.md), [Resource Exhaustion Handling](./resource-exhaustion-handling.md)
+
+<!-- Deep dive: claude/design/Errors/01-exception-hierarchy.md, claude/design/Errors/05-public-exception-catalog.md -->
+<!-- Overview: claude/overview/10-errors.md §10.1 -->

--- a/doc/feature-set/Errors/resource-exhaustion-handling.md
+++ b/doc/feature-set/Errors/resource-exhaustion-handling.md
@@ -1,0 +1,72 @@
+# Resource Exhaustion Handling
+> Every bounded resource declares how it fails — fail fast, wait, evict, or degrade — instead of hanging or throwing a generic error.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Errors](./README.md)
+**Assumes:** [Exhaustion Policy & ResourceExhaustedException](../Resources/exhaustion-policy-handling.md)
+
+## 🎯 What it solves
+
+Every embedded engine has bounded resources: a transaction pool, a page cache, a chunk segment's capacity. When one fills up, the caller needs to know two things immediately — *that* it happened, and whether retrying makes sense. Before this feature, that information was inconsistent: some limits (`MaxActiveTransactions`) were tracked in metrics but never enforced, a full page cache with all pages pinned could spin forever with no bound in Release builds, and a full chunk segment threw a generic `InvalidOperationException` indistinguishable from a programming bug. None of these surfaced a uniform, catchable signal.
+
+## ⚙️ How it works (in brief)
+
+Each bounded resource is tagged with an `ExhaustionPolicy` — `FailFast`, `Wait`, `Evict`, or `Degrade` — describing how it behaves at capacity. The policy is fixed per resource (not configurable) and reflects its semantics: a client-facing limit like the transaction pool fails fast; a cache evicts, then waits, before failing; a durability buffer waits up to its deadline. `FailFast` resources throw `ResourceExhaustedException` directly — a `TyphonException` with `IsTransient = true`, since exhaustion is expected to self-heal as load drains. `Wait` resources instead throw a `TyphonTimeoutException` subclass (`PageCacheBackpressureTimeoutException`, `WalBackPressureTimeoutException`) if the bounded wait itself expires — see [Timeout Exceptions & Deadlines](./timeout-exceptions-deadlines.md) — both signal the same underlying exhaustion, through whichever typed exception fits how the resource waits. `ExhaustionPolicy` is also a settable diagnostic tag on `ResourceNode` in the [resource tree](../Resources/resource-tree-registry.md), so tooling can show *why* a node behaves the way it does — though today only a handful of resources set a non-default value; most enforce their policy via a dedicated throw site without yet tagging their node.
+
+## 💻 Usage
+
+```csharp
+var options = new DatabaseEngineOptions
+{
+    Resources = new ResourceOptions
+    {
+        MaxActiveTransactions = 200,   // FailFast beyond this
+    }
+};
+
+using var dbe = new DatabaseEngine(options);
+
+try
+{
+    using var tx = dbe.CreateQuickTransaction();
+    // ... use tx
+    tx.Commit();
+}
+catch (ResourceExhaustedException ex)
+{
+    // ex.ResourcePath   → "Data/TransactionChain/CreateTransaction"
+    // ex.ResourceType   → ResourceType.Service
+    // ex.CurrentUsage / ex.Limit / ex.Utilization
+    if (ex.IsTransient)
+    {
+        // back off and retry later — the pool drains as transactions commit/rollback
+    }
+}
+```
+
+| Policy | Behavior at capacity | Example resource |
+|---|---|---|
+| `FailFast` | Throw `ResourceExhaustedException` immediately | Transaction pool (`MaxActiveTransactions`) |
+| `Wait` | Block until freed, bounded by the operation's deadline, then throw | Page cache eviction wait |
+| `Evict` | Remove a least-used entry and retry | Page cache, chunk accessor cache |
+| `Degrade` | Continue with reduced performance, no exception | Transaction object pool (allocates new), chunk segment auto-grow |
+
+## ⚠️ Guarantees & limits
+
+- **No unbounded hangs.** The page-cache eviction wait is bounded by the caller's deadline (see [Timeout Exceptions & Deadlines](./timeout-exceptions-deadlines.md)) in every build configuration — Release builds no longer spin forever when all pages are pinned.
+- **Typed, never generic.** Pool limits and chunk-segment-full surface as `ResourceExhaustedException`; a page-cache or WAL wait that expires surfaces as `PageCacheBackpressureTimeoutException`/`WalBackPressureTimeoutException` instead — never `InvalidOperationException`/`OutOfMemoryException`. `catch (ResourceExhaustedException)` covers the `FailFast` resources; `catch (TyphonException)` covers all of them uniformly.
+- **`IsTransient = true` is a hint, not a promise.** Exhaustion is expected to clear as concurrent work drains the resource, but the engine never retries on the caller's behalf — see [IsTransient](./transience-hint.md).
+- **`ExhaustionPolicy` is diagnostic metadata, not a runtime dispatcher.** Each resource hardcodes its own escalation logic (evict-then-wait, fail-fast, etc.); the enum on `ResourceNode` documents that behavior for introspection and tooling, it doesn't drive it.
+- **Self-healing policies (`Evict`, `Degrade`) can still end in `FailFast`.** E.g. the page cache evicts, then waits, then throws if the deadline still expires with no page free — `Wait`/`Evict` reduce the chance of exhaustion, they don't eliminate it.
+- **Limits are fixed at startup.** `ResourceOptions` (e.g. `MaxActiveTransactions`) is set once at `DatabaseEngine` construction and immutable thereafter — no hot-resize.
+
+## 🧪 Tests
+
+- [ExhaustionPolicyTests](../../../test/Typhon.Engine.Tests/Errors/ExhaustionPolicyTests.cs) — `FailFast` enforced at real boundaries (transaction pool over `MaxActiveTransactions`, `ChunkBasedSegment.AllocateChunk(s)`) and recovery once a slot frees up; `ResourceNode.ExhaustionPolicy` metadata tagging per policy value.
+- [ResourceOptionsTests](../../../test/Typhon.Engine.Tests/Resources/ResourceOptionsTests.cs) — `ExhaustionPolicy` enum completeness, `ResourceExhaustedException` construction/message/`Utilization` (incl. zero-limit edge case).
+
+## 🔗 Related
+- Related feature: [IsTransient retry hint](./transience-hint.md)
+- Sibling: [Timeout Exceptions & Deadline Propagation](./timeout-exceptions-deadlines.md) — `Wait` resources throw the `TyphonTimeoutException` subclasses this feature describes
+
+<!-- Deep dive: claude/design/Errors/03-exhaustion-policy.md -->
+<!-- Overview: claude/overview/10-errors.md, claude/overview/08-resources.md §8.7 -->

--- a/doc/feature-set/Errors/result-type.md
+++ b/doc/feature-set/Errors/result-type.md
@@ -1,0 +1,65 @@
+# Result<TValue,TStatus> Hot-Path Result Type
+> Zero-allocation dual-generic result struct for hot-path lookups that expect a miss — no exceptions, no boxing, no branch on access.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+
+Some lookups fail routinely as part of normal operation — a key isn't in the index yet, a component revision isn't visible at your snapshot tick, an entity was deleted. Throwing an exception for these expected outcomes is disproportionately expensive on paths that run millions of times per second (B+Tree lookups, MVCC revision-chain reads). A plain `bool` return loses information — every kind of "no" collapses into the same `false`, so callers can't tell "never existed" from "tombstoned" from "not visible yet." `Result<TValue, TStatus>` gives these hot paths a typed, zero-allocation way to say "here's your value" or "here's exactly why not," without paying exception overhead for outcomes that aren't errors.
+
+## ⚙️ How it works (in brief)
+
+`Result<TValue, TStatus>` is a readonly struct carrying a value and a status code side by side. `TStatus` is a small `byte` enum defined per subsystem — by convention `0` always means success. `IsSuccess`/`IsFailure` check the status via a raw byte comparison (no boxing, no virtual dispatch), and `Value`/`Status` are public readonly fields — no throwing getter, so there's no extra branch when you access `Value` after already checking `IsSuccess`. Each consuming subsystem defines its own status enum with only the outcomes that method can actually produce, so the signature itself documents every possible result. Actual errors (corruption, I/O failure, bounds violations) are never encoded this way — those still throw.
+
+## 💻 Usage
+
+Typhon's own hot paths follow this pattern internally — B+Tree key lookups return `Result<int, BTreeLookupStatus>`, and MVCC revision-chain reads return `Result<ComponentInfo.CompRevInfo, RevisionReadStatus>` with four distinct outcomes:
+
+```csharp
+public enum RevisionReadStatus : byte
+{
+    Success = 0,           // revision found and visible at this snapshot tick
+    NotFound = 1,          // entity has no revision chain (never created)
+    SnapshotInvisible = 2, // revision exists but isn't visible at the reader's tick
+    Deleted = 3,           // entity was tombstoned at or before the reader's tick
+}
+
+Result<ComponentInfo.CompRevInfo, RevisionReadStatus> result = GetCompRevInfoFromIndex(pk, info, tick);
+if (result.IsSuccess)
+{
+    var compRevInfo = result.Value; // direct field access — no throwing getter
+    // ... use compRevInfo
+}
+else
+{
+    switch (result.Status)
+    {
+        case RevisionReadStatus.NotFound: break;          // never existed
+        case RevisionReadStatus.SnapshotInvisible: break;  // not in our snapshot yet
+        case RevisionReadStatus.Deleted: break;             // tombstoned
+    }
+}
+```
+
+The same `Result<TValue, TStatus>` struct is `public` and generic, so your own performance-critical code can adopt the identical pattern: define a small `byte` enum for your method's expected outcomes (`0` = success) and return `Result<YourValue, YourStatusEnum>` instead of `bool` + `out` or an exception.
+
+## ⚠️ Guarantees & limits
+
+- Zero heap allocation in both the success and failure case — `TValue : unmanaged` and `TStatus : unmanaged, Enum` keep the whole struct blittable.
+- Benchmark-validated against `bool` + `out`: no measurable overhead (780 ns vs 785 ns for 64 lookups — noise-level difference). Status-enum `switch` compiles to a jump table.
+- `Value` and `Status` are plain public fields, not validated properties — accessing `Value` without checking `IsSuccess` first silently returns `default(TValue)`, not an exception. Same discipline as `Nullable<T>.Value` misuse, but without any guard.
+- Convention, not compiler-enforced: status `0` must mean success in every `TStatus` enum you define. `IsSuccess` assumes this.
+- Struct size follows Typhon's even-sized hot-path-struct rule (ADR-027) — e.g. `Result<int, BTreeLookupStatus>` is 8 bytes total, cache-friendly and division-friendly.
+- Reserved for *expected* non-error outcomes only. Corruption, I/O failure, and bounds violations remain exceptions — `Result` is not a general error-handling replacement.
+
+## 🧪 Tests
+
+- [ResultTests](../../../test/Typhon.Engine.Tests/Errors/ResultTests.cs) — success/failure construction, `IsSuccess`/`IsFailure`, default-value-on-failure `Value` access (the "misuse without checking `IsSuccess` first" case), and status-enum round-tripping for `BTreeLookupStatus`/`RevisionReadStatus`.
+
+## 🔗 Related
+
+- Related catalog entry: [TyphonException Hierarchy & Catalog](./exception-hierarchy.md) — contrasts `Result` (expected outcomes) against exceptions (actual errors)
+
+<!-- Deep dive: claude/design/Errors/04-result-type.md -->
+<!-- Overview: claude/overview/10-errors.md § Result Types for Hot Paths -->
+<!-- ADR: claude/adr/027-even-sized-hot-path-structs.md -->

--- a/doc/feature-set/Errors/runtime-access-validation.md
+++ b/doc/feature-set/Errors/runtime-access-validation.md
@@ -1,0 +1,88 @@
+# Runtime/Scheduler Declared-Access Validation
+> DEBUG-only `InvalidAccessException` when a system writes a component it never declared.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+
+Typhon's scheduler derives its execution DAG from what each system *declares* it writes
+(`SystemBuilder.Writes<T>()` / `SideWrites<T>()`), not from what the system body actually does. If a
+system's code drifts from its declaration — someone adds a `entity.Write(Comp)` call and forgets the
+matching builder declaration — the scheduler keeps building a DAG from stale information. Nothing about
+that failure is loud: the write still succeeds, but the parallelism/ordering guarantees the scheduler
+computed around the declared set are now silently wrong. This validator turns that drift into an
+immediate, specific exception in DEBUG builds, before it ships as a hard-to-reproduce race.
+
+## ⚙️ How it works (in brief)
+
+Every `EntityRef.Write<T>()` call, in DEBUG builds, is checked against the declared `Writes`/`SideWrites`
+set of the currently-executing system. A mismatch throws `InvalidAccessException` naming the system, the
+undeclared component type, and everything the system *did* declare. Systems that haven't declared any
+access yet (migration window) are exempt — the check only activates once a system declares at least one
+`Writes`/`SideWrites`. In RELEASE builds the check is `[Conditional("DEBUG")]`-stripped at the call site,
+so there is no trace of it in production binaries.
+
+## 💻 Usage
+
+```csharp
+class ClampSystem : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Clamp").Phase(Phase.Simulation).After("Movement")
+        .Writes<Position>();       // declares the only component this system may mutate
+
+    protected override void Execute(TickContext ctx)
+    {
+        foreach (var id in ctx.Entities)
+        {
+            var entity = ctx.Accessor.OpenMut(id);
+            ref var pos = ref entity.Write(Unit.Position);   // OK: Position is declared
+            pos.X = Math.Clamp(pos.X, 0, WorldWidth);
+
+            ref var vel = ref entity.Write(Unit.Velocity);   // DEBUG: throws InvalidAccessException
+        }                                                    // (Velocity was never declared)
+    }
+}
+
+try
+{
+    runtime.Tick();
+}
+catch (InvalidAccessException ex)
+{
+    // ex.SystemName == "Clamp", ex.UndeclaredType == typeof(Velocity)
+    // Fix: add `.Writes<Velocity>()` (or `.SideWrites<Velocity>()`) to Configure — never catch-and-continue.
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- DEBUG-only: `[Conditional("DEBUG")]` strips every check call site in RELEASE — zero runtime cost in
+  production, but also zero protection there. Treat a clean DEBUG test run as the enforcement gate, not
+  RELEASE behavior.
+- Fires only on writes. Reads are not cross-checked at runtime — `Reads<T>()`/`ReadsFresh<T>()`/
+  `ReadsSnapshot<T>()` correctness is enforced at `Build()` time (see [Declarative Scheduling](../Runtime/declarative-scheduling/README.md)), not per-call.
+- Exempts systems with zero declarations entirely (not just the specific undeclared type) — a
+  not-yet-migrated system that declares nothing passes silently. Declaring even one `Writes<T>()`
+  switches the system into fully-enforced mode.
+- `IsTransient` is `false` (inherited default) — this is a code-declaration bug, not a condition that
+  clears on retry. Fix the `Configure()` declaration; don't catch-and-retry.
+- Thread-local by construction: each worker thread tracks its own executing-system descriptor, so
+  concurrent dispatch across workers cannot cross-contaminate which system a violation is attributed to.
+- Not a substitute for `Build()`-time conflict detection (W×W, ambiguous R×W) — this check only catches
+  divergence between a system's declared writes and its actual write calls; it says nothing about
+  whether two systems' declarations conflict with each other.
+
+## 🧪 Tests
+
+- [SystemAccessValidatorTests](../../../test/Typhon.Engine.Tests/Runtime/SystemAccessValidatorTests.cs) — an undeclared write throws `InvalidAccessException` (`SystemName`/`UndeclaredType`); a no-declarations system passes silently (migration-window exemption); a declared write passes.
+
+## 🔗 Related
+
+- Related catalog entries: [TyphonException Hierarchy & Catalog](./exception-hierarchy.md), [IsTransient Retry Hint](./transience-hint.md)
+- Sibling feature: [Declarative Scheduling — Auto-DAG](../Runtime/declarative-scheduling/README.md) (the `Writes<T>()`/`SideWrites<T>()` declarations this validator enforces)
+- Sibling: [Access Conflict Detection](../Runtime/declarative-scheduling/access-conflict-detection.md) — `Build()`-time declared-conflict detection; this validator is the runtime, per-call complement
+
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md (Q6, Unit 4) -->
+<!-- Deep dive: claude/rules/runtime-scheduling.md (DV-01..DV-03) -->
+<!-- Overview: claude/overview/10-errors.md, claude/overview/13-runtime.md -->

--- a/doc/feature-set/Errors/schema-constraint-exceptions.md
+++ b/doc/feature-set/Errors/schema-constraint-exceptions.md
@@ -1,0 +1,83 @@
+# Schema & Constraint Violation Exceptions
+> Typed failures for "the engine refuses to proceed": incompatible schema, failed migration, version downgrade, duplicate key.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+
+Some failures aren't transient contention — they mean the data model itself is in a state the engine cannot safely reconcile: a struct changed in a way that can't be auto-migrated, a user-supplied migration function failed partway through, the database was written by a newer binary than the one opening it, or an insert would create a duplicate key in a column declared unique. Silently proceeding in any of these cases risks misreading bytes or corrupting an index. Typhon refuses instead, and reports exactly which case it hit through a dedicated, typed exception rather than a generic error.
+
+## ⚙️ How it works (in brief)
+
+Four exception types sit directly under `TyphonException`, each non-transient (`IsTransient == false` — retrying without changing the schema or the input never helps): `SchemaValidationException` (breaking schema mismatch on reopen, no migration registered — carries the full `SchemaDiff`), `SchemaMigrationException` (a registered migration function threw for one or more entities — carries per-entity `MigrationFailure` records; old segments are left untouched), `SchemaDowngradeException` (persisted schema revision is newer than the runtime struct's — opening with an older binary is refused outright), and `UniqueConstraintViolationException` (an insert/update would duplicate a key already present in a unique index). `SchemaValidationException` and `SchemaDowngradeException` share the `SchemaValidation` error code — both are "this component cannot be opened" from an operator's point of view; the exception type tells you which.
+
+## 💻 Usage
+
+```csharp
+try
+{
+    dbe.RegisterComponentFromAccessor<Player>();
+}
+catch (SchemaDowngradeException ex)
+{
+    log.LogCritical("Refusing to open '{Component}': persisted rev {Persisted} > runtime rev {Runtime}",
+        ex.ComponentName, ex.PersistedRevision, ex.RuntimeRevision);
+    throw;
+}
+catch (SchemaValidationException ex)
+{
+    foreach (var change in ex.Diff.FieldChanges)
+    {
+        log.LogError("{Field}: {Kind} ({Old} -> {New})", change.FieldName, change.Kind, change.OldType, change.NewType);
+    }
+    throw;
+}
+catch (SchemaMigrationException ex)
+{
+    log.LogError("Migration for '{Component}' failed on {Count} entities", ex.ComponentName, ex.FailedEntityCount);
+    foreach (var failure in ex.Failures)
+    {
+        log.LogError("  ChunkId={ChunkId}: {Exception}", failure.ChunkId, failure.Exception);
+    }
+    throw; // old segments untouched — fix the migration function and restart
+}
+```
+
+Duplicate keys surface at commit time, not registration:
+
+```csharp
+try
+{
+    using var tx = dbe.CreateQuickTransaction();
+    tx.Spawn<PlayerArch>(PlayerArch.PlayerId.Set(existingId)); // PlayerId has [Index] (unique)
+    tx.Commit();
+}
+catch (UniqueConstraintViolationException)
+{
+    // Not transient — same key will conflict again until the caller picks a different one.
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Never partially applied.** A `SchemaValidationException` or `SchemaDowngradeException` blocks registration before any data is touched; a `SchemaMigrationException` leaves old segments fully intact — fix the cause and re-run, nothing is lost either way.
+- **`IsTransient == false` on all four** — retrying without changing the struct, the migration function, the binary version, or the duplicate key never succeeds.
+- **`SchemaValidationException.Diff`** is the full `SchemaDiff` (every `FieldChange`/`IndexChange`, with a `CompatibilityLevel` per change) — enough to log or render without re-deriving it.
+- **`SchemaMigrationException.Failures`** caps detailed formatting in the exception message at 10 entries but the `IReadOnlyList<MigrationFailure>` itself carries every failure (`ChunkId`, hex dump of the old bytes, the thrown exception).
+- **`SchemaDowngradeException` is unconditional** — there is no `SchemaValidationMode` that allows opening data written by a newer revision.
+- **`UniqueConstraintViolationException` carries no typed context** (no key value, no index name) — catch it for control flow, log the surrounding operation for diagnostics.
+- All four share the catch-by-type model used across the hierarchy — `catch (TyphonException)` still catches them, but there's no common intermediate type to catch only "schema/constraint" failures as a group; catch each concretely or use `TyphonException`.
+
+## 🧪 Tests
+
+- [MigrationFunctionTests](../../../test/Typhon.Engine.Tests/Data/Schema/MigrationFunctionTests.cs) — a throwing user migration function surfaces as `SchemaMigrationException` (per-entity `MigrationFailure`); a breaking change with no registered migration surfaces as `SchemaValidationException`.
+- [SchemaValidationIntegrationTests](../../../test/Typhon.Engine.Tests/Data/Schema/SchemaValidationIntegrationTests.cs) — breaking field/index changes on reopen throw `SchemaValidationException` (`Diff`); a persisted revision newer than the runtime struct throws `SchemaDowngradeException`.
+
+## 🔗 Related
+
+- Related feature: [Schema Validation on Reopen](../Schema/schema-validation.md), [User-Defined Migration Functions](../Schema/migration-functions.md) — the mechanisms that throw `SchemaValidationException`/`SchemaMigrationException`
+- Source: `src/Typhon.Engine/Errors/public/SchemaValidationException.cs`, `SchemaMigrationException.cs`, `SchemaDowngradeException.cs`, `UniqueConstraintViolationException.cs`
+- Related catalog entries: [TyphonException Hierarchy & Catalog](./exception-hierarchy.md)
+
+<!-- Deep dive: claude/design/Errors/05-public-exception-catalog.md (Schema chain, Index chain tables) -->
+<!-- Overview: claude/overview/10-errors.md §10.1, claude/overview/04-data.md §4.10 Schema Evolution -->

--- a/doc/feature-set/Errors/storage-corruption-exceptions.md
+++ b/doc/feature-set/Errors/storage-corruption-exceptions.md
@@ -1,0 +1,58 @@
+# Storage & Corruption Exceptions
+> Typed failures for storage I/O, CRC32C page corruption, and another-process database locks.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+Storage-layer failures need very different responses: a generic I/O error might be transient, a CRC32C mismatch on a primary page never is and demands an operator alert, and a database already opened by another process needs to name the culprit so an operator can decide whether to wait or intervene. Without typed exceptions, all three look like the same opaque `IOException`/`InvalidOperationException`, forcing the caller to parse message text to tell them apart.
+
+## ⚙️ How it works (in brief)
+`StorageException` is the subsystem-grouping base (`TyphonException`, `IsTransient = false`) for I/O and capacity failures — `catch (StorageException)` covers the whole storage layer in one clause. `CorruptionException` adds `ComponentName` and `PageIndex` for any data-integrity violation; its subclass `PageCorruptionException` is the concrete case thrown when a page's CRC32C checksum doesn't match its contents, and carries the `ExpectedCrc`/`ComputedCrc` pair. There is no on-load repair path — Typhon retired Full-Page-Image repair, so a CRC mismatch on a primary page outside crash recovery is unhealable: the exception is the only outcome, never a silently-patched page. `DatabaseLockedException` is thrown at database open when another process (or another `DatabaseEngine` instance) already holds the file, and carries `OwnerPid`, `OwnerMachine`, and `StartedAt` so the caller can report or act on who's holding it.
+
+## 💻 Usage
+```csharp
+try
+{
+    var dbe = sp.GetRequiredService<DatabaseEngine>();
+    // ... normal ECS/transaction work — CRC verification runs transparently on page load
+}
+catch (DatabaseLockedException ex)
+{
+    log.LogError("database held by PID {Pid} on '{Machine}' since {StartedAt:u}",
+        ex.OwnerPid, ex.OwnerMachine, ex.StartedAt);
+}
+catch (PageCorruptionException ex)
+{
+    // never transient — a primary page failed CRC outside recovery, no on-load repair exists
+    log.LogCritical(ex, "page {Page} CRC mismatch: stored=0x{Expected:X8} computed=0x{Computed:X8}",
+        ex.PageIndex, ex.ExpectedCrc, ex.ComputedCrc);
+}
+catch (StorageException ex)
+{
+    // any other storage-layer failure (I/O, capacity)
+    log.LogError(ex, "storage failure: {ErrorCode}", ex.ErrorCode);
+}
+```
+
+## ⚠️ Guarantees & limits
+- `StorageException` and its subclasses are always `IsTransient = false` — none of these failures resolve themselves on retry; corruption and lock contention both need an external action (restore from backup, close the other process).
+- `PageCorruptionException` fires only for an *unhealable* mismatch on a primary page outside crash recovery — derived structures (secondary indexes, occupancy) are silently rebuilt instead of throwing, and a torn primary page caught *during* crash recovery either heals (if no live chunk references it) or fails the open loudly with a diagnostic bundle, rather than raising this exception mid-session.
+- `DatabaseLockedException` only fires for a same-machine lock held by a live PID, or any lock file from a different machine name (which can't be verified remotely and is always treated as live); a stale lock from a dead local process is cleared automatically and never reaches the caller as an exception.
+- `CorruptionException`'s `PageIndex` is `-1` when the corruption isn't tied to a specific page; `PageCorruptionException` always has a real page index.
+- `StorageException` carries a `StorageCapacityExceeded` (2004) error code reserved for capacity-exhaustion failures, but no current throw site uses it — today only the corruption and lock-contention subclasses are live.
+- Catching `Exception` instead of `StorageException` still works for compatibility, but loses the typed `ErrorCode`/`ComponentName`/`OwnerPid`-style diagnostics — prefer the specific or `StorageException` catch.
+
+## 🧪 Tests
+
+- [PageCrcVerificationTests](../../../test/Typhon.Engine.Tests/Durability/PageCrcVerificationTests.cs) — a CRC32C mismatch on `OnLoad` verification throws `PageCorruptionException`; contrasting zero-CRC, `RecoveryOnly`, and root-page paths that correctly skip verification without throwing.
+- [DatabaseFileLockingTests](../../../test/Typhon.Engine.Tests/Storage/DatabaseFileLockingTests.cs) — a live same-machine lock and an unverifiable cross-machine lock both throw `DatabaseLockedException` (`OwnerPid`/`OwnerMachine`); a stale local-PID lock is cleared instead of throwing.
+- [TyphonExceptionTests](../../../test/Typhon.Engine.Tests/Errors/TyphonExceptionTests.cs) — `CorruptionException` property and `IsTransient == false` assertions.
+
+## 🔗 Related
+- Source: `src/Typhon.Engine/Errors/public/StorageException.cs`, `CorruptionException.cs`, `DatabaseLockedException.cs`
+- Related catalog entries: [TyphonException Hierarchy & Catalog](./exception-hierarchy.md)
+- Related feature: [Database File Locking & Lifecycle](../Storage/file-locking-lifecycle.md), [Page Integrity — CRC32C, Seqlock Snapshots & A/B Page Pairing](../Storage/page-integrity.md)
+
+<!-- Deep dive: claude/design/Errors/01-exception-hierarchy.md, claude/design/Errors/05-public-exception-catalog.md -->
+<!-- Overview: claude/overview/10-errors.md §10.1, claude/overview/03-storage.md §3.9 -->
+<!-- Rules: claude/rules/durability.md — RB-04 (suspect primary pages heal or fail loudly) -->

--- a/doc/feature-set/Errors/timeout-exceptions-deadlines.md
+++ b/doc/feature-set/Errors/timeout-exceptions-deadlines.md
@@ -1,0 +1,96 @@
+# Timeout Exceptions & Deadline Propagation
+> Configurable, finite deadlines replace infinite waits, turning every contention hang into a typed, catchable timeout exception.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Errors](./README.md)
+**Assumes:** [Deadline & Timeout Propagation](../Foundation/deadline-timeout-propagation.md)
+
+## 🎯 What it solves
+
+Every lock acquisition and buffer claim in Typhon used to wait forever — `ref WaitContext.Null` meant any
+contention, stuck writer, or resource exhaustion hung the caller indefinitely, indistinguishable from a deadlock.
+There was no way to bound how long an operation could block, and no structured signal when it did. This feature
+gives every wait a finite, per-subsystem-configurable deadline and converts an expired wait into a specific
+exception type carrying what was being waited for and how long — never a silent hang, never a generic
+`System.TimeoutException`.
+
+## ⚙️ How it works (in brief)
+
+`TimeoutOptions` (on `DatabaseEngineOptions.Timeouts`) holds one `TimeSpan` per subsystem — page cache, B+Tree,
+transaction chain, revision chain, segment allocation — plus back-pressure and bulk-load checkpoint budgets.
+Each call site builds a `WaitContext.FromTimeout(...)` fresh (an absolute monotonic deadline, not a wall-clock
+one) and passes it `ref` into the lock primitive. Lock primitives never throw — they return `false` on expiry —
+so the *subsystem* checks the result and throws the appropriate `TyphonTimeoutException` subclass. The throw
+always happens at the acquisition point, before any mutation begins, so a timeout never leaves a structural
+operation half-done.
+
+## 💻 Usage
+
+```csharp
+var options = new DatabaseEngineOptions
+{
+    Timeouts = new TimeoutOptions
+    {
+        BTreeLockTimeout = TimeSpan.FromSeconds(2),
+        TransactionChainLockTimeout = TimeSpan.FromSeconds(10),
+    },
+};
+
+try
+{
+    using var tx = dbe.CreateQuickTransaction();
+    var e = tx.OpenMut(playerId);
+    e.Write(Player.Wallet).Gold -= price;
+    tx.Commit();
+}
+catch (TyphonTimeoutException ex)
+{
+    // Catches LockTimeoutException, TransactionTimeoutException,
+    // PageCacheBackpressureTimeoutException, and WalBackPressureTimeoutException alike.
+    _logger.LogWarning("Operation timed out after {Wait}ms", ex.WaitDuration.TotalMilliseconds);
+    // ex.IsTransient is always true here — caller decides whether/how to retry.
+}
+```
+
+| `TimeoutOptions` property | Default | Governs |
+|---|---|---|
+| `PageCacheLockTimeout` | 5s | Page cache state-transition locks |
+| `BTreeLockTimeout` | 5s | B+Tree insert/delete/lookup locks |
+| `TransactionChainLockTimeout` | 10s | Transaction chain create/remove/walk |
+| `RevisionChainLockTimeout` | 5s | MVCC revision read/add/cleanup |
+| `SegmentAllocationLockTimeout` | 10s | Chained-block allocator / segment growth |
+| `PageCacheBackpressureTimeout` | 5s | Waiting for dirty pages to flush so allocation can proceed |
+| `WalBackPressureTimeout` | 5s | Waiting for the WAL ring buffer to drain |
+| `DefaultCommitTimeout` / `DefaultUowTimeout` | 30s | Outer bound when `Transaction.Commit()` / a UoW is created without an explicit timeout |
+| `BulkLoadOptions.CheckpointTimeout` | 5 min | `BulkLoadSession.CompleteBulkLoad`'s forced synchronous checkpoint |
+
+## ⚠️ Guarantees & limits
+
+- `TyphonTimeoutException` is the common catchable base; `IsTransient` is always `true` for the whole family —
+  the resource is presumed available later, but the engine never retries automatically.
+- Four concrete leaves: `LockTimeoutException` (carries `ResourceName`), `TransactionTimeoutException` (carries
+  `TransactionId`), `PageCacheBackpressureTimeoutException` (carries `DirtyPageCount`/`EpochProtectedCount`),
+  `WalBackPressureTimeoutException` (carries `RequestedBytes`) — each also carries `WaitDuration`.
+- `BulkLoadCheckpointTimeoutException` is a deadline-driven timeout in spirit but inherits `DurabilityException`,
+  not `TyphonTimeoutException` — it does not surface in a `catch (TyphonTimeoutException)` block, and
+  `IsTransient` defaults to `false`. Unlike the other four, the underlying `BulkLoadSession` remains open after
+  this exception; the caller may retry `CompleteBulkLoad` or dispose the session.
+- Deadlines are monotonic (`Stopwatch`-based), not wall-clock — immune to NTP/DST jumps — and are computed fresh
+  at each call site rather than inherited, so nested lock acquisitions each get their own full window (not yet
+  a single shared transaction-wide budget — that is a future Execution Context tier).
+- Checking `WaitContext.ShouldStop` costs ~10-25ns per spin iteration — paid only while contended; the
+  uncontended fast path skips the check entirely.
+- Test code should use `TestWaitContext.Default` (a fresh 10s deadline) instead of `WaitContext.Null` in
+  multi-threaded contention tests, to avoid genuinely hanging the test runner on a regression.
+
+## 🧪 Tests
+
+- [DeadlinePropagationTests](../../../test/Typhon.Engine.Tests/Errors/DeadlinePropagationTests.cs) — `TimeoutOptions` defaults/overrides, `AccessControl`/`ResourceAccessControl` lock contention throwing `LockTimeoutException` once the deadline expires, and `TestWaitContext` expiry semantics.
+- [TyphonExceptionTests](../../../test/Typhon.Engine.Tests/Errors/TyphonExceptionTests.cs) — `LockTimeoutException`/`TransactionTimeoutException` typed properties (`ResourceName`/`TransactionId`/`WaitDuration`) and the `catch (TyphonTimeoutException)` mid-granularity roundtrip.
+
+## 🔗 Related
+
+- Related catalog entries: [Deadline & Timeout Propagation](../Foundation/deadline-timeout-propagation.md) (the underlying `Deadline`/`WaitContext` mechanism), [TyphonException Hierarchy & Catalog](./exception-hierarchy.md)
+
+<!-- Deep dive: claude/design/Errors/02-deadline-propagation.md -->
+<!-- Overview: claude/overview/10-errors.md, claude/overview/01-concurrency.md -->
+<!-- ADR: claude/adr/031-unified-concurrency-patterns.md (031 — Unified Concurrency Patterns) -->

--- a/doc/feature-set/Errors/transience-hint.md
+++ b/doc/feature-set/Errors/transience-hint.md
@@ -1,0 +1,64 @@
+# IsTransient Retry Hint
+> A virtual flag on every Typhon exception telling callers "this might succeed if you retry" — without the engine ever retrying for you.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Errors](./README.md)
+
+## 🎯 What it solves
+
+When an operation fails, the caller's next move depends entirely on *why* it failed. A duplicate key in a unique index will fail again no matter how many times you retry it; a lock acquisition that timed out under contention might well succeed a moment later. Without a uniform way to tell these apart, callers either retry everything (wasting time on failures that can never succeed) or retry nothing (giving up on contention that would have cleared in milliseconds). Typhon needs a single, consistent signal across its entire exception hierarchy — and it must never tempt the engine itself into silently retrying a transaction, because only the caller knows what side effects already happened.
+
+## ⚙️ How it works (in brief)
+
+`TyphonException` declares `virtual bool IsTransient => false`. Subclasses override it only when retrying is actually meaningful: `TyphonTimeoutException` (and everything under it — lock timeouts, transaction timeouts, page-cache and WAL back-pressure) overrides it to `true`, since a timeout means a resource was busy, not broken. `ResourceExhaustedException` likewise overrides it to `true` — pools and bounded resources drain over time. Everything else (corruption, schema mismatches, unique-constraint violations, WAL write failures) keeps the `false` default: retrying changes nothing because the cause isn't time-dependent. The flag is purely informational — Typhon never reads it internally to drive a retry loop.
+
+## 💻 Usage
+
+```csharp
+int attempts = 0;
+while (true)
+{
+    try
+    {
+        using var tx = dbe.CreateQuickTransaction();
+        var id = tx.Spawn<PlayerArch>(PlayerArch.Position.Set(in pos));
+        tx.Commit();
+
+        // Side effects AFTER commit only — never re-executed on retry.
+        networkLayer.BroadcastSpawn(id);
+        break;
+    }
+    catch (TyphonException ex) when (ex.IsTransient && ++attempts < 3)
+    {
+        // Caller decides: how many attempts, how long to wait, what to undo.
+        Thread.Sleep(50 * attempts);
+    }
+}
+```
+
+| Exception | `IsTransient` | Typical retry response |
+|---|---|---|
+| `TyphonTimeoutException` (lock, transaction, page-cache/WAL back-pressure) | `true` | Retry with backoff |
+| `ResourceExhaustedException` | `true` | Retry, or wait for the resource to drain |
+| `StorageException`, `DurabilityException`, schema/`UniqueConstraintViolationException` | `false` | Don't retry — surface or escalate |
+
+## ⚠️ Guarantees & limits
+
+- **Caller-owned retry, always** — the engine never loops on a failed transaction internally; it throws once and returns control. Retrying is entirely the caller's decision and implementation.
+- **Default is non-transient** — a new exception type that forgets to override `IsTransient` fails safe (no retry suggested) rather than encouraging callers to hammer a permanent failure.
+- **Only opt-in subclasses are transient** — `TyphonTimeoutException` and `ResourceExhaustedException` are the sole overrides today; the flag is fixed per exception type, not computed from runtime state.
+- **Not a substitute for idempotency analysis** — `IsTransient == true` only means "the resource might be free now," not "it's safe to blindly retry your lambda." Side effects performed before the failure point (network calls, external writes) are never undone by a transaction retry; place them after `Commit()`.
+- **Zero runtime cost** — a single virtual property read (no allocation, no dictionary lookup); the type hierarchy itself is the classification, there's no separate `ErrorCategory` enum to keep in sync.
+
+## 🧪 Tests
+
+- [TyphonExceptionTests](../../../test/Typhon.Engine.Tests/Errors/TyphonExceptionTests.cs) — default-`false` on the base `TyphonException`, opt-in `true` overrides on `LockTimeoutException`/`ResourceExhaustedException`, and non-transient assertions on `StorageException`/`CorruptionException`.
+
+## 🔗 Related
+
+- Parent feature: [Errors](./README.md)
+- Sibling: [TyphonException Hierarchy & Catalog](./exception-hierarchy.md) — defines the base `IsTransient` flag this feature documents
+- Sibling: [Timeout Exceptions & Deadline Propagation](./timeout-exceptions-deadlines.md) — the primary `IsTransient=true` exception family
+- Sibling: [Resource Exhaustion Handling](./resource-exhaustion-handling.md) — the other exception family that overrides `IsTransient=true`
+
+<!-- Deep dive: claude/design/Errors/01-exception-hierarchy.md, claude/design/Errors/05-public-exception-catalog.md -->
+<!-- Overview: claude/overview/10-errors.md §10.3 -->

--- a/doc/feature-set/Foundation/README.md
+++ b/doc/feature-set/Foundation/README.md
@@ -1,0 +1,30 @@
+# Foundation
+> Typhon's lowest-level building blocks — lock-free synchronization primitives, epoch-based memory safety, monotonic deadline/timeout propagation, pinned-memory allocators, and high-performance collections — that every other engine layer (storage, ECS, durability, query) is built on. Nearly the entire surface is `internal` engine plumbing (a few types, like `EpochManager` and `IMemoryResource`, are C# `public` but namespaced under `Typhon.Engine.Internals`); the only types meant for direct application use are `Deadline`, `WaitContext`, and `UnitOfWorkContext` — the timeout/cancellation values threaded into every `Commit()`.
+
+> 🔬 **Recommended:** read [in-depth-overview/01-foundation.md](../../in-depth-overview/01-foundation.md) (Chapter 01: Foundation) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Deadline & Timeout Propagation](./deadline-timeout-propagation.md) | Monotonic absolute-deadline timeouts bundled with cooperative cancellation, threaded through every Unit-of-Work via the 24-byte `UnitOfWorkContext` to eliminate timeout accumulation across nested calls. | ✅ Implemented | 🔵 Core |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Reader-Writer & Resource Lifecycle Locks](./access-control-lock-family/README.md) | CAS-only, allocation-free spin-locks every concurrent engine structure embeds for shared/exclusive or lifecycle access. | ✅ Implemented |
+| &nbsp;&nbsp;↳ [AccessControl (full-featured RW lock)](./access-control-lock-family/access-control.md) | 64-bit reader-writer lock with waiter fairness, in-place promotion, and contention tracking. | ✅ Implemented |
+| &nbsp;&nbsp;↳ [AccessControlSmall (compact RW lock)](./access-control-lock-family/access-control-small.md) | 32-bit reader-writer lock for thousands of embedded per-node/per-page latches with short critical sections. | ✅ Implemented |
+| &nbsp;&nbsp;↳ [ResourceAccessControl (3-mode lifecycle lock)](./access-control-lock-family/resource-access-control.md) | 32-bit Accessing/Modify/Destroy lock where structural growth doesn't block concurrent readers. | ✅ Implemented |
+| [Epoch-Based Resource Protection](./epoch-based-resource-protection.md) | Lock-free epoch/grace-period scheme that protects in-flight page-cache pages from eviction with 2 obligations per transaction instead of per-page ref-counting. | ✅ Implemented |
+| [High-Resolution Timers](./high-resolution-timers/README.md) | Self-calibrating sub-millisecond periodic timer services (three-phase Sleep→Yield→Spin wait, drift-free metronome scheduling) used for the deadline watchdog, telemetry flush, and epoch advancement, exposing per-tick jitter metrics. | ✅ Implemented |
+| &nbsp;&nbsp;↳ [Dedicated Timer (HighResolutionTimerService)](./high-resolution-timers/dedicated-timer.md) | A single periodic callback on its own thread, isolated from every other timer in the engine. | ✅ Implemented |
+| &nbsp;&nbsp;↳ [Shared Timer (HighResolutionSharedTimerService)](./high-resolution-timers/shared-timer.md) | One thread multiplexing many periodic callbacks, each at its own rate, waking only when the soonest one is due. | ✅ Implemented |
+| [In-Memory Hash Maps](./in-memory-hash-maps/README.md) | Open-addressing, pinned-memory hash set/map types with backward-shift deletion and JIT-specialized hashing that replace .NET `HashSet`/`Dictionary`/`ConcurrentDictionary` on hot paths. | ✅ Implemented |
+| &nbsp;&nbsp;↳ [Non-Concurrent HashMap\<TKey[, TValue]\>](./in-memory-hash-maps/non-concurrent-hash-map.md) | Single-threaded open-addressing hash set/map replacing `HashSet`/`Dictionary` on a hot path, zero per-entry GC pressure. | ✅ Implemented |
+| &nbsp;&nbsp;↳ [ConcurrentHashMap\<TKey[, TValue]\>](./in-memory-hash-maps/concurrent-hash-map.md) | Striped, lock-free-read hash set/map replacing `ConcurrentDictionary` on a shared hot path, per-stripe CAS writes. | ✅ Implemented |
+| [Page-Backed Linear Hash Map](./paged-linear-hash-map.md) | O(1) exact-match key/value index, persisted in fixed-size chunks, with crash-safe rebuild instead of WAL logging. | ✅ Implemented |
+| [Memory Allocators](./memory-allocators.md) | Pinned/unmanaged memory primitives that give every page cache, segment, and hash-map structure stable, GC-immune addresses with parent-owned leak tracking. | ✅ Implemented |
+| [Concurrent Bitmaps & Collections](./concurrent-bitmaps-collections.md) | Lock-free/CAS-guarded occupancy bitmaps (flat and 3-level) plus a pick/putback slot array for high-contention tracking. | ✅ Implemented |
+| [Hardware-Accelerated CRC32C Checksums](./crc32c-checksums.md) | SSE4.2/ARM-intrinsic CRC32C (Castagnoli polynomial) computation with software-table fallback (~1.3µs per 8KB page) — the checksum primitive backing every page-integrity check in storage and durability. | ✅ Implemented |

--- a/doc/feature-set/Foundation/access-control-lock-family/README.md
+++ b/doc/feature-set/Foundation/access-control-lock-family/README.md
@@ -1,0 +1,35 @@
+# Reader-Writer & Resource Lifecycle Locks
+> CAS-only, allocation-free spin-locks every concurrent engine structure embeds for shared/exclusive or lifecycle access.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+Typhon's microsecond-level latency targets rule out OS-level synchronization (mutexes, semaphores, `ReaderWriterLockSlim`) for the thousands of small, short-lived locks the engine needs — page latches, B+Tree node locks, component-table guards, transaction-pool locks. Three purpose-built lock shapes cover the recurring access patterns the engine actually needs — general reader/writer, a compact reader/writer for high-density embedding, and a three-mode lifecycle lock for structures that grow while being read — without the cost of kernel objects or heap allocation.
+
+## ⚙️ How it works (in brief)
+All three pack their entire state into a single atomic word (8, 4, and 4 bytes respectively) and transition exclusively via `Interlocked.CompareExchange` — no wait queues, no kernel handles, no managed allocation. Contention spins via .NET's `SpinWait` (busy-spin → yield → sleep) and never parks a thread. Every blocking entry point takes a `ref WaitContext` (monotonic deadline + `CancellationToken`); pass `ref WaitContext.Null` for an infinite, zero-overhead wait. Picking the right one is a tradeoff between memory footprint, waiter fairness, and access semantics — see the sub-features below.
+
+## Sub-features
+
+| Sub-feature | Size | Use it when... |
+|---|---|---|
+| [AccessControl](./access-control.md) | 8 bytes | Few instances, many threads, writer starvation under read pressure is unacceptable |
+| [AccessControlSmall](./access-control-small.md) | 4 bytes | Thousands of instances embedded per-node/per-page, fairness isn't needed |
+| [ResourceAccessControl](./resource-access-control.md) | 4 bytes | Structural growth must not block concurrent readers; destruction must drain everything |
+
+## ⚠️ Guarantees & limits
+- All three are `internal` engine types — application code never constructs or calls them directly; they're the plumbing inside `ComponentTable`, `TransactionChain`, page latches, B+Tree nodes, segment chains, etc.
+- Thread IDs are stored in exactly 16 bits everywhere (max 65,535) — consistent overflow headroom across the family, sized for 500+ core servers.
+- Pure userspace spin-wait, never OS-level parking — cheap for the engine's typical sub-microsecond hold times, wasteful if misused for long critical sections.
+- No deadlock detection by design: correctness rests on Typhon's MVCC (no cross-transaction lock holding) and strict latch-coupling order in the B+Tree/R-Tree, not on runtime detection in these primitives.
+- Contention surfaces through the profiler's trace-event stream (`TyphonEvent.Emit*`, gated and JIT-eliminated when the profiler is off) — not an opt-in callback interface.
+
+## 🧪 Tests
+- [AccessControlTests](../../../../test/Typhon.Engine.Tests/Concurrency/AccessControlTests.cs) — full-featured RW lock: shared/exclusive/promote-demote, fairness under contention, deadline+cancellation wiring.
+- [AccessControlSmallTests](../../../../test/Typhon.Engine.Tests/Concurrency/AccessControlSmallTests.cs) — compact RW lock: idle/shared/exclusive transitions, misuse-throws contract.
+- [ResourceAccessControlTests](../../../../test/Typhon.Engine.Tests/Concurrency/ResourceAccessControlTests.cs) — 3-mode Accessing/Modify/Destroy semantics, `MODIFY_PENDING` fairness, promote/demote.
+
+## 🔗 Related
+- Sub-features: [AccessControl](./access-control.md), [AccessControlSmall](./access-control-small.md), [ResourceAccessControl](./resource-access-control.md)
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/AccessControlFamily.md, claude/overview/01-concurrency.md §1.3-1.5, claude/adr/031-unified-concurrency-patterns.md -->

--- a/doc/feature-set/Foundation/access-control-lock-family/access-control-small.md
+++ b/doc/feature-set/Foundation/access-control-lock-family/access-control-small.md
@@ -1,0 +1,56 @@
+# AccessControlSmall (compact RW lock)
+> 32-bit reader-writer lock for thousands of embedded per-node/per-page latches with short critical sections.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+B+Tree nodes, page headers, archetype cluster slots — structures that exist by the thousands and each need their own lock, where an 8-byte `AccessControl` would waste memory and waiter fairness isn't worth the bookkeeping. AccessControlSmall trims the footprint to 4 bytes while keeping the same `WaitContext`-based timeout/cancellation contract as the rest of the family.
+
+## ⚙️ How it works (in brief)
+State is implicit rather than explicit: a non-zero thread-ID field means Exclusive, a non-zero 15-bit counter means Shared, both zero means Idle — so the common-case Idle→Exclusive transition is a single CAS against zero. There's no waiter tracking, so under sustained read pressure a pending writer can be starved (reach for `AccessControl` if that matters). Misuse — re-entering exclusive on the same thread, exiting from the wrong thread, promoting without holding shared, counter overflow — throws `InvalidOperationException` instead of silently corrupting state.
+
+## 💻 Usage
+```csharp
+// Each B+Tree node / page / cluster slot embeds its own 4-byte latch
+public struct BTreeNode
+{
+    public AccessControlSmall Latch;
+    // ... keys, values, child pointers
+}
+
+// Short critical section, infinite wait (WaitContext.Null = zero overhead)
+node.Latch.EnterSharedAccess(ref WaitContext.Null);
+try { return ref node.Keys[index]; }
+finally { node.Latch.ExitSharedAccess(); }
+
+// Exclusive-only usage — a single state-machine guard, no readers
+var ctx = WaitContext.FromTimeout(TimeSpan.FromSeconds(1));
+if (latch.EnterExclusiveAccess(ref ctx))
+{
+    try { /* mutate */ }
+    finally { latch.ExitExclusiveAccess(); }
+}
+
+// Generic enter/exit when shared-vs-exclusive is decided at runtime
+node.Latch.Enter(exclusive: true, ref ctx);
+try { /* ... */ }
+finally { node.Latch.Exit(exclusive: true); }
+```
+
+## ⚠️ Guarantees & limits
+- 4 bytes per instance — designed to be embedded inline by the thousands (per-node, per-page).
+- No waiter fairness: continuous shared acquisitions can starve a pending exclusive/promote.
+- No re-entrancy: re-entering exclusive access on the same thread throws rather than deadlocking.
+- Max 32,767 concurrent shared holders (15-bit counter); overflow throws `InvalidOperationException`.
+- `WasContended` is a sticky diagnostic bit, cleared only by `Reset()`.
+- `internal` type — engine plumbing, not callable from application code.
+
+## 🧪 Tests
+- [AccessControlSmallTests](../../../../test/Typhon.Engine.Tests/Concurrency/AccessControlSmallTests.cs) — idle/shared/exclusive transitions, misuse throws (exit without enter, wrong-thread exit), multi-thread blocking.
+
+## 🔗 Related
+- Parent feature: [Reader-Writer & Resource Lifecycle Locks](./README.md)
+- Sibling: [AccessControl](./access-control.md) — full-featured RW lock with waiter fairness, for low-instance-count high-contention resources.
+- Sibling: [ResourceAccessControl](./resource-access-control.md) — 3-mode lifecycle lock for structures where growth mustn't block readers.
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/AccessControlSmall.md -->

--- a/doc/feature-set/Foundation/access-control-lock-family/access-control.md
+++ b/doc/feature-set/Foundation/access-control-lock-family/access-control.md
@@ -1,0 +1,66 @@
+# AccessControl (full-featured RW lock)
+> 64-bit reader-writer lock with waiter fairness, in-place promotion, and contention tracking.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+Some engine structures are touched by many threads but exist as a single shared instance — the transaction pool's central lock, a page cache's occupancy map, a segment's buffer lock. For these, raw lock size doesn't matter, but starving a writer under continuous read pressure does. AccessControl gives that handful of high-traffic, low-instance-count structures a true reader-writer lock with fairness guarantees and built-in contention visibility, without the overhead of .NET's `ReaderWriterLockSlim`.
+
+## ⚙️ How it works (in brief)
+The entire lock state — mode, shared-reader count, three waiter counters, the exclusive holder's thread ID, a sticky contention flag — packs into one 64-bit word, mutated only via CAS. A **writer-preferring "class of waiters" fairness policy** blocks new shared (read) acquisitions whenever an exclusive or promoter waiter exists, so continuous readers can never starve a pending writer indefinitely — though there's no strict FIFO ordering within a waiter class. A thread holding Shared can call `TryPromoteToExclusiveAccess` to upgrade in place (no release-then-reacquire window) when it's the sole reader; `DemoteFromExclusiveAccess` reverses it.
+
+## 💻 Usage
+```csharp
+private AccessControl _control;
+
+// Shared (read) access, bounded wait
+var ctx = WaitContext.FromTimeout(TimeSpan.FromMilliseconds(100));
+if (_control.EnterSharedAccess(ref ctx))
+{
+    try { /* read */ }
+    finally { _control.ExitSharedAccess(); }
+}
+
+// Exclusive (write) access, infinite wait — WaitContext.Null costs nothing extra
+_control.EnterExclusiveAccess(ref WaitContext.Null);
+try { /* write */ }
+finally { _control.ExitExclusiveAccess(); }
+
+// Read, then upgrade in place only if needed
+if (_control.EnterSharedAccess(ref ctx))
+{
+    try
+    {
+        if (NeedsUpdate() && _control.TryPromoteToExclusiveAccess(ref ctx))
+        {
+            try { ApplyUpdate(); }
+            finally { _control.DemoteFromExclusiveAccess(); }
+        }
+    }
+    finally { _control.ExitSharedAccess(); }
+}
+```
+
+| Acquisition | Method | Blocking |
+|---|---|---|
+| Shared (read) | `EnterSharedAccess(ref WaitContext)` / `TryEnterSharedAccess()` | Waits / non-blocking |
+| Exclusive (write) | `EnterExclusiveAccess(ref WaitContext)` / `TryEnterExclusiveAccess()` | Waits / non-blocking |
+| Promote shared → exclusive | `TryPromoteToExclusiveAccess(ref WaitContext)` | Waits; fails if other readers are present |
+| Demote exclusive → shared | `DemoteFromExclusiveAccess()` | Never blocks |
+
+## ⚠️ Guarantees & limits
+- 8 bytes per instance — reserve for low-instance-count, high-contention resources; use `AccessControlSmall` for per-node/per-page locks numbering in the thousands.
+- Writer-preferring fairness via three sticky waiter counters; priority order is Promoter > Exclusive > Shared.
+- Max 255 concurrent shared holders and max 255 waiters per class (8-bit counters); overflow is a `Debug.Assert` in this type (compare `AccessControlSmall`, which throws on overflow).
+- `WasContended` is a sticky diagnostic bit, cleared only by `Reset()`.
+- `internal` type — engine plumbing, not callable from application code.
+
+## 🧪 Tests
+- [AccessControlTests](../../../../test/Typhon.Engine.Tests/Concurrency/AccessControlTests.cs) — shared/exclusive acquisition, in-place promote/demote, timeout and cancellation paths, `WasContended` sticky bit, multi-thread blocking/contention.
+
+## 🔗 Related
+- Parent feature: [Reader-Writer & Resource Lifecycle Locks](./README.md)
+- Sibling: [AccessControlSmall](./access-control-small.md) — compact 4-byte variant for thousands of embedded per-node/per-page latches.
+- Sibling: [ResourceAccessControl](./resource-access-control.md) — 3-mode lifecycle lock for structures where growth mustn't block readers.
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/AccessControl.md, claude/adr/017-64bit-access-control-state.md, claude/adr/018-adaptive-spin-wait.md -->

--- a/doc/feature-set/Foundation/access-control-lock-family/resource-access-control.md
+++ b/doc/feature-set/Foundation/access-control-lock-family/resource-access-control.md
@@ -1,0 +1,63 @@
+# ResourceAccessControl (3-mode lifecycle lock)
+> 32-bit Accessing/Modify/Destroy lock where structural growth doesn't block concurrent readers.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+Append-only and extend-only structures (chained block allocators, enumerable segment chains) have an access pattern a plain reader-writer lock handles badly: appending a new block doesn't invalidate anything an in-flight enumerator is reading, so a writer-style exclusive lock would block readers for no reason — but tearing the structure down still must wait for every reader and every in-flight modification to finish. ResourceAccessControl encodes that compatibility relationship directly instead of forcing it through two RW locks that don't agree with each other.
+
+## ⚙️ How it works (in brief)
+Three modes, not two: **Accessing** (many concurrent holders, keeps the resource alive), **Modify** (single holder, but compatible with concurrent Accessing — it only excludes other Modify/Destroy), and **Destroy** (terminal, drains everything, never released). A `MODIFY_PENDING` flag stops new Accessing holders from starving a Modify (or a promote) once it starts waiting for the count to drain; `TryPromoteToModify`/`DemoteFromModify` let an Accessing holder upgrade in place. Once `EnterDestroy` succeeds the instance is permanently dead — there is no `ExitDestroy`.
+
+## 💻 Usage
+```csharp
+private ResourceAccessControl _access;
+
+// Reader/enumerator: keeps the resource alive, doesn't block appenders
+_access.EnterAccessing(ref WaitContext.Null);
+try { /* traverse the chain */ }
+finally { _access.ExitAccessing(); }
+
+// Same, via the scoped guard (auto-exits on Dispose)
+using (_access.EnterAccessingScoped(ref WaitContext.Null))
+{
+    /* traverse the chain */
+}
+
+// Append/extend: compatible with concurrent Accessing, exclusive vs. other Modify
+_access.EnterModify(ref WaitContext.Null);
+try { /* append a new block */ }
+finally { _access.ExitModify(); }
+
+// Teardown: terminal, waits for every Accessing/Modify holder to drain first
+var ctx = WaitContext.FromTimeout(TimeSpan.FromSeconds(30));
+if (!_access.EnterDestroy(ref ctx))
+{
+    throw new TimeoutException("Could not acquire destroy lock");
+}
+// _access is now permanently dead — no further Enter* call will ever succeed
+```
+
+| Mode | Concurrent with Accessing | Concurrent with Modify | Concurrent with Destroy |
+|---|---|---|---|
+| Accessing | Yes (many) | Yes | No |
+| Modify | Yes | No (single holder) | No |
+| Destroy | No | No | No (terminal) |
+
+## ⚠️ Guarantees & limits
+- 4 bytes per instance.
+- Modify being compatible with Accessing is the type's whole point — don't reach for it as a generic RW-lock substitute where modification must exclude readers.
+- Destroy is one-way: once acquired, the instance cannot be reused; there's no `Reset()`-and-retry within the same lifetime.
+- Max 255 concurrent Accessing holders (8-bit counter); overflow throws `InvalidOperationException`.
+- `MODIFY_PENDING` is the only fairness mechanism — it protects a waiting Modify/promote from new Accessing holders, not from another Modify.
+- `internal` type — engine plumbing, not callable from application code.
+
+## 🧪 Tests
+- [ResourceAccessControlTests](../../../../test/Typhon.Engine.Tests/Concurrency/ResourceAccessControlTests.cs) — Accessing/Modify compatibility, `MODIFY_PENDING` blocking new Accessing while a Modify/promote drains, promote/demote, Destroy's terminal drain-then-die semantics.
+
+## 🔗 Related
+- Parent feature: [Reader-Writer & Resource Lifecycle Locks](./README.md)
+- Sibling: [AccessControl](./access-control.md) — full-featured RW lock with waiter fairness, for low-instance-count high-contention resources.
+- Sibling: [AccessControlSmall](./access-control-small.md) — compact 4-byte variant for thousands of embedded per-node/per-page latches.
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/ResourceAccessControl.md, claude/adr/016-three-mode-resource-access-control.md -->

--- a/doc/feature-set/Foundation/concurrent-bitmaps-collections.md
+++ b/doc/feature-set/Foundation/concurrent-bitmaps-collections.md
@@ -1,0 +1,62 @@
+# Concurrent Bitmaps & Collections
+> Lock-free/CAS-guarded occupancy bitmaps (flat and 3-level) plus a pick/putback slot array for high-contention tracking.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](./README.md)
+
+## 🎯 What it solves
+
+Several engine subsystems need to know, under concurrent access, "which slot is taken" or "which slot is free" without paying a lock per slot: which blocks inside a memory-allocator page are occupied, which pages a backup snapshot has already copy-on-write captured, which array entry a worker is currently processing. A general-purpose `bool[]` behind a lock would serialize every subsystem that touches it at high frequency. These primitives give each use case the cheapest synchronization shape that still holds up under concurrent readers and writers.
+
+## ⚙️ How it works (in brief)
+
+`ConcurrentBitmap` is a flat array of 64-bit words — `Set`/`Clear`/`IsSet` go straight through `Interlocked.Or`/`And` on one word, no hierarchy. `ConcurrentBitmapL3Any` (and its unsynchronized sibling `BitmapL3Any`) layer two small summary levels (L1, L2) on top of the ground-truth L0 bitmap so enumerating *set* bits can skip whole empty 64- or 4096-bit regions instead of testing every bit one by one; `ConcurrentBitmapL3Any.Set` holds a short spin-lock across all three levels to keep the summary consistent, `Clear`/`IsSet` don't. `ConcurrentBitmapL3All` inverts the idea — it tracks when a word becomes *completely full* so `FindNextUnsetL0`/`FindNextUnsetL1` can hierarchically skip full regions while hunting for a free slot; every level update is a plain Interlocked CAS with a self-correcting double-check for races, so it never blocks, and capacity grows by atomically appending a whole new bank rather than resizing in place. `ConcurrentArray<T>` is a fixed-size slot array with pick/putback semantics: `Pick` atomically claims and nulls a slot (`Interlocked.Exchange`), `PutBack` restores it, `Remove` spin-waits for a slot currently held by another thread.
+
+## 💻 Usage
+
+```csharp
+// Page-occupancy: BlockAllocatorBase claims/releases a free block within an allocator page
+var blockMap = new ConcurrentBitmapL3All("MyAllocatorBlockMap", parentResource, memoryAllocator, entryCountPerPage);
+
+int blockId = -1;
+while (blockMap.FindNextUnsetL0(ref blockId) && !blockMap.SetL0(blockId)) { } // claim the next free slot
+blockMap.ClearL0(blockId);                                                    // release it later
+
+// Concurrent slot pool: workers exclusively own an item while processing it
+var pool = new ConcurrentArray<MyWorkItem>(capacity: 256);
+int index = pool.Add(item);
+if (pool.Pick(index, out var owned))      // atomic claim; false = already taken or empty
+{
+    Process(owned);
+    pool.PutBack(index, owned);           // release back for the next picker
+}
+```
+
+| Type | Capacity | Concurrency |
+|---|---|---|
+| `ConcurrentBitmap` | caller-defined, fixed | Lock-free `Set`/`Clear`/`IsSet` |
+| `ConcurrentBitmapL3Any` / `BitmapL3Any` | up to 262,144 bits (64×64×64), fixed | `Set` spin-locked across levels (`Any`); `BitmapL3Any` is single-threaded only |
+| `ConcurrentBitmapL3All` | 262,144 bits per bank, multi-bank growable | Fully lock-free CAS, self-correcting hints |
+| `ConcurrentArray<T>` | fixed at construction | `Pick`/`PutBack`/`Remove` atomic per slot |
+
+## ⚠️ Guarantees & limits
+
+- All four types are `internal` (`Typhon.Engine.Internals`) — engine plumbing, no public API surface.
+- `ConcurrentBitmapL3Any.Set` serializes through one spin-lock scoped to that bitmap instance — concurrent `Set` calls on the *same* instance don't run in parallel; `Clear` and `IsSet` never take it.
+- `ConcurrentBitmapL3All`'s L0 bit is always the ground truth; L1/L2 summary bits are best-effort hints that self-correct after a race, so a summary can be transiently stale but `IsSet`/`ClearL0`/`SetL0` results are always exact.
+- The 3-level scheme is sized for ≤64×64×64 = 262,144 bits per instance/bank; beyond that, `ConcurrentBitmapL3All` grows by appending a new bank (`Grow()`) rather than enlarging the existing one — `ConcurrentBitmapL3Any`/`BitmapL3Any` have no growth path at all, capacity is fixed at construction.
+- `ConcurrentBitmapL3All` is wired into the engine's resource tree and metrics pipeline (`IResource`, `IMetricSource`, `IDebugPropertiesProvider`) — capacity, utilization, and per-bank stats are reportable.
+- `ConcurrentArray<T>.Remove` spin-waits indefinitely on a slot currently picked by another thread, and will wait forever if called on a slot that holds no item — callers must pair every `Pick` with `PutBack` or `Release`.
+- `ConcurrentArray<T>.Add` throws once `Capacity` is reached; there is no automatic growth.
+- `BitmapL3Any` carries no synchronization at all — single-threaded use only; it exists primarily as the no-overhead baseline against which `ConcurrentBitmapL3Any`'s locking cost is benchmarked.
+
+## 🧪 Tests
+- [ConcurrentBitmapL3AllTests](../../../test/Typhon.Engine.Tests/Collections/ConcurrentBitmapL3AllTests.cs) — `ConcurrentBitmapL3All` lock-free CAS set/clear, hierarchical `FindNextUnsetL0`/L1 skip-full-regions, multi-bank `Grow()`.
+- [ConcurrentBitmapL3Test](../../../test/Typhon.Engine.Tests/Collections/ConcurrentBitmapL3Test.cs) — `ConcurrentBitmapL3Any` set-bit enumeration across the L1/L2 summary hierarchy.
+
+## 🔗 Related
+
+- Sibling: [Page Allocation & Occupancy Tracking](../Storage/page-allocation-occupancy.md) — uses this bitmap family (`BitmapL3`) to track free/occupied pages in the database file.
+
+<!-- Deep dive: claude/overview/11-utilities.md §D.1-D.2 -->
+<!-- ADR: claude/adr/041-treiber-stack-chunk-allocator.md — chunk-level slot allocation moved off this bitmap family to a free list; these bitmaps remain the page-occupancy and backup-tracking primitive -->
+<!-- Design: claude/design/Durability/PitBackup/02-backup-creation.md — ConcurrentBitmapL3All as the CoW page-tracking bitmap -->

--- a/doc/feature-set/Foundation/crc32c-checksums.md
+++ b/doc/feature-set/Foundation/crc32c-checksums.md
@@ -1,0 +1,46 @@
+# Hardware-Accelerated CRC32C Checksums
+> SSE4.2/ARM-intrinsic CRC32C checksum primitive that backs every page and WAL-record integrity check.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](./README.md)
+
+## 🎯 What it solves
+
+Storage media can silently corrupt data — torn writes on power loss, bit rot, firmware bugs writing the right bytes to the wrong place. None of these announce themselves; without a checksum, corrupted data is read back and trusted. Detecting this requires computing and verifying a checksum on every single page and WAL record, on every read and write, without becoming the bottleneck itself.
+
+## ⚙️ How it works (in brief)
+
+Every page header and WAL record carries a CRC32C (Castagnoli polynomial) checksum, computed over its bytes and verified on every load. The checksum field itself is excluded from its own computation (it can't checksum itself), so the primitive treats that region as zeros rather than requiring a separate buffer copy. Computation uses the CPU's native CRC32 instruction (SSE4.2 on x86/x64, CRC32C on ARM64) when available, falling back to a software lookup table on unsupported hardware — same result, different speed.
+
+## 💻 Usage
+
+This is transparent engine plumbing — every page write/read and WAL record write/replay is checksummed automatically, there's nothing application code calls directly:
+
+```csharp
+using var tx = dbe.CreateQuickTransaction();
+
+EntityRef e = tx.OpenMut(entityId);
+ref Position p = ref e.Write(Unit.Pos);
+p.X += 1f;
+tx.Commit();
+// Pages touched by the commit get their CRC32C stamped on write;
+// a future read verifies it and throws on mismatch — no app code involved.
+```
+
+## ⚠️ Guarantees & limits
+
+- **~1.3µs per 8KB page** on SSE4.2 x64 (hardware path); software fallback is roughly 6x slower — negligible relative to I/O latency either way.
+- Detects all single-bit and double-bit errors, and the large majority of multi-bit burst errors — standard error-detection properties of CRC32C.
+- **Not cryptographic** — does not protect against intentional tampering, only accidental corruption. Not a threat model concern for an embedded database engine.
+- Same algorithm and code path checksums both page headers and WAL records, so storage and durability share one integrity guarantee.
+- Hardware acceleration requires SSE4.2 (x86, ubiquitous since 2008) or ARMv8-A; older hardware silently uses the slower software table with no behavior change.
+
+## 🧪 Tests
+- [Crc32CUtilTests](../../../test/Typhon.Engine.Tests/Durability/Crc32CUtilTests.cs) — canonical CRC32C test vectors (`"123456789"` → `0xE3069283`), empty-span zero result, determinism.
+
+## 🔗 Related
+
+- Sibling: [Page Checksums & Seqlock Snapshots](../Durability/page-checksums-seqlock.md) — pairs this CRC32C primitive with a lock-free seqlock for checkpoint page snapshots.
+
+<!-- ADR: claude/adr/015-crc32c-page-checksums.md -->
+<!-- Overview: claude/overview/03-storage.md, claude/overview/06-durability.md §6.1, §6.7 -->
+<!-- Overview: claude/overview/11-utilities.md -->

--- a/doc/feature-set/Foundation/deadline-timeout-propagation.md
+++ b/doc/feature-set/Foundation/deadline-timeout-propagation.md
@@ -1,0 +1,65 @@
+# Deadline & Timeout Propagation
+> Monotonic absolute deadlines bundled with cooperative cancellation, shared by reference through every nested call so timeouts never accumulate.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Foundation](./README.md)
+
+## 🎯 What it solves
+
+Relative timeouts compound: a 5-second budget handed to three nested calls, each restarting its own 5-second clock, can take 15 seconds in the worst case — the original "limit" was meaningless. Wall-clock timeouts (`DateTime.UtcNow`) compound the problem further: NTP sync or DST can jump the clock backward or forward, making a timeout expire instantly or never. Typhon's lock primitives and transactions operate at microsecond granularity, where this drift is the difference between a sub-millisecond commit and a thread that hangs indefinitely. Deadline propagation converts a caller's relative timeout into an absolute, monotonic endpoint exactly once, then threads it — together with a cooperative cancellation signal — through every nested operation without re-deriving it.
+
+## ⚙️ How it works (in brief)
+
+`Deadline` is an 8-byte readonly struct wrapping a `Stopwatch.GetTimestamp()` value; `Deadline.FromTimeout(timeout)` converts a relative `TimeSpan` to an absolute deadline once, at the operation's entry point. `WaitContext` (16 bytes) bundles a `Deadline` with a `CancellationToken` and is passed `ref` to every blocking `Enter*` call on Typhon's lock primitives; its `ShouldStop` property is the single check performed once per spin iteration. `UnitOfWorkContext` (24 bytes) embeds a `WaitContext` plus a Unit-of-Work identifier and a holdoff counter, and flows by `ref` through an entire Unit of Work or transaction; `ThrowIfCancelled()` is the cooperative yield-point check, and the holdoff counter — incremented/decremented around critical sections — suppresses cancellation mid-section without disabling the deadline itself.
+
+## 💻 Usage
+
+```csharp
+using var uow = db.CreateUnitOfWork();
+using var tx = uow.CreateTransaction();
+
+// One conversion, at the top: a 5s relative timeout becomes an absolute monotonic deadline.
+var ctx = UnitOfWorkContext.FromTimeout(TimeSpan.FromSeconds(5));
+
+UpdateAccountBalance(tx, accountId, newBalance);
+
+try
+{
+    tx.Commit(ref ctx);   // every lock acquired during commit shares ctx's single deadline
+}
+catch (TyphonTimeoutException)
+{
+    // ctx's deadline expired before commit finished — no partial work was left behind.
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `Deadline.FromTimeout(Timeout.InfiniteTimeSpan)` | — | Returns `Deadline.Infinite` — never expires |
+| `Deadline.FromTimeout(TimeSpan.Zero)` / negative | — | Returns `Deadline.Zero` — already expired, fails immediately |
+| `UnitOfWorkContext.None` | — | Infinite deadline, no cancellation — for internal cleanup/rollback paths only |
+
+## ⚠️ Guarantees & limits
+
+- **No accumulation** — the relative-to-absolute conversion happens once at the entry point; every nested call checks the same absolute endpoint, so total elapsed time is bounded by the original timeout regardless of call depth.
+- **Monotonic, not wall-clock** — built on `Stopwatch.GetTimestamp()`; immune to NTP adjustments, DST transitions, and manual clock changes that would make a `DateTime.UtcNow`-based timeout expire early or never.
+- **Fail-safe default** — `default(Deadline)`, `default(WaitContext)`, and `default(UnitOfWorkContext)` are all already-expired; a forgotten initialization fails fast instead of hanging forever. Unbounded waits require explicitly opting in via `Deadline.Infinite`, `WaitContext.Null`, or `UnitOfWorkContext.None`.
+- **~10-25ns per expiry check** — one `Stopwatch.GetTimestamp()` (effectively a single `RDTSC` on modern x64) plus a comparison; the cancellation check short-circuits to near-free when no token is attached.
+- **Holdoff defers, never disables** — `BeginHoldoff()`/`EndHoldoff()` make `ThrowIfCancelled()` a no-op for the duration of a critical section so a timeout can't abort work partway through; the deadline keeps running underneath and is re-checked the instant the holdoff exits.
+- **`Deadline.ToCancellationToken()` allocates** — bridges to a `CancellationTokenSource` + timer for interop with non-Typhon async APIs (e.g. `HttpClient`); not for use in spin loops or per-iteration hot paths.
+- A background watchdog polls registered deadlines at 200Hz (~5ms resolution) to fire `CancellationToken`s for code paths that need to observe expiry without spinning — an internal mechanism, not directly exposed.
+
+## 🧪 Tests
+- [DeadlineTests](../../../test/Typhon.Engine.Tests/Concurrency/DeadlineTests.cs) — monotonic expiry: default/zero/infinite states, `FromTimeout` conversion, `Min()` composition.
+- [WaitContextTests](../../../test/Typhon.Engine.Tests/Concurrency/WaitContextTests.cs) — deadline+cancellation composition, `ShouldStop` short-circuiting, `FromTimeout`/`FromToken` construction.
+- [UnitOfWorkContextTests](../../../test/Typhon.Engine.Tests/Concurrency/UnitOfWorkContextTests.cs) — 24-byte struct layout, `ThrowIfCancelled`, holdoff begin/end nesting that suppresses cancellation without disabling the deadline.
+- [TransactionUnitOfWorkContextTests](../../../test/Typhon.Engine.Tests/Concurrency/TransactionUnitOfWorkContextTests.cs) — `Commit(ref ctx)`/`Rollback(ref ctx)` propagation end-to-end, expired-deadline and cancelled-token paths matching the usage sample above.
+
+## 🔗 Related
+
+- Sibling: [High-Resolution Timers](./high-resolution-timers/README.md) — the deadline watchdog polls registered deadlines via the shared timer at 200Hz.
+- Sibling: [Deadline & Cooperative Cancellation](../Transactions/deadline-cancellation.md) — applies this deadline/cancellation primitive to transaction commit.
+- Sibling: [Timeout Exceptions & Deadline Propagation](../Errors/timeout-exceptions-deadlines.md) — surfaces deadline expiry as typed, catchable exceptions.
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/Deadline.md, claude/design/Foundation/Concurrency/WaitContext.md -->
+<!-- Overview: claude/overview/01-concurrency.md §1.1-1.2, §1.6 -->
+<!-- ADRs: 031 — Unified Concurrency Patterns (claude/adr/031-unified-concurrency-patterns.md), 034 — UnitOfWorkContext Struct Design (claude/adr/034-unitofworkcontext-struct-design.md) -->

--- a/doc/feature-set/Foundation/epoch-based-resource-protection.md
+++ b/doc/feature-set/Foundation/epoch-based-resource-protection.md
@@ -1,0 +1,61 @@
+# Epoch-Based Resource Protection
+> Lock-free scheme that keeps in-flight cache pages alive with 2 obligations per transaction, not per-page ref-counting.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](./README.md)
+
+## 🎯 What it solves
+
+Every transaction reads and writes pages in Typhon's memory-mapped page cache while other threads concurrently evict cold pages to make room. The cache must never reclaim a page a live transaction is still touching, but tracking that safely can't cost a synchronized increment/decrement on every single page access — at microsecond transaction latencies, that overhead (and the leak risk of a missed release) is unacceptable. Epoch-based protection gives every transaction blanket protection for all pages it touches, for the cost of two cheap calls instead of one per page.
+
+## ⚙️ How it works (in brief)
+
+A transaction "enters" an epoch scope when it starts and "exits" when it ends; entering pins the engine's current global epoch counter to that thread. Every page the transaction touches gets stamped with that epoch value. The page cache computes the lowest epoch still pinned by any active thread and treats it as a watermark: pages stamped at or above the watermark are still possibly in use and are skipped during eviction; everything below it is fair game. Because protection is granted to the whole scope rather than per page, there is nothing to release page-by-page and nothing to leak — but a long-running transaction holds back eviction for *every* page touched since it started, not just its own.
+
+## 💻 Usage
+
+This is transparent engine plumbing — transactions enter/exit epoch scopes automatically, there's nothing to call directly:
+
+```csharp
+using var tx = dbe.CreateQuickTransaction();  // epoch scope entered here
+
+EntityRef e = tx.OpenMut(entityId);
+ref Position p = ref e.Write(Unit.Pos);       // pages touched are epoch-protected
+p.X += 1f;
+tx.Commit();                                  // epoch scope exited on tx dispose
+```
+
+The only thing application code can observe directly is read-only diagnostics on `DatabaseEngine.EpochManager`, useful for spotting a transaction that's holding the cache back from evicting:
+
+```csharp
+var epochs = dbe.EpochManager;
+long behind = epochs.GlobalEpoch - epochs.MinActiveEpoch;  // large gap → a long-lived scope is stalling eviction
+int liveThreads = epochs.ActiveSlotCount;
+```
+
+| Property | Meaning |
+|----------|---------|
+| `GlobalEpoch` | Current epoch counter, advances on every outermost scope exit. |
+| `MinActiveEpoch` | Lowest epoch any active thread is pinned at — the eviction watermark. |
+| `ActiveSlotCount` | Number of threads currently registered with the engine. |
+| `IsCurrentThreadInScope` | Whether the calling thread is currently inside a scope. |
+
+## ⚠️ Guarantees & limits
+
+- **Constant cost regardless of pages touched** — one scope enter and one scope exit per transaction; a transaction touching 1 page or 10,000 pages pays the same protection overhead.
+- **No leaks possible** — there is no per-page handle to forget to release; scope exit is the only release point.
+- **Protection is by time window, not by identity** — a page is protected if its epoch overlaps *any* active scope, even one that never touched that page. Keep transactions/unit-of-work scopes short; a long-running one delays eviction of pages it never accessed.
+- **Wait-free fast path** — entering/exiting a scope is a few nanoseconds (thread-local read/write plus one atomic increment), no contention with other threads in the common case.
+- Page reclamation under heavy, sustained concurrency can lag further behind than a ref-counted scheme would, trading some extra cache pressure for the lock-free guarantee.
+
+## 🧪 Tests
+- [EpochManagerTests](../../../test/Typhon.Engine.Tests/Concurrency/EpochManagerTests.cs) — enter/exit scope epoch advancement, nested scopes, `MinActiveEpoch` across multiple threads, thread-death slot reclamation, registry exhaustion.
+- [EpochPageCacheTests](../../../test/Typhon.Engine.Tests/Storage/EpochPageCacheTests.cs) — epoch-tagged pages surviving eviction while a scope is active, eviction unblocked after scope exit.
+
+## 🔗 Related
+
+- Sibling: [Optimistic Lock Coupling (per-node concurrency)](../Indexing/olc-concurrency.md) — B+Tree/R-Tree lock-free reads rely on this epoch protection to keep pages alive.
+- Sibling: [Reader-Writer & Resource Lifecycle Locks](./access-control-lock-family/README.md) — the complementary lock-based concurrency primitive family.
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/EpochSystem.md -->
+<!-- ADR: claude/adr/033-epoch-based-page-eviction.md -->
+<!-- Overview: claude/overview/01-concurrency.md §1.7 -->

--- a/doc/feature-set/Foundation/high-resolution-timers/README.md
+++ b/doc/feature-set/Foundation/high-resolution-timers/README.md
@@ -1,0 +1,40 @@
+# High-Resolution Timers
+> Self-calibrating sub-millisecond periodic timers (Sleep→Yield→Spin) powering the deadline watchdog, telemetry flush, and epoch advancement.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+
+Several engine subsystems need periodic execution well below `Thread.Sleep`'s nominal granularity — a deadline watchdog scanning for expirations every 5ms, telemetry flushing every 100ms, epoch advancement at 10ms. `Thread.Sleep(1)` actually resolves anywhere from ~0.5ms (modern Windows/Linux) to ~15.6ms (older Windows), and that gap varies by platform and OS version — a naive timer either misses its window badly on some machines or burns a full core spinning on all of them. High-resolution timers give every periodic subsystem a shared, drift-free metronome instead of each one reinventing wait logic.
+
+## ⚙️ How it works (in brief)
+
+A three-phase wait (`Thread.Sleep(1)` while far from the target → `Thread.Yield()` as it nears → `Thread.SpinWait` for the final ~50µs) trades CPU for precision only when precision is actually needed. The split point is calibrated once at startup by measuring this machine's actual `Thread.Sleep(1)` cost, so the same code self-tunes across Windows, Linux, and macOS without configuration. Each tick advances from the *scheduled* time, not the actual wake time, so timing error never compounds across ticks (metronome scheduling, not a chain of relative delays). Two scheduling policies share this wait loop — see the sub-features below — and both surface tick count, missed ticks, and mean/max timing-error-in-microseconds through the engine's resource graph.
+
+## Sub-features
+
+| Sub-feature | Thread model | Use it when... |
+|---|---|---|
+| [Dedicated Timer](./dedicated-timer.md) | One thread per timer | A single handler needs guaranteed isolation from every other periodic task (e.g. a heartbeat) |
+| [Shared Timer](./shared-timer.md) | One thread, many callbacks | Several lightweight periodic tasks (deadline watchdog, telemetry, epoch advance) shouldn't each pay for a dedicated thread |
+
+## ⚠️ Guarantees & limits
+
+- Both timer flavors are `internal` engine plumbing — application code never constructs one directly; they're the infrastructure behind `DeadlineWatchdog`, telemetry flush, and epoch advancement.
+- Timing error is sub-50µs on a lightly loaded system regardless of interval length — it's dominated by the Yield→Spin handoff, not by how long the wait is.
+- Sub-millisecond intervals keep a logical core busy in the Yield+Spin phases (the Sleep phase has no room to engage); intervals ≥5ms on modern OSes let the Sleep phase absorb most of the wait, dropping CPU usage to near zero.
+- A callback that throws is caught, logged, and skipped — one bad handler never kills the timer thread.
+- Per-tick and per-callback metrics (tick count, missed ticks, mean/max timing error, invocation counts) are exposed through `IMetricSource`, so they appear in resource graph snapshots and any OTel bridge built on it — no separate instrumentation needed.
+
+## 🧪 Tests
+- [HighResolutionTimerServiceBaseTests](../../../../test/Typhon.Engine.Tests/Concurrency/HighResolutionTimerServiceBaseTests.cs) — shared wait-loop mechanics common to both flavors: thread lifecycle, calibration, dispose/double-dispose.
+- [HighResolutionTimerServiceTests](../../../../test/Typhon.Engine.Tests/Concurrency/HighResolutionTimerServiceTests.cs) — dedicated timer: fire rate, callback timestamps, drift-free metronome scheduling.
+- [HighResolutionSharedTimerServiceTests](../../../../test/Typhon.Engine.Tests/Concurrency/HighResolutionSharedTimerServiceTests.cs) — shared timer: multiple independent registrations, idle-when-empty, per-registration disposal.
+
+## 🔗 Related
+
+- Related features: [Deadline & Timeout Propagation](../deadline-timeout-propagation.md), [Resource Tree Registry](../../Resources/resource-tree-registry.md), [Metric Reporting](../../Resources/metric-reporting.md)
+- Sub-features: [Dedicated Timer](./dedicated-timer.md), [Shared Timer](./shared-timer.md)
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/high-resolution-timer.md -->
+<!-- Overview: claude/overview/01-concurrency.md -->

--- a/doc/feature-set/Foundation/high-resolution-timers/dedicated-timer.md
+++ b/doc/feature-set/Foundation/high-resolution-timers/dedicated-timer.md
@@ -1,0 +1,57 @@
+# Dedicated Timer (HighResolutionTimerService)
+> A single periodic callback on its own thread, isolated from every other timer in the engine.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [High-Resolution Timers](./README.md)
+
+## 🎯 What it solves
+
+Some periodic handlers can't tolerate sharing a thread: if a slow callback elsewhere in the process delays the tick, a safety-critical check (a heartbeat, a hard real-time gate) is delayed with it. `HighResolutionTimerService` dedicates a full thread and the engine's calibrated three-phase wait loop to exactly one callback at a fixed interval, so its timing is never a function of what else is registered elsewhere.
+
+## ⚙️ How it works (in brief)
+
+Constructing a `HighResolutionTimerService` does not start it — the thread starts on an explicit `Start()` call. From then on, the timer maintains a metronome anchor (`nextTick += intervalTicks` after every fire, never recomputed from "now") and invokes the single callback once per tick with the scheduled and actual `Stopwatch` timestamps. If the thread falls behind by more than one interval, it skips forward rather than bursting through the backlog, and counts the skipped ticks as missed. `Dispose()` stops the thread (joined with a 2-second timeout) and removes the timer from the resource tree.
+
+## 💻 Usage
+
+```csharp
+// Engine-internal usage — application code does not construct this directly.
+var heartbeat = new HighResolutionTimerService(
+    name: "HeartbeatMonitor",
+    intervalTicks: Stopwatch.Frequency / 1000,  // 1ms
+    callback: (scheduled, actual) => HeartbeatMonitor.CheckAlive(),
+    parent: resourceRegistry.TimerDedicated,
+    logger: loggerFactory.CreateLogger<HighResolutionTimerService>());
+
+heartbeat.Start();   // thread starts here; already visible in the resource tree
+
+// Inspect timing/invocation metrics directly or via the resource graph
+Console.WriteLine($"Timing error: {heartbeat.MeanTimingErrorUs:F1}us, invocations: {heartbeat.InvocationCount}");
+
+heartbeat.Dispose(); // stops the thread, removes from the resource tree
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `intervalTicks` | — (required, > 0) | Period between invocations, in `Stopwatch` ticks; `Stopwatch.Frequency / 1000` ≈ 1ms |
+| `parent` | — (required) | Resource-tree parent; dedicated timers register under `registry.TimerDedicated` |
+
+## ⚠️ Guarantees & limits
+
+- Full thread isolation — no other timer or callback can delay this one's tick.
+- `internal sealed` engine type — used by subsystems that own their own dedicated timer (e.g. a heartbeat monitor), not constructible from application code.
+- Callback budget is a soft contract (target < 100µs); a slow callback delays only this timer's own subsequent ticks, never another timer's.
+- Exceptions thrown by the callback are caught, logged, and do not stop the timer.
+- 1ms intervals keep one logical core near-fully busy (Yield+Spin, no room for the Sleep phase); 5ms+ intervals let Sleep absorb most of the wait, dropping CPU to near zero.
+- One OS thread (default 1MB stack) per instance — appropriate for a handful of isolated timers, not for dozens of lightweight periodic tasks (use the shared timer for those).
+- `MeanTimingErrorUs`/`MaxTimingErrorUs`/`InvocationCount`/`MissedTicks` are available both as direct properties and through `IMetricSource` resource-graph snapshots.
+
+## 🧪 Tests
+- [HighResolutionTimerServiceTests](../../../../test/Typhon.Engine.Tests/Concurrency/HighResolutionTimerServiceTests.cs) — fire-rate accuracy, callback timestamp delivery, exception-in-callback doesn't kill the timer, per-tick/callback metrics.
+- [HighResolutionTimerServiceBaseTests](../../../../test/Typhon.Engine.Tests/Concurrency/HighResolutionTimerServiceBaseTests.cs) — `Start()`/`Dispose()` thread lifecycle, calibration, invalid-interval/null-callback validation.
+
+## 🔗 Related
+
+- Parent feature: [High-Resolution Timers](./README.md)
+- Sibling: [Shared Timer](./shared-timer.md)
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/high-resolution-timer.md §6 -->

--- a/doc/feature-set/Foundation/high-resolution-timers/shared-timer.md
+++ b/doc/feature-set/Foundation/high-resolution-timers/shared-timer.md
@@ -1,0 +1,64 @@
+# Shared Timer (HighResolutionSharedTimerService)
+> One thread multiplexing many periodic callbacks, each at its own rate, waking only when the soonest one is due.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [High-Resolution Timers](./README.md)
+
+## 🎯 What it solves
+
+A dedicated thread per periodic task doesn't scale: the deadline watchdog (200Hz), telemetry flush (10Hz), and epoch advancement (10-100Hz) are all lightweight, non-critical, and would otherwise each pay for an idle OS thread. `HighResolutionSharedTimerService` lets any number of independent periodic callbacks register on one thread, each keeping its own period, without one slow registration starving the others' accuracy under normal load.
+
+## ⚙️ How it works (in brief)
+
+Each `Register()` call adds a callback with its own interval to a copy-on-write registration list and lazily starts the shared thread on first use. Every cycle, the timer computes the nearest next-fire time across all active registrations — it wakes only when something is actually due, not on a fixed base tick — then fires every callback whose time has come, in sequence, on that one thread. Disposing the handle returned by `Register()` deactivates the callback; an inactive entry is lazily swept from the list. Because callbacks run sequentially, this is best-suited to fast handlers (target < 100µs) — see the contract below. The engine's own `DeadlineWatchdog` registers a 200Hz (5ms) callback on this timer.
+
+## 💻 Usage
+
+```csharp
+// Engine-internal usage — application code does not register callbacks directly.
+var shared = new HighResolutionSharedTimerService(
+    parent: resourceRegistry.Timer,
+    logger: loggerFactory.CreateLogger<HighResolutionSharedTimerService>());
+
+// Telemetry flush every 100ms
+var telemetryReg = shared.Register(
+    "TelemetryFlush",
+    intervalTicks: Stopwatch.Frequency / 10,
+    callback: (scheduled, actual) => TelemetryManager.Flush());
+
+// Epoch advancement every 10ms
+var epochReg = shared.Register(
+    "EpochAdvance",
+    intervalTicks: Stopwatch.Frequency / 100,
+    callback: (scheduled, actual) => epochManager.TryAdvance());
+
+Console.WriteLine($"Active registrations: {shared.ActiveRegistrations}, mean error: {shared.MeanTimingErrorUs:F1}us");
+
+telemetryReg.Dispose();  // unregisters; thread keeps running for the remaining callbacks
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `intervalTicks` (per `Register` call) | — (required, > 0) | This callback's own period, independent of every other registration |
+| No active registrations | — | `GetNextTick()` returns "idle"; thread polls every 100ms instead of spinning |
+
+## ⚠️ Guarantees & limits
+
+- `internal sealed` engine type plus an `internal` `ITimerRegistration` handle — used by `DeadlineWatchdog` and engine housekeeping, not constructible/registerable from application code.
+- Callback contract: target < 100µs, no blocking calls. A slow callback delays every other due callback in that cycle; invocations over 100µs are counted (`SlowInvocationCount`) per registration.
+- Exceptions thrown by a callback are caught, logged, and do not stop the timer or other registrations.
+- Wakes only for the nearest due registration — adding a slow 200ms task does not force a fast 5ms task's neighbors to tick faster, and vice versa.
+- Registration/unregistration takes a lock and copies the registration array; intended for rare events (startup/shutdown), not a per-tick hot path.
+- With the fastest registration at 5ms (the engine's deadline watchdog), the Sleep phase still engages on modern OSes, keeping the shared thread's CPU cost near zero.
+- Per-registration metrics (`InvocationCount`, `LastCallbackDuration`, `MaxCallbackDuration`, `SlowInvocationCount`) are available on the `ITimerRegistration` handle; aggregate timer metrics (tick count, missed ticks, timing error) are available on the service itself and via `IMetricSource`.
+
+## 🧪 Tests
+- [HighResolutionSharedTimerServiceTests](../../../../test/Typhon.Engine.Tests/Concurrency/HighResolutionSharedTimerServiceTests.cs) — multiple independent registrations, dispose deactivates without stopping the thread, idles when nothing is due.
+- [DeadlineWatchdogTests](../../../../test/Typhon.Engine.Tests/Concurrency/DeadlineWatchdogTests.cs) — the engine's own 200Hz consumer registered on this timer.
+
+## 🔗 Related
+
+- Parent feature: [High-Resolution Timers](./README.md)
+- Sibling: [Dedicated Timer](./dedicated-timer.md)
+- Sibling: [Deadline & Timeout Propagation](../deadline-timeout-propagation.md) — the engine's `DeadlineWatchdog` registers its 200Hz poll callback on this timer.
+
+<!-- Deep dive: claude/design/Foundation/Concurrency/high-resolution-timer.md §7 -->

--- a/doc/feature-set/Foundation/in-memory-hash-maps/README.md
+++ b/doc/feature-set/Foundation/in-memory-hash-maps/README.md
@@ -1,0 +1,34 @@
+# In-Memory Hash Maps
+> Open-addressing hash set/map types that replace `HashSet`/`Dictionary`/`ConcurrentDictionary` on hot paths, with near-zero GC pressure.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+Engine-internal hot paths build and probe sets/maps constantly — entity-ID sets for a query result, a view's tracked entities, destroyed-chunk tracking during a commit — and .NET's general-purpose collections aren't built for this: `ConcurrentDictionary` allocates a heap node per entry, modulo-based bucketing wastes cycles, and a full resize re-acquires every lock. Typhon needs a key/value container that stores entries flat and contiguous, hashes a 4/8/16-byte key in a couple of cycles, and never asks the GC to track thousands of small objects per collection.
+
+## ⚙️ How it works (in brief)
+Both variants use open addressing with linear probing over a single flat entry array, so a lookup scans contiguous memory instead of chasing pointers through scattered nodes. Deletion uses backward-shift instead of tombstones, so probe chains never degrade from accumulated deletes. The hash function is JIT-specialized on `sizeof(TKey)` — a one-multiply Fibonacci hash for 4/8/16-byte keys, a generic byte-scan fallback otherwise — so there's no runtime dispatch. `TKey` must be `unmanaged, IEquatable<TKey>`; managed key types (`string`, `Type`) aren't supported, fall back to `Dictionary`/`ConcurrentDictionary` for those.
+
+## Sub-features
+
+| Sub-feature | Concurrent | Use it when... |
+|---|---|---|
+| [Non-Concurrent HashMap\<TKey[, TValue]\>](./non-concurrent-hash-map.md) | No | Single-threaded hot path — a query result set, a per-system tracked-entity set |
+| [ConcurrentHashMap\<TKey[, TValue]\>](./concurrent-hash-map.md) | Yes (striped OLC) | Same shape, but accessed from multiple threads concurrently |
+
+## ⚠️ Guarantees & limits
+- `internal` engine types (`Typhon.Engine.Internals`) — engine plumbing, not callable from application code; none of the four types are `[PublicAPI]`.
+- `TKey` must be `unmanaged` and `IEquatable<TKey>`; `TValue` may be any type (managed values land in a parallel array instead of inline storage).
+- Lookup is typically 1.5-3x faster than `Dictionary<TKey,TValue>`; insert is roughly on par at small sizes (resize cost dominates).
+- All four implement `IDisposable` — entries live in GC-pinned arrays (Pinned Object Heap), not unmanaged memory, but still require explicit disposal to drop the reference promptly.
+- Not a drop-in replacement for every use of `Dictionary`: no ordered enumeration/range queries (use a B+Tree for that), and short-lived collections under ~100 entries don't justify the `Dispose()` discipline.
+
+## 🧪 Tests
+- [HashMapTests](../../../../test/Typhon.Engine.Tests/Collections/InMemoryHashMapTests.cs) — non-concurrent set/map: open addressing, backward-shift delete, resize at load factor.
+- [ConcurrentHashMapTests](../../../../test/Typhon.Engine.Tests/Collections/ConcurrentInMemoryHashMapTests.cs) — striped concurrent set/map: lock-free reads, per-stripe CAS writes.
+
+## 🔗 Related
+- Sub-features: [Non-Concurrent HashMap](./non-concurrent-hash-map.md), [ConcurrentHashMap](./concurrent-hash-map.md)
+- Sibling: [Page-Backed Linear Hash Map](../paged-linear-hash-map.md) — same open-addressing hashing family, persisted to page storage instead of pinned memory.
+
+<!-- Deep dive: claude/design/Foundation/Collections/in-memory-hash-map.md, claude/overview/11-utilities.md §H.1 -->

--- a/doc/feature-set/Foundation/in-memory-hash-maps/concurrent-hash-map.md
+++ b/doc/feature-set/Foundation/in-memory-hash-maps/concurrent-hash-map.md
@@ -1,0 +1,56 @@
+# ConcurrentHashMap\<TKey[, TValue]\>
+> Striped, lock-free-read hash set/map — the replacement for `ConcurrentDictionary<TKey,TValue>` on a shared hot path.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+Some hot-path collections are genuinely shared across threads — tracking destroyed chunk IDs during concurrent commits, for instance. `ConcurrentDictionary` handles this but allocates a node per entry and serializes every write through internal segment locks; under heavy contention that shows up directly in commit latency. `ConcurrentHashMap<TKey[, TValue]>` gives the same open-addressing/backward-shift design as the non-concurrent variant, partitioned into independent stripes so unrelated keys never contend, with reads that touch no shared, mutable state at all.
+
+## ⚙️ How it works (in brief)
+The table is split into independent stripes (at least 64, scaled with core count), each a self-contained open-addressing table selected by the top bits of the key's hash. Reads are lock-free: they snapshot a per-stripe version, probe, then re-check the version — if a writer raced in, the read retries. Writes take a per-stripe CAS lock (spin-then-yield, never an OS wait), so two writers only contend if they land on the same stripe. Resize happens per-stripe under that stripe's own lock; every other stripe stays fully accessible.
+
+## 💻 Usage
+```csharp
+// Set: lock-free tracking shared across concurrent commit threads
+// (the actual pattern used by ComponentTable for destroyed-chunk tracking)
+private readonly ConcurrentHashMap<int> _destroyedChunkIds = new(64);
+
+void TrackDestroyedChunkId(int chunkId) => _destroyedChunkIds.TryAdd(chunkId);
+bool wasDestroyed = _destroyedChunkIds.Contains(chunkId);   // lock-free read
+
+// Map: shared cache keyed by entity ID, read-heavy / write-light
+var cache = new ConcurrentHashMap<long, float>(1024);
+if (!cache.TryGetValue(entityId, out float cached))         // lock-free
+{
+    cached = cache.GetOrAdd(entityId, ComputeExpensiveValue(entityId));
+}
+cache.TryUpdate(entityId, newValue, comparisonValue);        // CAS-style conditional update
+cache.Dispose();
+```
+
+| Member | Concurrency |
+|---|---|
+| `Contains(key)` / `TryGetValue(key, out value)` / indexer getter | Lock-free (OLC) |
+| `TryAdd` / `TryRemove` / `GetOrAdd` / `TryUpdate` / indexer setter | Per-stripe CAS lock |
+| `Clear()` | Acquires **all** stripe locks, in order |
+| `Count` | Approximate — sums per-stripe counts without locking |
+| `EnsureCapacity(n)` | Locks and grows individual stripes as needed |
+
+## ⚠️ Guarantees & limits
+- `TKey` must be `unmanaged, IEquatable<TKey>`; `TValue` is unconstrained on the map variant.
+- Lock-free reads never block and never write shared state; they retry (cheaply) only if a write raced on the same stripe during the probe.
+- Writes only contend when two threads hash to the *same* stripe — with 64+ stripes, collision probability per individual write stays in the low single digits even at 16 concurrent writers.
+- `Count`/`StripeCount` are diagnostic, not transactional — `Count` can be stale by the time it returns under concurrent mutation.
+- Measured 3-4x faster than `ConcurrentDictionary` on disjoint-key inserts across thread counts, ~25-35% faster on a 90/10 read/write mix.
+- Enumeration (`foreach`) is best-effort and unlocked — it may observe a partial state under concurrent writes; don't use it where a consistent snapshot is required.
+- Entries live in GC-pinned arrays (Pinned Object Heap); `Dispose()` releases all stripes' references.
+- `internal` (`Typhon.Engine.Internals`) — engine plumbing only.
+
+## 🧪 Tests
+- [ConcurrentHashMapTests](../../../../test/Typhon.Engine.Tests/Collections/ConcurrentInMemoryHashMapTests.cs) — striped lock-free reads (OLC retry on a raced write), per-stripe CAS writes, `Clear()` all-stripe locking, concurrent disjoint-key inserts.
+
+## 🔗 Related
+- Parent feature: [In-Memory Hash Maps](./README.md)
+- Sibling: [Non-Concurrent HashMap](./non-concurrent-hash-map.md) — same open-addressing/backward-shift design for single-threaded hot paths.
+
+<!-- Deep dive: claude/design/Foundation/Collections/in-memory-hash-map.md §7-8.3-8.4, claude/overview/11-utilities.md §H.1 -->

--- a/doc/feature-set/Foundation/in-memory-hash-maps/non-concurrent-hash-map.md
+++ b/doc/feature-set/Foundation/in-memory-hash-maps/non-concurrent-hash-map.md
@@ -1,0 +1,62 @@
+# Non-Concurrent HashMap\<TKey[, TValue]\>
+> Single-threaded open-addressing hash set/map — the default replacement for `HashSet<T>`/`Dictionary<TKey,TValue>` on a hot path.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](../README.md)
+
+## 🎯 What it solves
+Most hot-path sets and maps in the engine are touched by exactly one thread at a time — a query's result set, a view's tracked entity-ID set, a per-system dirty-entity map rebuilt every tick. `Dictionary`/`HashSet` work, but each entry is a separate heap-tracked node and every lookup pays a `GetHashCode()`/modulo cost that's overkill for blittable keys like `long` entity IDs. `HashMap<TKey>` and `HashMap<TKey, TValue>` give the same semantics over a single flat, contiguous array with no per-entry allocation.
+
+## ⚙️ How it works (in brief)
+Entries are packed `[hash | key]` (set) or `[hash | key | value]` (map) in one array on the Pinned Object Heap, sized to a power of two and grown by doubling once the 0.75 load factor is crossed. Lookups probe linearly from the key's hash bucket; deletes use backward-shift to avoid leaving tombstones behind. If `TValue` contains managed references, values are stored in a parallel array instead of inline — transparent to the caller, just slightly slower than the fully-inline unmanaged path.
+
+## 💻 Usage
+```csharp
+// Set: tracking a result set of entity IDs (the actual pattern used by EcsQuery's full-scan path)
+var pkResult = new HashMap<long>();          // initialCapacity defaults to 64
+reader.ExecuteFullScan(plan, evaluators, ct, tx, pkResult);
+
+foreach (long pk in pkResult)
+{
+    var entityId = EntityId.FromRaw(pk);
+    // ...
+}
+pkResult.Dispose();
+
+// Map: caching a derived value per key
+var cache = new HashMap<int, float>(256);
+if (!cache.TryGetValue(key, out float cached))
+{
+    cached = cache.GetOrAdd(key, ComputeExpensiveValue(key));
+}
+cache.TryUpdate(key, newValue);              // no-op if key absent
+cache[key] = newValue;                       // indexer adds-or-overwrites
+cache.Dispose();
+```
+
+| Member | Effect |
+|---|---|
+| `TryAdd(key[, value])` | Insert if absent; `false` if the key already exists (value unchanged) |
+| `Contains(key)` / `TryGetValue(key, out value)` | O(1) average lookup |
+| `TryRemove(key[, out value])` | Backward-shift delete, no tombstone |
+| `GetOrAdd(key, value)` | Atomic-within-thread get-or-insert (map only) |
+| `EnsureCapacity(n)` | Pre-grow to avoid resizes during a known-size bulk build |
+| `Clone()` | Independent snapshot copy — used for old-set/new-set delta comparisons (set only) |
+| `GetPartitionEnumerator(i, n)` | Contiguous index-range slice for manual parallel iteration (set only) |
+
+## ⚠️ Guarantees & limits
+- Single-threaded only — no internal synchronization; concurrent access from multiple threads is undefined behavior. Use [ConcurrentHashMap](./concurrent-hash-map.md) instead.
+- `TKey` must be `unmanaged, IEquatable<TKey>`; `TValue` is unconstrained on the map variant.
+- O(1) average for add/lookup/remove; worst case O(n) under pathological hash collisions (not expected with the built-in hash strategy).
+- Lookup is ~1.5-3x faster than `Dictionary<TKey,TValue>` in measured benchmarks; insert is roughly on par (resize cost dominates at small sizes).
+- Entries live in a GC-pinned array, not unmanaged memory — `Dispose()` drops the reference but the GC still reclaims it; disposal isn't strictly required for correctness, only for prompt release.
+- `internal` (`Typhon.Engine.Internals`) — engine plumbing only.
+
+## 🧪 Tests
+- [HashMapTests](../../../../test/Typhon.Engine.Tests/Collections/InMemoryHashMapTests.cs) — `TryAdd`/`Contains`/`TryGetValue`/`TryRemove`/`GetOrAdd`/`Clone()`, backward-shift delete, resize at 0.75 load factor.
+- [HashMapPartitionTests](../../../../test/Typhon.Engine.Tests/Collections/HashMapPartitionTests.cs) — `GetPartitionEnumerator` contiguous-range slicing for manual parallel iteration.
+
+## 🔗 Related
+- Parent feature: [In-Memory Hash Maps](./README.md)
+- Sibling: [ConcurrentHashMap](./concurrent-hash-map.md) — same design, striped for safe concurrent access when a hot path is shared across threads.
+
+<!-- Deep dive: claude/design/Foundation/Collections/in-memory-hash-map.md §8.1-8.2, claude/overview/11-utilities.md §H.1 -->

--- a/doc/feature-set/Foundation/memory-allocators.md
+++ b/doc/feature-set/Foundation/memory-allocators.md
@@ -1,0 +1,60 @@
+# Memory Allocators
+> Pinned/unmanaged memory primitives every page cache, segment, and hash-map layers on for stable, GC-immune addresses.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](./README.md)
+
+## 🎯 What it solves
+
+Typhon's hot paths hold raw pointers into engine-owned memory for microseconds at a time — page cache buffers, B+Tree node arenas, hash-map backing storage. A garbage collector that's free to move or compact objects mid-access would invalidate those pointers and corrupt unsafe code. Every such allocation also needs to show up somewhere when something leaks: a forgotten unmanaged block doesn't throw, it just silently grows the process. Memory Allocators give engine subsystems addresses that never move and a parent-owned accounting trail for every byte taken.
+
+## ⚙️ How it works (in brief)
+
+A `MemoryAllocator` hands out two flavors of block: unmanaged ones backed by `NativeMemory.AlignedAlloc` (no GC interaction at all, optional power-of-2 alignment) and managed ones backed by a POH byte array (GC-allocated but pinnable on demand via `GCHandle`). Every block is created with an explicit owning resource and is registered as that owner's child in the engine's resource tree, not the allocator's — so a leaked block shows up under the subsystem that requested it, not lost in a flat pool. Higher-level allocators (`BlockAllocator` for fixed-stride slots, `ChainedBlockAllocator` for linked chains, `StructAllocator<T>` for typed slots) all draw their backing storage from a `MemoryAllocator` and add their own allocation/free semantics on top.
+
+## 💻 Usage
+
+Application code never calls the allocator directly — it's wired once at host startup and consumed internally by every engine subsystem that needs raw memory (page cache, B+Tree arenas, hash maps):
+
+```csharp
+services.AddResourceRegistry();
+services.AddMemoryAllocator(opts => opts.Name = "MyApp Memory Allocator");
+// ... AddPagedMemoryMappedFile / AddDatabaseEngine etc. resolve IMemoryAllocator from DI
+```
+
+The only surface application code can touch directly is `IMemoryResource` — implement it on a custom resource type if you want it to report its size into the resource tree:
+
+```csharp
+internal sealed class MyCache : IMemoryResource
+{
+    public int EstimatedMemorySize => _bufferBytes; // excludes child resources
+    // ... rest of IResource members
+}
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `MemoryAllocatorOptions.Name` | `"Default Memory Allocator"` | Display name of the allocator's resource-tree node. |
+
+## ⚠️ Guarantees & limits
+
+- **Stable addresses** — unmanaged blocks never move for their lifetime; managed blocks only move while unpinned, and pinning is ref-counted so concurrent pinners are safe.
+- **Leak visibility, not leak prevention** — every block is a child resource of its caller, so an undisposed block is visible in the resource tree (and via `MemoryAllocator`'s `PinnedBytes` / `PinnedLiveBlocks` metrics) rather than silently invisible; nothing reclaims it automatically.
+- **Resource tree is organized by owner, not by allocator** — a block's parent is the subsystem that requested it (e.g. a hash map or chained allocator), so diagnostics group memory by what's using it.
+- **Alignment is caller's choice, not free** — unmanaged allocation accepts a power-of-2 alignment; requesting one larger than the natural size wastes the padding (tracked via the `Memory:AlignmentWaste` profiler event when alignment-waste tracing is on).
+- **No automatic compaction or defragmentation** — block allocators (`BlockAllocator`, `ChainedBlockAllocator`) hand out fixed-stride slots from a freelist; freeing a slot makes it reusable but never shrinks the backing block.
+- **Profiler-attributed** — every alloc/free carries a 16-bit source tag so allocation volume can be attributed back to the originating subsystem when memory tracing is enabled; zero cost when it's off.
+
+## 🧪 Tests
+- [MemoryAllocatorInstrumentationTests](../../../test/Typhon.Engine.Tests/Memory/MemoryAllocatorInstrumentationTests.cs) — `PinnedBytes`/`PinnedLiveBlocks` counters, peak-never-regresses, source-tag attribution and default "unattributed" tag.
+- [BlockAllocatorTests](../../../test/Typhon.Engine.Tests/Memory/BlockAllocatorTests.cs) — fixed-stride slot alloc/free/freelist reuse via `BlockAllocator`.
+- [StructAllocatorTests](../../../test/Typhon.Engine.Tests/Memory/BlockAllocatorTests.cs) — typed slots with `ICleanable` reset-on-free via `StructAllocator<T>` (same file as `BlockAllocatorTests`).
+- [ChainedBlockAllocatorTests](../../../test/Typhon.Engine.Tests/Memory/ChainedBlockAllocatorTests.cs) — linked-chain block growth via `ChainedBlockAllocator`.
+
+## 🔗 Related
+
+- Related feature: [Resource Tree & Registry](../Resources/resource-tree-registry.md) — how `IMemoryResource` plugs into the broader resource tree
+- Sibling: [Page Allocation & Occupancy Tracking](../Storage/page-allocation-occupancy.md) — the page cache draws its backing storage from this allocator.
+
+<!-- Deep dive: claude/design/Foundation/Memory/memory-allocators.md -->
+<!-- Overview: claude/overview/11-utilities.md §Category F -->
+<!-- ADR: claude/adr/009-pinned-memory-unsafe-code.md -->

--- a/doc/feature-set/Foundation/paged-linear-hash-map.md
+++ b/doc/feature-set/Foundation/paged-linear-hash-map.md
@@ -1,0 +1,71 @@
+# Page-Backed Linear Hash Map
+> O(1) exact-match key/value index, persisted in fixed-size chunks, with crash-safe rebuild instead of WAL logging.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Foundation](./README.md)
+
+## 🎯 What it solves
+
+Some indexes only ever need exact-match lookup — no range scans, no ordering — and for those, walking a B+Tree's `O(log n)` node chain on every lookup spends cycles a flat hash table wouldn't. `PagedHashMap<TKey, TValue, TStore>` is that flat alternative: an `O(1)` average-case lookup/insert/delete structure that lives in the same page-backed storage as everything else in the engine, grows incrementally (no stop-the-world resize), and survives a crash without ever touching the WAL. Its first consumer is spatial Layer-1 occupancy: "is this grid cell occupied, and by what" — a pure exact-match question at high update rate.
+
+## ⚙️ How it works (in brief)
+
+Entries are grouped into fixed-size bucket chunks addressed by `hash(key) mod bucketCount`; each bucket grows an overflow chain only when its chunk fills up. The map grows one bucket at a time (linear hashing) instead of doubling the whole table at once, so no single insert pays for a full rehash. Each bucket chunk carries its own optimistic-concurrency (OLC) version field, so reads are lock-free and writers only ever serialize with other writers on the *same* bucket — contention on unrelated keys never blocks. The map keeps no write-ahead log entries of its own: because it is fully derived from other durable state (e.g., the entity data it indexes), a crash is handled by rebuilding it from that source rather than replaying a log.
+
+## 💻 Usage
+
+`PagedHashMap<TKey, TValue, TStore>` is `internal` — engine plumbing consumed by other subsystems (currently `SpatialIndexState.OccupancyMap`), not called from application code. A consumer creates one over a dedicated `ChunkBasedSegment` and drives it through a `ChunkAccessor`:
+
+```csharp
+// One hash map owns its segment exclusively (chunk 0 is reserved for its meta).
+using var guard = EpochGuard.Enter(epochManager);
+var segment = new ChunkBasedSegment<PersistentStore>(epochManager, new PersistentStore(mmf), stride: 256);
+var occupancyMap = PagedHashMap<long, int, PersistentStore>.Create(
+    segment, initialBuckets: 64, allowMultiple: false, changeSet);
+
+// Insert / lookup / remove, all under a ChunkAccessor scope.
+var accessor = segment.CreateChunkAccessor(changeSet);
+try
+{
+    long cellKey = PackCellKey2D(cellX, cellY);
+    occupancyMap.Insert(cellKey, entityCount, ref accessor, changeSet);
+
+    if (occupancyMap.TryGet(cellKey, out int count, ref accessor))
+    {
+        // cell is occupied
+    }
+
+    occupancyMap.Remove(cellKey, out _, ref accessor, changeSet);
+}
+finally
+{
+    accessor.Dispose();
+}
+
+// Reconnect to a persisted map after restart.
+var reopened = PagedHashMap<long, int, PersistentStore>.Open(segment);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `initialBuckets` (`Create`) | 64 | Initial bucket count; must be a power of 2. Higher avoids early splits for known-large maps. |
+| `allowMultiple` | `false` | `true` stores multiple values per key via an internal variable-sized buffer; changes `Insert`/`Remove` semantics and disables `Upsert`. |
+
+## ⚠️ Guarantees & limits
+
+- **O(1) average lookup/insert/delete** — typically 2-3 chunk reads per operation, versus a B+Tree's `O(log n)` node chain.
+- **No range or prefix queries** — exact-match only; reach for the B+Tree index variants when ordering matters.
+- **Lock-free reads, per-bucket write serialization** — writers on different buckets never block each other; only same-bucket writers contend.
+- **Gradual growth** — splits one bucket at a time as load factor crosses 0.75, never a stop-the-world full rehash.
+- **No WAL participation** — the map is a derived structure; crash recovery rebuilds it from its authoritative source rather than replaying log entries. It must never be the only copy of data it indexes.
+- **`internal` type** — not part of the public surface; not yet wired into the `[Index]` attribute / `ComponentTable` index system (planned future integration).
+- One hash map owns its `ChunkBasedSegment` exclusively — chunk 0 is hardcoded as its meta chunk, so multiple maps cannot share a segment.
+
+## 🧪 Tests
+- [PagedHashMapTests](../../../test/Typhon.Engine.Tests/Data/HashMapTests.cs) — meta/directory struct layout, linear-hash bucket resolution across splits, `Create`/`Open` round-trip, insert/lookup/remove over a `ChunkAccessor`.
+
+## 🔗 Related
+
+- Compare: [Specialized B+Tree Key-Size Variants](../Indexing/btree-key-variants.md) — the ordered/range-query alternative
+- Sibling: [In-Memory Hash Maps](./in-memory-hash-maps/README.md) — same open-addressing/backward-shift hashing family, kept in pinned memory instead of page storage.
+
+<!-- Deep dive: claude/design/Foundation/Collections/linear-hash-map.md -->

--- a/doc/feature-set/Hosting/README.md
+++ b/doc/feature-set/Hosting/README.md
@@ -1,0 +1,21 @@
+# Hosting
+> A thin `Microsoft.Extensions.DependencyInjection` integration seam: extension methods that register the engine's top-level singletons (resource registry, allocator, epoch manager, timer, watchdog, paged MMF, database engine) and bind their option types via `IOptions<T>`, giving an application a single canonical chain to bootstrap a working `DatabaseEngine`. Singleton/Scoped/Transient twins let test and tooling hosts scope an engine instance per DI scope, an injectable `IWalFileIO` seam swaps the WAL's disk backend for an in-memory one, and small conveniences (`AddTyphonProfiler`, `EnsureFileDeleted`) round out startup/teardown for tests and tooling.
+
+> 🔬 **Recommended:** Hosting doesn't have its own in-depth-overview chapter — read [in-depth-overview/01-foundation.md §9](../../in-depth-overview/01-foundation.md) (Chapter 01: Foundation, alongside the primitives it wires up) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [DI Engine Bootstrap Chain](di-bootstrap-chain/README.md) | `Add*()` extension methods on `IServiceCollection` that register and wire the engine's top-level singletons into a working `DatabaseEngine` | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Singleton/Scoped/Transient Lifetime Variants](di-bootstrap-chain/lifetime-variants.md) | Every `Add*` with a lifetime choice ships as `Add.../AddScoped.../AddTransient...` twins sharing one factory delegate | ✅ Implemented | 🔵 Core |
+| [Engine Options Configuration Surface](engine-options-configuration/README.md) | `IOptions<T>`-based configuration for engine services, set via configure delegates on each `Add*()` DI call | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Options Validation Hooks](engine-options-configuration/options-validation-stubs.md) | `AddOptions<T>().Validate(...)` is wired on every options type but its predicate is a no-op stub today; `ResourceOptions.Validate()` / `PagedMMFOptions.IsValid` are the real, directly-callable fail-fast checks | 🚧 Partial | 🟣 Advanced |
+| [Clean-Slate Database File Deletion](ensure-file-deleted.md) | `EnsureFileDeleted<TO>(IServiceProvider)` resolves `IOptions<TO>` in a fresh scope and deletes the backing database file it points at — the supported way to start test/tooling runs from a clean slate | ✅ Implemented | 🔵 Core |
+| [Profiler Launch Override Hook](profiler-launch-override-hook.md) | `AddTyphonProfiler(Func<ProfilerLaunchConfig,ProfilerLaunchConfig>)` lets a host adjust the profiler launch config (resolved from `typhon.telemetry.json` + env) in code, e.g. to layer CLI args on top; zero-code default self-wiring is unaffected if not called | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Pluggable WAL I/O Backend (IWalFileIO seam)](wal-io-injection-seam.md) | `AddDatabaseEngine` resolves an optional internal `IWalFileIO` from the container so tests/benchmarks can register `InMemoryWalFileIO` and run the full WAL + checkpoint pipeline with zero disk I/O; production falls back to the disk-backed `WalFileIO` — the interface and both implementations are `internal`, not reachable from application code | ✅ Implemented |

--- a/doc/feature-set/Hosting/di-bootstrap-chain/README.md
+++ b/doc/feature-set/Hosting/di-bootstrap-chain/README.md
@@ -1,0 +1,95 @@
+# DI Engine Bootstrap Chain
+> One `using`, one fluent chain of `Add*` calls — wires the engine's singletons into your DI container.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Hosting](../README.md)
+
+## 🎯 What it solves
+
+A `DatabaseEngine` needs a page cache, a memory allocator, an epoch manager, a deadline watchdog
+and a shared timer all constructed and cross-wired correctly before it can be used — get the
+wiring or the disposal order wrong and you leak native memory-mapped-file handles or resource-tree
+nodes. `ServiceCollectionExtensions` packages that wiring as ordinary
+`Microsoft.Extensions.DependencyInjection` extension methods, so a host application stands up the
+engine the same way it stands up any other ASP.NET Core or generic-host service: register it once,
+resolve `DatabaseEngine` from the container.
+
+## ⚙️ How it works (in brief)
+
+Each `Add*` method is a thin factory registration: it resolves its own dependencies from
+`IServiceProvider` (e.g. `AddManagedPagedMMF` needs `IMemoryAllocator`, `EpochManager` and
+`IResourceRegistry` already registered) and binds an options type via `IOptions<T>` if one exists.
+Call order doesn't matter — registration is lazy, dependencies are only resolved when something
+asks the container for `DatabaseEngine`. Most extensions have three lifetime variants (see the
+[Singleton/Scoped/Transient Lifetime Variants](./lifetime-variants.md) sub-feature); the canonical
+setup below is all-singleton.
+
+## 💻 Usage
+
+```csharp
+using Typhon.Engine;
+
+var services = new ServiceCollection();
+services.AddLogging(b => b.AddFilter((_, level) => level >= LogLevel.Warning));
+
+services
+    .AddResourceRegistry()
+    .AddMemoryAllocator()
+    .AddEpochManager()
+    .AddHighResolutionSharedTimer()
+    .AddDeadlineWatchdog()
+    .AddManagedPagedMMF(opts =>
+    {
+        opts.DatabaseName      = "MyApp";
+        opts.DatabaseDirectory = @"C:\data\myapp";
+        opts.DatabaseCacheSize = 65536UL * 8192;   // 512 MiB page cache
+    })
+    .AddDatabaseEngine(engineOpts =>
+    {
+        engineOpts.Wal = new WalWriterOptions
+        {
+            WalDirectory = @"C:\data\myapp\wal",
+            UseFUA       = false,
+        };
+    });
+
+var serviceProvider = services.BuildServiceProvider();
+var engine = serviceProvider.GetRequiredService<DatabaseEngine>();
+```
+
+| Extension | Registers | Options type |
+|---|---|---|
+| `AddResourceRegistry` | `IResourceRegistry` | `ResourceRegistryOptions` |
+| `AddMemoryAllocator` | `IMemoryAllocator` | `MemoryAllocatorOptions` |
+| `AddEpochManager` | `EpochManager` | — |
+| `AddHighResolutionSharedTimer` | `HighResolutionSharedTimerService` | — |
+| `AddDeadlineWatchdog` | `DeadlineWatchdog` | — |
+| `AddManagedPagedMMF` | `ManagedPagedMMF` | `ManagedPagedMMFOptions` |
+| `AddPagedMemoryMappedFile` | `PagedMMF` | `PagedMMFOptions` |
+| `AddDatabaseEngine` | `DatabaseEngine` | `DatabaseEngineOptions` |
+
+## ⚠️ Guarantees & limits
+
+- Call order is irrelevant — the dependency graph is enforced at resolution time, not registration
+  time. Omit a required `Add*` and `GetRequiredService<DatabaseEngine>()` throws at the first
+  missing dependency, not at startup.
+- Options validation is wired but unimplemented (`Validate(_ => true)` stubs) — validate your own
+  option values before passing the `configure` delegate if correctness matters.
+- `EnsureFileDeleted<TO>(provider)` is a test/tooling convenience that opens a scope, resolves
+  `IOptions<TO>`, and deletes the backing database file — not part of normal application startup.
+- One `IResourceRegistry` per process is the intended topology; multiple `DatabaseEngine`
+  instances are siblings under the same registry, not separate trees.
+- See [Lifetime Variants](./lifetime-variants.md) for what's safe to mix when you move off the
+  all-singleton default.
+
+## 🧪 Tests
+
+- [DatabaseFileLockingTests](../../../../test/Typhon.Engine.Tests/Storage/DatabaseFileLockingTests.cs) — builds the full `Add*` chain by hand (outside `TestBase`) and exercises both the happy path and wiring-adjacent failure modes (stale/live/cross-machine lock, corrupt lock file)
+
+## 🔗 Related
+
+- Source: [`TyphonBuilderExtensions.cs`](../../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs)
+- Reference consumer: `tools/Typhon.Workbench/Sessions/EngineLifecycle.cs`
+- Related feature: [Pluggable WAL I/O Backend](../wal-io-injection-seam.md)
+- Sub-features: [Singleton/Scoped/Transient Lifetime Variants](./lifetime-variants.md)
+
+<!-- Deep dive: claude/design/Hosting/di-extensions.md -->

--- a/doc/feature-set/Hosting/di-bootstrap-chain/lifetime-variants.md
+++ b/doc/feature-set/Hosting/di-bootstrap-chain/lifetime-variants.md
@@ -1,0 +1,106 @@
+# Singleton/Scoped/Transient Lifetime Variants
+> Every `Add*` that has a lifetime choice ships as `Add...`, `AddScoped...`, and `AddTransient...` twins.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [DI Engine Bootstrap Chain](./README.md)
+
+## 🎯 What it solves
+
+The canonical setup is all-singleton, but not every host wants that. Test fixtures want one
+isolated `DatabaseEngine` (own page cache, own WAL backend) per test while still sharing the
+process-wide epoch manager and resource registry. Tooling that probes options wants a disposable,
+one-shot instance. Rather than force a single topology, each engine service that has a meaningful
+lifetime choice is registered through three parallel extension methods that differ only in the
+`ServiceDescriptor` lifetime they produce.
+
+## ⚙️ How it works (in brief)
+
+`Add<X>()`, `AddScoped<X>()`, and `AddTransient<X>()` share the same factory delegate — they
+resolve the same dependencies from `IServiceProvider` and bind the same options type — only the
+registered `ServiceLifetime` differs. This is offered for `IResourceRegistry`,
+`IMemoryAllocator`, `EpochManager`, `PagedMMF`/`ManagedPagedMMF`, and `DatabaseEngine`.
+`AddHighResolutionSharedTimer` and `AddDeadlineWatchdog` have no scoped/transient twin — they're
+singleton-only, because each owns (or multiplexes callbacks on) a single background thread that's
+meant to be shared process-wide, not duplicated per scope.
+
+The standard DI lifetime rule applies: a service can only depend on services of an equal or longer
+lifetime. A **singleton** `DatabaseEngine` requires every upstream dependency to also be singleton;
+a **scoped** one can sit on singleton dependencies — the common test pattern (share
+`IResourceRegistry`/`EpochManager`/timers process-wide, scope `ManagedPagedMMF`/`DatabaseEngine`).
+
+## 💻 Usage
+
+```csharp
+// TestBase's pattern: shared process-wide primitives, one scoped engine per test provider.
+services
+    .AddResourceRegistry()
+    .AddMemoryAllocator()
+    .AddEpochManager()
+    .AddHighResolutionSharedTimer()
+    .AddDeadlineWatchdog()
+    .AddScopedManagedPagedMemoryMappedFile(opts =>
+    {
+        opts.DatabaseName      = "Fixture1";
+        opts.DatabaseDirectory = tempDir;
+        opts.DatabaseCacheSize = 65536UL * 512;
+    })
+    .AddScopedDatabaseEngine(engineOpts => { /* ... */ });
+
+services.AddScoped<IWalFileIO>(_ => new InMemoryWalFileIO());   // scoped: fresh backend per scope
+
+var provider = services.BuildServiceProvider();
+
+using (var scope = provider.CreateScope())
+{
+    var engine = scope.ServiceProvider.GetRequiredService<DatabaseEngine>();
+    // ... use engine ...
+}   // scope disposal tears down the page cache + WAL backend
+
+// Reopen the SAME database (crash/recovery tests): create the next scope only after this one is
+// disposed — see the IOptions<T> caveat below.
+using (var scope2 = provider.CreateScope())
+{
+    var engine2 = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>();
+}
+```
+
+| Extension family | Lifetimes available |
+|---|---|
+| `AddResourceRegistry` / `AddScopedResourceRegistry` / `AddTransientResourceRegistry` | Singleton, Scoped, Transient |
+| `AddMemoryAllocator` / `AddScopedMemoryAllocator` / `AddTransientMemoryAllocator` | Singleton, Scoped, Transient |
+| `AddEpochManager` / `AddScopedEpochManager` / `AddTransientEpochManager` | Singleton, Scoped, Transient |
+| `AddPagedMemoryMappedFile` / `AddScopedPagedMemoryMappedFile` / `AddTransientPagedMemoryMappedFile` | Singleton, Scoped, Transient |
+| `AddManagedPagedMMF` / `AddScopedManagedPagedMemoryMappedFile` / `AddTransientManagedPagedMemoryMappedFile` | Singleton, Scoped, Transient |
+| `AddDatabaseEngine` / `AddScopedDatabaseEngine` / `AddTransientDatabaseEngine` | Singleton, Scoped, Transient |
+| `AddHighResolutionSharedTimer` | Singleton only |
+| `AddDeadlineWatchdog` | Singleton only |
+
+## ⚠️ Guarantees & limits
+
+- **Lifetime direction is enforced by the container, not the engine.** Registering a singleton
+  `DatabaseEngine` on top of a scoped `ManagedPagedMMF` throws at
+  `BuildServiceProvider(validateScopes: true)` (or on first resolution without that flag) — a
+  standard DI captive-dependency failure, not an engine-specific check.
+- **Scoped is the supported test-isolation pattern — one live scope at a time per provider.** A
+  scope's `DatabaseEngine` gets its own page cache and (if `IWalFileIO` is also scoped) its own
+  in-memory WAL backend; disposing the scope tears it down without touching the shared singletons
+  below it. Two *concurrently live* scopes from the same provider are not independent: `IOptions<T>`
+  is resolved once and cached for the provider's lifetime, so both would target the same configured
+  database path.
+- **Transient constructs a brand-new native-backed instance on every resolution** — for
+  `ManagedPagedMMF`/`DatabaseEngine` a new page cache each time something asks the container.
+  Reserve it for one-shot experiments, not services resolved repeatedly.
+- **No scoped/transient `HighResolutionSharedTimer` or `DeadlineWatchdog`.** Both are
+  process-wide by design; every scope that needs a watchdog shares the one singleton instance.
+
+## 🧪 Tests
+
+- [DatabaseFileLockingTests](../../../../test/Typhon.Engine.Tests/Storage/DatabaseFileLockingTests.cs) — builds a manual Scoped chain (`AddScopedManagedPagedMemoryMappedFile` + `AddScopedDatabaseEngine`) outside `TestBase`, then verifies scope-disposal tears the engine (and its lock file) down
+
+## 🔗 Related
+
+- Source: [`TyphonBuilderExtensions.cs`](../../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs)
+- Reference consumer: `test/Typhon.Engine.Tests/TestBase.cs`
+- Related feature: [Pluggable WAL I/O Backend](../wal-io-injection-seam.md)
+- Parent feature: [DI Engine Bootstrap Chain](./README.md)
+
+<!-- Deep dive: claude/design/Hosting/di-extensions.md -->

--- a/doc/feature-set/Hosting/engine-options-configuration/README.md
+++ b/doc/feature-set/Hosting/engine-options-configuration/README.md
@@ -1,0 +1,91 @@
+# Engine Options Configuration Surface
+> `IOptions<T>`-based configuration for every engine service, set with a `configure` delegate on each `Add*()` call.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Hosting](../README.md)
+
+## 🎯 What it solves
+
+Bootstrapping a `DatabaseEngine` means tuning several independent subsystems — page cache size,
+WAL directory and durability knobs, lock timeouts, MVCC cleanup cadence, transient storage, and
+background statistics. Hardcoding these in constructors would force every consumer to know the
+engine's internal wiring and recompile for any tuning change. The Options Configuration Surface
+gives every DI registration a single, idiomatic .NET pattern — a `configure` delegate bound
+through `Microsoft.Extensions.Options` — to set these values at startup without touching how the
+services are constructed or wired together.
+
+## ⚙️ How it works (in brief)
+
+Each `Add*` extension (`AddDatabaseEngine`, `AddManagedPagedMMF`, `AddPagedMemoryMappedFile`,
+`AddMemoryAllocator`, `AddResourceRegistry`) calls `services.AddOptions<TOptions>()` and applies
+your `configure` delegate via `.Configure(...)`. The resulting `IOptions<TOptions>` is resolved
+inside that service's factory when the container first builds it, so values are effectively frozen
+at `BuildServiceProvider()` for singleton registrations. `DatabaseEngineOptions` is a composite: it
+groups per-subsystem option types (`Resources`, `Timeouts`, `DeferredCleanup`, `Wal`, `Transient`,
+`Statistics`) instead of one flat bag of properties, so you only touch the knobs you need.
+
+## 💻 Usage
+
+```csharp
+var services = new ServiceCollection();
+services.AddLogging(b => b.AddFilter((_, level) => level >= LogLevel.Warning));
+
+services
+    .AddResourceRegistry()
+    .AddMemoryAllocator()
+    .AddEpochManager()
+    .AddHighResolutionSharedTimer()
+    .AddDeadlineWatchdog()
+    .AddManagedPagedMMF(opts =>
+    {
+        opts.DatabaseName      = "MyGame";
+        opts.DatabaseDirectory = @"C:\Data\MyGame";
+        opts.DatabaseCacheSize = 65536UL * 8192;      // 512 MiB page cache
+    })
+    .AddDatabaseEngine(engineOpts =>
+    {
+        engineOpts.Resources.MaxActiveTransactions = 2000;
+        engineOpts.Wal.WalDirectory = @"C:\Data\MyGame\wal";
+        engineOpts.Wal.UseFUA       = false;           // GroupCommit workload, no per-write FUA
+        engineOpts.Statistics       = null;            // disable background stats worker
+    });
+
+var provider = services.BuildServiceProvider();
+var engine   = provider.GetRequiredService<DatabaseEngine>();
+```
+
+| Options type | Registered by | Key knobs |
+|---|---|---|
+| `DatabaseEngineOptions` | `AddDatabaseEngine` | `Resources`, `Timeouts`, `DeferredCleanup`, `Wal`, `Transient`, `Statistics` |
+| `PagedMMFOptions` / `ManagedPagedMMFOptions` | `AddPagedMemoryMappedFile` / `AddManagedPagedMMF` | `DatabaseName`, `DatabaseDirectory`, `DatabaseCacheSize` |
+| `MemoryAllocatorOptions` | `AddMemoryAllocator` | `Name` (diagnostics label only) |
+| `ResourceRegistryOptions` | `AddResourceRegistry` | `Name` (diagnostics label only) |
+
+## ⚠️ Guarantees & limits
+
+- `configure` is optional on every `Add*` call — omit it to run on defaults (2 MiB page cache,
+  the engine's minimum; WAL in `./wal`; `UseFUA = true`; etc.).
+- Options are read once, effectively at `BuildServiceProvider()` for singletons — mutating an
+  already-resolved `IOptions<T>.Value` afterward has no effect on a running engine.
+- Calling the same `Add*()` more than once accumulates `Configure` callbacks (every registered
+  delegate runs, in order) rather than replacing the previous one — avoid double-registration.
+- Scoped/Transient variants (`AddScopedDatabaseEngine`, `AddTransientManagedPagedMemoryMappedFile`,
+  etc.) accept the same `configure` delegate, but mixing lifetimes across the dependency chain
+  risks a captive-dependency failure under `BuildServiceProvider(validateScopes: true)` — the
+  canonical setup is all-singleton.
+- `MemoryAllocatorOptions` and `ResourceRegistryOptions` are configurable but, in practice, only
+  expose a diagnostics `Name` today — there is nothing else to tune on them.
+- See [Options Validation Hooks](./options-validation-stubs.md) for what configuration mistakes
+  are — and are not — caught before they reach the engine.
+
+## 🧪 Tests
+
+- [ResourceOptionsTests](../../../../test/Typhon.Engine.Tests/Resources/ResourceOptionsTests.cs) — `DatabaseEngineOptions.Resources` composite property and its defaults (`DatabaseEngineOptions_HasResourceOptionsProperty` / `_ResourceOptions_HasDefaults`)
+- [TransactionChainTests](../../../../test/Typhon.Engine.Tests/Data/TransactionChainTests.cs) — `TransactionChainMaxActiveTests` fixture configures `AddScopedDatabaseEngine(options => options.Resources.MaxActiveTransactions = ...)` and proves the `configure` delegate value actually reaches and is enforced by the running engine
+
+## 🔗 Related
+
+- Source: [`TyphonBuilderExtensions.cs`](../../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs), [`DatabaseEngine.cs` — `DatabaseEngineOptions`](../../../../src/Typhon.Engine/Ecs/public/DatabaseEngine.cs), [`PagedMMFOptions.cs`](../../../../src/Typhon.Engine/Storage/public/PagedMMFOptions.cs), [`WalWriterOptions.cs`](../../../../src/Typhon.Engine/Durability/public/WalWriterOptions.cs)
+- Sub-features: [Options Validation Hooks](./options-validation-stubs.md)
+- Sibling: [DI Engine Bootstrap Chain](../di-bootstrap-chain/README.md) — the `Add*()` calls this surface's `configure` delegates bind options onto.
+
+<!-- Deep dive: claude/design/Hosting/di-extensions.md — Options Reference (Quick), claude/overview/README.md -->

--- a/doc/feature-set/Hosting/engine-options-configuration/options-validation-stubs.md
+++ b/doc/feature-set/Hosting/engine-options-configuration/options-validation-stubs.md
@@ -1,0 +1,80 @@
+# Options Validation Hooks
+> The `AddOptions<T>().Validate(...)` wiring exists on every options type today, but its predicate is a no-op stub.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Hosting](../README.md)
+
+## 🎯 What it solves
+
+.NET's Options pattern supports fail-fast validation: `AddOptions<T>().Validate(predicate)` runs
+the predicate on first `IOptions<T>.Value` access and throws `OptionsValidationException` before
+bad configuration reaches a service constructor. Typhon attaches this hook to every options type
+(`DatabaseEngineOptions`, `PagedMMFOptions`/`ManagedPagedMMFOptions`, `MemoryAllocatorOptions`,
+`ResourceRegistryOptions`) so real validation logic has one designated place to land per
+subsystem, without changing any `Add*()` call signature when it does.
+
+## ⚙️ How it works (in brief)
+
+Every `Add*` extension that accepts a `configure` delegate attaches
+`optionsBuilder.Validate(_ => { /* TODO */ return true; })` right after `.Configure(configure)`.
+All four sites currently return `true` unconditionally — the hook fires but never rejects
+anything. Two option types separately expose their own real, standalone validation you can call
+yourself: `ResourceOptions.Validate()` (throws `InvalidOperationException` if page cache + WAL +
+shadow-buffer sizing exceeds `TotalMemoryBudgetBytes`) and `PagedMMFOptions.IsValid` /
+`Validate(bool silent, out string)` (checks `DatabaseName`, `DatabaseDirectory`, and
+`DatabaseCacheSize` well-formedness). Neither is wired into the `Add*()`/DI path — invoking them
+is on you.
+
+## 💻 Usage
+
+```csharp
+var resourceOptions = new ResourceOptions
+{
+    PageCachePages         = 262144,      // 2 GB
+    MaxActiveTransactions  = 1000,
+    WalRingBufferSizeBytes = 8 << 20,     // 8 MB
+};
+resourceOptions.Validate();               // throws InvalidOperationException if over budget — call it yourself
+
+var mmfOptions = new ManagedPagedMMFOptions { DatabaseName = "MyGame", DatabaseCacheSize = 4096 };
+if (!mmfOptions.IsValid)
+{
+    mmfOptions.Validate(silent: false, out _);   // throws with a readable message
+}
+
+services
+    .AddManagedPagedMMF(o =>
+    {
+        o.DatabaseName      = mmfOptions.DatabaseName;
+        o.DatabaseCacheSize = mmfOptions.DatabaseCacheSize;
+    })
+    .AddDatabaseEngine(o => o.Resources = resourceOptions);
+    // AddOptions<T>().Validate(...) still runs for both calls above, but its predicate
+    // always returns true — it will not catch a bad DatabaseCacheSize or budget overrun.
+```
+
+## ⚠️ Guarantees & limits
+
+- The `.Validate(...)` hook attached inside `Add*()` is wired but **non-functional** — its
+  predicate is `_ => true` (marked `// TODO` in source, four separate sites). It never throws
+  `OptionsValidationException`, regardless of how invalid the configured values are.
+- The hook is only attached when a `configure` delegate is passed to the `Add*()` call — calling
+  it with no delegate skips even the stub.
+- `ResourceOptions.Validate()` and `PagedMMFOptions.IsValid` / `Validate(bool, out string)` are
+  real, independent, and callable today — but nothing in the `Add*()`/DI path calls them for you.
+- Do not rely on `BuildServiceProvider()` or `GetRequiredService<DatabaseEngine>()` to surface a
+  configuration mistake (oversized cache, invalid database name, WAL sizing over budget) — none
+  of these are caught before the engine attempts to open its backing files.
+- Until the stubs are implemented, calling `ResourceOptions.Validate()` / `PagedMMFOptions.IsValid`
+  yourself — before or inside your `configure` delegate — is the only fail-fast path available.
+
+## 🧪 Tests
+
+- [ResourceOptionsTests](../../../../test/Typhon.Engine.Tests/Resources/ResourceOptionsTests.cs) — the real, callable `ResourceOptions.Validate()`: passes on defaults/large budgets, throws `InvalidOperationException` with a readable message when fixed allocations exceed `TotalMemoryBudgetBytes`; no test exercises the `Add*()`-wired `.Validate(_ => true)` stub itself (there is nothing to assert — it never rejects)
+
+## 🔗 Related
+
+- Source: [`TyphonBuilderExtensions.cs`](../../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs) (`ConfigureMemoryAllocatorOptions`, `ConfigureResourceRegistryOptions`, `AddPagedMMF`, `AddDatabaseEngine` — the four `.Validate(_ => true)` sites), [`ResourceOptions.cs` — `Validate()`](../../../../src/Typhon.Engine/Resources/public/ResourceOptions.cs), [`PagedMMFOptions.cs` — `IsValid`/`Validate`](../../../../src/Typhon.Engine/Storage/public/PagedMMFOptions.cs)
+- Parent feature: [Engine Options Configuration Surface](./README.md)
+- Sibling: [DI Engine Bootstrap Chain](../di-bootstrap-chain/README.md) — the `Add*()` calls whose `configure` delegate this stubbed hook should fail-fast on.
+
+<!-- Deep dive: claude/design/Hosting/di-extensions.md — "Validation hooks are stubs" -->

--- a/doc/feature-set/Hosting/ensure-file-deleted.md
+++ b/doc/feature-set/Hosting/ensure-file-deleted.md
@@ -1,0 +1,77 @@
+# Clean-Slate Database File Deletion
+> Delete a Typhon database's backing file (and lock file) before opening it fresh.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Hosting](./README.md)
+
+## 🎯 What it solves
+
+Tests, benchmarks, and tooling need to start each run against an empty database — no leftover
+file from a prior run. Reaching into the filesystem by hand means duplicating whatever naming/path
+logic the engine uses to locate its backing file, and getting it subtly wrong (missing the lock
+file, racing NTFS's deferred delete) causes flaky "file in use" failures on the next open.
+
+## ⚙️ How it works (in brief)
+
+`EnsureFileDeleted<TO>` is an extension on `IServiceProvider`. It opens a DI scope, resolves the
+registered `IOptions<TO>` for the paged-file options type you're using (`PagedMMFOptions` or
+`ManagedPagedMMFOptions`), and deletes the database file and its `.lock` file at the path those
+options describe. It reads the same `DatabaseName`/`DatabaseDirectory` the engine itself will use
+to open the file, so there is no separate path logic to keep in sync. Deletion is best-effort —
+failures (e.g. file not present) are swallowed, not thrown.
+
+## 💻 Usage
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Typhon.Engine;
+
+var services = new ServiceCollection();
+services
+    .AddResourceRegistry()
+    .AddMemoryAllocator()
+    .AddEpochManager()
+    .AddHighResolutionSharedTimer()
+    .AddDeadlineWatchdog()
+    .AddManagedPagedMMF(opts =>
+    {
+        opts.DatabaseName      = "MyTestDb";
+        opts.DatabaseDirectory = testDirectory;
+    })
+    .AddDatabaseEngine();
+
+var sp = services.BuildServiceProvider();
+
+// Before the first GetRequiredService<DatabaseEngine>() call — wipe any leftover file.
+sp.EnsureFileDeleted<ManagedPagedMMFOptions>();
+
+var engine = sp.GetRequiredService<DatabaseEngine>();
+```
+
+## ⚠️ Guarantees & limits
+
+- **Options-driven, not path-guessing.** Resolves the exact `IOptions<TO>` the engine would use,
+  so the deleted file always matches what a subsequent `AddDatabaseEngine`/`AddManagedPagedMMF`
+  resolution would open.
+- **Deletes the lock file too.** Both the `.bin` database file and its companion `.lock` file are
+  removed, so a stale lock can't block reopening.
+- **Waits out NTFS deferred delete.** Polls briefly after `File.Delete` so a subsequent create at
+  the same path doesn't race the OS's pending-delete state.
+- **Best-effort, silent on failure.** Errors (e.g. no file existed) are caught and ignored —
+  this is a convenience for clean-slate setup, not a verified-delete guarantee. Do not use it to
+  assert deletion succeeded.
+- **Must be called before the engine opens the file.** Calling it against a `DatabaseEngine`/
+  `ManagedPagedMMF` that already holds the file open will not release that handle first.
+- **Generic parameter must match the registered options type** (`PagedMMFOptions` for
+  `AddPagedMemoryMappedFile`, `ManagedPagedMMFOptions` for `AddManagedPagedMMF`) — resolving the
+  wrong `TO` throws if it isn't registered in the container.
+
+## 🧪 Tests
+
+- [DatabaseFileLockingTests](../../../test/Typhon.Engine.Tests/Storage/DatabaseFileLockingTests.cs) — `EnsureDeleted_RemovesLock` asserts both the `.bin` and `.lock` files are removed; every other test in the fixture calls `sp.EnsureFileDeleted<ManagedPagedMMFOptions>()` as its clean-slate setup step
+
+## 🔗 Related
+
+- Source: [`TyphonBuilderExtensions.cs`](../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs) (`EnsureFileDeleted<TO>`), [`PagedMMFOptions.cs`](../../../src/Typhon.Engine/Storage/public/PagedMMFOptions.cs) (`EnsureFileDeleted`)
+- Sibling: [Engine Options Configuration Surface](engine-options-configuration/README.md) — resolves the same `IOptions<TO>` this feature deletes the backing file for.
+
+<!-- Deep dive: claude/design/Hosting/di-extensions.md, claude/overview/03-storage.md -->

--- a/doc/feature-set/Hosting/profiler-launch-override-hook.md
+++ b/doc/feature-set/Hosting/profiler-launch-override-hook.md
@@ -1,0 +1,78 @@
+# Profiler Launch Override Hook
+> Adjust the resolved profiler launch config in code, on top of file/env, without giving up zero-code defaults.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Hosting](./README.md)
+
+## 🎯 What it solves
+
+The profiler self-wires from `typhon.telemetry.json` (+ `TYPHON__PROFILER__*` env vars) with zero host
+code. Some hosts still need to decide the trace path or live port in code — e.g. layering `--trace`/
+`--live` CLI args on top of the file config, or computing a per-run trace path (timestamped, per-match,
+per-test-case) that a static JSON value can't express. This hook adds that one escape hatch without
+requiring every host to hand-roll profiler bootstrap.
+
+## ⚙️ How it works (in brief)
+
+`AddTyphonProfiler` registers a delegate that maps the config resolved from file + environment to the
+effective `ProfilerLaunchConfig`. The engine's runtime bootstrap (`TyphonRuntime.Create`) resolves and
+applies it automatically when profiling starts — no other wiring is needed. If the delegate returns
+`null`, the resolved config is used unchanged. Precedence is fixed: JSON file → environment →
+your delegate. If you never call `AddTyphonProfiler`, nothing changes — the zero-code self-wiring path
+runs exactly as before.
+
+## 💻 Usage
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Typhon.Engine;
+
+var services = new ServiceCollection();
+services.AddDatabaseEngine();
+
+// Layer CLI args on top of typhon.telemetry.json / env — CLI wins where it sets a value.
+services.AddTyphonProfiler(resolved => resolved.MergedWith(ProfilerLaunchConfig.FromArgs(args)));
+
+var provider = services.BuildServiceProvider();
+var engine = provider.GetRequiredService<DatabaseEngine>();
+
+// serviceProvider must be passed here for the override to be resolved and applied.
+var runtime = TyphonRuntime.Create(engine, sched => { /* register systems */ }, serviceProvider: provider);
+```
+
+| Registration | Effect |
+|---|---|
+| `AddTyphonProfiler(resolved => resolved.MergedWith(ProfilerLaunchConfig.FromArgs(args)))` | CLI flags (`--trace`, `--live [port]`, `--live-wait <ms>`) override unset-only fields of the file/env config. |
+| `AddTyphonProfiler(resolved => resolved with { TraceFilePath = ComputePath() })` | Fully computed trace path, ignoring whatever the file/env supplied. |
+
+## ⚠️ Guarantees & limits
+
+- **Opt-in, additive.** Calling `AddTyphonProfiler` never changes behavior unless the `IServiceProvider`
+  is also passed to `TyphonRuntime.Create` — the override is only resolved from that container.
+- **⚠️ Zero-arg call resolves to a different, unrelated overload.** `Typhon.Engine` also declares
+  `TelemetryServiceExtensions.AddTyphonProfiler(IServiceCollection)` (forces early `TelemetryConfig`
+  init; no delegate parameter). C# overload resolution prefers that exact-arity match over this
+  hook's optional-parameter overload, so `services.AddTyphonProfiler()` with **no** argument silently
+  calls the *other* method and never registers a `ProfilerLaunchOverride`. Always pass a delegate
+  explicitly to reach this hook.
+- **Cannot enable profiling from a closed master gate.** The delegate only runs once
+  `typhon.telemetry.json`'s master `Typhon:Profiler:Enabled` (or the legacy `Typhon:Telemetry:Enabled` +
+  `Typhon:Telemetry:Profiler:Enabled` pair) is already on; it can add or change *where* output goes
+  (trace file / live port), not flip profiling on for a session where it's off. If the resulting
+  config still has no output channel, nothing is exported.
+- **Best-effort.** Profiler startup — including your delegate — runs inside a try/catch that never
+  crashes the host; a throwing delegate disables profiling for that session with a logged diagnostic,
+  it does not fault application startup.
+- **Runs once per process.** The hook fires the first time `TyphonRuntime.Create` self-wires the
+  profiler; it is not re-invoked per runtime instance.
+
+## 🧪 Tests
+
+- [ProfilerLaunchConfigTests](../../../test/Typhon.Engine.Tests/Profiler/ProfilerLaunchConfigTests.cs) — `MergedWith` precedence (`MergedWith_OverrideTraceWinsWhenSet`, `_BaseRetainedWhenOverrideUnset`, `_NullOverride_ReturnsBase`) and `TypicalLayering_ConfigFirstThenArgsOverride`, which its own comment ties directly to "the `AddTyphonProfiler` hook"; no fixture calls `AddTyphonProfiler` itself — this covers the merge logic the delegate composes over
+
+## 🔗 Related
+
+- Source: [`TyphonBuilderExtensions.cs`](../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs) (`AddTyphonProfiler`), [`ProfilerBootstrap.cs`](../../../src/Typhon.Engine/Profiler/internals/ProfilerBootstrap.cs) (`TryStart`), [`ProfilerLaunchConfig.cs`](../../../src/Typhon.Engine/Profiler/public/ProfilerLaunchConfig.cs), [`TyphonRuntime.cs`](../../../src/Typhon.Engine/Runtime/public/TyphonRuntime.cs) (`Create`)
+- Colliding overload: [`TelemetryServiceExtensions.cs`](../../../src/Typhon.Engine/Observability/public/TelemetryServiceExtensions.cs) (`AddTyphonProfiler(IServiceCollection)`, no delegate)
+- Sibling: [Profiler Session Lifecycle & Zero-Code Bootstrap](../Profiler/profiler-lifecycle-bootstrap.md) — the zero-code self-wiring this hook layers an override on top of.
+
+<!-- Deep dive: claude/design/Profiler/README.md, claude/design/Profiler/profiler-user-manual.md -->

--- a/doc/feature-set/Hosting/wal-io-injection-seam.md
+++ b/doc/feature-set/Hosting/wal-io-injection-seam.md
@@ -1,0 +1,77 @@
+# Pluggable WAL I/O Backend (IWalFileIO seam)
+> Swap the WAL's disk backend for an in-memory one and run the full WAL + checkpoint pipeline with zero disk I/O.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Hosting](./README.md)
+
+## 🎯 What it solves
+
+WAL and checkpoint are mandatory in Typhon — there is no "no-WAL" engine mode
+([ADR-054](../../../claude/adr/054-remove-no-wal-mode.md)). That's correct for production, but a
+fast inner loop (unit tests, benchmarks, throwaway shell sessions) still needs to avoid touching
+disk on every WAL segment write. This seam lets a host replace the low-level file-IO backend the
+WAL talks to, so tests exercise the exact same durability pipeline as production without a
+divergent "fast but different" code path.
+
+## ⚙️ How it works (in brief)
+
+`AddDatabaseEngine`'s factory resolves an optional `IWalFileIO` from the DI container before
+constructing the engine. If nothing is registered — the production case — `GetService` returns
+`null` and the engine builds its own disk-backed backend. If a host registers one, that instance
+is used instead; every other code path (WAL records, checkpoints, recovery) is unchanged.
+`IWalFileIO` and its implementations are `internal` to `Typhon.Engine`: only assemblies granted
+`[InternalsVisibleTo]` (Typhon's own test, benchmark, and shell assemblies) can see the interface
+or register a backend — this is not a seam for arbitrary application code.
+
+## 💻 Usage
+
+```csharp
+// Host assembly with InternalsVisibleTo on Typhon.Engine (test/benchmark/shell code)
+using Typhon.Engine.Internals;
+
+services
+    .AddSingleton<IWalFileIO>(_ => new InMemoryWalFileIO())   // or AddScoped for per-scope isolation
+    .AddDatabaseEngine(o =>
+    {
+        o.Wal = new WalWriterOptions { UseFUA = false };        // FUA is moot with no real disk
+        o.Resources.CheckpointIntervalMs = int.MaxValue;        // keep the checkpoint thread idle
+    });
+
+var engine = serviceProvider.GetRequiredService<DatabaseEngine>();
+// Full WAL + checkpoint pipeline runs; no segment files are created on disk.
+```
+
+| Registration lifetime | When to use |
+|---|---|
+| `AddScoped<IWalFileIO>` | One engine per DI scope (e.g. a test fixture that opens/reopens within one run) — each scope gets its own isolated in-memory backend. |
+| `AddSingleton<IWalFileIO>` | One engine per process lifetime (benchmark harness). |
+
+To exercise the real disk-backed path instead (crash/replay fixtures that must survive a process
+restart), register `new WalFileIO()` — the same internal type the engine falls back to when
+nothing is injected.
+
+## ⚠️ Guarantees & limits
+
+- **Production is unaffected.** No production DI setup registers `IWalFileIO`, so the engine
+  always resolves `null` and builds its own disk-backed `WalFileIO`.
+- **Internal seam, not public API.** `IWalFileIO`, `WalFileIO`, and `InMemoryWalFileIO` are all
+  `internal`; only friend assemblies (via `[InternalsVisibleTo]`) can reference or register them.
+- **Same pipeline, different medium.** Injecting `InMemoryWalFileIO` does not skip WAL records,
+  checkpoints, or recovery — only where the bytes land changes. Behavior under test matches
+  production storage semantics.
+- **`WalManager` never disposes an injected backend.** Its lifetime is owned by whichever DI
+  scope/container registered it. `InMemoryWalFileIO.Dispose` is idempotent, so double-dispose
+  across recovery + steady-state is safe.
+- **The supported replacement for the removed no-WAL mode.** Durability stays a real, always-on
+  knob (WAL always runs); only the storage medium is pluggable.
+
+## 🧪 Tests
+
+- [WalIntegrationTests](../../../test/Typhon.Engine.Tests/Durability/WalIntegrationTests.cs) — registers `AddSingleton<IWalFileIO>(new WalFileIO())` to swap in the real disk-backed implementation and runs the full WAL/checkpoint/reopen/crash-recovery pipeline against it — the documented alternative to the default in-memory backend
+
+## 🔗 Related
+
+- Source: [`TyphonBuilderExtensions.cs`](../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs) (`CreateDatabaseEngine`), [`IWalFileIO.cs`](../../../src/Typhon.Engine/Durability/internals/IWalFileIO.cs), [`InMemoryWalFileIO.cs`](../../../src/Typhon.Engine/Durability/internals/InMemoryWalFileIO.cs), [`WalFileIO.cs`](../../../src/Typhon.Engine/Durability/internals/WalFileIO.cs)
+- Sibling: [Write-Ahead Log (WAL v2 logical records)](../Durability/wal-v2.md) — the durability pipeline this seam swaps the disk backend under, unchanged.
+- Sibling: [Pluggable Storage Backend (Persistent vs Transient)](../Storage/pluggable-storage-backend/README.md) — the analogous backend-injection seam for page storage instead of WAL.
+
+<!-- Deep dive: claude/design/Hosting/di-extensions.md — IWalFileIO section, ADR-054: Remove the no-WAL engine mode (claude/adr/054-remove-no-wal-mode.md), claude/overview/06-durability.md -->

--- a/doc/feature-set/Indexing/README.md
+++ b/doc/feature-set/Indexing/README.md
@@ -1,0 +1,29 @@
+# Indexing
+> Concurrent B+Tree secondary indexes — automatically built and maintained per `[Index]`-tagged `ComponentTable` field, in four key-width-specialized variants under a per-node optimistic-concurrency (OLC) protocol — back point lookups, ordered range scans, and (on `Versioned` components) MVCC-correct historical reconstruction of index membership over time. Primary-key access is no longer part of this surface: the PK B+Tree has been removed in favor of `EntityMap`/ECS entity APIs.
+
+> 🔬 **Recommended:** read [in-depth-overview/03-indexing.md](../../in-depth-overview/03-indexing.md) (Chapter 03: Indexing) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Secondary Index Storage Modes](secondary-index-storage-modes/README.md) | An indexed field is either unique or `AllowMultiple`; the choice drives the on-disk value representation and which mutation API path is used | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Unique (Single-Value) Secondary Index](secondary-index-storage-modes/unique-secondary-index.md) | One key maps to exactly one entity — the B+Tree value is a chunk-id directly, no buffer indirection | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Multi-Value Secondary Index (AllowMultiple)](secondary-index-storage-modes/multi-value-secondary-index.md) | Many entities share one key — the B+Tree value is a growable HEAD buffer of chunk-ids, at a fixed +4-byte-per-entity cost | ✅ Implemented | 🔵 Core |
+| [Lookup and Range-Scan Operations](lookup-and-range-scan.md) | Lock-free point lookups and ordered range scans over any secondary index, MVCC-correct at your transaction's snapshot | ✅ Implemented | 🔵 Core |
+| [Index Handle Resolution (IndexRef)](index-ref-resolution.md) | Opaque, zero-allocation handle to a PK or secondary index, resolved once on the cold path via `GetPKIndexRef`/`GetIndexRef` and reused on the hot path with O(1) schema-evolution staleness checks | ✅ Implemented | 🟣 Advanced |
+| [Versioned (HEAD/TAIL) Secondary Indexes for MVCC](versioned-secondary-indexes.md) | `AllowMultiple` indexes maintain a HEAD buffer (current set) plus an append-only TAIL of version transitions so index membership stays correct across updates and deletes | ✅ Implemented | 🟣 Advanced |
+| [Transaction-Local Index Overlay (Read-Your-Own-Writes)](transaction-local-index-overlay.md) | Planned per-transaction overlay so index lookups see that transaction's own uncommitted writes | 📋 Planned | 🟣 Advanced |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Specialized B+Tree Key-Size Variants](btree-key-variants.md) | Four key-width-specialized B+Tree implementations (16/32/64-bit and `String64`), automatically selected by an indexed field's CLR type | ✅ Implemented |
+| [Compound Move/MoveValue (field-update fast path)](compound-move-operations.md) | Atomic remove+insert for indexed-field updates — one traversal, one lock on the common same-leaf case | ✅ Implemented |
+| [Temporal (Point-in-Time) Index Query](temporal-index-query.md) | Reconstructs which entities held a key's value at a past TSN by replaying the index's append-only TAIL history | 🚧 Partial |
+| [TAIL Retention / Garbage Collection](tail-garbage-collection.md) | Bounds TAIL version-history growth via boundary-sentinel-preserving pruning — built and tested, not yet auto-triggered | 🚧 Partial |
+| [Optimistic Lock Coupling (per-node concurrency)](olc-concurrency.md) | Per-node OLC version latches give lock-free optimistic readers and leaf-only write latching for B+Tree/R-Tree index operations | ✅ Implemented |
+| [Index Diagnostics & Consistency Checking](btree-diagnostics.md) | Always-on per-instance contention counters plus an on-demand `tsh` structural walk to diagnose B+Tree contention and validate integrity | ✅ Implemented |
+| [B+Tree Node Layout and Capacity Tuning](btree-node-layout-tuning.md) | Cache-line-aware 256-byte B+Tree node layout with per-key-type capacities, tuned through a multi-phase profiling effort | ✅ Implemented |
+| [Batched Index Maintenance for Bulk Commits](batched-index-maintenance.md) | Commit-path rework that batches secondary-index updates per commit; accessor-reuse has shipped, sorted-key application has not | 🚧 Partial |

--- a/doc/feature-set/Indexing/batched-index-maintenance.md
+++ b/doc/feature-set/Indexing/batched-index-maintenance.md
@@ -1,0 +1,79 @@
+# Batched Index Maintenance for Bulk Commits
+> Commit-path rework that batches secondary-index updates per commit; the accessor-reuse half has shipped, the sorted-apply half has not.
+
+**Status:** 🚧 Partial · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Bulk-mutation transactions — world-load, content generation, large batch imports touching thousands to hundreds
+of thousands of entities in one commit — pay two costs naive per-entity index maintenance doesn't have to: page
+accessor churn (a fresh accessor per index per entity, repeatedly rented/returned) and random key order (B+Tree
+and value-buffer operations land in whatever order the entities happen to iterate in, thrashing the index page
+cache instead of streaming through it sequentially). A 200K-entity bulk create with four secondary indexes was
+measured at ~196 ms in index maintenance alone under the original fully-naive scheme.
+
+## ⚙️ How it works (in brief)
+
+The fix is a two-phase commit-path rework, entirely internal — no new public API either way. **Phase A (shipped):**
+`Transaction.Commit()` now hoists one long-lived `ChunkAccessor` per index per component type out of the per-entity
+loop — instead of thousands of short-lived ones — and runs the whole component type's mutation loop with warm
+accessor `CommitChanges` suppressed (`ChunkBasedSegment.EnterBatchMode`/`ExitBatchMode`), flushing dirty pages
+only every 1,024 entities rather than after every single one. This is unconditional for every commit touching a
+`Versioned` component with at least one indexed field — there is no size threshold or opt-in. **Phase B (not yet
+implemented):** deferring secondary-index writes until after the per-entity commit loop, sorting them by key per
+index, and applying them in sorted order — turning random index-page and value-buffer access into sequential,
+cache-friendly access. Phase B is where most of the modeled savings live; Phase A alone does not reorder anything,
+so index operations during a bulk commit still land in entity-iteration order today.
+
+## 💻 Usage
+
+```csharp
+[Component]
+public partial struct ItemData
+{
+    [Index(AllowMultiple = true)] public int ItemTypeId;
+    [Index(AllowMultiple = true)] public int Rarity;
+    [Index(AllowMultiple = true)] public long OwnerId;
+}
+
+using var tx = dbe.CreateQuickTransaction();
+for (int i = 0; i < 200_000; i++)
+{
+    tx.Spawn<Item>(Item.Data.Set(GenerateItem(i)));
+}
+tx.Commit();   // accessor-reuse batching (Phase A) already applies transparently; sorted application
+               // (Phase B) does not exist yet — index writes still happen in entity-iteration order
+```
+
+## ⚠️ Guarantees & limits
+
+- **Phase A is shipped and unconditional:** per-component-type accessor hoisting plus suppressed/periodic
+  `CommitChanges` (every 1,024 entities) is live for every commit of a `Versioned` component with indexed fields —
+  see `Transaction._batchIndexActive`/`_batchIndexAccessors` and the batched overloads of `IndexMaintainer.UpdateIndices`
+  / `RemoveSecondaryIndices` that accept pre-created accessors. No size threshold gates it; even a single-entity
+  commit goes through the hoisted-accessor path.
+- **Phase B (sort-by-key, deferred apply) is not implemented.** No `IndexOpBuffer`, `DeferredIndexOp`, or sorted
+  apply pass exist in the codebase — index operations within a commit are still applied in entity-iteration order,
+  not key order. This is the larger share of the design's modeled savings (sorted VSBS/page-cache locality was
+  attributed ~72% of the total gain in the design analysis).
+- Fully transparent either way: no change to `Transaction.Commit()`'s signature or to any indexing API — existing
+  call sites benefit automatically, with no opt-in, now or once Phase B lands.
+- Modeled savings for Phase A alone on the 200K-entity, 4-secondary-index case study: ~1.4× faster index
+  maintenance (~196 ms → ~136 ms). Modeled savings for Phase A+B together: ~2.9× faster commit overall, ~4× faster
+  on index maintenance specifically — that combined figure is design-time only until Phase B ships.
+- Scoped to commit-path restructuring only — no change to B+Tree node layout, the OLC protocol, or split/merge
+  behavior; index operations are not parallelized across threads.
+- The primary-key index is and remains unaffected by either phase — entities are already iterated in PK order
+  during commit, so it keeps its existing inline, sequential update path.
+- Phase B's design analysis covers MVCC visibility (the brief window between revision commit and deferred index
+  apply is not observable under snapshot isolation), unique-constraint semantics under reordering, WAL impact
+  (none — WAL serializes component data, not index state), and view-notification ordering (safe — same-TSN delta
+  entries are order-independent); this analysis is design-time, pending Phase B's implementation and test
+  verification.
+
+## 🔗 Related
+
+- Source (Phase A, shipped): `src/Typhon.Engine/Transactions/public/Transaction.cs` (`_batchIndexActive`), `src/Typhon.Engine/Transactions/internals/IndexMaintainer.cs`, `src/Typhon.Engine/Storage/internals/ChunkBasedSegment.cs` (`EnterBatchMode`/`ExitBatchMode`)
+- Related feature: [Secondary Index Storage Modes](./secondary-index-storage-modes/README.md) — the indexes this optimization maintains
+
+<!-- Deep dive: claude/design/Indexing/batched-index-maintenance.md — full design, ARPG ItemData case study, Phase A/B breakdown -->

--- a/doc/feature-set/Indexing/btree-diagnostics.md
+++ b/doc/feature-set/Indexing/btree-diagnostics.md
@@ -1,0 +1,91 @@
+# Index Diagnostics & Consistency Checking
+> Always-on contention counters plus an on-demand structural walk for troubleshooting B+Tree indexes.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Lock-free index concurrency ([OLC](./olc-concurrency.md)) trades a simple whole-tree lock for retry-driven
+correctness: readers and writers can race, restart, and fall back to a slower path under contention. When a
+workload feels slower than expected, or a stress run produces a result you don't trust, "is this index
+contended?" and "is this index's structure actually sound?" are the two questions you need answered without
+attaching a profiler or stepping through engine internals. Typhon answers both cheaply: contention counters
+update unconditionally as part of every index operation, and a full structural walk is one shell command away.
+
+## ⚙️ How it works (in brief)
+
+Every B+Tree index instance carries a handful of `long` counters — bumped only on the retry/fallback/structural
+paths (version-check failures, optimistic→pessimistic fallbacks, splits, merges) — so the steady-state lookup
+and insert paths pay nothing extra. They give a coarse signal of how much retry/fallback traffic an index is
+absorbing under concurrent load. Separately, `tsh`'s `btree-validate` command walks an index from root to leaf
+under an epoch guard, checking key ordering, parent/child linkage, and B-link sibling chaining, and reports
+pass/fail with the first violation found — useful after a stress run, a crash-recovery rebuild, or whenever
+you suspect corruption rather than just contention.
+
+## 💻 Usage
+
+Inspect an index and validate its structure from the `tsh` shell:
+
+```
+tsh> open game.typhon
+tsh> load-schema bin/Game.Components.dll
+
+tsh> btree Player.Name
+  B+Tree: Player.Name (unique)
+  ──────────────────────────────────────
+  Total nodes:     128
+  Chunk capacity:  512
+  Fill factor:     25.0%
+  Node size:       256 bytes
+
+tsh> btree-validate Player.Name
+  Validating B+Tree Player.Name...
+  Validation passed
+```
+
+| Command | Purpose |
+|---------|---------|
+| `btree <Component.Field>` | Node count, chunk capacity, fill factor, node size |
+| `btree-dump <Component.Field> [--level N \| --chunk N]` | Raw node/chunk inspection |
+| `btree-validate <Component.Field>` | Full structural walk; reports pass or the first violation |
+
+The contention counters (`OptimisticRestarts`, `PessimisticFallbacks`, `SplitCount`, `MergeCount`, …) aren't
+wired to a `tsh` command yet — today they're consumed by the engine's own stress-test and benchmark harnesses,
+which read them straight off the index instance to confirm a concurrent workload actually exercised the
+retry/fallback paths it was meant to:
+
+```csharp
+// Engine-internal / stress-harness code (InternalsVisibleTo), not part of the public Typhon.Engine surface.
+TestContext.Out.WriteLine(
+    $"Restarts={tree.OptimisticRestarts} Fallbacks={tree.PessimisticFallbacks} " +
+    $"Splits={tree.SplitCount} Merges={tree.MergeCount}");
+```
+
+## ⚠️ Guarantees & limits
+
+- Counters are always-on and incremented unconditionally — no flag to enable, nothing to forget to turn off —
+  but they only move on retry/fallback/structural paths, so they add no cost to the steady-state hot path.
+- Counters are per-index-instance and process-lifetime; they reset to zero on engine restart and are not
+  persisted, checkpointed, or aggregated across indexes.
+- `btree-validate` is read-only and safe to run against a live database; it runs under an epoch guard so it
+  observes a consistent epoch, but it is a point-in-time walk, not a continuous monitor.
+- `btree-validate` checks structural soundness (key ordering, child linkage, B-link sibling chaining) — it does
+  not check that index entries match the component data they're supposed to reference.
+- The contention counters and the descent-trace forensic hook used for deep OLC bug investigation are
+  engine-internal; they require `InternalsVisibleTo` access (as `tsh`, the test suite, and benchmarks have) and
+  are not part of the stable public `Typhon.Engine` API.
+
+## 🧪 Tests
+
+- [OlcBTreeStressTests](../../../test/Typhon.Engine.Tests/Data/OlcBTreeStressTests.cs) — `LogDiagnostics`/`tree.ResetDiagnostics()`: reads `OptimisticRestarts`/`PessimisticFallbacks`/`SplitCount`/`MergeCount`/`ContentionSplitCount` straight off a stressed tree instance, the same counters this feature documents
+- [BTreeTests](../../../test/Typhon.Engine.Tests/Data/BTreeTests.cs) — pervasive `tree.CheckConsistency(...)` calls exercise the same structural walk (key ordering, parent/child linkage, B-link sibling chaining) that `tsh btree-validate` runs via `DiagnosticCommandExecutor`
+
+## 🔗 Related
+
+- Sibling feature: [Optimistic Lock Coupling](./olc-concurrency.md)
+- Sibling feature: [tsh Schema Shell Commands](../Schema/tsh-schema-commands.md) — same shell, same interactive-diagnostics pattern
+- Source: `src/Typhon.Engine/Indexing/internals/BTreeBase.cs`, `src/Typhon.Engine/Indexing/internals/BTree.cs`, `src/Typhon.Engine/Indexing/internals/OlcDescentTrace.cs`, `src/Typhon.Shell/Commands/DiagnosticCommandExecutor.cs`
+
+<!-- Deep dive: claude/design/Indexing/public-api.md#diagnostics -->
+<!-- Deep dive: claude/design/Indexing/concurrent-index-scaling.md — OLC restart/fallback paths these counters measure -->
+<!-- Deep dive: claude/design/Indexing/latch-coupled-smo.md — Latch-Coupled Split/Merge -->

--- a/doc/feature-set/Indexing/btree-key-variants.md
+++ b/doc/feature-set/Indexing/btree-key-variants.md
@@ -1,0 +1,68 @@
+# Specialized B+Tree Key-Size Variants
+> One cache-aligned B+Tree node layout per key width, picked automatically from the field's type — invisible to application code.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Every indexed field — primary key or secondary index — needs an ordered, concurrent lookup structure, but indexed key types span an 8×-wide range (1-byte `byte` up to 64-byte `String64`). A single one-size-fits-all B+Tree would either waste node space on narrow keys (fewer keys per cache-line-sized node, deeper trees, more cache misses) or be unable to address wide keys at all. Typhon avoids this by giving each key-width tier its own specialized tree implementation, so a `byte`-keyed index and a `long`-keyed index both get a node layout packed for their key size, without the application ever picking one.
+
+## ⚙️ How it works (in brief)
+
+Four concrete tree types — `L16BTree` (keys ≤ 16-bit), `L32BTree` (32-bit), `L64BTree` (64-bit), `String64BTree` (fixed 64-byte string) — share one generic algorithm (`BTree<TKey, TStore>`) but each defines its own fixed-size node struct, sized so more keys fit in a narrow-key node than a wide-key one. Which variant backs a given index is decided automatically when the schema is built, from the indexed field's declared type — application code never names or constructs a tree class directly. Every variant is further specialized over `TStore`: `PersistentStore` (durable, WAL-protected, backs `Versioned`/`SingleVersion` tables) or `TransientStore` (in-memory, backs `Transient` tables) — again chosen by the table's storage discipline, not by the caller.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+public struct Player
+{
+    [Index]                       // unique secondary index -> L32BTree<int, ...> (32-bit key)
+    public int PlayerId;
+
+    [Index(AllowMultiple = true)] // non-unique secondary index -> String64BTree<...>
+    public String64 Guild;
+
+    public float PositionX;       // not indexed
+}
+
+// Cold path: resolve once, reuse the IndexRef on the hot path.
+var idIndex = engine.GetIndexRef<Player, int>(p => p.PlayerId);
+
+// Hot path: range-scan through Transaction — never through the tree directly.
+using var tx = engine.CreateQuickTransaction();
+using var found = tx.EnumerateIndex<Player, int>(idIndex, minKey: 100, maxKey: 200);
+foreach (var entry in found)
+{
+    // entry.EntityPK, entry.Key, entry.Component
+}
+```
+
+| Key type(s) | Variant | Capacity (keys/node) |
+|---|---|---|
+| `byte`, `sbyte`, `short`, `ushort`, `char` | `L16BTree` | 38 |
+| `int`, `uint`, `float` | `L32BTree` | 29 |
+| `long`, `ulong`, `double` | `L64BTree` | 19 |
+| `String64` | `String64BTree` | 4 |
+
+## ⚠️ Guarantees & limits
+
+- Variant selection is fully automatic and type-driven — there is no API to request a specific tree implementation; it follows from the field's declared type and `[Index(AllowMultiple = ...)]`.
+- All four variants expose the identical operation surface and concurrency model (OLC optimistic reads, B-link splits) through `IndexRef`/`Transaction` — no behavioral difference between tiers at the application level.
+- Node capacity scales inversely with key width (38 → 29 → 19 → 4), so narrower-keyed indexes pack more entries per node and produce shallower trees for the same entry count.
+- `String64` keys are fixed at 64 bytes; there is no variable-length string index.
+- Persistent vs. transient backing follows the owning table's storage discipline (`Versioned`/`SingleVersion` = durable, `Transient` = in-memory) — not independently selectable per index.
+- Schema evolution that changes an indexed field's type invalidates previously-resolved `IndexRef`s (`CapturedLayoutVersion` check); re-resolve via `GetIndexRef`/`GetPKIndexRef`.
+
+## 🧪 Tests
+
+- [BtreeTests](../../../test/Typhon.Engine.Tests/Data/BTreeTests.cs) — `ForwardInsertionTest`/`ForwardFloatInsertionTest`/`ReverseInsertionTest`/`ReverseString64InsertionTest` exercise all four key-width tiers (`int`/`L32`, `float`/`L32`, `byte`/`L16`, `String64`) through the shared `BTree<TKey, TStore>` algorithm
+- [OlcLatchTests](../../../test/Typhon.Engine.Tests/Data/OlcLatchTests.cs) — chunk-size verification (`Index16Chunk_Size_Is256Bytes`, `Index32Chunk_Size_Is256Bytes`, `Index64Chunk_Size_Is256Bytes`, `Index32Chunk_Capacity_Is29`) confirms the per-variant node layout the table above documents
+
+## 🔗 Related
+
+- Sibling: [B+Tree Node Layout and Capacity Tuning](./btree-node-layout-tuning.md) — per-key-width node capacities this feature's variants use
+
+<!-- Deep dive: claude/design/Indexing/public-api.md — public surface, internal type hierarchy, per-variant capacities -->
+<!-- Deep dive: claude/adr/021-specialized-btree-variants.md — why per-key-size specialization over one generic tree -->
+<!-- Deep dive: claude/adr/022-64byte-cache-aligned-nodes.md — node-size sizing rationale (64B → 128B → 256B evolution) -->

--- a/doc/feature-set/Indexing/btree-node-layout-tuning.md
+++ b/doc/feature-set/Indexing/btree-node-layout-tuning.md
@@ -1,0 +1,64 @@
+# B+Tree Node Layout and Capacity Tuning
+> Cache-line-aware 256-byte node layout, the product of a multi-phase profiling effort — invisible to, and not configured by, application code.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Every B+Tree operation walks from root to leaf, and each node visited is a potential cache miss or DRAM round-trip. Two things determine how expensive that walk is: how many cache lines a node spans, and how many keys fit in a node (which sets the tree's height for a given entry count). Naively, those two goals fight each other — bigger nodes mean fewer levels but more bytes touched per node. Typhon's B+Tree node layout was tuned through a multi-phase profiling effort (issues #98, #163) to resolve this trade-off, so application developers get shallow, cache-efficient trees without sizing anything themselves.
+
+## ⚙️ How it works (in brief)
+
+Every node — `Index16Chunk`, `Index32Chunk`, `Index64Chunk`, `IndexString64Chunk` — is fixed at **256 bytes, four 64-byte cache lines**, laid out as a 16-byte-plus-key header (`Control`, `OlcVersion` latch, `PrevChunk`/`NextChunk` sibling links, `LeftValue`, `HighKey`) followed by parallel `Keys[N]`/`Values[N]` arrays. The size was reached in stages: profiling first showed tree *height* dominated cost more than per-node cache-line count, so nodes doubled from 64→128 bytes (issue #98), then evolved again to the current 256 bytes. Capacity `N` is computed per key-width tier so each tier fills the 256 bytes as densely as possible — narrower keys pack more entries per node, shallower trees, fewer levels walked per operation. The same effort also reworked the surrounding algorithm: lazy sibling loading (`NodeRelatives` only loads left/right siblings on the ~5% of operations that actually spill or split), iterative (not recursive) root-to-leaf descent, and SIMD-accelerated key search within a node. None of this is a knob — node size, capacity, and which concrete tree type backs a field are all resolved automatically from the field's declared type at schema-build time.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+public struct Player
+{
+    [Index]                       // -> L32BTree, 256-byte node, 29 keys/node
+    public int PlayerId;
+
+    [Index(AllowMultiple = true)] // -> L64BTree, 256-byte node, 19 keys/node
+    public long GuildId;
+}
+
+// Application code never names a node type or a node size — it only ever
+// resolves an IndexRef and queries through Transaction.
+var idIndex = engine.GetIndexRef<Player, int>(p => p.PlayerId);
+using var tx = engine.CreateQuickTransaction();
+using var found = tx.EnumerateIndex<Player, int>(idIndex, minKey: 100, maxKey: 200);
+```
+
+| Header field | Size | Purpose |
+|---|---|---|
+| `Control` | 4 B | `StateFlags` (incl. `IsLeaf`) + `Count` |
+| `OlcVersion` | 4 B | per-node optimistic-lock-coupling latch |
+| `PrevChunk` / `NextChunk` | 4+4 B | doubly-linked sibling pointers (B-link right-link) |
+| `LeftValue` | 4 B | leftmost child pointer (internal nodes) |
+| `HighKey` | `sizeof(TKey)` | B-link upper bound, `== Next.firstKey` |
+| `Keys[N]` / `Values[N]` | remainder | sorted key array + parallel value array |
+
+## ⚠️ Guarantees & limits
+
+- Node size is fixed at compile time (`Debug.Assert(sizeof(Index{16,32,64}Chunk) == 256)`); there is no per-table or per-index size override.
+- Capacity scales inversely with key width: `L16BTree`=38, `L32BTree`=29, `L64BTree`=19 keys/node; `String64BTree` stays at 4 because a 64-byte key already consumes most of the budget. See [B+Tree Key-Size Variants](./btree-key-variants.md) for the full type-to-variant mapping.
+- The layout benefits Insert, Remove, and Lookup roughly equally (all are root-to-leaf descents); RangeScan benefits only on the initial descent to the starting leaf, not on the subsequent leaf-linked-list walk.
+- Gains are structural (fewer tree levels, fewer pointer-chases, fewer DRAM round-trips), not raw memory-bandwidth gains — they hold even on CPUs without an adjacent-line prefetcher, though the within-node binary/SIMD search assumes a stride-prefetcher-friendly access pattern.
+- Going materially past 256 bytes is not free: wider nodes mean more bytes touched (and more cache lines beyond what the prefetcher reliably covers) per node visited, so this is a tuned ceiling, not a "bigger is always better" knob — see ADR-022 for the alternatives considered.
+- Schema authors interact with this only indirectly, through `[Index]`/`[Index(AllowMultiple = true)]` on a field — there is no API surface to request a non-default node size or capacity.
+
+## 🧪 Tests
+
+- [OlcLatchTests](../../../test/Typhon.Engine.Tests/Data/OlcLatchTests.cs) — `Index16Chunk_Size_Is256Bytes`/`Index32Chunk_Size_Is256Bytes`/`Index64Chunk_Size_Is256Bytes`/`Index32Chunk_Capacity_Is29`: pins the fixed 256-byte node size and per-tier capacity this feature describes
+- [BTreeTests](../../../test/Typhon.Engine.Tests/Data/BTreeTests.cs) — exercises trees built at these exact node capacities across all four key-width tiers, indirectly validating the layout under real insert/remove/range-scan traffic
+
+## 🔗 Related
+
+- Sibling feature: [B+Tree Key-Size Variants](./btree-key-variants.md) — how the key type selects the concrete tree implementation
+
+<!-- Deep dive: claude/design/Indexing/btree-insert-optimization.md — the 64→128-byte profiling study, lazy NodeRelatives, iterative descent, SIMD search -->
+<!-- Deep dive: claude/design/Indexing/btree-phase5-analysis.md — deep cost-breakdown analysis and further quick-win optimizations -->
+<!-- Deep dive: claude/adr/022-64byte-cache-aligned-nodes.md — sizing rationale and the 64B→128B→256B evolution -->
+<!-- Deep dive: claude/overview/04-data.md#node-structure-256-bytes-four-cache-lines — current node structure diagram -->

--- a/doc/feature-set/Indexing/compound-move-operations.md
+++ b/doc/feature-set/Indexing/compound-move-operations.md
@@ -1,0 +1,85 @@
+# Compound Move/MoveValue (field-update fast path)
+> Atomic remove+insert for indexed-field updates — one traversal, one lock on the common same-leaf case.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Updating an indexed field's value (a position changing, a status enum flipping) requires the index to
+relocate the entity from its old key to its new key. A naive implementation does this as two independent
+operations — remove the old key, insert the new key — each paying its own lock acquisition and full
+root-to-leaf traversal. For `AllowMultiple` indexes with version-history (TAIL) tracking, the naive path is
+worse still: two extra lookups to recover the HEAD buffer IDs needed for TAIL linking. Most field updates are
+small (a counter increment, a position nudge), so the old and new keys frequently land in the same leaf —
+making the second traversal pure waste.
+
+## ⚙️ How it works (in brief)
+
+`Move` (unique indexes) and `MoveValue` (`AllowMultiple` indexes) descend for both the old and new key in one
+pass, sharing the common root-to-fork path. If both keys resolve to the same leaf, the operation takes a
+single write-lock and performs the remove and insert as one in-node operation — no entry-count change, so no
+split/merge risk. If the keys resolve to different leaves, both are locked in ascending chunk-id order
+(deadlock-free) and the remove/insert happen under that paired lock; if either leaf can't safely absorb the
+change in place, the call falls back to a pessimistic, structurally-aware path. For `MoveValue`, the HEAD
+buffer IDs for both the old and new key are read inline while the leaf is already locked, instead of issuing
+separate lookups afterward. This is entirely internal — there is no separate API to invoke; any commit that
+changes an indexed field's value uses this path automatically.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Unit", 1, StorageMode = StorageMode.SingleVersion)]
+struct Unit
+{
+    [Index]                         // unique index → uses compound Move
+    public int Id;
+
+    [Index(AllowMultiple = true)]   // secondary, multi-value → uses compound MoveValue
+    public int Status;
+}
+
+[Archetype(7)]
+partial class UnitArchetype : Archetype<UnitArchetype>
+{
+    public static readonly Comp<Unit> U = Register<Unit>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+EntityRef e = tx.OpenMut(id);
+ref Unit u = ref e.Write(UnitArchetype.U);
+u.Status = (int)UnitStatus.Engaged;   // indexed field change
+tx.Commit();                          // index relocation runs as a single compound Move/MoveValue — no app code involved
+```
+
+There is no tuning knob — the engine always attempts the same-leaf fast path first, falls back to the
+dual-leaf path, and finally to the pessimistic path; the choice is made per-call based on where the old and
+new keys land.
+
+## ⚠️ Guarantees & limits
+
+- Triggered automatically whenever a transaction commits a change to a field carrying `[Index]` — no separate
+  API call exists, and there is nothing to opt into or out of.
+- Same-leaf updates take exactly one write-lock and one traversal; cross-leaf updates take two write-locks,
+  acquired in ascending chunk-id order to avoid deadlocks, after a single shared traversal prefix.
+- The old key's entry is only removed once the new key is confirmed absent (unique indexes) or the buffer
+  operations succeed (multi-value indexes) — a failed move leaves the index unchanged, not half-applied.
+- If a cross-leaf move would overflow the destination leaf or underflow the source leaf, it bails out of the
+  optimistic path and falls back to a pessimistic, structurally-aware move (handles split/merge correctly);
+  this fallback is rare in practice.
+- For `AllowMultiple` indexes, `MoveValue` returns both the old and new HEAD buffer IDs in one call, used
+  inline for TAIL (version-history) maintenance — no standalone lookups are issued.
+- Design-time estimate: ~57-62% faster than Remove+Add for same-leaf moves, ~30-41% faster cross-leaf, and
+  ~64-71% faster than the four-operation multi-value path; actual savings depend on how often field updates
+  keep the entity in the same leaf.
+
+## 🧪 Tests
+
+- [OlcBTreeTests](../../../test/Typhon.Engine.Tests/Data/OlcBTreeTests.cs) — `#114 — Compound Move/MoveValue` region: same-leaf/cross-leaf `Move`, deadlock-free opposite-direction moves, `MoveValue` same-leaf/cross-leaf/last-element-removes-key, and the old-key-not-found/new-key-exists failure paths
+- [ClusterIndexTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterIndexTests.cs) — `TickFence_FieldMutation_BTreeMoveExecuted`: end-to-end exercise of the same `Move` operation via the cluster/SV tick-fence deferred commit path
+
+## 🔗 Related
+
+- Sibling features: [Unique (single-value) secondary index](./secondary-index-storage-modes/unique-secondary-index.md), [Multi-value secondary index (AllowMultiple)](./secondary-index-storage-modes/multi-value-secondary-index.md)
+
+<!-- Deep dive: claude/design/Indexing/concurrent-index-scaling.md §5.5, §6 -->
+<!-- Deep dive: claude/design/Indexing/public-api.md -->

--- a/doc/feature-set/Indexing/index-ref-resolution.md
+++ b/doc/feature-set/Indexing/index-ref-resolution.md
@@ -1,0 +1,69 @@
+# Index Handle Resolution (IndexRef)
+> Resolve an index once on the cold path, then reuse the handle for free on every hot-path call.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Hot-path code (a per-tick query, a lookup inside a system loop) needs to repeatedly target the same primary-key or
+secondary index without paying repeated resolution cost — naming a `ComponentTable`, finding which field, confirming
+it's actually indexed. Doing that lookup by name on every call costs dictionary/string work for no reason, since the
+target never changes between calls. `IndexRef` separates the two: pay the resolution cost once, then carry a cheap,
+fixed-size handle into the hot path indefinitely.
+
+## ⚙️ How it works (in brief)
+
+`DatabaseEngine.GetPKIndexRef<T>()` and `DatabaseEngine.GetIndexRef<T, TKey>(selector)` are the only ways to obtain an
+`IndexRef`. Both validate eagerly — component registered, field exists, field carries `[Index]` — and throw immediately
+on failure rather than deferring the error to first use. On success they return a small readonly struct identifying the
+target table and field, plus a snapshot of the table's current index-layout version. Every API that accepts an
+`IndexRef` checks that snapshot against the table's live version before use — an O(1) integer compare — so a handle
+captured before a schema migration that reshuffles indexed fields is detected and rejected rather than silently
+misreading another field.
+
+## 💻 Usage
+
+```csharp
+// Cold path — resolve once, e.g. at startup or before entering a hot loop.
+var nameIndex = dbe.GetIndexRef<Player, String64>(p => p.Name);
+var idIndex   = dbe.GetPKIndexRef<Player>();
+
+// Hot path — pass the handles in repeatedly; no re-resolution, no allocation.
+using (var tx = dbe.CreateQuickTransaction())
+{
+    using var hits = tx.EnumerateIndex<Player, String64>(nameIndex, minKey: default, maxKey: String64.MaxValue);
+    foreach (var hit in hits)
+    {
+        // hit.EntityPK, hit.Key, hit.Component
+    }
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- `GetPKIndexRef<T>()` / `GetIndexRef<T, TKey>(selector)` throw `InvalidOperationException` immediately if the
+  component isn't registered, the field doesn't exist, or the field isn't `[Index]`-annotated — failures surface at
+  resolution time, not on first hot-path use.
+- Resolution validates against the table's current schema; any later staleness check is a single integer compare
+  (`CapturedLayoutVersion` vs. the table's live layout version) — no dictionary lookup, no page-cache access.
+- A handle becomes stale the moment its owning table's index layout changes (e.g. an index added/removed/reordered by
+  schema evolution). The next use throws rather than reading the wrong field; the only recovery is to call
+  `GetIndexRef`/`GetPKIndexRef` again.
+- `IndexRef` is a 16-byte `readonly struct` — copy it into fields, locals, or closures freely; there is nothing to
+  dispose.
+- `GetPKIndexRef<T>()` resolves and reports `IsPrimaryKey == true`, but primary-key lookups go through ECS entity
+  APIs / `EntityMap`, not `Transaction.EnumerateIndex` — passing a PK `IndexRef` there throws. `IndexRef` is for
+  secondary indexes in range/lookup APIs.
+
+## 🧪 Tests
+
+- [IndexRefTests](../../../test/Typhon.Engine.Tests/Data/IndexRefTests.cs) — `GetPKIndexRef`/`GetIndexRef` success and failure paths (unregistered type, non-indexed field), plus the `Validate()` staleness check
+- [BulkEnumerateTests](../../../test/Typhon.Engine.Tests/Data/BulkEnumerateTests.cs) — `StaleIndexRef_Throws` exercises the same staleness check on the hot-path `Transaction.EnumerateIndex` call
+
+## 🔗 Related
+
+- Sibling: [Lookup and Range-Scan Operations](./lookup-and-range-scan.md) — the hot-path API `IndexRef` handles are resolved for
+- Sibling: [Indexed Field Predicates (WhereField)](../Querying/fluent-query-api/wherefield-indexed-predicate.md) — `WhereField` compiles down to an index lookup via `IndexRef`
+
+<!-- Deep dive: claude/design/Indexing/public-api.md — public surface, IndexRef layout, staleness contract -->
+<!-- Deep dive: claude/overview/04-data.md §4.7 B+Tree Indexes -->

--- a/doc/feature-set/Indexing/lookup-and-range-scan.md
+++ b/doc/feature-set/Indexing/lookup-and-range-scan.md
@@ -1,0 +1,61 @@
+# Lookup and Range-Scan Operations
+> Lock-free point lookups and ordered range scans over any secondary index, MVCC-correct at your transaction's snapshot.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Application code routinely needs "find the entity with key X" or "give me all entities with key between A and B, in order" — without scanning the whole table and without index reads blocking concurrent writers. A naive index read taking a lock for the duration of a scan would serialize readers against writers and tank throughput under the high-core-count workloads Typhon targets. Lookup and range-scan operations give you both point and ranged access to a secondary index's sorted key space, reading concurrently with in-flight writes and returning only the component versions visible to your transaction's snapshot.
+
+## ⚙️ How it works (in brief)
+
+`Transaction.EnumerateIndex<T, TKey>` takes an `IndexRef` plus a `[minKey, maxKey]` bound and streams matching entities in ascending key order; pass `minKey == maxKey` for a point lookup. Internally it walks the index's leaf chain using per-leaf optimistic version validation — no lock is held while reading, and only a leaf that was concurrently modified during the read is re-read. For `AllowMultiple` (non-unique) indexes, each key's value set is expanded transparently; you iterate `(EntityPK, Key, Component)` triples regardless of uniqueness. Every candidate is checked against the entity's revision chain at the transaction's snapshot TSN, so deleted or not-yet-committed versions are filtered out before you ever see them. The same range-scan machinery also backs the fluent `Query<T>()` pipeline when a predicate or ordering can be served by a secondary index.
+
+## 💻 Usage
+
+```csharp
+var nameIndex = engine.GetIndexRef<Player, String64>(p => p.Name);
+
+using var tx = engine.CreateQuickTransaction();
+
+// Range scan — all players with Name in ["Anna", "Marco"], ascending
+using (var range = tx.EnumerateIndex<Player, String64>(nameIndex, "Anna", "Marco"))
+{
+    foreach (var hit in range)
+    {
+        // hit.EntityPK, hit.Key, hit.Component (or hit.CurrentComponent for zero-copy)
+    }
+}
+
+// Point lookup — minKey == maxKey
+using var point = tx.EnumerateIndex<Player, String64>(nameIndex, "Marco", "Marco");
+if (point.MoveNext())
+{
+    var found = point.CurrentComponent;
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Reads are lock-free (optimistic lock coupling): a concurrent writer never blocks a scan, and a scan never blocks a writer. A version conflict triggers a re-read of only the affected leaf, not a tree-wide restart.
+- Results are MVCC-correct: only revisions committed and visible at the transaction's snapshot TSN are yielded; uncommitted writes from other transactions and tombstoned entities are skipped transparently.
+- `EnumerateIndex` only accepts secondary `IndexRef`s — passing a primary-key `IndexRef` throws `InvalidOperationException` (use ECS entity APIs for PK lookups).
+- Iteration order from `EnumerateIndex` is ascending by key; the fluent `Query<T>()` pipeline can request descending order when an `OrderBy` plan selects the same index.
+- The returned enumerator is a `ref struct` tied to the issuing `Transaction` and its epoch scope — it cannot outlive the transaction or escape across threads/async boundaries.
+- `CurrentComponent` gives a zero-copy `ref readonly` into page memory valid only until the next `MoveNext()`; use `Current` (which copies) if you need the value to outlive that step.
+- Long-running scans periodically refresh the engine epoch internally so a single large range read doesn't pin reclamation indefinitely.
+
+## 🧪 Tests
+
+- [BulkEnumerateTests](../../../test/Typhon.Engine.Tests/Data/BulkEnumerateTests.cs) — `SecondaryIndex_UniqueField`/`SecondaryIndex_AllowMultiple`/`StaleIndexRef_Throws`/`ZeroCopy_ReadReturnsRefIntoPageMemory`: `Transaction.EnumerateIndex` ascending order, zero-copy reads, MVCC visibility (`MVCC_Visibility`, `DeletedEntity_Skipped`)
+- [BtreeTests](../../../test/Typhon.Engine.Tests/Data/BTreeTests.cs) — `RangeScan_TightBounds_OnlyQualifyingEntries`/`RangeScan_MultiLeaf_CorrectOrdering`/`RangeScanDescending_ReturnsReverseOrder`/`RangeScan_AfterDeletions_CorrectEntries`: the leaf-chain range-scan machinery underneath `EnumerateIndex`
+
+## 🔗 Related
+
+- Sibling: [Optimistic Lock Coupling (per-node concurrency)](./olc-concurrency.md) — the lock-free concurrency protocol this operation relies on
+- Sibling: [Index Handle Resolution (IndexRef)](./index-ref-resolution.md) — the handle passed into `EnumerateIndex`
+- Sibling: [Indexed Field Predicates (WhereField)](../Querying/fluent-query-api/wherefield-indexed-predicate.md) — compiles down to this same range-scan machinery
+
+<!-- Deep dive: claude/design/Indexing/public-api.md — operation surface, OLC concurrency model, B-link descent -->
+<!-- Deep dive: claude/overview/04-data.md §4.7 B+Tree Indexes — node layout, concurrency model -->
+<!-- Deep dive: claude/overview/05-query.md §5.5 Pipeline Executor — how range scans feed the fluent Query<T>() pipeline -->

--- a/doc/feature-set/Indexing/olc-concurrency.md
+++ b/doc/feature-set/Indexing/olc-concurrency.md
@@ -1,0 +1,78 @@
+# Optimistic Lock Coupling (per-node concurrency)
+> Lock-free index reads and leaf-only write latching replace whole-tree locking — transparent to your code.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Every index lookup, range scan, insert, update, and delete touches the same B+Tree. A single whole-tree lock
+would serialize all of that traffic — one writer at a time, blocking every concurrent reader, while readers
+themselves contend on a shared counter just to prove they didn't conflict with anything. At the core counts
+Typhon targets, that becomes the dominant scaling bottleneck for any workload that mixes index reads and
+writes. Optimistic Lock Coupling (OLC) removes the whole-tree lock so index throughput scales with how many
+cores are touching genuinely independent parts of the tree, not with how many cores are touching the tree at
+all.
+
+## ⚙️ How it works (in brief)
+
+Each B+Tree (and R-Tree) node carries its own small version counter instead of the tree holding one global
+lock. Readers traverse by reading a node's version, reading its data, then re-validating the version was
+unchanged — no lock is ever taken, so a reader and a writer can touch the same node at the same instant
+without either blocking. Writers descend the same lock-free way, then take an exclusive latch on just the leaf
+they're modifying — and, on the rare structural change (split or merge), its parent too, latched bottom-up to
+stay deadlock-free. If a version check fails mid-traversal because of a concurrent split, the operation
+follows a right-link to the node's new sibling, or restarts from the root if the failure is higher up;
+structurally retired nodes are only reclaimed once Typhon's epoch mechanism confirms no in-flight reader can
+still see them.
+
+## 💻 Usage
+
+```csharp
+// No API surface to call — every index operation already runs through OLC.
+// Concurrent readers and writers on the same index never block each other:
+
+var nameIndex = engine.GetIndexRef<Player, String64>(p => p.Name);
+
+// Thread A — range scan, fully lock-free
+using var tx = engine.CreateQuickTransaction();
+using var range = tx.EnumerateIndex<Player, String64>(nameIndex, "Anna", "Marco");
+foreach (var hit in range) { /* ... */ }
+
+// Thread B — concurrent insert on the same index, only latches the leaf it touches
+using var tx2 = engine.CreateQuickTransaction();
+EntityRef e = tx2.Spawn<PlayerArchetype>();
+e.Write(PlayerArchetype.P).Name = "Diego";
+tx2.Commit();
+```
+
+No tuning knobs — there is nothing to configure. OLC is the only concurrency path for index reads and writes.
+
+## ⚠️ Guarantees & limits
+
+- Readers never acquire a lock and never block a writer; a writer latches only the node(s) it mutates — one
+  for a simple insert/remove, up to two during a split or merge, acquired bottom-up to prevent deadlock.
+- A reader whose version check fails re-reads just the affected node (or follows a right-link after a
+  concurrent split) — it never restarts an entire scan, only the step that raced.
+- The same protocol covers both the B+Tree (primary and secondary indexes) and the spatial R-Tree — one
+  concurrency model for all index access in Typhon.
+- Nodes retired by a merge are kept alive until epoch reclamation confirms no reader still references them —
+  no use-after-free under contention.
+- After a bounded number of failed optimistic attempts, an operation falls back to pessimistic top-down
+  latch-coupling to guarantee forward progress; this is invisible to callers beyond an occasional latency tail.
+- Purely an internal concurrency mechanism — there is no API to enable, disable, or tune it. It underlies every
+  index lookup, range scan, insert, remove, and the compound Move/MoveValue operations.
+
+## 🧪 Tests
+
+- [OlcLatchTests](../../../test/Typhon.Engine.Tests/Data/OlcLatchTests.cs) — the per-node latch primitive itself: `TryWriteLock`/`WriteUnlock`/`ReadVersion`/`ValidateVersion`/`MarkObsolete`, plus `Concurrent_ReadersAndWriter_VersionConsistency`
+- [OlcBTreeTests](../../../test/Typhon.Engine.Tests/Data/OlcBTreeTests.cs) — tree-level optimistic reads racing writers (`TryGet_ConcurrentReadersWithOneWriter_ReadersGetCorrectValues`), concurrent splits/merges, and epoch-deferred node reclamation (`DeferredDeallocation_*`)
+- [OlcBTreeStressTests](../../../test/Typhon.Engine.Tests/Data/OlcBTreeStressTests.cs) — `[Explicit]` 32-thread mixed read/write/remove stress variant of the same scenarios, for restart/fallback/split/merge paths that need heavier contention to trigger
+
+## 🔗 Related
+
+- Sibling features: [Lookup and Range-Scan Operations](./lookup-and-range-scan.md), [Compound Move/MoveValue](./compound-move-operations.md)
+
+<!-- Deep dive: claude/design/Indexing/concurrent-index-scaling.md — OLC design, protocols, epoch integration -->
+<!-- Deep dive: claude/design/Indexing/latch-coupled-smo.md — bottom-up latch coupling for splits/merges, correctness fixes -->
+<!-- Deep dive: claude/overview/04-data.md#concurrency-model-optimistic-lock-coupling-olc — concurrency model summary -->
+<!-- Deep dive: claude/overview/01-concurrency.md §1.8 OlcLatch — latch implementation, spin strategy -->

--- a/doc/feature-set/Indexing/secondary-index-storage-modes/README.md
+++ b/doc/feature-set/Indexing/secondary-index-storage-modes/README.md
@@ -1,0 +1,69 @@
+# Secondary Index Storage Modes
+> Unique vs AllowMultiple: the per-field choice that decides an index's on-disk value shape and per-entity storage cost.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Indexing](../README.md)
+**Assumes:** [Component & Field Schema Declaration](../../Schema/component-field-declaration.md)
+
+## 🎯 What it solves
+
+Modeling a field as `[Index]` always builds a B+Tree, but a 1:1 field (a player ID, a SKU) and a 1:N field (a guild
+ID, a status) cannot use the same on-disk value shape — one entity per key needs no more than a pointer, many
+entities per key need a growable set. The storage mode chosen for an indexed field — unique or `AllowMultiple` —
+isn't just a uniqueness constraint at the application level; it picks a different B+Tree value representation,
+adds (or doesn't add) a hidden per-entity bookkeeping field, and routes commits through a different compound
+B+Tree operation. Picking the right mode keeps both storage footprint and commit cost proportional to what the
+field actually models.
+
+## ⚙️ How it works (in brief)
+
+A unique index's B+Tree value is the entity's component chunk-id itself — direct, no indirection. An
+`AllowMultiple` index's value is a HEAD buffer ID: a `VariableSizedBufferSegment` holding the current set of
+chunk-ids that share the key. To remove or relocate a single entity's slot inside a HEAD buffer in O(1) instead of
+scanning it, every `AllowMultiple`-indexed field adds a hidden 4-byte `ElementId` to the component's storage
+overhead — unique fields add nothing. The mode also picks the commit-time B+Tree operation: unique fields use
+`Add`/`Move`/`Remove`; `AllowMultiple` fields use `Add`/`MoveValue`/`RemoveValue`, and on `Versioned` components
+additionally maintain a per-key TAIL history buffer. Both shapes share the identical OLC concurrency model and the
+same read API (`Transaction.EnumerateIndex`) — the difference is invisible to a caller and shows up only in
+storage footprint and commit cost.
+
+## Sub-features
+
+| Sub-feature | Declared as | On-disk value | Extra per-entity cost |
+|-------------|-------------|----------------|------------------------|
+| [Unique (single-value) secondary index](./unique-secondary-index.md) | `[Index]` (default) | Key → chunk-id, directly | none |
+| [Multi-value secondary index (AllowMultiple)](./multi-value-secondary-index.md) | `[Index(AllowMultiple = true)]` | Key → HEAD buffer of chunk-ids (+ TAIL on `Versioned`) | +4 bytes (`ElementId`) |
+
+## ⚠️ Guarantees & limits
+
+- The mode is fixed per field at schema registration; switching between unique and `AllowMultiple` is a schema
+  change, not a runtime toggle — it bumps the table's index-layout version and invalidates every previously
+  resolved `IndexRef`.
+- The 4-byte `ElementId` overhead applies to every `AllowMultiple`-indexed field on every component instance,
+  regardless of storage mode (`SingleVersion`/`Versioned`/`Transient`) — it is what lets the commit path remove an
+  entity from its HEAD buffer without a linear scan.
+- The TAIL history segment is allocated once per table, only if at least one `AllowMultiple` index exists on it,
+  and each key's TAIL buffer is populated lazily on that key's first mutation — a table with only unique indexes
+  never allocates it.
+- Unique-field commits (`Move`) are a single tree traversal that write-locks at most two leaves. `AllowMultiple`
+  commits (`MoveValue`/`RemoveValue`) do that same traversal plus splice the entity into/out of a HEAD buffer (and,
+  on `Versioned` tables, append TAIL entries) — strictly more work per commit for the same field shape.
+- Both modes expose the identical read surface — `Transaction.EnumerateIndex` over ascending key order — so
+  choosing a mode never changes how query code is written, only what it costs underneath.
+- The mode applies uniformly across all three component storage modes (`SingleVersion`/`Versioned`/`Transient`);
+  only `SingleVersion`/`Versioned` indexes are queried via `Transaction.EnumerateIndex` — `Transient`-indexed
+  fields are built and maintained the same way but are read through the ECS query pipeline (`WhereField`)
+  instead.
+
+## 🧪 Tests
+
+- [BtreeTests](../../../../test/Typhon.Engine.Tests/Data/BTreeTests.cs) — unique vs. `AllowMultiple` B+Tree value representation side by side (`CheckTree`/`CheckRemove` vs. `CheckMultipleTree`/`CheckByteMultipleTree`/`CheckFloatMultipleTree`)
+- [BulkEnumerateTests](../../../../test/Typhon.Engine.Tests/Data/BulkEnumerateTests.cs) — `SecondaryIndex_UniqueField`/`SecondaryIndex_AllowMultiple` show both modes read through the identical `Transaction.EnumerateIndex` surface
+
+## 🔗 Related
+
+- See also: [Specialized B+Tree Key-Size Variants](../btree-key-variants.md), [IndexRef — Resolve-Once Index Handle](../index-ref-resolution.md)
+- See also: [Indexed Field Predicates (WhereField)](../../Querying/fluent-query-api/wherefield-indexed-predicate.md) — the query-planner path for `Transient`-indexed fields
+- Sub-features: [Unique (single-value) secondary index](./unique-secondary-index.md), [Multi-value secondary index (AllowMultiple)](./multi-value-secondary-index.md)
+
+<!-- Deep dive: claude/overview/04-data.md §4.7 B+Tree Indexes — Single vs Multiple, Versioned Secondary Indexes (HEAD/TAIL) -->
+<!-- Deep dive: claude/design/Indexing/public-api.md -->

--- a/doc/feature-set/Indexing/secondary-index-storage-modes/multi-value-secondary-index.md
+++ b/doc/feature-set/Indexing/secondary-index-storage-modes/multi-value-secondary-index.md
@@ -1,0 +1,90 @@
+# Multi-Value Secondary Index (AllowMultiple)
+> Many entities share one key — the B+Tree value is a growable HEAD buffer of chunk-ids, at a fixed +4-byte-per-entity cost.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Indexing](../README.md)
+
+## 🎯 What it solves
+
+Grouping fields — a guild ID shared by every member, a status or rarity tier with a handful of distinct values —
+need many entities mapped to the same key. A unique index's one-value-per-key slot cannot hold that. The
+`AllowMultiple` storage mode stores an indirected, variable-length set of chunk-ids per key instead, sized to the
+group's actual membership rather than reserved up front for a worst case.
+
+## ⚙️ How it works (in brief)
+
+Each key's B+Tree value is a HEAD buffer ID — a `VariableSizedBufferSegment` holding the current set of entity
+chunk-ids that share the key. To remove or relocate a single entity's slot inside that buffer in O(1) instead of
+scanning it, every `AllowMultiple`-indexed field carries a hidden 4-byte `ElementId` (the entity's own slot
+within the HEAD buffer) added to the component's storage overhead — this is paid by every component instance with
+such a field, not just ones currently sharing a key with others. Commit-time mutation runs `MoveValue` (value
+change) and `RemoveValue` (deletion) instead of the unique path's `Move`/`Remove`, both addressed directly by that
+`ElementId`. On `Versioned` components, every gain or loss additionally appends to a per-key TAIL history buffer
+— a single `TailVSBS` segment shared by all `AllowMultiple` indexes on the table, allocated once if any exist and
+populated lazily per key on that key's first mutation. `SingleVersion`/`Transient` components get the HEAD buffer
+only — no revision chain means there is no history to keep.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.GuildMember", 1)]   // Versioned by default
+struct GuildMember
+{
+    [Index(AllowMultiple = true)]
+    public long GuildId;
+    public String64 Name;
+}
+
+[Archetype(43)]
+partial class MemberArchetype : Archetype<MemberArchetype>
+{
+    public static readonly Comp<GuildMember> M = Register<GuildMember>();
+}
+
+var guildIndex = dbe.GetIndexRef<GuildMember, long>(m => m.GuildId);
+
+using (var tx = dbe.CreateQuickTransaction())
+{
+    tx.Spawn<MemberArchetype>(MemberArchetype.M.Set(new GuildMember { GuildId = 7, Name = "Aria" }));
+    tx.Spawn<MemberArchetype>(MemberArchetype.M.Set(new GuildMember { GuildId = 7, Name = "Beck" }));
+    tx.Commit();
+}
+
+// Enumerate every current member of guild 7 — minKey == maxKey selects one key's whole group
+using (var tx = dbe.CreateQuickTransaction())
+{
+    using var members = tx.EnumerateIndex<GuildMember, long>(guildIndex, 7, 7);
+    foreach (var entry in members)
+    {
+        // entry.EntityPK, entry.Key, entry.Component
+    }
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Every `AllowMultiple`-indexed field costs +4 bytes (`ElementId`) per component instance, regardless of storage
+  mode — paid even while the field's current value happens to be unique to one entity.
+- TAIL history exists only for `AllowMultiple` indexes on `Versioned` components (see the Storage Mode Feature
+  Matrix in `claude/overview/04-data.md`); `SingleVersion`/`Transient` carry the HEAD buffer only, with no history.
+- `MoveValue`/`RemoveValue` do strictly more commit-time work than the unique path's `Move`/`Remove`: they splice
+  an entry into and/or out of a HEAD buffer, and on `Versioned` tables also append TAIL entries — cost is
+  proportional to the change being made, not to the group's size.
+- HEAD buffer membership order is not guaranteed (an unordered set with swap-compact removal); only the ordering
+  of keys across a range scan is guaranteed ascending.
+- TAIL entries are pruned once no active transaction's snapshot can still need them (the `MinTSN` boundary); one
+  boundary entry per chain is retained so a reader exactly at the prune point still resolves correctly.
+
+## 🧪 Tests
+
+- [BtreeTests](../../../../test/Typhon.Engine.Tests/Data/BTreeTests.cs) — `CheckMultipleTree`/`CheckByteMultipleTree`/`CheckFloatMultipleTree`: HEAD buffer growth, `RemoveValue` by `ElementId`, and BTree-entry cleanup once a key's last element is removed
+- [BulkEnumerateTests](../../../../test/Typhon.Engine.Tests/Data/BulkEnumerateTests.cs) — `SecondaryIndex_AllowMultiple`: multiple entities sharing one key, read back via `GetIndexRef` + `Transaction.EnumerateIndex`
+
+## 🔗 Related
+
+- Parent feature: [Secondary Index Storage Modes](./README.md)
+- Sibling: [Unique (single-value) secondary index](./unique-secondary-index.md)
+- See also: [Versioned (HEAD/TAIL) Secondary Indexes for MVCC](../versioned-secondary-indexes.md), [Temporal (Point-in-Time) Index Query](../temporal-index-query.md)
+
+<!-- Deep dive: claude/overview/04-data.md §4.7 B+Tree Indexes — Versioned Secondary Indexes (HEAD/TAIL) -->
+<!-- Deep dive: claude/design/Indexing/VersionedSecondaryIndexes.md -->
+<!-- Deep dive: claude/design/Indexing/public-api.md -->

--- a/doc/feature-set/Indexing/secondary-index-storage-modes/unique-secondary-index.md
+++ b/doc/feature-set/Indexing/secondary-index-storage-modes/unique-secondary-index.md
@@ -1,0 +1,84 @@
+# Unique (Single-Value) Secondary Index
+> One key maps to exactly one entity — the B+Tree value is a chunk-id directly, no buffer indirection, no per-entity overhead.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Indexing](../README.md)
+
+## 🎯 What it solves
+
+Fields that are inherently 1:1 with the entity that owns them — a player ID, an item SKU, a session token — need
+a lookup whose stored value *is* the entity reference, not a pointer to a set that happens to contain one entry.
+Modeling such a field as unique gets exactly that representation, with no indirection and no per-entity
+bookkeeping cost paid for a "set" that can never hold more than one member.
+
+## ⚙️ How it works (in brief)
+
+For a unique field, the B+Tree value at each key is the entity's component chunk-id, stored directly in the leaf
+— there is no separate HEAD buffer and no hidden `ElementId` added to the component's storage layout. On commit,
+`Add` inserts a brand-new key, `Move` atomically relocates an existing key in a single tree traversal when the
+indexed field's value changes (write-locking at most two leaves — the old key's and the new key's), and `Remove`
+deletes the key outright on entity deletion. A second entity attempting to claim an already-mapped key is
+rejected at commit, since the value slot has room for exactly one chunk-id.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+struct Player
+{
+    [Index]   // unique — AllowMultiple defaults to false
+    public int PlayerId;
+    public String64 Name;
+}
+
+[Archetype(42)]
+partial class PlayerArchetype : Archetype<PlayerArchetype>
+{
+    public static readonly Comp<Player> P = Register<Player>();
+}
+
+// Cold path — resolve once, reuse on the hot path
+var idIndex = dbe.GetIndexRef<Player, int>(p => p.PlayerId);
+
+using (var tx = dbe.CreateQuickTransaction())
+{
+    tx.Spawn<PlayerArchetype>(PlayerArchetype.P.Set(new Player { PlayerId = 42, Name = "Nova" }));
+    tx.Commit();
+}
+
+// Point lookup — minKey == maxKey; the value found is the entity's own chunk-id, no indirection to resolve
+using (var tx = dbe.CreateQuickTransaction())
+{
+    using var hit = tx.EnumerateIndex<Player, int>(idIndex, 42, 42);
+    foreach (var entry in hit)
+    {
+        // entry.EntityPK, entry.Key, entry.Component
+    }
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Zero storage overhead beyond the field itself — no hidden `ElementId`, and no TAIL history segment is allocated
+  on account of this index.
+- `Move` is the commit-time operation for a value change: one descent, at most two leaf write-locks, never a
+  separate remove-then-insert pair.
+- A duplicate key on create or update throws `UniqueConstraintViolationException` (`TyphonErrorCode.UniqueConstraintViolation`,
+  4001; non-transient) at `Commit()`, not at `Spawn`/`Write` time — the key is only resolved against the B+Tree at commit.
+- `Transaction.EnumerateIndex` is the only read path; there is no separate `TryGet`-style point-lookup entry point
+  in the public API — pass `minKey == maxKey` for a point lookup.
+- Switching a field to `AllowMultiple` later is a schema change: it adds the 4-byte `ElementId` overhead to every
+  existing component instance and reroutes commit-path operations from `Move`/`Remove` to `MoveValue`/`RemoveValue`.
+
+## 🧪 Tests
+
+- [BtreeTests](../../../../test/Typhon.Engine.Tests/Data/BTreeTests.cs) — `ForwardInsertionTest`/`ReverseInsertionTest`/`CheckTree`/`CheckRemove` family: Add/Remove correctness for the single-value B+Tree across all key widths, no `ElementId` overhead
+- [BulkEnumerateTests](../../../../test/Typhon.Engine.Tests/Data/BulkEnumerateTests.cs) — `SecondaryIndex_UniqueField`: engine-level round trip through `GetIndexRef` + `Transaction.EnumerateIndex`
+
+## 🔗 Related
+
+- Parent feature: [Secondary Index Storage Modes](./README.md)
+- Sibling: [Multi-value secondary index (AllowMultiple)](./multi-value-secondary-index.md)
+
+<!-- Deep dive: claude/overview/04-data.md §4.7 B+Tree Indexes -->
+<!-- Deep dive: claude/design/Indexing/public-api.md -->
+<!-- Deep dive: claude/design/Errors/05-public-exception-catalog.md — Index chain -->

--- a/doc/feature-set/Indexing/tail-garbage-collection.md
+++ b/doc/feature-set/Indexing/tail-garbage-collection.md
@@ -1,0 +1,80 @@
+# TAIL Retention / Garbage Collection
+> Bounds TAIL version-history growth via boundary-sentinel-preserving pruning — built and tested, not yet auto-triggered.
+
+**Status:** 🚧 Partial · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+[Versioned Secondary Indexes](./versioned-secondary-indexes.md) append a TAIL entry every time an `AllowMultiple`
+indexed field on a `Versioned` component gains or loses a value — that's what makes temporal ("who held this value
+at TSN T") queries possible. TAIL is append-only by design, so under sustained churn on a given key (a field that
+keeps flipping between a small set of values, for instance) it grows without bound: nothing today reclaims entries
+that no transaction can possibly still need. TAIL retention/GC is the reclamation half of that design — it exists
+as a tested primitive, but the trigger that would run it automatically isn't wired up yet.
+
+## ⚙️ How it works (in brief)
+
+Given a TAIL buffer and a `retentionTSN` (the oldest TSN any in-flight transaction could still query), pruning
+groups entries by chain (the entity/key-value pairing a TAIL sequence belongs to). For each chain it discards every
+entry older than the newest one at or below `retentionTSN`, keeping that single newest entry as a **boundary
+sentinel** — the fact a reader sitting exactly at the retention edge needs to know whether the chain was Active or
+Tombstoned. A chain whose sentinel is a Tombstone with nothing newer than it is dropped entirely, sentinel
+included, since there's no longer any reader that could land on it. Pruning rewrites the kept entries into a fresh
+buffer rather than mutating in place.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.GuildMember", 1)]   // Versioned by default
+struct GuildMember
+{
+    [Index(AllowMultiple = true)]
+    public long GuildId;
+}
+
+// Every commit that moves an entity between GuildId values appends a TAIL entry for the old
+// and new value (see Versioned Secondary Indexes) — no extra call needed for that part:
+using (var tx = dbe.CreateQuickTransaction())
+{
+    ref var m = ref tx.OpenMut(aria).Write(MemberArchetype.M);
+    m.GuildId = nextGuildId;   // one more TAIL entry, every commit, indefinitely
+    tx.Commit();
+}
+
+// There is no application-facing Prune()/Compact() call today. TailGarbageCollector.Prune exists
+// and is unit-tested in isolation, but nothing in the commit, checkpoint, or deferred-cleanup path
+// invokes it yet — so the entry appended above is never reclaimed for the life of the process.
+// Once wired, pruning is designed to run automatically (no API call), the same way HEAD/TAIL
+// maintenance itself requires none.
+```
+
+## ⚠️ Guarantees & limits
+
+- **Boundary-correct today as a primitive** — for any `retentionTSN` passed in, the kept set always lets a reader
+  at that exact TSN resolve Active/Tombstoned correctly; entries with `TSN > retentionTSN` are never discarded.
+- **Dead chains collapse fully** — a chain whose last surviving state is a Tombstone with no later activity is
+  removed entirely rather than leaving a permanent one-entry remnant.
+- **Not yet automatically triggered** — no `MinTSN`-advance hook, checkpoint hook, or background scheduler calls
+  it. `DeferredCleanupManager` (which already drives the analogous component-revision and content-chunk reclamation
+  on `MinTSN`/tail-transaction-completion) has no TAIL GC integration today.
+- **Unbounded TAIL growth in production today** — every value transition on an `AllowMultiple` indexed field of a
+  `Versioned` component adds a TAIL entry that nothing currently removes; storage cost scales with field churn over
+  the life of the process, not with retention need.
+- **Compaction reallocates the buffer** — a successful prune returns a new TAIL buffer ID distinct from the input;
+  the caller is responsible for repointing the HEAD buffer's `TailBufferId` to it (the not-yet-built integration
+  layer's job, not application code's).
+- **Tested in isolation only** — unit tests drive `TailGarbageCollector.Prune` directly against a TAIL buffer; no
+  concurrency/stress coverage exists yet for pruning racing live writers or temporal readers.
+- **No public API** — this is an internal engine primitive; there is nothing for application code to call, configure, or observe.
+
+## 🧪 Tests
+
+- [VersionedIndexTests](../../../test/Typhon.Engine.Tests/Data/VersionedIndexTests.cs) — Phase 5 `GC Tests` region: `TailGC_PruneOldEntries_KeepsBoundarySentinel`, `TailGC_DeadChain_FullyRemoved`, `TailGC_NoOldEntries_NothingPruned` — drives `TailGarbageCollector.Prune` directly, in isolation from any auto-trigger
+
+## 🔗 Related
+
+- Sibling feature: [Versioned (HEAD/TAIL) Secondary Indexes for MVCC](./versioned-secondary-indexes.md)
+- Source: `src/Typhon.Engine/Indexing/internals/TailGarbageCollector.cs`
+- Source: `src/Typhon.Engine/Ecs/internals/DeferredCleanupManager.cs` (analogous `MinTSN`-driven cleanup; TAIL GC is not yet integrated here)
+
+<!-- Deep dive: claude/design/Indexing/VersionedSecondaryIndexes.md §10 GC / Retention Integration -->

--- a/doc/feature-set/Indexing/temporal-index-query.md
+++ b/doc/feature-set/Indexing/temporal-index-query.md
@@ -1,0 +1,73 @@
+# Temporal (Point-in-Time) Index Query
+> Reconstructs which entities held a key's value at a past TSN by replaying the index's append-only version history.
+
+**Status:** 🚧 Partial · **Visibility:** Internal · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Current-state secondary indexes only ever answer "who matches this value *now*". Once a matching entity's field
+changes or the entity is deleted, the old membership fact is gone from the index — there is no way to ask "which
+entities had `Status = Active` as of last Tuesday's snapshot" without falling back to a full scan and walking every
+candidate entity's revision chain by hand. Temporal index query answers that question directly off the index
+itself: given a key and a historical TSN, it returns exactly the entities that were associated with that key at
+that moment, in time proportional to how often the key's membership has changed rather than how many entities
+exist.
+
+## ⚙️ How it works (in brief)
+
+[Versioned secondary indexes](./versioned-secondary-indexes.md) already record, for every `AllowMultiple` key, an
+append-only TAIL log of `(ChainId, TSN, Active/Tombstone)` transitions alongside the current-state HEAD set. A
+temporal query looks up the key's TAIL buffer, scans every entry with `TSN <= targetTSN`, and keeps only the
+most-recent entry per chain ID — chains whose latest qualifying state is Active are the answer. If the key has
+never been mutated since it was created (no TAIL buffer allocated yet), the current HEAD set is returned directly,
+since it has been correct for every TSN since the key's creation.
+
+## 💻 Usage
+
+There is no public entry point yet — `TemporalIndexQuery`, the `IndexedFieldInfo`/`TailVSBS` it reads, and
+`VersionedIndexEntry` are all `internal` types with no `InternalsVisibleTo` grant to application assemblies, and no
+`Transaction`/query-builder method calls into them. The shape below is the actual call the engine's own test suite
+exercises — shown to illustrate the contract, not as code an application can compile against today:
+
+```csharp
+// Engine-internal only — illustrative, not callable from application code.
+var ifi = componentTable.IndexedFieldInfos[fieldIndex];   // the AllowMultiple field's index metadata
+float key = 1.0f;
+
+List<int> chainIdsActiveAtTsn = TemporalIndexQuery.Query(
+    ifi, (byte*)&key, targetTSN: snapshotTsn, componentTable.TailVSBS, changeSet: null);
+
+// Results are revision-chain handles, not EntityIds — resolving a chain ID back to an
+// entity/component is also internal-only today.
+```
+
+## ⚠️ Guarantees & limits
+
+- **No public API surface yet.** Nothing in `Transaction`, the query builder, or `PointInTimeAccessor` calls this
+  today — it is verified, tested engine plumbing without an application-facing entry point.
+- Applies only to `[Index(AllowMultiple = true)]` fields on `Versioned` components — the same scope as the TAIL
+  history it reads; `SingleVersion`/`Transient` indexes carry no TAIL to query.
+- Returns revision-chain IDs, not `EntityId`s — turning a chain ID into the entity/component data as of the target
+  TSN is a separate step with no public surface either.
+- Cost is O(H) per query, where H is the total number of TAIL transitions ever recorded for that key — not the
+  number of entities currently or historically matching it. A key churned by frequent updates costs more to query
+  than a stable one, independent of result size.
+- A boundary-sentinel-preserving TAIL pruning algorithm exists but isn't wired to an automatic trigger yet, so TAIL
+  history is effectively unbounded today; there is also no "target TSN older than retained history" error path —
+  that case is only meaningful once pruning is actually scheduled.
+- Chain ID reuse is handled correctly: if an old entity is deleted and a new one is later created reusing the same
+  chain ID under the same key, the Tombstone between them separates the two in the TAIL stream, so a query never
+  conflates them — but it does mean chain-ID-level history isn't the same thing as one entity's history.
+
+## 🧪 Tests
+
+- [VersionedIndexTests](../../../test/Typhon.Engine.Tests/Data/VersionedIndexTests.cs) — Phase 3 `Temporal Query Tests` region: `TemporalQuery_NoMutation_FallsBackToHead`, `TemporalQuery_AtCreate_ReturnsEntity`, `TemporalQuery_OldKey_AfterUpdate_SingleEntity_StillVisible`/`_MultiEntity_CorrectCount`, `TemporalQuery_AfterBackfill_ReturnsCorrectSnapshot`
+
+## 🔗 Related
+
+- Sibling feature: [Versioned (HEAD/TAIL) Secondary Indexes for MVCC](./versioned-secondary-indexes.md)
+- Sibling feature: [Multi-value secondary index (AllowMultiple)](./secondary-index-storage-modes/multi-value-secondary-index.md)
+- Source: `src/Typhon.Engine/Indexing/internals/TemporalIndexQuery.cs`, `src/Typhon.Engine/Indexing/internals/TailGarbageCollector.cs`
+
+<!-- Deep dive: claude/design/Indexing/VersionedSecondaryIndexes.md §8 Read Path / Query Algorithm -->
+<!-- Deep dive: claude/overview/04-data.md §Versioned Secondary Indexes (HEAD/TAIL Architecture) -->

--- a/doc/feature-set/Indexing/transaction-local-index-overlay.md
+++ b/doc/feature-set/Indexing/transaction-local-index-overlay.md
@@ -1,0 +1,43 @@
+# Transaction-Local Index Overlay (Read-Your-Own-Writes)
+> Planned per-transaction overlay so index lookups see that transaction's own uncommitted writes.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Secondary indexes are maintained on the commit path, not as part of the transaction body. So today, an entity you just `Spawn`ed or updated inside a still-open transaction is invisible to `EnumerateIndex` calls made later in that same transaction — even though direct component reads of that entity work fine via the transaction's own read-your-own-writes cache. This asymmetry is surprising: code that creates an entity and immediately looks it up by a secondary key gets a miss, not the entity it just wrote.
+
+## ⚙️ How it works (in brief)
+
+A per-transaction, in-memory overlay records the index-key additions and removals implied by the transaction's own `Spawn`/update/delete calls, without touching the persistent B+Tree. Index reads (`EnumerateIndex` and friends) merge the overlay with the persistent tree before returning results, so uncommitted same-transaction changes appear alongside committed data. On `Commit()`, the overlay's changes are written into the persistent B+Tree exactly as they are today; on rollback or dispose, the overlay is simply discarded — no B+Tree undo is needed. Point lookups stay cheap (an O(1) dictionary check plus the existing tree lookup); range scans against the overlay's uncommitted entries may be more limited than committed-data range scans (e.g. unordered until merged) — final behavior depends on the implementation.
+
+## 💻 Usage
+
+```csharp
+// Illustrative only — not implemented yet. Today, this pattern misses:
+var nameIndex = engine.GetIndexRef<Player, String64>(p => p.Name);
+
+using var tx = engine.CreateQuickTransaction();
+var id = tx.Spawn<Player>(Player.Data.Set(player));   // component written; index NOT yet updated
+
+using var hit = tx.EnumerateIndex<Player, String64>(nameIndex, player.Name, player.Name);
+hit.MoveNext();   // false today — overlay would make this true once shipped
+
+tx.Commit();
+```
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** No `TransactionIndexOverlay`, `_additions`/`_removals` tracking, or overlay-aware merge path exists in `src/Typhon.Engine/Indexing/` today; this entry documents a planned fix, not shipped behavior.
+- **Current behavior:** `EnumerateIndex` and other secondary-index lookups only ever see committed data — a transaction cannot find its own just-created or just-updated entities via an index until it commits. Workaround today: track entity IDs directly instead of relying on an index lookup for an entity you just wrote in the same transaction.
+- Once delivered, intended to give full read-your-own-writes semantics for index reads, matching the guarantee component reads already have via the transaction cache.
+- Designed to preserve today's rollback simplicity (discard an in-memory structure, no B+Tree undo) and today's write amplification (one physical B+Tree write per field at commit, not one per intermediate update).
+- Memory cost scales with the indexed fields a transaction actually touches — expected small for typical transactions (tens to low hundreds of entities).
+- Primary-key lookups are unaffected by this gap: PK access goes through the transaction's component cache, not the secondary-index path.
+
+## 🔗 Related
+
+- Related feature: [Lookup and Range-Scan Operations](./lookup-and-range-scan.md) — the read path this overlay would augment
+- Related feature: [Batched Index Maintenance for Bulk Commits](./batched-index-maintenance.md) — another planned change to the same commit-path index machinery
+
+<!-- Deep dive: claude/overview/04-data.md §Index Maintenance Timing (Known Limitation) and §Planned Fix: Transaction-Local Index Overlay -->

--- a/doc/feature-set/Indexing/versioned-secondary-indexes.md
+++ b/doc/feature-set/Indexing/versioned-secondary-indexes.md
@@ -1,0 +1,97 @@
+# Versioned (HEAD/TAIL) Secondary Indexes for MVCC
+> The mechanism that keeps `AllowMultiple` index membership correct across updates and deletes on `Versioned` components.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Indexing](./README.md)
+
+## 🎯 What it solves
+
+Naively maintained secondary indexes are destructive: when an indexed field changes from value A to B, the entity
+is unlinked from A and linked to B, and when an entity is deleted its index entries must be cleaned up too. Done
+carelessly, both steps break MVCC guarantees — a value change can leave a brief window where the entity is in
+neither key's result set, and a deleted entity's stale entries can linger and get handed back to callers, who then
+dereference a chain that's gone. On `Versioned` components, every `[Index(AllowMultiple = true)]` field is
+protected against both failure modes by construction, as part of ordinary commit processing.
+
+## ⚙️ How it works (in brief)
+
+Each `AllowMultiple` key holds two buffers. The HEAD buffer is the current entity set — unchanged from a plain
+multi-value index, and what `Transaction.EnumerateIndex` reads. The TAIL buffer is an append-only log of
+`(ChainId, TSN, Active/Tombstone)` entries: one Active entry whenever an entity gains the key's value (create, or
+update into it), one Tombstone whenever it loses it (update away, or delete). TAIL is allocated lazily on a key's
+first mutation and linked from the HEAD buffer's header, so a key that's never been touched costs nothing extra.
+Both HEAD and TAIL are updated together, automatically, inside `Transaction.Commit` — there is no separate API to
+call and no way to opt out for an `AllowMultiple` field on a `Versioned` component.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.GuildMember", 1)]   // Versioned by default
+struct GuildMember
+{
+    [Index(AllowMultiple = true)]
+    public long GuildId;
+    public String64 Name;
+}
+
+[Archetype(43)]
+class MemberArchetype : Archetype<MemberArchetype>
+{
+    public static readonly Comp<GuildMember> M = Register<GuildMember>();
+}
+
+var guildIndex = dbe.GetIndexRef<GuildMember, long>(m => m.GuildId);
+
+EntityId aria;
+using (var tx = dbe.CreateQuickTransaction())
+{
+    aria = tx.Spawn<MemberArchetype>(MemberArchetype.M.Set(new GuildMember { GuildId = 7, Name = "Aria" }));
+    tx.Commit();
+}
+
+// Move Aria to guild 9 — HEAD(7) loses her, HEAD(9) gains her, and TAIL records both transitions
+// with this commit's TSN. No extra calls: it happens as part of Write + Commit.
+using (var tx = dbe.CreateQuickTransaction())
+{
+    ref var m = ref tx.OpenMut(aria).Write(MemberArchetype.M);
+    m.GuildId = 9;
+    tx.Commit();
+}
+
+// Current-state membership is exactly the HEAD set — guild 7 is now empty, guild 9 has Aria.
+using var tx2 = dbe.CreateQuickTransaction();
+using var g7 = tx2.EnumerateIndex<GuildMember, long>(guildIndex, 7, 7); // empty
+using var g9 = tx2.EnumerateIndex<GuildMember, long>(guildIndex, 9, 9); // Aria
+```
+
+## ⚠️ Guarantees & limits
+
+- HEAD/TAIL maintenance applies only to `[Index(AllowMultiple = true)]` fields on `Versioned` components.
+  `SingleVersion` and `Transient` `AllowMultiple` indexes keep the HEAD set only — without a revision chain there
+  is no history to append, so TAIL is never allocated for them.
+- Maintenance is unconditional and automatic for every create, update-into/out-of a value, and delete on a
+  qualifying field — there is no method to call, no flag to set, and no way for a commit to skip it.
+- `Transaction.EnumerateIndex` reads HEAD only, at the same O(K) cost as a non-versioned `AllowMultiple` index —
+  adopting `Versioned` storage for the extra correctness costs nothing on this read path.
+- Delete is first-class: the HEAD entry is removed and a TAIL Tombstone is appended in the same commit, so a
+  deleted entity never reappears in a current-state `EnumerateIndex` result and never requires a follow-up cleanup
+  pass.
+- Each TAIL entry is 12 bytes and is written once per value transition, not once per entity — cost scales with how
+  often the field changes, not with how many entities currently hold the value.
+- TAIL is what powers [point-in-time reconstruction](./temporal-index-query.md) ("who held this value at TSN T")
+  and is bounded by a not-yet-auto-triggered [pruning algorithm](./tail-garbage-collection.md) — today the
+  directly usable guarantee is that current-state `EnumerateIndex` results are always accurate, including
+  immediately after deletes and value changes.
+
+## 🧪 Tests
+
+- [VersionedIndexTests](../../../test/Typhon.Engine.Tests/Data/VersionedIndexTests.cs) — Phase 1 (`AllocateTailBuffer_AddAndReadEntry`, lazy TAIL allocation) and Phase 2 (`Update_IndexedField_TailHasTombstoneAndActive`, `Delete_Entity_TailHasTombstone`, `Update_BackfillsTail_AllEntriesPresent`): HEAD+TAIL maintenance on create/update/delete
+
+## 🔗 Related
+
+- Sibling feature: [Multi-value secondary index (AllowMultiple)](./secondary-index-storage-modes/multi-value-secondary-index.md)
+- Sibling feature: [Secondary Index Storage Modes](./secondary-index-storage-modes/README.md)
+- Sibling feature: [Temporal (Point-in-Time) Index Query](./temporal-index-query.md) — reads this feature's TAIL history to answer point-in-time queries
+
+<!-- Deep dive: claude/design/Indexing/VersionedSecondaryIndexes.md -->
+<!-- ADR: claude/adr/039-versioned-secondary-index-architecture.md -->
+<!-- Deep dive: claude/overview/04-data.md §Versioned Secondary Indexes (HEAD/TAIL Architecture) -->

--- a/doc/feature-set/Observability/README.md
+++ b/doc/feature-set/Observability/README.md
@@ -1,0 +1,21 @@
+# Observability
+> Zero-overhead telemetry infrastructure for Typhon: a single hierarchical static-readonly gating surface shared by the typed-event Profiler, a `System.Diagnostics.Activity`-based tracing surface for correlating Typhon with a host's own OTLP trace, OpenTelemetry metrics export from the Resource Graph and ECS layer, and resource-derived health checks / threshold alerting for production monitoring.
+
+> 🔬 **Recommended:** read [in-depth-overview/12-observability.md](../../in-depth-overview/12-observability.md) (Chapter 12: Observability, which also covers Profiler — the two share one chapter) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Telemetry Configuration & Gating](telemetry-config-gating.md) | Hierarchical, JSON/env-var-driven static-readonly bool surface (~200 flags) that the JIT dead-code-eliminates when off, gating both Activity tracing and the typed-event Profiler with zero overhead when disabled | ✅ Implemented | 🟢 Start Here |
+| [Distributed Tracing (Activity API)](distributed-tracing.md) | Centralized `ActivitySource` and OTel-semantic attribute constants for correlating Typhon with a host's own OTLP trace — engine-internal operations aren't auto-instrumented on it yet (that's the Profiler's job) | 🚧 Partial | 🔵 Core |
+| [OpenTelemetry Metrics Export](otel-metrics-export/README.md) | Observable-pattern OTel `Meter` exporters that periodically snapshot internal state and expose it as gauges/counters for Prometheus/OTLP scraping, with zero overhead when no collector is listening | 🚧 Partial | 🔵 Core |
+| &nbsp;&nbsp;↳ [Resource Graph Metrics Bridge](otel-metrics-export/resource-graph-metrics-bridge.md) | Every Resource System node exposed as a standard OTel Meter for Prometheus/OTLP scraping | 🚧 Partial | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [ECS Metrics Exporter](otel-metrics-export/ecs-metrics-exporter.md) | Per-archetype EntityMap health and per-component-type transient memory as zero-cost OTel gauges | 🚧 Partial | 🟣 Advanced |
+| [Resource-Aware Health Checks](health-checks.md) | Framework-agnostic `ITyphonHealthCheck` (Healthy/Degraded/Unhealthy worst-of-composite) backed by `ResourceHealthChecker`, reading the cached resource snapshot for cheap, frequent liveness/readiness polling | ✅ Implemented | 🔵 Core |
+| [Per-Domain Named Metrics Catalog](per-domain-metrics-catalog.md) | Documented target list of ~40 fixed-name OTel instruments (`typhon.tx.*`, `typhon.wal.*`, `typhon.lock.*`...) across 8 domains, distinct from today's generic resource-path/ECS exporters | 📋 Planned | 🟣 Advanced |
+| [Threshold-Based Resource Alerting](threshold-alerting.md) | `ResourceAlertGenerator` raises Warning/Critical `ResourceAlert`s on health-state transitions, using `FindRootCause` to trace symptoms back to the upstream bottleneck via a hardcoded wait-dependency graph | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+*No internal-only features in this category — every feature here is directly usable from application code (config knobs, DI extensions, or classes constructed/called directly by host apps).*

--- a/doc/feature-set/Observability/distributed-tracing.md
+++ b/doc/feature-set/Observability/distributed-tracing.md
@@ -1,0 +1,66 @@
+# Distributed Tracing (Activity API)
+> A centralized `System.Diagnostics.ActivitySource` and OTel-semantic attribute constants for correlating Typhon with an application's own OTLP trace.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Observability](./README.md)
+
+## 🎯 What it solves
+Diagnosing a slow or failed operation across a whole application usually means correlating "what the app asked for"
+with "what happened downstream" — an HTTP handler, a gRPC call, a database operation, all as one connected trace
+instead of separate, timestamp-correlated logs. `TyphonActivitySource` gives host applications a ready-made,
+OTel-semantic `ActivitySource` to fold their own Typhon-adjacent instrumentation into, using the same attribute
+naming (`typhon.transaction.tsn`, `typhon.entity.id`, ...) the engine's other observability surfaces use, exportable
+to any OTLP backend (Jaeger, Grafana Tempo, etc.) alongside the rest of the application's trace.
+
+## ⚙️ How it works (in brief)
+`TyphonActivitySource.Instance` is a single `System.Diagnostics.ActivitySource` (name `Typhon.Engine`); `TyphonSpanAttributes`
+supplies matching OTel-semantic attribute-name constants (transaction, entity, index, page-cache, ECS). Spans started on it
+nest automatically under whatever `Activity.Current` the host already has open — no explicit context plumbing — and export
+through the standard OpenTelemetry SDK. **The engine itself does not yet call this source internally**: Transaction, Entity,
+B+Tree, and page-cache operations are instrumented instead through the engine's own [Typed-Event Profiler](../../../claude/overview/09-observability.md#98-typed-event-profiler)
+(`TyphonEvent`) — a separate, higher-throughput, non-OTel pipeline consumed by the Typhon Workbench rather than an OTLP
+backend. The Profiler does capture `Activity.Current`'s trace context when a host span is open, so its records nest under
+an application's OTel trace for correlation, but no engine operation materializes as an `Activity` on this `ActivitySource`
+today; it exists for hosts that want to add their own manually-instrumented spans using the same naming convention.
+
+## 💻 Usage
+```csharp
+// Program.cs / host startup — register Typhon's source with the OTel SDK
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService("MyApp"))
+    .WithTracing(tracing => tracing
+        .AddSource(TyphonActivitySource.Name)   // "Typhon.Engine"
+        .AddOtlpExporter(o => o.Endpoint = new Uri("http://localhost:4317")));
+
+// Manual instrumentation of your own code, nesting under the same source and attribute convention
+using var activity = TyphonActivitySource.Instance.StartActivity("MyApp.CustomStep");
+activity?.SetTag(TyphonSpanAttributes.EntityId, entityId);
+```
+
+| Attribute group | Constants | Typical use |
+|---|---|---|
+| Transaction | `TransactionTsn`, `TransactionStatus`, `TransactionComponentCount`, `TransactionConflictDetected` | Tagging a host-defined span around a UoW |
+| Entity | `EntityId`, `ComponentType`, `ComponentRevision`, `ReadFound` | Tagging a host-defined span around an ECS operation |
+| Index | `IndexName`, `IndexOperation`, `IndexNodeSplit`, `IndexNodeMerge` | Tagging a host-defined span around an index operation |
+| Page cache | `PageId`, `PageSource`, `CacheHit` | Tagging a host-defined span around a storage operation |
+
+## ⚠️ Guarantees & limits
+- **No engine-internal spans yet** — `TyphonActivitySource` is real, callable API, but nothing in `Typhon.Engine` calls
+  `StartActivity` on it today; Transaction/Entity/B+Tree/page-cache visibility comes from the Typed-Event Profiler instead,
+  which is not exported via OTLP. Treat this feature as attribute-naming + correlation infrastructure for your own spans,
+  not as auto-instrumentation.
+- **`StartActivity` returns `null` with no listener registered** — always use `?.` (`activity?.SetTag(...)`); this is
+  standard `Activity` API behavior, not Typhon-specific.
+- **~150–250 ns per span when enabled** — `Activity` allocation cost if you do start spans on this source; too heavy for
+  per-row hot loops, where the Profiler's ~25–50 ns/event typed records are the right tool instead.
+- **WAL and Checkpoint spans are not yet designed as `Activity` spans** — `typhon.wal.flush` and `typhon.checkpoint` exist
+  only as Profiler event kinds, not on this OTel-facing surface.
+- Standard `Activity.Current` / `AsyncLocal<Activity>` semantics apply — spans started on a worker thread inherit
+  whatever activity was current on the thread that scheduled the work; this is .NET runtime behavior, not configurable.
+
+## 🔗 Related
+- Sibling: [Telemetry Configuration & Gating](./telemetry-config-gating.md) — gates whether this `ActivitySource`'s spans (and the Profiler) are active
+- Sibling: [Profiler](../Profiler/README.md) — the typed-event pipeline that actually instruments engine internals today; this `ActivitySource` doesn't yet
+
+<!-- Deep dive: claude/overview/09-observability.md §9.3 Traces — note the "Implemented Trace Spans" table there describes Profiler typed events, not literal Activity spans on this source -->
+<!-- Guide: claude/design/Observability/activitysource-startactivity-guide.md -->
+<!-- Stack setup: claude/design/Observability/01-monitoring-stack-setup.md -->

--- a/doc/feature-set/Observability/health-checks.md
+++ b/doc/feature-set/Observability/health-checks.md
@@ -1,0 +1,79 @@
+# Resource-Aware Health Checks
+> A framework-agnostic Healthy/Degraded/Unhealthy verdict, derived from live resource utilization, for cheap liveness/readiness polling.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Observability](./README.md)
+
+## 🎯 What it solves
+Container orchestrators and load balancers need a single, cheap-to-call answer to "is this instance OK?" —
+checked every few seconds, sometimes sub-second. Deriving that answer by hand means picking thresholds for page
+cache fill, WAL ring fill, transaction pool load, etc., and reducing them all to one verdict in every host
+application. `ITyphonHealthCheck` does that reduction once, against the engine's own resource utilization data,
+so a Kubernetes liveness probe or a `/health` endpoint gets a ready-made composite status instead of reimplementing
+threshold logic per deployment.
+
+## ⚙️ How it works (in brief)
+`ResourceHealthChecker` implements `ITyphonHealthCheck` (no ASP.NET Core dependency) and reads the
+`ResourceMetricsExporter`'s cached `ResourceSnapshot` — it never walks the resource graph itself. `CheckHealth()`
+is the cheap path: it looks only at the single most-utilized resource and compares it to that resource's
+threshold, suitable for frequent liveness polling. `GetDetailedResult()` walks every resource with a capacity
+metric and returns the **worst-of-all** status plus the lists of degraded/unhealthy paths, for dashboards and
+`/health/details` endpoints. Thresholds default to 80%/95% (degraded/unhealthy) and tighten to 60%/80% for
+resources marked architecturally critical (`Durability/WALRingBuffer`, `DataEngine/TransactionPool`); any path
+can be overridden.
+
+## 💻 Usage
+```csharp
+using Typhon.Engine;
+
+services.AddTyphonObservabilityBridge(options =>
+{
+    // Tighten or relax thresholds per resource path (leading "Root/" is optional).
+    options.Thresholds["Storage/PageCache"] = new HealthThresholds(0.70, 0.90);
+});
+
+var healthCheck = serviceProvider.GetRequiredService<ITyphonHealthCheck>();
+
+// Cheap path — e.g. a Kubernetes liveness probe.
+HealthStatus status = healthCheck.CheckHealth();
+if (status == HealthStatus.Unhealthy)
+{
+    return Results.StatusCode(503);
+}
+
+// Detailed path — e.g. a dashboard or readiness endpoint.
+HealthCheckResult detail = healthCheck.GetDetailedResult();
+Console.WriteLine(detail.Description); // "Storage/PageCache at 92% utilization (Degraded)"
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `ObservabilityBridgeOptions.Thresholds["<path>"]` | unset (falls back to built-in) | `HealthThresholds(degraded, unhealthy)` override for one resource path |
+| `HealthThresholds.Default` | 0.80 / 0.95 | Applied to any resource without an explicit or critical-default entry |
+| `HealthThresholds.Critical` | 0.60 / 0.80 | Built-in default for `Durability/WALRingBuffer` and `DataEngine/TransactionPool` |
+
+## ⚠️ Guarantees & limits
+- **Worst-of-all composite** — overall status is the single most severe status across all resources carrying a
+  Capacity metric; one critical resource is never averaged away by many healthy ones.
+- Only resources that report a `Capacity` metric participate; pure Memory/DiskIO/Throughput sources and grouping
+  nodes are excluded from health computation.
+- `CheckHealth()` is sized for frequent polling — it inspects only the most-utilized node
+  (`ResourceSnapshot.FindMostUtilized()`); `GetDetailedResult()` does a full node walk and suits less frequent
+  dashboard calls.
+- Reads the exporter's cached snapshot, not live state — status reflects the last `SnapshotInterval` refresh
+  (default 5s; see the Resource Metrics Export feature for the snapshot lifecycle).
+- `ITyphonHealthCheck` has no ASP.NET Core dependency; bridging to
+  `Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck` is a thin adapter the host writes (`HealthStatus`
+  maps 1:1, `Description`/`Data` pass straight through).
+- Health checks classify, not explain — for root-cause attribution behind a Degraded/Unhealthy verdict, pair this
+  with the threshold-alerting side of the same bridge.
+
+## 🧪 Tests
+- [ObservabilityBridgeTests](../../../test/Typhon.Engine.Tests/Observability/Bridge/ObservabilityBridgeTests.cs) — `ResourceHealthChecker.CheckHealth`/`GetDetailedResult` threshold crossings (Healthy/Degraded/Unhealthy), custom per-path thresholds, and worst-of-all composite status
+
+## 🔗 Related
+- Sibling: [Threshold-Based Resource Alerting](./threshold-alerting.md) — same resource snapshot; adds root-cause attribution and push notifications on top of this Healthy/Degraded/Unhealthy classification
+- Sibling: [Resource Budget Configuration (ResourceOptions)](../Resources/resource-budgets-options.md) — the startup-configured limits these health thresholds are measured against
+- Source: `ITyphonHealthCheck.cs`, `ResourceHealthChecker.cs`, `ObservabilityBridgeOptions.cs` (`src/Typhon.Engine/Observability/public/`)
+
+<!-- Deep dive: claude/overview/09-observability.md §9.5 Health Checks -->
+<!-- Design: claude/design/Resources/08-observability-bridge.md §3 Graph → Health Checks Mapping -->

--- a/doc/feature-set/Observability/otel-metrics-export/README.md
+++ b/doc/feature-set/Observability/otel-metrics-export/README.md
@@ -1,0 +1,55 @@
+# OpenTelemetry Metrics Export
+> Observable-pattern OTel `Meter` exporters that snapshot internal state and expose it as gauges/counters for Prometheus/OTLP scraping.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Observability](../README.md)
+
+## 🎯 What it solves
+
+Operators want Typhon's internal numbers — page cache utilization, WAL ring fill, per-archetype entity counts,
+transient memory pressure — in the dashboards and scrapers they already run (Prometheus, Grafana, SigNoz,
+`dotnet-counters`). Hand-instrumenting every internal counter as an OTel instrument, and keeping that
+instrumentation in sync as resources and archetypes come and go, is repetitive work every host application would
+otherwise duplicate. Typhon exposes two purpose-built `Meter`s instead, each translating a different slice of
+engine state into standard `System.Diagnostics.Metrics` instruments.
+
+## ⚙️ How it works (in brief)
+
+Both exporters use the same **observable** pattern: rather than pushing measurements on every state change, they
+register `CreateObservableGauge`/`CreateObservableCounter` callbacks that are only invoked when an OTel listener
+(a `MeterListener`, a Prometheus scrape, an OTLP export tick) actually asks for a value. The Resource Graph bridge
+reads a periodically-refreshed `ResourceSnapshot` cache; the ECS exporter reads live engine fields directly (no
+cache, no extra counters) since those reads are already cheap. Either way, an idle process with no collector
+attached pays nothing beyond — for the Resource Graph bridge — the background snapshot timer.
+
+## Sub-features
+
+| Sub-feature | Exports | Use it when... |
+|---|---|---|
+| [Resource Graph Metrics Bridge](./resource-graph-metrics-bridge.md) | Memory/Capacity/DiskIO/Throughput/Duration for every `IResourceGraph` node | Wiring Prometheus/OTLP/Grafana dashboards for engine-wide resource pressure (page cache, WAL ring, transaction pool, ...) |
+| [ECS Metrics Exporter](./ecs-metrics-exporter.md) | Per-archetype entity/EntityMap gauges, per-component transient memory gauges | Watching archetype growth, EntityMap hashing health, or Transient-mode component memory in a dashboard |
+
+## ⚠️ Guarantees & limits
+
+- Zero overhead when nothing is listening: observable callbacks only run on a scrape/collection pass, never on
+  a timer of their own.
+- The two exporters are independent — different `Meter` names (`Typhon.Resources` vs `Typhon.ECS`), different
+  registration paths, no shared state. You can wire up either, both, or neither.
+- **Partial coverage** — only resource-graph nodes and ECS archetype/transient state are exported this way today.
+  The broader metrics catalog in [`claude/overview/09-observability.md` §9.2](../../../../claude/overview/09-observability.md#92-metrics)
+  (transaction counts, lock contention, B+Tree mutations, WAL/checkpoint counters) is captured by the
+  [Typed-Event Profiler](../README.md) and `TickTelemetryRing`, not yet bridged into OTel instruments.
+- `EcsMetricsExporter` has no DI registration extension yet (unlike the Resource Graph bridge's
+  `AddTyphonObservabilityBridge`) — construct it directly against a `DatabaseEngine` and register its `Meter`
+  with your `MeterProvider`.
+- Cardinality is bounded by resource-node count / archetype count / component-type count, not by entity count or
+  operation volume — these are gauges over current state, not per-event counters.
+
+## 🧪 Tests
+- [ObservabilityBridgeTests](../../../../test/Typhon.Engine.Tests/Observability/Bridge/ObservabilityBridgeTests.cs) — exercises the shared observable-callback pattern (snapshot-backed gauges, per-kind opt-out, `MeterListener` instrument registration) via the Resource Graph bridge; the ECS exporter sub-feature has no dedicated coverage yet
+
+## 🔗 Related
+
+- Sub-features: [Resource Graph Metrics Bridge](./resource-graph-metrics-bridge.md), [ECS Metrics Exporter](./ecs-metrics-exporter.md)
+- Related features: [Resource-Aware Health Checks](../health-checks.md), [Threshold-Based Resource Alerting](../threshold-alerting.md) — read the same `ResourceMetricsExporter` snapshot as this bridge
+
+<!-- Deep dive: claude/design/Resources/08-observability-bridge.md, claude/overview/09-observability.md §9.2 -->

--- a/doc/feature-set/Observability/otel-metrics-export/ecs-metrics-exporter.md
+++ b/doc/feature-set/Observability/otel-metrics-export/ecs-metrics-exporter.md
@@ -1,0 +1,67 @@
+# ECS Metrics Exporter
+> Per-archetype EntityMap health and per-component-type transient memory, as zero-cost OTel gauges.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Observability](../README.md)
+
+## 🎯 What it solves
+
+Archetype growth (entity counts, hash-table load factor, bucket splits) and Transient-mode component memory
+pressure are exactly the signals an operator wants on a dashboard when diagnosing skewed entity distributions or
+runaway transient allocation — but today they're only visible by stepping through `DatabaseEngine` internals in
+a debugger or via storage introspection APIs. The ECS Metrics Exporter surfaces them as standard OTel
+instruments without adding a single counter to the ECS hot path.
+
+## ⚙️ How it works (in brief)
+
+`EcsMetricsExporter` creates a `Meter` named `"Typhon.ECS"` and registers five observable instruments. Each
+callback walks the engine's existing archetype-state array or component-table list directly — no cache, no
+background timer, no new bookkeeping field — and reads fields that are already maintained for other purposes
+(`EntityMap.EntryCount`, `EntityMap.LoadFactor`, `TransientComponentSegment.PageCount`). Because every field read
+is already either plain or naturally atomic on x64, there is no `Interlocked` overhead added anywhere; the cost
+exists only when an OTel collector actually scrapes.
+
+## 💻 Usage
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Typhon.Engine;
+
+var dbe = serviceProvider.GetRequiredService<DatabaseEngine>();
+using var ecsExporter = new EcsMetricsExporter(dbe);
+
+// Point an OTel MeterProvider at the exporter's meter:
+services.AddOpenTelemetry().WithMetrics(builder => builder
+    .AddMeter(EcsMetricsExporter.MeterName)            // "Typhon.ECS"
+    .AddPrometheusExporter());                          // or AddOtlpExporter(), AddConsoleExporter(), ...
+```
+
+| Metric | Type | Tag | Description |
+|---|---|---|---|
+| `typhon.ecs.entity_count` | Gauge | `typhon.ecs.archetype` | Live entity count per archetype |
+| `typhon.ecs.entitymap.load_factor` | Gauge | `typhon.ecs.archetype` | EntityMap hash-table load factor (0.0–1.0) per archetype |
+| `typhon.ecs.entitymap.splits_total` | Counter | `typhon.ecs.archetype` | Cumulative EntityMap bucket splits per archetype |
+| `typhon.ecs.transient.allocated_bytes` | Gauge | `typhon.ecs.component_type` | Transient heap memory allocated per `StorageMode.Transient` component type |
+| `typhon.ecs.transient.utilization` | Gauge | `typhon.ecs.component_type` | Transient chunk utilization (allocated/capacity) per component type |
+
+## ⚠️ Guarantees & limits
+
+- No DI registration extension exists yet — unlike the Resource Graph bridge's `AddTyphonObservabilityBridge`,
+  you construct `EcsMetricsExporter` directly and own its lifetime.
+- Entity-count and EntityMap gauges only appear for archetypes that have an initialized `EntityMap`; archetypes
+  with no entities spawned yet are absent from the output, not zero.
+- Transient gauges only cover component tables with `StorageMode.Transient` and an initialized
+  `TransientComponentSegment` — Versioned, SingleVersion, and Committed tables don't report through this
+  exporter (they're covered by the Resource Graph bridge instead, where instrumented).
+- All reads are zero-overhead by design: no new counters, no `Interlocked`, no allocation on the observable
+  callback path beyond the `IEnumerable` iterator itself.
+- `EcsMetricsExporter` implements `IDisposable`; disposing it disposes the `Meter` and detaches its instruments.
+- No dedicated automated test coverage yet (unlike `ResourceMetricsExporter`, which has fixture coverage in
+  `ObservabilityBridgeTests`) — verify wiring manually against a `MeterListener` until that gap closes.
+
+## 🔗 Related
+
+- Sibling: [Resource Graph Metrics Bridge](./resource-graph-metrics-bridge.md) — the other OTel metrics exporter; covers Resource Graph nodes instead of ECS/archetype state
+- Related feature: [Entity Archetype Model](../../Ecs/entity-archetype-model.md), [Storage Modes](../../Ecs/storage-modes/README.md)
+- Parent feature: [OpenTelemetry Metrics Export](./README.md)
+
+<!-- Deep dive: claude/design/Observability/README.md, claude/overview/09-observability.md §9.2 -->

--- a/doc/feature-set/Observability/otel-metrics-export/resource-graph-metrics-bridge.md
+++ b/doc/feature-set/Observability/otel-metrics-export/resource-graph-metrics-bridge.md
@@ -1,0 +1,90 @@
+# Resource Graph Metrics Bridge
+> Every Resource System node, exposed as a standard `System.Diagnostics.Metrics.Meter` for any OTel exporter to pick up.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Observability](../README.md)
+
+## 🎯 What it solves
+
+Typhon's Resource System already tracks memory, capacity, disk I/O, throughput, and duration for every
+significant engine resource (page cache, WAL ring, transaction pool, indexes, ...), but that data lives behind
+an engine-internal snapshot API, not a metrics endpoint. Hand-writing OTel instruments for 50–300 resource nodes,
+and keeping them in sync as resources are added or removed, is busywork every host application would otherwise
+repeat.
+
+## ⚙️ How it works (in brief)
+
+`ResourceMetricsExporter` creates one `Meter` named `"Typhon.Resources"` and registers one *observable*
+instrument per metric kind (Memory, Capacity, DiskIO, Throughput, Duration) — not one instrument per resource.
+Each observable callback reads the most recently captured `ResourceSnapshot` and yields one `Measurement<T>` per
+node that reports that kind, tagged with a `resource_path` attribute (and `metric_name` for the named
+Throughput/Duration metrics). `ResourceMetricsService` is a self-contained `Timer` that calls `UpdateSnapshot()`
+on the configured interval — that periodic snapshot is the only standing cost; the observable callbacks
+themselves only run when something actually scrapes. Metric names are built by `OTelMetricNameBuilder`, which
+converts a resource path and metric kind into a dotted, snake_cased OTel name (e.g.
+`typhon.resource.memory.allocated_bytes`).
+
+## 💻 Usage
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Typhon.Engine;
+
+services.AddSingleton<IResourceGraph>(sp => resourceGraph);
+services.AddTyphonObservabilityBridge(options =>
+{
+    options.SnapshotInterval = TimeSpan.FromSeconds(5);
+    options.MetricNamePrefix = "typhon.resource";     // default
+    options.ExportDurationMetrics = false;             // opt out of a metric kind
+});
+
+// Start the background snapshot loop (registration alone does not start it).
+var bridgeService = serviceProvider.GetRequiredService<ResourceMetricsService>();
+bridgeService.Start();
+
+// Point an OTel MeterProvider at the bridge's meter (ASP.NET Core / OpenTelemetry.Extensions.Hosting):
+services.AddOpenTelemetry().WithMetrics(builder => builder
+    .AddMeter(ResourceMetricsExporter.MeterName)       // "Typhon.Resources"
+    .AddPrometheusExporter());                          // or AddOtlpExporter(), AddConsoleExporter(), ...
+```
+
+| Metric kind | OTel name suffix | Example |
+|---|---|---|
+| Memory | `memory.allocated_bytes`, `memory.peak_bytes` | `typhon.resource.memory.allocated_bytes` |
+| Capacity | `capacity.current`, `capacity.maximum`, `capacity.utilization` | `typhon.resource.capacity.utilization` |
+| DiskIO | `disk_io.read_ops`, `disk_io.write_ops`, `disk_io.read_bytes`, `disk_io.write_bytes` | `typhon.resource.disk_io.write_bytes` |
+| Throughput | `throughput.count` (tagged `metric_name`) | `typhon.resource.throughput.count{metric_name="CacheHits"}` |
+| Duration | `duration.last_us`, `duration.avg_us`, `duration.max_us` (tagged `metric_name`) | `typhon.resource.duration.avg_us{metric_name="Checkpoint"}` |
+
+| Option | Default | Effect |
+|---|---|---|
+| `MetricNamePrefix` | `"typhon.resource"` | Namespace prefix for every emitted metric name |
+| `ExportMemoryMetrics` / `ExportCapacityMetrics` / `ExportDiskIOMetrics` / `ExportThroughputMetrics` / `ExportDurationMetrics` | `true` | Per-kind opt-out — skips registering that instrument entirely |
+| `SnapshotInterval` | 5 s | How often the underlying snapshot (read by every callback) refreshes |
+
+## ⚠️ Guarantees & limits
+
+- One instrument per metric *kind*, not per resource — cardinality comes from the `resource_path` (and
+  `metric_name`) attribute, not from instrument count, so adding resources never requires new registration.
+- Observable callbacks read a cached snapshot; they never touch the resource graph directly, so an idle OTel
+  pipeline (no exporter attached) costs nothing beyond the snapshot interval itself.
+- Values are only as fresh as the last `UpdateSnapshot()` — driven by `ResourceMetricsService.SnapshotInterval`
+  (default 5 s), not by the OTel scrape interval.
+- A resource only appears in a given instrument's output if its `IMetricSource.ReadMetrics` actually wrote that
+  metric kind for the current snapshot — nodes that don't report a kind are simply absent, not zero.
+- `ResourceMetricsExporter` implements `IDisposable`; disposing it disposes the `Meter` and detaches every
+  instrument — do this once, at host shutdown.
+- Prometheus auto-converts dots to underscores, so the same dotted OTel names work unmodified for both
+  OTLP/Grafana and Prometheus scraping.
+
+## 🧪 Tests
+- [ObservabilityBridgeTests](../../../../test/Typhon.Engine.Tests/Observability/Bridge/ObservabilityBridgeTests.cs) — `OTelMetricNameBuilder` name/path normalization and snake_casing, `ResourceMetricsExporter` snapshot lifecycle, per-kind metric opt-out, and `MeterListener`-observed instrument registration
+
+## 🔗 Related
+
+- Sibling: [ECS Metrics Exporter](./ecs-metrics-exporter.md) — the other OTel metrics exporter; covers ECS/archetype state instead of Resource Graph nodes
+- Sibling: [Observability Bridge (Resources to OTel/Health/Alerts)](../../Resources/observability-bridge-resources.md) — the same bridge, documented from the Resources category's side
+- Related features: [Resource-Aware Health Checks](../health-checks.md), [Threshold-Based Resource Alerting](../threshold-alerting.md) — read the same `ResourceMetricsExporter` snapshot
+- Related feature: [Metric Reporting (IMetricSource / IMetricWriter)](../../Resources/metric-reporting.md) — how resources produce the data this exports
+- Parent feature: [OpenTelemetry Metrics Export](./README.md)
+
+<!-- Deep dive: claude/design/Resources/08-observability-bridge.md §2, claude/design/Observability/implementing-metric-sources.md, claude/adr/032-resource-system-architecture.md -->

--- a/doc/feature-set/Observability/per-domain-metrics-catalog.md
+++ b/doc/feature-set/Observability/per-domain-metrics-catalog.md
@@ -1,0 +1,75 @@
+# Per-Domain Named Metrics Catalog
+> A documented target list of ~40 fixed-name OTel instruments (typhon.tx.*, typhon.wal.*, typhon.lock.*...) — not yet wired to any exporter.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Observability](./README.md)
+
+## 🎯 What it solves
+
+Dashboards and alert rules are easiest to build against stable, well-known metric names — `typhon.tx.committed`,
+`typhon.wal.ring_fill`, `typhon.lock.contentions` — rather than against dynamically-generated, path-tagged metrics
+that change shape as resources are added or renamed. The engine's high-value domains (transactions, page cache,
+disk I/O, locking, B+Tree indexes, WAL/checkpoint, allocation, backup) don't yet have such a fixed surface: today's
+exporters report whatever the Resource Graph happens to track, tagged by resource path, which is great for generic
+coverage but not for a dashboard author who wants one unchanging name per concept.
+
+## ⚙️ How it works (in brief)
+
+The architecture overview's Metrics Catalog enumerates ~40 instruments across eight domains — Transaction, Page
+Cache, I/O, Concurrency/AccessControl, B+Tree Index, WAL/Durability, Allocation Infrastructure, and Backup — each
+with a fixed name, an OTel instrument type (Counter, Histogram, or Gauge), a description, and (where relevant) a
+cross-reference to a Resource Taxonomy node. This is presently a documentation-only design target: no `Meter` in
+the codebase registers any of these specific names. The two exporters that do exist
+(`ResourceMetricsExporter`, `EcsMetricsExporter`) use a different, generic naming scheme (`typhon.resource.*`,
+`typhon.ecs.*`) built from resource paths and metric kinds, not the fixed per-domain names catalogued here.
+
+## 💻 Usage
+
+Not implemented — no Meter registers these names today; nothing below compiles against the current API.
+
+```csharp
+// Illustrative only — not a real/current Typhon API. No exporter registers these instruments today.
+// var meter = new Meter("Typhon.Engine", "1.0.0");
+//
+// var txCommitted = meter.CreateCounter<long>("typhon.tx.committed",
+//     unit: "{transactions}", description: "Successful commits");
+//
+// var walFlushDuration = meter.CreateHistogram<double>("typhon.wal.flush_duration_us",
+//     unit: "us", description: "FUA write latency (us)");
+//
+// var ringFill = meter.CreateObservableGauge("typhon.wal.ring_fill",
+//     () => walRingBuffer.FillRatio, unit: "1", description: "Ring buffer utilization (0.0-1.0)");
+```
+
+| Domain | Example names | Types |
+|---|---|---|
+| Transaction | `typhon.tx.count`, `typhon.tx.committed`, `typhon.tx.duration_us` | Counter, Histogram, Gauge |
+| Page Cache | `typhon.cache.hits`, `typhon.cache.hit_ratio`, `typhon.cache.evictions` | Counter, Gauge |
+| I/O | `typhon.io.page_reads`, `typhon.io.read_duration_us` | Counter, Histogram |
+| Concurrency / AccessControl | `typhon.lock.acquisitions`, `typhon.lock.contention_duration_us` | Counter, Histogram |
+| B+Tree Index | `typhon.index.lookups`, `typhon.index.node_splits` | Counter, Gauge |
+| WAL / Durability | `typhon.wal.flushes`, `typhon.checkpoint.duration_ms` | Counter, Histogram, Gauge |
+| Allocation Infrastructure | `typhon.alloc.segment_pages`, `typhon.alloc.bitmap_scans` | Gauge, Counter |
+| Backup | `typhon.backup.snapshot_duration_ms`, `typhon.backup.pages_changed` | Histogram, Counter |
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** None of the ~40 catalogued names are registered as OTel instruments anywhere in
+  `src/Typhon.Engine/Observability` today — the only live meters are `Typhon.Resources` (resource-path-tagged) and
+  `Typhon.ECS` (per-archetype/per-component gauges), both with naming schemes distinct from this catalog.
+- Intended to coexist with, not replace, the generic [Resource Graph Metrics Bridge](./otel-metrics-export/resource-graph-metrics-bridge.md)
+  bridge: the catalog targets fixed, dashboard-stable names for the highest-value domains; the resource bridge
+  stays dynamic/generic for everything else.
+- No decision yet on emission mechanism — wiring live `Counter`/`Histogram` calls into hot paths (tx commit, lock
+  acquire, B+Tree split) has a real per-call cost on a microsecond-budget engine, versus exposing the same data as
+  observable gauges/counters read from existing counters at scrape time (the pattern the two live exporters use).
+  That tradeoff is unresolved and will shape the final design.
+- Names, types, and descriptions in the linked catalog table are a design target, not a frozen API — treat them as
+  subject to change before implementation begins.
+
+## 🔗 Related
+
+- Related feature: [Resource Graph Metrics Bridge](./otel-metrics-export/resource-graph-metrics-bridge.md) — the exporter that IS implemented today, with a different naming scheme
+- Sibling: [ECS Metrics Exporter](./otel-metrics-export/ecs-metrics-exporter.md) — the other exporter that already ships, using per-archetype/component naming instead of this catalog's fixed per-domain names
+- Related features: [Resource-Aware Health Checks](./health-checks.md), [Threshold-Based Resource Alerting](./threshold-alerting.md) — consume the same Resource Graph data this catalog would expose under fixed names
+
+<!-- Deep dive: claude/overview/09-observability.md §9.2 Metrics, Metrics Catalog -->

--- a/doc/feature-set/Observability/telemetry-config-gating.md
+++ b/doc/feature-set/Observability/telemetry-config-gating.md
@@ -1,0 +1,84 @@
+# Telemetry Configuration & Gating
+> One hierarchical static-readonly bool surface that gates both tracing and the typed-event profiler at zero cost when off.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Observability](./README.md)
+
+## 🎯 What it solves
+Typhon instruments roughly 200 call-site families across concurrency, storage, indexing, query, ECS, and durability.
+Application developers need to turn this on selectively for diagnosis — a single subsystem, a single sub-operation —
+without shipping a different binary, without a config system per instrumentation track, and without paying for the
+"is anyone watching" check when nothing is. `TelemetryConfig` is the one place that answers "is X being observed
+right now" for both distributed tracing spans and the typed-event Profiler.
+
+## ⚙️ How it works (in brief)
+`TelemetryConfig` is resolved once, at static-class load, from `typhon.telemetry.json` plus environment variables,
+into ~200 `static readonly bool *Active` fields. Flags are organized as a tree (e.g. `Concurrency` → `AccessControl`
+→ `Contention`) with parent-implies-children semantics: a disabled parent silences every descendant regardless of
+its own setting, and a leaf with no explicit key inherits its parent's effective state. Because each field is
+`static readonly`, the JIT can prove it never changes after class init and deletes a disabled `if (TelemetryConfig.XxxActive)`
+block entirely at Tier 1 — the same gate is read by both Activity-based span producers and the typed-event Profiler's
+emit calls, so there is one on/off surface for both tracks, not two.
+
+## 💻 Usage
+```csharp
+// Hot-path producer code — the gate is the only cost when the flag is off.
+if (TelemetryConfig.DataMvccChainWalkActive)
+{
+    RecordChainWalkDepth(depth);
+}
+
+// Optional host startup — Typhon.Engine self-initializes via a module initializer,
+// but a DI host can force resolution explicitly before building the service provider.
+services.AddTyphonProfiler();
+
+// Log what was actually resolved at startup.
+_logger.LogInformation(TelemetryConfig.GetConfigurationSummary());
+```
+
+`typhon.telemetry.json` (working directory, or next to the assembly):
+```json
+{
+  "Typhon": {
+    "Profiler": {
+      "Enabled": true,
+      "Concurrency": {
+        "Enabled": true,
+        "AccessControl": { "Contention": { "Enabled": true } }
+      }
+    }
+  }
+}
+```
+
+| Source | Precedence | Example |
+|---|---|---|
+| Environment variable (`__` hierarchy separator) | Highest | `TYPHON__PROFILER__CONCURRENCY__ENABLED=true` |
+| `typhon.telemetry.json` in the working directory | 2nd | shape above |
+| `typhon.telemetry.json` next to the assembly | 3rd | shape above |
+| Built-in defaults | Lowest | every flag `false` |
+
+## ⚠️ Guarantees & limits
+- Resolved once per process (static constructor, forced early by a module initializer) and immutable thereafter —
+  no runtime toggle; changing a flag means editing config/environment and restarting.
+- Every flag defaults to `false` — a fresh deployment instruments nothing until explicitly opted in.
+- Parent-implies-children: disabling a subtree's root disables every descendant even if individually set `true`.
+- Benchmark-verified zero overhead: a `static readonly false` guard measures identical to no guard at all
+  (~0.22 ns); `true` costs ~0.22 ns more; a mutable `static` field or interface dispatch costs 200–500%+ more for
+  the equivalent check.
+- One resolved value gates two independent consumers — [distributed tracing](./distributed-tracing.md) spans and
+  the typed-event Profiler — so enabling/disabling a subsystem affects both uniformly.
+- The legacy `Typhon:Telemetry:*` config namespace is still read via a back-compat shim for one release (emits a
+  deprecation warning to `Console.Error`); new code should use `Typhon:Profiler:*`.
+
+## 🧪 Tests
+- [TelemetryConfigResolverTests](../../../test/Typhon.Engine.Tests/Observability/TelemetryConfigResolverTests.cs) — parent-implies-children resolution: parent-off cascades to children despite explicit `true`, explicit leaf override wins, implicit leaf inherits parent
+- [TelemetryConfigGateShapeTests](../../../test/Typhon.Engine.Tests/Observability/TelemetryConfigGateShapeTests.cs) — enforces every `*Active` field is `public static readonly bool` (the structural invariant the JIT dead-code-elimination guarantee depends on)
+- [TelemetryConfigCpuSamplingTests](../../../test/Typhon.Engine.Tests/Profiler/TelemetryConfigCpuSamplingTests.cs) — end-to-end resolution of a real flag from `typhon.telemetry.json`, composed `XxxActive` derivation, and `GetConfigurationSummary()` diagnostics
+
+## 🔗 Related
+- Sibling: [Distributed Tracing (Activity API)](./distributed-tracing.md) — one of the two consumers this gating surface controls
+- Sibling: [Profiler](../Profiler/README.md) — the typed-event pipeline that is this gating surface's other consumer
+- Source: `src/Typhon.Engine/Observability/public/TelemetryConfig.cs`, `TelemetryConfigResolver.cs`, `TelemetryServiceExtensions.cs`
+
+<!-- Deep dive: claude/overview/09-observability.md §9.1 -->
+<!-- ADR: claude/adr/019-runtime-telemetry-toggle.md -->

--- a/doc/feature-set/Observability/threshold-alerting.md
+++ b/doc/feature-set/Observability/threshold-alerting.md
@@ -1,0 +1,82 @@
+# Threshold-Based Resource Alerting
+> Warning/Critical alerts on resource health transitions, with automatic root-cause tracing to the upstream bottleneck.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Observability](./README.md)
+
+## 🎯 What it solves
+A health check tells an operator *that* something is wrong; it doesn't say *why*, and polling it manually to catch
+transitions doesn't scale. Production monitoring needs push-style notifications — fire a Warning/Critical event the
+moment a resource crosses a threshold — and, more importantly, needs to point at the actual bottleneck rather than
+whichever downstream resource happens to be visibly full. `ResourceAlertGenerator` plus `ResourceMetricsService`
+give you both: threshold-crossing alerts, and a root cause pointing at the upstream resource that's really
+constraining the system.
+
+## ⚙️ How it works (in brief)
+`ResourceAlertGenerator.GenerateAlert` checks one resource's utilization against its `HealthThresholds` and returns
+`null` if it's healthy, a `Warning` alert if it's past the degraded threshold, or `Critical` if past the unhealthy
+threshold. It then calls `ResourceSnapshot.FindRootCause`, which walks a small hardcoded wait-dependency graph
+(e.g. `TransactionPool` waits on `WALRingBuffer`, which waits on `WALSegments`) and follows it through any
+upstream node that is *also* above the high-utilization bar, returning the resource at the end of that chain. This
+is architectural knowledge, not runtime wait tracking — it identifies the likely cause, not a measured one.
+`ResourceMetricsService` drives this on a timer: it takes a snapshot, computes overall health, and — only when the
+worst-of-all status **escalates** (Healthy→Degraded, Healthy→Unhealthy, Degraded→Unhealthy) — sweeps every
+degraded/unhealthy resource and raises one `AlertRaised` event per resource. Recovery transitions never raise
+alerts, which keeps a flapping resource from generating an alert storm.
+
+## 💻 Usage
+```csharp
+using Typhon.Engine;
+
+services.AddTyphonObservabilityBridge(options =>
+{
+    options.Thresholds["Storage/PageCache"] = new HealthThresholds(0.70, 0.90);
+});
+
+var alertService = serviceProvider.GetRequiredService<ResourceMetricsService>();
+alertService.AlertRaised += (_, alert) =>
+{
+    Console.WriteLine($"[{alert.Severity}] {alert.Title}");
+    Console.WriteLine($"  Root cause: {alert.RootCausePath} ({alert.RootCauseUtilization:P0})");
+    // Ship to PagerDuty/Slack/AlertManager here.
+};
+alertService.Start(); // snapshots + health checks every SnapshotInterval (default 5s)
+
+// One-shot check outside the service, e.g. from a diagnostics endpoint:
+var generator = serviceProvider.GetRequiredService<ResourceAlertGenerator>();
+ResourceAlert alert = generator.GenerateAlert(snapshot, "Root/DataEngine/TransactionPool");
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `ObservabilityBridgeOptions.Thresholds["<path>"]` | unset (falls back to `HealthThresholds.Default`) | Per-path degraded/unhealthy bar used by both the alert generator and health checker |
+| `ResourceSnapshot.FindRootCause(path, threshold)` | `threshold = 0.8` | How high an upstream node's utilization must be to be accepted as the next link in the causal chain |
+| `ObservabilityBridgeOptions.SnapshotInterval` | 5s | How often `ResourceMetricsService` re-checks health and can raise a new alert wave |
+
+## ⚠️ Guarantees & limits
+- **Alerts fire only on escalating state transitions** — never on recovery, never repeatedly for a resource stuck
+  at the same status. This is deliberate anti-flood behavior, not a bug if you expected steady-state re-alerting.
+- A single escalation raises one `AlertRaised` event **per currently degraded/unhealthy resource**, not just the
+  one that crossed the line — a pre-existing Warning can re-fire alongside a new Critical in the same sweep.
+- Root cause tracing (`FindRootCause`) only follows edges in a small hardcoded dependency table
+  (`TransactionPool → WALRingBuffer → WALSegments`, `PageCache → ManagedPagedMMF`, `ShadowBuffer → SnapshotStore`);
+  resources outside that table return themselves as their own root cause.
+- `ResourceAlertGenerator`'s per-path thresholds come **only** from `ObservabilityBridgeOptions.Thresholds`, falling
+  back to `HealthThresholds.Default` (80%/95%) — unlike `ResourceHealthChecker`, it does **not** apply the built-in
+  60%/80% critical defaults for `WALRingBuffer`/`TransactionPool`. Set those explicitly in `Thresholds` if you want
+  alert severity to match the health check's stricter bar.
+- `ResourceAlert` carries only symptom/root-cause path, utilization, severity, and timestamp — no message text or
+  cascading-effects list; format the notification payload from those fields at the integration boundary.
+- Reads the same cached `ResourceSnapshot` as metrics export and health checks — alert freshness is bounded by
+  `SnapshotInterval`, not real time.
+
+## 🧪 Tests
+- [ObservabilityBridgeTests](../../../test/Typhon.Engine.Tests/Observability/Bridge/ObservabilityBridgeTests.cs) — `ResourceAlertGenerator` Warning/Critical threshold crossings plus `FindRootCause` attribution across the wait-dependency graph, and `ResourceMetricsService` escalation-only alert firing (no re-alert on recovery)
+
+## 🔗 Related
+- Related feature: [Resource-Aware Health Checks](./health-checks.md)
+- Sibling: [Root-Cause Cascade Analysis (FindRootCause)](../Resources/snapshot-query-api/root-cause-cascade-analysis.md) — the dependency-walk machinery `GenerateAlert` calls to attribute a symptom to its upstream bottleneck
+- Sibling: [Resource Budget Configuration (ResourceOptions)](../Resources/resource-budgets-options.md) — the startup-configured limits these thresholds are percentages of
+- Source: `ResourceAlertGenerator.cs`, `ResourceMetricsService.cs`, `ResourceSnapshot.cs` (`FindRootCause`) in `src/Typhon.Engine/Observability/public/` and `src/Typhon.Engine/Resources/public/`
+
+<!-- Deep dive: claude/design/Resources/08-observability-bridge.md §4 Graph → Alerts Mapping -->
+<!-- ADR: claude/adr/032-resource-system-architecture.md -->

--- a/doc/feature-set/Profiler/README.md
+++ b/doc/feature-set/Profiler/README.md
@@ -1,0 +1,31 @@
+# Profiler
+> Typhon's engine-embedded, zero-allocation typed-event profiler: any-thread ~25-50ns span/instant capture into per-thread ring buffers, drained by a dedicated consumer thread and exported to a versioned `.typhon-trace` file and/or a live TCP feed for the Workbench trace viewer. Built-in instrumentation covers transactions, the B+Tree, page cache, WAL, checkpoint, and ECS automatically; opt-in extensions on the same pipeline add GC events, native memory tracking, per-tick gauges, CPU sampling, off-CPU scheduling, source attribution, query definition export, and domain-specific forensic tracing, each independently gated and zero-cost when off.
+
+> 🔬 **Recommended:** Profiler doesn't have its own in-depth-overview chapter — read [in-depth-overview/12-observability.md](../../in-depth-overview/12-observability.md) (Chapter 12: Observability, merged since the typed-event pipeline the two share is one cohesive story) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Profiler Session Lifecycle & Zero-Code Bootstrap](profiler-lifecycle-bootstrap.md) | `TyphonProfiler.Start`/`Stop` (idempotent) manage the consumer/exporter threads and process-exit safety net; `ProfilerBootstrap` self-wires the whole session from `typhon.telemetry.json` + `TyphonRuntime.Create` with no host orchestration required | ✅ Implemented | 🟢 Start Here |
+| [Trace Export](trace-export/README.md) | `IProfilerExporter` fan-out: each attached exporter gets its own OS thread and bounded queue (drop-newest on backpressure, refcounted batches); file and live-TCP sinks cover offline post-mortem and real-time attach | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [File-Based Trace Export (.typhon-trace)](trace-export/file-trace-export.md) | Write the whole session to a versioned binary file for offline post-mortem analysis in the Workbench | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Live TCP Streaming Export](trace-export/live-tcp-trace-export.md) | Stream a running session over TCP so the Workbench can watch a process tick-by-tick, right now | ✅ Implemented | 🔵 Core |
+| [Configuration & Performance Tuning](profiler-configuration-tuning.md) | `typhon.telemetry.json` / `TYPHON__PROFILER__*` env overrides drive independent static-readonly-bool gates per subsystem (JIT-eliminated when off); `ProfilerOptions` documents the consumer/drain tunables (cadence, per-exporter queue depth, merge-buffer size) | ✅ Implemented | 🔵 Core |
+| [Per-Tick Gauge/Metric Snapshots](gauge-snapshots.md) | One packed record per tick exposes memory, page-cache, WAL, and transaction counters to the trace viewer | ✅ Implemented | 🔵 Core |
+| [Custom Application-Defined Spans](custom-named-spans.md) | Reserved wire-format span kind (`NamedSpan`, ID 246) for app-defined span names — read/replay support exists, but no producer factory exists in `TyphonEvent` yet | 📋 Planned | 🟣 Advanced |
+| [GC Event Tracing](gc-event-tracing.md) | See every .NET garbage collection and EE-suspension pause on the same timeline as your transactions | ✅ Implemented | 🟣 Advanced |
+| [Unmanaged Memory Allocation Tracing](unmanaged-allocation-tracing.md) | See every native (unmanaged) allocation and free on the profiler timeline, tagged by subsystem | 🚧 Partial | 🟣 Advanced |
+| [Off-CPU Thread Scheduling Capture (Windows)](offcpu-thread-scheduling.md) | `EtwSchedulingPump` emits one `ThreadContextSwitch` record per closed on-CPU slice via the NT Kernel Logger, showing when and why Typhon threads left the CPU | ✅ Implemented | 🟣 Advanced |
+| [Integrated CPU Sampling (Statistical Call Tree)](cpu-sampling-calltree.md) | In-process EventPipe `SampleProfiler` captures call stacks for the session, embedded as a trailer section and rendered as a dotTrace-style Call Tree | ✅ Implemented | 🟣 Advanced |
+| [Query Definition & Execution Export](query-definition-export.md) | Captures every View/EcsQuery's structural definition once per session plus per-execution args and call sites, correlated to the existing query span chain | 🚧 Partial | 🟣 Advanced |
+| [Domain-Specific Tracing Instrumentation Expansion](domain-tracing-expansion.md) | Two-tier compile-time gated tracing rollout across nine engine domains (Concurrency, Storage, Memory, Data, Query, ECS, Spatial, Scheduler/Runtime, Durability, Subscriptions), zero cost when off | 🚧 Partial | 🟣 Advanced |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Typed-Event Capture Pipeline](typed-event-capture-pipeline.md) | Any-thread ~25-50ns ref-struct span/instant emission into per-thread SPSC ring buffers, drained by a dedicated timestamp-sorting consumer thread; zero allocation, JIT-eliminated when disabled | ✅ Implemented |
+| [Built-in Engine Instrumentation Catalog](builtin-subsystem-instrumentation.md) | Automatic, no-app-code-required span/instant coverage of Scheduler, Transactions, ECS, B+Tree, Page Cache (incl. async-completion pairing), WAL, Checkpoint, Statistics and Cluster Migration — 37+ wire-stable event kinds decoded by a shared `TraceEventDecoder` | ✅ Implemented |
+| [Span Source Attribution (Go-to-Source)](source-attribution.md) | Every span optionally carries a compile-time-deterministic source location for one-click editor handoff and inline preview in the Workbench | ✅ Implemented |
+| [Lock-Contention Forensics (Deep Diagnostics)](lock-contention-diagnostics.md) | Post-mortem visibility into which threads waited on which locks, for how long, and why | 📋 Planned |

--- a/doc/feature-set/Profiler/builtin-subsystem-instrumentation.md
+++ b/doc/feature-set/Profiler/builtin-subsystem-instrumentation.md
@@ -1,0 +1,60 @@
+# Built-in Engine Instrumentation Catalog
+> Every transaction, B+Tree op, page fetch, WAL flush, checkpoint phase, and cluster migration is already traced — no app code required.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+Diagnosing "why was this tick slow" or "why did commit latency spike" normally means going back to add instrumentation to the suspect code path, reproducing the problem, then removing the instrumentation afterward. That loop is expensive, and for a microsecond-budget engine the code you'd instrument is exactly the code you can't afford to slow down while investigating it. Typhon avoids the loop entirely for its own internals: the engine's Scheduler, Transaction, ECS, B+Tree, Page Cache, WAL, Checkpoint, Statistics, and Cluster Migration subsystems are already instrumented at every call site that matters, permanently, so turning the profiler on retroactively explains a run you didn't know you'd need to explain.
+
+## ⚙️ How it works (in brief)
+
+Dozens of call sites baked into these nine subsystems each open a typed [event](./typed-event-capture-pipeline.md) — `TyphonEvent.BeginTransactionCommit`, `BeginBTreeInsert`, `BeginPageCacheFetch`, `BeginWalFlush`, `BeginCheckpointCycle`, and so on — the same producer surface every part of the engine uses, so adding this catalog didn't require a second capture mechanism. Every one of these baseline kinds shares the default gate (`TelemetryConfig.ProfilerActive`) rather than needing its own category flag, so flipping the single master switch lights up all nine subsystems at once. Because every kind shares the same record framing, one generator-emitted `TraceEventDecoder` dispatches all of them into the DTOs the trace file, live TCP stream, and Workbench viewer consume — extending the catalog doesn't require touching consumer code. Page-cache disk I/O gets a two-record pattern: the synchronous kickoff span closes when the call returns, and a completion record carrying the *same* `SpanId` is emitted later from whatever thread-pool thread actually finished the read/write/flush, so the viewer can show both "how long did the call take" and "how long did the OS actually take" for the same operation.
+
+## 💻 Usage
+
+Nothing to write against these subsystems — enable the profiler and the coverage is already there:
+
+```csharp
+// typhon.telemetry.json next to your executable is the only "code" this feature needs:
+// { "Typhon": { "Telemetry": { "Enabled": true, "Profiler": { "Enabled": true } } } }
+
+using var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+runtime.Start();
+
+// No TyphonEvent calls anywhere above. Every transaction this workload commits, every B+Tree insert/split/merge
+// its indexes perform, every page-cache fetch/read/write/evict, every WAL flush, every checkpoint phase, every
+// statistics rebuild, and every archetype-cluster migration already lands in the trace — open it in the
+// Workbench (or a `.typhon-trace` file) to see it, per §5 of the user manual.
+```
+
+`TyphonEvent` itself is `internal` to `Typhon.Engine` — application code was never meant to call it for these subsystems; this is the engine documenting itself, not an extension point. If you need your *own* code in the same flame graph, that's a separate (currently unimplemented) mechanism — see [Custom Application-Defined Spans](./custom-named-spans.md).
+
+## ⚠️ Guarantees & limits
+
+- **Nine subsystems, always on once the profiler is on** — Scheduler (`TickStart`/`TickEnd`/`Phase*`/`SystemReady`/`SystemSkipped`/`SchedulerChunk`), Transaction (`Commit`/`Rollback`/`CommitComponent`/`Persist`), ECS (`Spawn`/`Destroy`/`QueryExecute`/`QueryCount`/`QueryAny`/`ViewRefresh`), B+Tree (`Insert`/`Delete`/`NodeSplit`/`NodeMerge`), Page Cache (`Fetch`/`DiskRead`/`DiskWrite`/`AllocatePage`/`Flush`/`Evicted`/two async-completion kinds/`Backpressure`), WAL (`Flush`/`SegmentRotate`/`Wait`), Checkpoint (`Cycle`/`Collect`/`Write`/`Fsync`/`Transition`/`Recycle`), Statistics (`Rebuild`), and Cluster Migration (one span per archetype batch) — none of these need a per-subsystem JSON flag; only `Profiler.Enabled` gates them.
+- **One exception**: `PageCacheFetch` is suppressed by default (`TyphonEvent.SuppressedKinds`) because it fires on every cache lookup — potentially millions of times per second — and would saturate a ring buffer if left on unconditionally. The other page-cache kinds fire at disk-operation/eviction frequency and are on by default.
+- **Async completions are duration-gated** — `PageCacheDiskReadCompleted`/`WriteCompleted`/`FlushCompleted` only emit when the async tail exceeds a threshold (1 ms by default), so a fast, uninteresting completion doesn't double the record count for every I/O.
+- **Wire-stable, append-only IDs** — each kind's numeric ID is part of the on-disk format; the engine never renumbers or reuses one, so old `.typhon-trace` files keep decoding correctly as the catalog grows.
+- **Decoded by one shared path** — `TraceEventDecoder.DecodeBlock` walks any mix of these kinds (plus every other registered kind) through a single dispatch, so nothing in this catalog needs bespoke client-side parsing.
+- **This catalog, not the opt-in extras** — GC tracing, unmanaged-memory tracking, per-tick gauges, CPU sampling, off-CPU scheduling, source attribution, and query-definition export are separate, individually-gated observability extensions layered on the same pipeline; they're not part of this always-on baseline.
+- **Coverage is fixed, not extensible from application code** — `TyphonEvent`'s producer surface lives in `Typhon.Engine.Internals`; adding a new built-in kind is an engine change, not something a host application can register.
+
+## 🧪 Tests
+
+- [TyphonEventKindSuppressionTests](../../../test/Typhon.Engine.Tests/Profiler/TyphonEventKindSuppressionTests.cs) — the default suppression deny-list: only `PageCacheFetch` is suppressed by default, the other 9 page-cache kinds and every other subsystem's kinds are open
+- [TraceEventEncodeEquivalenceTests](../../../test/Typhon.Engine.Tests/Profiler/TraceEventEncodeEquivalenceTests.cs) — per-kind wire-encode equivalence across the built-in event set, catching struct-layer vs. codec argument-order/field-thread-through bugs
+
+## 🔗 Related
+
+- Sibling features: [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md) (the producer/consumer mechanism these call sites use), [Custom Application-Defined Spans](./custom-named-spans.md) (app-side equivalent, not yet implemented)
+- Sibling: [Telemetry Configuration & Gating](../Observability/telemetry-config-gating.md) — the gating surface that turns this instrumentation on/off
+- Sibling: [Distributed Tracing (Activity API)](../Observability/distributed-tracing.md) — the actual source of span correlation today; Transaction/B+Tree/page-cache visibility comes from this catalog, not `Activity`
+- Source: `src/Typhon.Engine/Profiler/internals/{SchedulerSpanEvents,TransactionEvents,EcsLifecycleEvents,BTreeEvents,PageCacheEvents,WalEvents,CheckpointEvents,StatisticsEvents,ClusterMigrationEvent}.cs`, `src/Typhon.Engine/Profiler/public/TraceEventDecoder.BlockWalker.cs`, `src/Typhon.Engine/Profiler/internals/HandGlue/TraceEventDecoder.HandGlue.cs`
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §4.4, claude/overview/09-observability.md §9.8 -->
+<!-- User manual: claude/design/Profiler/profiler-user-manual.md §10 — quick-reference event kind table -->
+<!-- ADRs: 047 — Typed-Event Profiler Architecture (claude/adr/047-typed-event-profiler-architecture.md), 050 — Typed-Event Source Generator (claude/adr/050-typed-event-source-generator.md) -->

--- a/doc/feature-set/Profiler/cpu-sampling-calltree.md
+++ b/doc/feature-set/Profiler/cpu-sampling-calltree.md
@@ -1,0 +1,89 @@
+# Integrated CPU Sampling (Statistical Call Tree)
+> See exactly where CPU cycles burn, down to the method and source line, with no external profiler.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+Typed spans tell you how long an instrumented operation took, but not *why* — the time inside an
+uninstrumented callee, a BCL method, or a hot loop is invisible to span-based tracing. Answering "where does
+`MovementSystem.Execute` actually spend its CPU?" normally means reaching for a separate tool with its own 
+launch ritual, its own output file, and no way to line results up against
+the transaction/B+Tree/page-cache timeline you already captured. CPU sampling closes that gap in-process: it
+captures statistical call stacks for the whole session and folds them into the same trace file, correlated
+against everything else your run recorded.
+
+## ⚙️ How it works (in brief)
+When enabled, the engine opens an in-process EventPipe session against its own process and lets the .NET runtime's
+own ~1 kHz sampler capture managed call stacks for the
+session lifetime. Nothing is parsed while it runs: the raw stream is buffered and only decoded, symbol-resolved
+against portable PDBs, and embedded as a trailer section of the `.typhon-trace` file once the session stops.
+The Workbench renders the result as a dotTrace-style **Call Tree** — self/total time per method, hot-path
+highlight, and a "Subsystems" breakdown by engine category — scoped to any time range, span, or system you pick,
+with click-to-source on every frame.
+
+## 💻 Usage
+```csharp
+// typhon.telemetry.json next to your executable — CPU sampling is opt-in, alongside its profiler siblings:
+// {
+//   "Typhon": {
+//     "Telemetry": { "Enabled": true },
+//     "Profiler": {
+//       "Enabled": true,
+//       "Trace": "session.typhon-trace",
+//       "CpuSampling": { "Enabled": true }
+//     }
+//   }
+// }
+
+using Typhon.Engine;
+
+// Zero-code path — the bootstrap starts the sampler before session metadata is captured and stops/parses
+// it as part of ordinary trace teardown. No sampler-specific calls are needed in application code.
+var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+
+// ...run the workload — every managed thread is sampled for the session's lifetime...
+
+TyphonProfiler.Stop();   // session stops, stream is parsed off-thread, samples embedded in the trace file
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:CpuSampling:Enabled` | `false` | Starts the in-process EventPipe sampler; embeds resolved stacks in the trace on stop |
+| `TYPHON__PROFILER__CPUSAMPLING__ENABLED` | — | Environment override for the flag above |
+
+## ⚠️ Guarantees & limits
+- **No external tool, no special launch** — a managed NuGet-backed session opened from inside the process;
+  no `dotnet-trace` global tool, no pre-CLR environment variable, no machine-installed dependency.
+- **No hot-path cost** — sampling runs on the runtime's own sampler thread at a fixed ~1 kHz cadence; it never
+  touches the typed-event producer path. Disabled entirely when the config flag is off.
+- **File mode only (v1)** — samples are resolved and embedded at session stop; live-TCP streaming does not
+  yet carry CPU samples.
+- **Managed stacks only** — native (C/C++) frames are not captured; BCL and dynamically-generated frames
+  resolve name-only (no source line) where no local PDB exists. Engine and application code with a portable
+  PDB resolves to `file:line:method` with click-to-source.
+- **Statistical, not exhaustive** — a 1 kHz sampler; short-lived or rare code paths may be under-represented.
+  Wider time ranges give more samples (more accurate) but blend more distinct behavior together — the Call
+  Tree panel shows the active scope's sample count and a density sparkline so you can judge that trade-off.
+- **Thread-time, classified** — the sampler catches every managed thread whether or not it's actually on a
+  core. Samples are classified on-CPU / voluntary-wait / involuntary-stall (GC suspension, OS preemption); the
+  view you pick decides which classes are folded into the tree versus collapsed into a labelled aggregate.
+- **Best-effort** — if the runtime diagnostics server is unavailable (e.g. `DOTNET_EnableDiagnostics=0`) or
+  the session fails to start, the engine logs one line and continues without CPU samples; a sampling failure
+  never aborts or corrupts the rest of the trace.
+- **No persisted intermediate file** — the raw EventPipe stream lives in a transient temp file only while the
+  session is running; it is deleted once parsed, never a trace-adjacent deliverable.
+
+## 🧪 Tests
+- [CpuSamplerSessionTests](../../../test/Typhon.Engine.Tests/Profiler/CpuSamplerSessionTests.cs) — session lifecycle idempotency, QPC anchor, graceful-degrade when EventPipe diagnostics are unavailable
+- [CpuSampleParserTests](../../../test/Typhon.Engine.Tests/Profiler/CpuSampleParserTests.cs) — `.nettrace` parse + symbol resolution driven against a real in-process capture of a CPU-burning workload
+- [CpuSampleSectionRoundTripTests](../../../test/Typhon.Engine.Tests/Profiler/CpuSampleSectionRoundTripTests.cs) — CPU-sample trailer section write/read, absent-section case, and hard rejection of pre-v11 traces
+
+## 🔗 Related
+- Sibling features: [Configuration & Performance Tuning](./profiler-configuration-tuning.md), [Profiler Session Lifecycle & Zero-Code Bootstrap](./profiler-lifecycle-bootstrap.md), [GC Event Tracing](./gc-event-tracing.md)
+- Source: `src/Typhon.Engine/Profiler/internals/CpuSamplerSession.cs`, `src/Typhon.Engine/Profiler/internals/CpuSample.cs`, `src/Typhon.Engine/Profiler/internals/CpuSampleParser.cs`, `src/Typhon.Engine/Profiler/internals/CpuSampleSectionEncoder.cs`, `src/Typhon.Engine/Profiler/public/ProfilerLauncher.cs`
+
+<!-- Deep dive: claude/design/Profiler/11-cpu-sampling-integration.md, claude/design/Profiler/06-profiler-feature-roadmap.md -->
+<!-- Overview: claude/overview/09-observability.md -->

--- a/doc/feature-set/Profiler/custom-named-spans.md
+++ b/doc/feature-set/Profiler/custom-named-spans.md
@@ -1,0 +1,62 @@
+# Custom Application-Defined Spans
+> A reserved wire-format span kind for app-defined names, designed to nest into the profiler flame graph — not yet callable from application code.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+Application code often has its own hot paths — a save pipeline step, a custom job, a request handler — that a
+developer wants to see in the same flame graph as Typhon's built-in transaction/B+Tree/page-cache spans, without
+Typhon engine changes for every new span name. Today only Typhon's own instrumented call sites emit spans; there is
+no supported way for host application code to add its own span into the same trace.
+
+## ⚙️ How it works (in brief)
+
+The wire format reserves a span kind for exactly this purpose: `TraceEventKind.NamedSpan` (wire ID `246`) carries an
+inline UTF-8 name instead of a fixed typed payload, and the trace file / sidecar cache formats both support an
+optional trailing name-intern table (`SpanNameTable` section, magic `"SPAN"`) so repeated names aren't re-written in
+full on every span. That plumbing exists on the read/replay side (`Typhon.Profiler` library reads and replays a
+`SpanNameTable` if one is present). What's missing is the producer half: no factory on `TyphonEvent` mints a
+`NamedSpan` record from an app-supplied string today.
+
+## 💻 Usage
+
+Not implemented — no factory exists yet, so nothing below compiles against the current engine.
+
+```csharp
+// Illustrative only — not a real/current Typhon API. TyphonEvent has no BeginNamedSpan/EmitNamedSpan
+// factory today. This is the shape the design docs describe, but it does not exist in source.
+// using var scope = TyphonEvent.BeginNamedSpan("MyCustomSpan");
+// ... app-specific work ...
+```
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** `src/Typhon.Engine/Profiler/internals/TyphonEvent.cs` — the producer surface every other
+  span factory (`BeginBTreeInsert`, `BeginTransactionCommit`, etc.) lives on — has no `BeginNamedSpan` or
+  `EmitNamedSpan` method. `Typhon.Generators.TraceEventGenerator` has no NamedSpan-specific codegen either. The only
+  reference to `TraceEventKind.NamedSpan` in `src/Typhon.Engine` or `test/` is a single entry in an
+  enum-exhaustiveness suppression test (`TyphonEventKindSuppressionTests.cs`) — there is no producer call site
+  anywhere in the codebase.
+- The wire slot is reserved and stable: `TraceEventKind.NamedSpan = 246` in the current `.typhon-trace` format
+  (v8+). It was `200` until 2026-05-10, when it was found to collide with `EcsQueryMaskAnd` and was reassigned; v7
+  traces carrying a kind-200 `NamedSpan` record are unaffected (older format), but the two kinds are indistinguishable
+  under the pre-fix numbering.
+- The `SpanNameTable` intern-table format exists only in the file writer/reader and sidecar-cache
+  writer/reader (`Typhon.Profiler`); it is populated by replaying a table that was already in a source file, never
+  by the engine's own `FileExporter`, which never constructs one.
+- The Workbench viewer's chunk decoder recognizes kind `246` but falls back to a generic span decode — the interned
+  name is not surfaced on the server DTO or rendered distinctly in the UI today.
+- `claude/design/Profiler/typhon-profiler.md` and `claude/design/Profiler/profiler-user-manual.md` both describe a
+  `TyphonEvent.BeginNamedSpan(string)` factory as if already usable, at wire kind `200`. Both statements are stale
+  against current source — treat those sections as a design target, not a working API, until this feature is built.
+
+## 🔗 Related
+
+- Sibling: [Built-in Engine Instrumentation Catalog](./builtin-subsystem-instrumentation.md) — the engine-side equivalent this app-defined span kind is designed to parallel
+- Sibling: [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md) — the producer surface (`TyphonEvent`) a future `BeginNamedSpan` factory would extend
+- Source: `src/Typhon.Profiler/TraceEventKind.cs` (`NamedSpan = 246`), `src/Typhon.Profiler/TraceFileWriter.cs`,
+  `TraceFileCacheWriter.cs` / `TraceFileCacheReader.cs` (`SpanNameTable` plumbing)
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §4.4, §5 (Producer API) — describes the intended shape; needs a refresh once implemented -->
+<!-- claude/design/Profiler/profiler-user-manual.md §2.1 — user-facing mention, also stale -->

--- a/doc/feature-set/Profiler/domain-tracing-expansion.md
+++ b/doc/feature-set/Profiler/domain-tracing-expansion.md
@@ -1,0 +1,103 @@
+# Domain-Specific Tracing Instrumentation Expansion
+> Nine new domains of forensic-grade tracing — locks, spatial, scheduler, storage, MVCC, query, durability — zero cost when off.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+The original built-in instrumentation covers nine coarse-grained subsystems (transaction commit, B+Tree ops,
+page cache, WAL, checkpoint, ...) but stops short of the questions you ask once a workload is deployed and you
+can't attach a debugger: which thread waited on which lock, why a spatial query traversed so many R-Tree nodes,
+how long a scheduler worker sat idle, or where in the MVCC chain a read stalled. Getting that detail used to
+mean adding ad hoc instrumentation, reproducing the problem, then ripping the instrumentation back out. This
+feature extends the same always-on tracing pipeline into nine additional engine domains so that level of
+forensic detail is a config flag away, not a code change.
+
+## ⚙️ How it works (in brief)
+
+Every new event kind is gated by a two-tier compile-time scheme layered on top of the master `Profiler:Enabled`
+switch: Tier 2 adds one `static readonly bool` flag per category, resolved once from a nested JSON tree
+(`Profiler:<Domain>:<Category>:<Leaf>:Enabled`) at class load — a child inherits its parent's effective state
+unless it overrides it. Because the flags are `static readonly`, the JIT proves a disabled branch is dead code
+and deletes the guarded call outright; a release-build IL dead-code-elimination test enforces this for every
+category before it ships — the same proof discipline the base [toggle mechanism](./profiler-configuration-tuning.md)
+already applies. Call sites whose method body is sub-100ns or fires over 100k times/sec require the Tier-2 gate;
+low-frequency sites can rely on the parent domain gate alone. The nine domains — Concurrency, Storage, Memory,
+Data (Transaction/MVCC/BTree), Query, ECS, Spatial, Scheduler/Runtime, Durability, and Subscription dispatch —
+each landed as an independent phase, so coverage depth varies: some categories have every emission site wired,
+others ship the wire format and config flag with the actual producer call deferred to a follow-up.
+
+## 💻 Usage
+
+```csharp
+// typhon.telemetry.json — turn on forensic detail only for the domains you're investigating;
+// everything else stays off (and costs 0 ns) by default:
+// {
+//   "Typhon": {
+//     "Profiler": {
+//       "Enabled": true,
+//       "Data":        { "Enabled": true },                  // Transaction/MVCC/BTree slow paths
+//       "Durability":  { "Enabled": true },                  // WAL split spans, Checkpoint, Recovery
+//       "Spatial":     { "Enabled": true, "Query": { "Enabled": true } },
+//       "Concurrency": { "Enabled": false }                  // leave lock tracing off — extreme frequency
+//     }
+//   }
+// }
+
+using Typhon.Engine;
+
+TelemetryConfig.EnsureInitialized();
+Console.WriteLine(TelemetryConfig.GetConfigurationSummary());
+
+// Gates are public static fields, one per category/leaf — same shape as the original nine subsystems:
+if (TelemetryConfig.DataMvccChainWalkActive)
+{
+    Console.WriteLine("MVCC slow-path chain walks are landing in the trace.");
+}
+```
+
+| Domain root | Default | Coverage in this drop |
+|---|---|---|
+| `Typhon:Profiler:Concurrency:Enabled` | `false` | AccessControl / AccessControlSmall / ResourceAccessControl / Epoch / AdaptiveWaiter / OlcLatch — fully wired |
+| `Typhon:Profiler:Spatial:Enabled` | `false` | Query / RTree / Grid / Cell / ClusterMigration / TierIndex / Maintain / Trigger — fully wired |
+| `Typhon:Profiler:Storage:Enabled` / `:Memory:Enabled` | `false` | Segment / FileHandle / OccupancyMap / DirtyWalk / AlignmentWaste — fully wired |
+| `Typhon:Profiler:Data:Enabled` | `false` | Transaction lifecycle + MVCC cleanup wired; BTree Search/RangeScan/NodeCow ship gate + codec, producer call deferred |
+| `Typhon:Profiler:Query:Enabled` / `:ECS:Enabled` | `false` | Parse/Plan and low-frequency ECS paths wired; hot-loop Iterate/Filter/ProcessEntry deferred |
+| `Typhon:Profiler:Scheduler:Enabled` / `:Runtime:Enabled` | `true`\* / `false` | System / Worker / Overload / Graph + UoW phase markers wired |
+| `Typhon:Profiler:Durability:Enabled` | `false` | WAL split spans + Recovery phase set wired; extreme-frequency `Frame` / `Record` / `UoW:State` ship gate + codec only |
+
+\* `Scheduler` keeps its pre-expansion default; the new leaves underneath it default off.
+
+## ⚠️ Guarantees & limits
+
+- **Zero cost when off, proven not assumed** — every Tier-2 leaf added by this expansion is covered by the same
+  release-build IL-elimination test that gates the profiler's toggle mechanism; a category that fails the test
+  doesn't ship.
+- **"Partial" means uneven producer wiring, not uneven design** — every domain's wire IDs, codecs, and config
+  flags are landed; several extreme-frequency call sites (BTree hot paths, ECS `ProcessEntry`, per-subscriber
+  dispatch, WAL `Frame`, `Recovery:Record`, `UoW:State`/`:Deadline`) ship the format and gate but defer the
+  actual emission call to a follow-up — flipping their flag on today produces no events yet.
+- **Wire IDs never renumber** — new domains occupy fresh, append-only `TraceEventKind` ranges; existing kinds
+  that gained payload fields (e.g. `TransactionRollback`'s reason byte, `PageEvicted`'s dirty bit) did so
+  wire-additively, so older `.typhon-trace` files still decode.
+- **Same consumer pipeline** — new events flow through the existing decoder/exporter/Workbench trace-viewer
+  path; no new tooling is required to view them.
+- **Config resolves once at class load** — editing `typhon.telemetry.json` or the `TYPHON__PROFILER__*` env
+  vars after the process starts has no effect until restart.
+- **Extreme-frequency leaves stay deny-listed even when their parent category is on** — e.g. per-step
+  `AdaptiveWaiter` events and `Durability:Recovery:Record` stay off under a broad `Enabled: true` to avoid
+  saturating the trace ring; they require explicitly enabling the leaf.
+
+## 🧪 Tests
+
+- [TelemetryConfigResolverTests](../../../test/Typhon.Engine.Tests/Observability/TelemetryConfigResolverTests.cs) — the Tier-2 parent-implies-children resolution formula: parent off disables children even if explicitly enabled, explicit leaf override wins when the parent is on
+- [ConcurrencyTracingStressTests](../../../test/Typhon.Engine.Tests/Concurrency/ConcurrencyTracingStressTests.cs) — end-to-end stress test for the Concurrency domain under real `AccessControl` contention; `[Explicit]` since it needs the domain's flag enabled via env var/JSON, with the fixture's own doc comment showing how
+
+## 🔗 Related
+
+- Sibling features: [Built-in Engine Instrumentation Catalog](./builtin-subsystem-instrumentation.md) (the original nine-subsystem baseline this expansion builds on), [Configuration & Performance Tuning](./profiler-configuration-tuning.md) (the gating mechanism these new flags plug into)
+- Source: `src/Typhon.Engine/Observability/public/TelemetryConfig.cs`, `src/Typhon.Engine/Profiler/internals/{SpatialQueryEvents,SpatialMaintainEvents,SpatialRTreeEvents,SpatialMiscEvents,DataPlaneEvents,DurabilityEvents,StorageMemoryEvents,SubscriptionDispatchEvents}.cs`
+
+<!-- Deep dive: claude/design/Profiler/07-tracing-instrumentation/README.md — umbrella (architecture, category tree, phasing, decisions) -->
+<!-- Per-domain design: claude/design/Profiler/07-tracing-instrumentation/01-tier2-gating-infrastructure.md, 02-concurrency.md, 03-spatial.md, 04-scheduler-runtime.md, 05-storage-memory.md, 06-data-plane.md, 07-query-ecs-view.md, 08-durability.md, 09-subscription-dispatch.md -->
+<!-- ADR: 019 — runtime telemetry toggle (JIT dead-code-elimination) (claude/adr/019-runtime-telemetry-toggle.md) -->

--- a/doc/feature-set/Profiler/gauge-snapshots.md
+++ b/doc/feature-set/Profiler/gauge-snapshots.md
@@ -1,0 +1,91 @@
+# Per-Tick Gauge/Metric Snapshots
+> One packed record per tick exposes memory, page-cache, WAL, and transaction counters to the trace viewer.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+Span-based tracing tells you what happened and how long it took, but it doesn't show continuous state —
+how full the page cache is, how much is queued in the WAL commit buffer, how many transactions are live —
+between the discrete events that touch them. Without a periodic sample, answering "was the engine under
+memory or I/O pressure during that slow stretch of ticks" means bolting ad hoc logging onto internal
+counters and correlating it by hand afterward. Per-tick gauge snapshots give the trace viewer numeric
+time-series tracks for engine resource state, aligned to the same timeline as the flame graph, with zero
+instrumentation required in application code.
+
+## ⚙️ How it works (in brief)
+
+At the end of every tick (when enabled, wired through the scheduler), the engine reads a fixed set of
+`Interlocked`-updated counters from memory, page cache, transient store, WAL, and transaction/UoW subsystems
+in one pass and packs them into a single `PerTickSnapshot` record — so every value in that record shares
+exactly one timestamp. Each value is tagged with a stable `GaugeId` (grouped into category ranges: memory,
+GC heap, page cache, transient store, WAL, transactions/UoW) and a `GaugeValueKind` declaring its wire shape.
+Fixed-at-startup capacities (e.g. total page-cache pages) are emitted only in the very first snapshot; the
+viewer caches them as reference lines. Cumulative counters (e.g. total commits) are monotonic — the viewer
+derives per-tick throughput by subtracting consecutive snapshots.
+
+## 💻 Usage
+
+`GaugeSnapshotEmitter` is engine-internal — it runs automatically once wired to the scheduler. There is
+nothing to call from application code; enabling the feature is a config toggle:
+
+```csharp
+// typhon.telemetry.json next to your executable:
+// {
+//   "Typhon": {
+//     "Telemetry": { "Enabled": true },
+//     "Profiler": { "Enabled": true, "Gauges": { "Enabled": true } }
+//   }
+// }
+
+using var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+runtime.Start();
+
+// No TyphonEvent calls anywhere above — one PerTickSnapshot lands per tick automatically. Open the trace
+// in the Workbench: the gauge region above the flame graph populates with Memory / Page Cache / WAL /
+// Transactions+UoW tracks, sharing the same time axis as everything else.
+```
+
+If you're writing your own consumer against `.typhon-trace` files (rather than using the Workbench viewer),
+`GaugeId` and `GaugeValueKind` are public types in `Typhon.Profiler` — use them to decode a `PerTickSnapshot`
+payload's `{gaugeId, valueKind, value}` triples.
+
+| Config key | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:Gauges:Enabled` | `false` | Enables the end-of-tick snapshot pass and `PerTickSnapshot` emission |
+
+## ⚠️ Guarantees & limits
+
+- **Zero cost when disabled** — gated by `TelemetryConfig.ProfilerGaugesActive`, a `static readonly bool`
+  the JIT dead-code-eliminates when off.
+- **Sub-microsecond when enabled** — one pass over roughly twenty `Interlocked` source fields plus one
+  record emit, once per tick, on the scheduler thread.
+- **One snapshot, one timestamp** — all values in a given `PerTickSnapshot` are tagged as of the same
+  instant; they are not independently time-stamped samples.
+- **Cumulative counters are monotonic U64** — never reset mid-session. Consumers must diff consecutive
+  snapshots to get a rate; U64 (not U32) avoids rollover at sustained high throughput.
+- **Fixed-at-init capacities emitted once** — total page-cache pages, transient-store max bytes, WAL
+  commit-buffer capacity, and WAL staging-pool capacity appear only in the first snapshot of a session.
+- **GC heap-size gauges are always sampled when Gauges is on** — Gen0…POH sizes and committed bytes come
+  from `GC.GetGCMemoryInfo()` every tick regardless of whether GC event tracing is separately enabled; they
+  are not the same feature as per-collection `GcStart`/`GcEnd`/`GcSuspension` spans.
+- **Wire-stable, append-only `GaugeId` numbering** — existing IDs are never renumbered; new gauges append
+  within a category range or open a new one, so old trace files keep decoding correctly.
+- **Coverage today**: unmanaged memory, GC heap, page-cache buckets + pending I/O + file size, transient
+  store bytes, WAL commit buffer + staging pool, transaction-chain and UoW live/cumulative counts. Arena/pool
+  allocation gauges and lock-wait gauges are reserved ranges only — not yet wired.
+
+## 🧪 Tests
+
+- [PerTickSnapshotEventCodecTests](../../../test/Typhon.Engine.Tests/Profiler/PerTickSnapshotEventCodecTests.cs) — wire round-trip for every `GaugeValueKind` variant plus empty-payload and boundary-size edge cases
+
+## 🔗 Related
+
+- Sibling features: [Configuration & Performance Tuning](./profiler-configuration-tuning.md), [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md)
+- Source: `src/Typhon.Engine/Profiler/internals/GaugeSnapshotEmitter.cs`, `src/Typhon.Profiler/GaugeId.cs`
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §6.6, §12, claude/design/Profiler/profiler-user-manual.md §5.3 -->
+<!-- Roadmap: claude/design/Profiler/06-profiler-feature-roadmap.md §2.2 -->

--- a/doc/feature-set/Profiler/gc-event-tracing.md
+++ b/doc/feature-set/Profiler/gc-event-tracing.md
@@ -1,0 +1,83 @@
+# GC Event Tracing
+> See every .NET garbage collection and EE-suspension pause on the same timeline as your transactions.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+Typhon is deliberately unmanaged-heavy, but the process still runs on the CLR, and any managed allocation
+that leaks into a hot path shows up as a GC pause you can't otherwise correlate to what the engine was doing
+at that instant. Without in-trace visibility, "was that latency spike a checkpoint stall or a GC?" requires
+cross-referencing a separate GC log by wall-clock time — slow, and never quite lines up. GC event tracing
+puts collection starts, ends, and execution-engine suspension windows directly on the profiler timeline, next
+to the transaction/B+Tree/page-cache spans they may be blocking.
+
+## ⚙️ How it works (in brief)
+
+A dedicated `EventListener` subscribes to the CLR's `Microsoft-Windows-DotNETRuntime` provider (the same
+EventPipe path `dotnet-counters` uses, so it works identically on Windows/Linux/macOS) and translates GC
+lifecycle callbacks into records on a small lock-free queue — never touching your producer threads. A
+separate ingestion thread drains that queue and emits the records through the normal typed-event pipeline on
+its own thread slot, so GC capture cost never lands on engine hot paths. `GcEnd` additionally snapshots
+`GC.GetGCMemoryInfo()` for per-generation heap sizes, which also feed the gauge region's Memory track.
+
+## 💻 Usage
+
+Nothing to call — flip the config flag and the engine wires up the listener and ingestion thread for you:
+
+```csharp
+// typhon.telemetry.json next to your executable:
+// { "Typhon": { "Telemetry": { "Enabled": true }, "Profiler": { "Enabled": true, "GcTracing": { "Enabled": true } } } }
+
+using Typhon.Engine;
+
+var runtime = TyphonRuntime.Create(dbe, schedule =>   // ProfilerBootstrap starts GcTracingHost, if enabled
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+
+// …run your workload…
+
+TyphonProfiler.Stop();   // optional; ordinary shutdown detaches the listener and joins the ingestion thread too
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:GcTracing:Enabled` | `false` | Starts the `EventListener` + ingestion thread; emits `GcStart`/`GcEnd`/`GcSuspension` and populates the GC heap-size gauges |
+
+## ⚠️ Guarantees & limits
+
+- **Off the hot path** — the CLR's GC callback thread only enqueues a small struct; translation into wire
+  records happens later, on a dedicated ingestion thread, never on an engine-owned thread slot.
+- **Cross-platform** — same EventPipe provider on Windows, Linux, and macOS; no ETW-only dependency (that's
+  a separate, Windows-only feature for OS thread scheduling).
+- **Three record kinds**: `GcStart` (generation, reason, type, count), `GcEnd` (same plus pause duration,
+  promoted bytes, per-generation size-after values for Gen0/1/2/LOH/POH, and total committed bytes),
+  `GcSuspension` (a span covering `GCSuspendEEBegin` → `GCRestartEEEnd`, tagged with the suspend reason).
+  Suspension spans are process-level — no parent span, no attribution to the transaction that happened to be
+  running.
+- **Only GC-caused suspensions are recorded** — the EE also suspends for reasons unrelated to garbage
+  collection (e.g., the CPU sampler's stack walks), and those are filtered out rather than flooding the trace.
+- **Negligible overhead** — GC events occur at human/collection timescales (not per-span), so the ingestion
+  thread's steady-state cost is effectively zero; measured combined overhead with GC tracing + other opt-in
+  extras enabled is under 1% on tested workloads.
+- **Gated independently** — `Typhon:Profiler:GcTracing:Enabled` is its own flag; it costs nothing when off
+  and doesn't require enabling memory-allocation tracing or gauges.
+- **Resolved once at startup** — like every `TelemetryConfig` gate, this is read at class load; toggling the
+  JSON/env var after the process starts has no effect until restart.
+- **Viewer** shows a dedicated GC track: red bars for suspension windows, start/end markers for collections,
+  and a stacked-area Gen0–POH view in the Memory gauge track — pre-computed at trace-open time so its scale
+  stays stable while you pan across a large trace.
+
+## 🧪 Tests
+
+- [GcTracingHostTests](../../../test/Typhon.Engine.Tests/Profiler/GcTracingHostTests.cs) — ingestion-thread → `TyphonEvent` emit path, records injected directly into the queue to exercise processing independent of a real GC
+- [GcEventListenerTests](../../../test/Typhon.Engine.Tests/Profiler/GcEventListenerTests.cs) — `IsGcSuspendReason` filter that keeps CPU-sampler-induced EE suspensions out of the GC track
+
+## 🔗 Related
+
+- Sibling features: [Configuration & Performance Tuning](./profiler-configuration-tuning.md), [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md), [Built-in Engine Instrumentation Catalog](./builtin-subsystem-instrumentation.md)
+- Source: `src/Typhon.Engine/Profiler/internals/{GcEventListener,GcIngestionThread,GcEventQueue,GcEventRecord,GcTracingHost,GcSuspensionEvent}.cs`, `src/Typhon.Profiler/GcEnums.cs`
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §6.7, claude/design/Profiler/06-profiler-feature-roadmap.md §3.1 -->
+<!-- User manual: claude/design/Profiler/profiler-user-manual.md §3.1, §5.3, §8.2 -->

--- a/doc/feature-set/Profiler/lock-contention-diagnostics.md
+++ b/doc/feature-set/Profiler/lock-contention-diagnostics.md
@@ -1,0 +1,70 @@
+# Lock-Contention Forensics (Deep Diagnostics)
+> Post-mortem visibility into which threads waited on which locks, for how long, and why.
+
+**Status:** 📋 Planned · **Visibility:** Internal · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+When a stress test shows an unexplained latency spike or an occasional transaction timeout under load,
+span timing alone can't tell you whether a thread was doing work or sitting blocked on a lock. Aggregate
+contention counters ("47 contention events averaging 340µs") lose the per-event detail needed to actually
+fix it: which lock, which two threads, what the holder was doing, and whether it's a recurring pattern.
+This feature is designed to answer "why did thread 7 wait 2.3ms for thread 3, and does it keep happening?"
+without attaching an external profiler.
+
+## ⚙️ How it works (in brief)
+
+The design captures contention only — not every lock acquisition — so the fast, uncontended path (the vast
+majority of lock operations) keeps its current zero-overhead behavior. A capture point fires only when a
+thread actually has to wait: it would record the waiter and holder thread IDs, the lock's identity, a call
+stack at the wait point, and the resulting wait duration, then surface each event as a span so it can appear
+inline in a flame graph (nested under whatever transaction triggered it) or as its own trace when contention
+happens outside a transaction.
+
+## 💻 Usage
+
+Not usable yet — no engine emission exists. The roadmap reserves wire event-kind range 70-74
+(`LockAcquire` / `LockRelease` / `LockWaitBegin` / `LockWaitEnd`) for this feature; none of these event
+kinds, and no contention-capture hook on `AccessControl`, `AccessControlSmall`, or `ResourceAccessControl`,
+are implemented today.
+
+```csharp
+// Illustrative only — design complete, not implemented yet. No "Typhon:Profiler:LockContention" config
+// key, no TyphonEvent factory, and no contention-capture hook exist in source today.
+// var runtime = TyphonRuntime.Create(dbe, schedule => { /* ... */ });
+// // ...contention on AccessControl/AccessControlSmall/ResourceAccessControl would emit
+// // LockWaitBegin/LockWaitEnd spans automatically, no call-site changes required...
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:LockContention:Enabled` (proposed) | `false` | Not implemented — no such config key exists today |
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** No wire event kinds, capture hooks, or config surface exist in
+  `src/Typhon.Engine/Foundation/Concurrency/internals/` today; this is a complete design awaiting a build slot.
+- **Contention-only by design** — capturing every acquire/release was estimated at 1M+ events/sec (1.8B over
+  30 minutes); capturing only actual waits cuts that by 100-10,000x while keeping exactly what's useful for
+  debugging.
+- **Zero overhead on the fast path** — the design only does work (stack capture, event record) once a thread
+  has already determined it must wait; threads that acquire immediately pay nothing extra.
+- **Holder identification is exact for exclusive waits** — `AccessControl`/`AccessControlSmall` already track
+  the current exclusive holder's thread ID as part of their atomic lock state, so the design can read it with
+  no extra bookkeeping. For shared-lock contention there is no single holder to name (multiple threads can
+  hold a shared lock at once); the design records it as "waiting on shared readers" rather than a thread ID.
+- **Would use the 16-bit thread-ID convention** already shared by `AccessControl`, `AccessControlSmall`, and
+  `ResourceAccessControl` — no new thread-identity mechanism.
+- **Scoped to three lock types**: `AccessControl`, `AccessControlSmall`, `ResourceAccessControl`. General
+  span tracing, memory tracing, and I/O tracing are separate features, not part of this one.
+- **Reserved wire range 70-74** is held for this feature and won't be reused by other event kinds in the
+  meantime.
+
+## 🔗 Related
+
+- Sibling features: [GC Event Tracing](./gc-event-tracing.md), [Off-CPU Thread Scheduling Capture](./offcpu-thread-scheduling.md), [Configuration & Performance Tuning](./profiler-configuration-tuning.md)
+- Sibling: [Reader-Writer & Resource Lifecycle Locks](../Foundation/access-control-lock-family/README.md) — the `AccessControl`/`AccessControlSmall`/`ResourceAccessControl` lock family this feature would instrument
+- Source (existing, related): `src/Typhon.Engine/Foundation/Concurrency/internals/AccessControl.cs`, `AccessControlSmall.cs`, `ResourceAccessControl.cs` — no contention-capture code present yet
+
+<!-- Deep dive: claude/design/Profiler/03-deep-diagnostics.md, claude/design/Profiler/06-profiler-feature-roadmap.md §2.3 -->
+<!-- Architecture overview: claude/overview/09-observability.md, claude/overview/01-concurrency.md -->

--- a/doc/feature-set/Profiler/offcpu-thread-scheduling.md
+++ b/doc/feature-set/Profiler/offcpu-thread-scheduling.md
@@ -1,0 +1,95 @@
+# Off-CPU Thread Scheduling Capture (Windows)
+> See exactly when and why each engine thread lost the CPU, down to the kernel wait reason.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+Span timing tells you how long an operation took, but not whether the thread was actually
+running for that whole span or sitting off-CPU — blocked on a lock, waiting on I/O, or simply
+preempted by the OS scheduler. Without that distinction, a slow span and a starved thread look
+identical on the timeline. This feature fills the gap: it records every point where a
+Typhon-registered OS thread was switched out, how long it had held the CPU, and the kernel's
+own reason for the switch — so the Workbench viewer can render the off-CPU gaps between
+on-CPU slices instead of leaving them as unexplained dead time.
+
+## ⚙️ How it works (in brief)
+
+A dedicated pump opens the Windows NT Kernel Logger ETW session and subscribes to kernel
+context-switch and dispatcher-ready events for the whole machine, filtering to only the
+threads Typhon itself has registered. Each time a tracked thread is switched off the CPU, the
+pump closes out that on-CPU slice and emits one record carrying the slice duration, the CPU it
+ran on, the kernel wait reason, and how long the thread had waited on the ready queue before it
+last got scheduled in. This runs on its own background thread, independent of the engine's
+worker threads, and produces the raw slice data — the Workbench renders it as the off-CPU gaps
+alongside the existing span timeline.
+
+## 💻 Usage
+
+Nothing to call — flip the config flag and the engine wires up the ETW pump for you:
+
+```csharp
+// typhon.telemetry.json next to your executable:
+// {
+//   "Typhon": {
+//     "Telemetry": { "Enabled": true },
+//     "Profiler": {
+//       "Enabled": true,
+//       "Runtime": { "ThreadScheduling": { "Enabled": true } }
+//     }
+//   }
+// }
+
+using Typhon.Engine;
+
+var runtime = TyphonRuntime.Create(dbe, schedule =>   // ProfilerBootstrap starts EtwSchedulingPump, if enabled
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+
+// …run your workload (must run elevated — see Guarantees & limits)…
+
+TyphonProfiler.Stop();   // optional; ordinary shutdown stops the ETW session and joins the pump thread too
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:Runtime:ThreadScheduling:Enabled` | `false` | Opens the NT Kernel Logger session and emits one `ThreadContextSwitch` record per closed on-CPU slice |
+
+## ⚠️ Guarantees & limits
+
+- **Windows only.** The capture is built on the NT Kernel Logger; on non-Windows hosts the pump
+  skips itself and logs one diagnostic line — the rest of the profiler is unaffected.
+- **Requires elevation.** The process must run as Administrator or as a member of
+  `Performance Log Users`. Without it, `Start` fails gracefully (one stderr line), and the trace
+  continues without scheduling data.
+- **Machine-wide singleton.** The NT Kernel Logger session can only have one owner per machine.
+  If another tool (PerfView, WPR, xperf) already holds it, the pump fails to start the same way
+  — gracefully, with a diagnostic, never aborting the trace.
+- **Scoped to Typhon's own threads.** Only OS threads Typhon has registered are recorded; pool,
+  finalizer, GC-server threads, other processes, and the pump's own thread are filtered out.
+- **Off by default, opt-in, and independent.** Gated by its own config key; costs nothing when
+  disabled and can be enabled without turning on any other profiler sub-feature.
+- **Precise, not statistical.** Every on-CPU slice for a tracked thread is captured exactly from
+  kernel events — this is not sampling, so short slices are not missed the way a fixed-rate
+  sampler would miss them.
+- **Complements, does not replace, CPU sampling.** This gives exact off-CPU *timing* and wait
+  reason with no call stack; the separate CPU-sampling feature gives a statistical call stack at
+  the cost of a fixed sampling cadence. Enabling CPU sampling enables this capture by default
+  where supported, so the on-CPU/off-CPU classification in the Workbench has both signals.
+- **Timestamps cross-walk directly.** The kernel's QPC clock is the same clock
+  `Stopwatch.GetTimestamp()` uses on Windows, so slice timestamps need no conversion to line up
+  with the rest of the trace.
+
+## 🧪 Tests
+
+- [EtwSchedulingPumpTests](../../../test/Typhon.Engine.Tests/Profiler/EtwSchedulingPumpTests.cs) — `IsStaleEntry` prune-decision helper (regression test for an unbounded `_threadStates` growth bug); the ETW session itself isn't unit-testable and is exercised only in practice
+- [ThreadSchedulingTests](../../../test/Typhon.Engine.Tests/Profiler/ThreadSchedulingTests.cs) — `ThreadWaitReason` wire-stability and `ThreadContextSwitchEventDto` encode/decode round-trip
+
+## 🔗 Related
+
+- Sibling features: [Configuration & Performance Tuning](./profiler-configuration-tuning.md), [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md), [Built-in Engine Instrumentation Catalog](./builtin-subsystem-instrumentation.md)
+- Source: `src/Typhon.Engine/Profiler/internals/EtwSchedulingPump.cs`, `src/Typhon.Engine/Profiler/internals/ThreadSchedulingEvents.cs`, `src/Typhon.Profiler/ThreadWaitReason.cs`
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §6.8, claude/design/Profiler/11-cpu-sampling-integration.md §2.1, §8.7 -->
+<!-- Architecture overview: claude/overview/09-observability.md -->

--- a/doc/feature-set/Profiler/profiler-configuration-tuning.md
+++ b/doc/feature-set/Profiler/profiler-configuration-tuning.md
@@ -1,0 +1,98 @@
+# Configuration & Performance Tuning
+> Dial each profiler subsystem on or off, and tune the drain pipeline, without touching a build.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+Profiling is only "zero when disabled" if disabling it truly costs nothing, and only safe to enable in
+production if you can turn on just the subsystem you need — not the whole tracer. Typhon exposes both knobs
+outside the binary: a config file (or environment variables) toggles each opt-in subsystem independently, and
+a settings object governs how the drain pipeline buffers events, trading latency against CPU.
+
+## ⚙️ How it works (in brief)
+`typhon.telemetry.json` (or `TYPHON__PROFILER__*` env vars) is read once, at class load, into
+`TelemetryConfig` — a set of `static readonly bool` gates, one per subsystem, each combined with the master
+`Profiler.Enabled` switch (e.g. `ProfilerGcTracingActive = ProfilerActive && ProfilerGcTracingEnabled`). Because
+the fields are `static readonly`, the JIT proves a `false` gate can never flip and deletes the guarded code
+outright. `ProfilerOptions` is a separate settings object governing the consumer thread's drain cadence and
+buffering; today it ships with engine-tuned defaults (see limits).
+
+## 💻 Usage
+```csharp
+// typhon.telemetry.json — dropped next to the executable, or set the TYPHON__PROFILER__* equivalents:
+// {
+//   "Typhon": {
+//     "Profiler": {
+//       "Enabled": true,
+//       "GcTracing":         { "Enabled": true },
+//       "MemoryAllocations": { "Enabled": false },
+//       "CpuSampling":       { "Enabled": false },
+//       "Gauges":            { "Enabled": true }
+//     }
+//   }
+// }
+
+using Typhon.Engine;
+
+// Force the static constructor to run (and the JIT gate to resolve) before your hot paths compile,
+// then log exactly what's active — useful at startup for a diagnostic banner.
+TelemetryConfig.EnsureInitialized();
+Console.WriteLine(TelemetryConfig.GetConfigurationSummary());
+
+// Individual gates are public fields — branch on them for app-side diagnostics if you need to:
+if (TelemetryConfig.ProfilerGcTracingActive)
+{
+    Console.WriteLine("GC tracing is capturing to the trace.");
+}
+```
+
+```bash
+# Override a single sub-flag for one run, no file edit:
+TYPHON__PROFILER__GAUGES__ENABLED=false dotnet run
+```
+
+| Config key | Default | Enables |
+|---|---|---|
+| `Typhon:Profiler:Enabled` | `false` | Master gate — every flag below is forced off when this is `false` |
+| `Typhon:Profiler:GcTracing:Enabled` | `false` | GC ingestion thread; `GcStart`/`GcEnd`/`GcSuspension` records |
+| `Typhon:Profiler:MemoryAllocations:Enabled` | `false` | Per-alloc/free `MemoryAllocEvent` for `PinnedMemoryBlock` traffic |
+| `Typhon:Profiler:CpuSampling:Enabled` | `false` | In-process CPU stack sampling, embedded in the trace file |
+| `Typhon:Profiler:Gauges:Enabled` | `false` | Per-tick `PerTickSnapshot` (memory, page cache, WAL, tx/UoW) |
+
+`ProfilerOptions` fields (engine-internal defaults today — see limits):
+
+| Field | Default | Controls |
+|---|---|---|
+| `ConsumerCadence` | 1 ms | Drain-thread wake interval — lower = lower live-viewer latency, higher CPU |
+| `PerExporterChannelDepth` | 4 | Batches buffered per exporter before drop-newest kicks in |
+| `MergeBufferBytes` | 512 KB | Per-pass merge scratch capacity on the drain thread |
+| `SpilloverBufferCount` / `SpilloverBufferSizeBytes` | 8 × 16 MiB | Overflow rings a producer chains onto when its primary ring fills |
+
+## ⚠️ Guarantees & limits
+- Disabled subsystems cost exactly 0 ns — Tier 1 JIT dead-code-eliminates the guarded block (ADR-019),
+  proven by benchmark, not just claimed. Every sub-flag is independent: `GcTracing` costs nothing on
+  `MemoryAllocations` or `Gauges`.
+- Gates resolve once, at class load — editing the JSON/env after the process starts has no effect until restart.
+- Effective precedence, highest to lowest: environment variables → `typhon.telemetry.json` → built-in
+  (all-`false`) defaults. The legacy `Typhon:Telemetry:Profiler:*` namespace still works via a deprecated
+  back-compat shim (logs a warning to `stderr`); target `Typhon:Profiler:*` going forward.
+- Measured overhead with GcTracing + MemoryAllocations + Gauges all on: under 1% scheduler-thread cost on
+  tested workloads.
+- `ProfilerOptions` tuning is not yet exposed on the standard zero-code path (`AddTyphonProfiler` +
+  `TyphonRuntime.Create`): the internal bootstrap always constructs `new ProfilerOptions()`. Setting a custom
+  instance requires calling `TyphonProfiler.Start` directly, which is `internal` — reachable only by hosts with
+  no `TyphonRuntime` of their own (today, Typhon's own tooling). No public override hook exists yet.
+- `TyphonProfiler.TotalDroppedEvents > 0` after a run means the producer outran the consumer — check
+  `ConsumerCadence` and spillover sizing first.
+
+## 🧪 Tests
+- [TelemetryConfigGateShapeTests](../../../test/Typhon.Engine.Tests/Observability/TelemetryConfigGateShapeTests.cs) — enforces every `*Active` gate field is `public static readonly bool`, the structural precondition the JIT dead-code-elimination claim depends on
+- [TelemetryConfigCpuSamplingTests](../../../test/Typhon.Engine.Tests/Profiler/TelemetryConfigCpuSamplingTests.cs) — one gate worked end-to-end: reads from `typhon.telemetry.json`, composes `Active = ProfilerActive && Enabled`, surfaces in `GetConfigurationSummary`
+
+## 🔗 Related
+- Sibling: [Profiler Session Lifecycle & Zero-Code Bootstrap](./profiler-lifecycle-bootstrap.md) — reads this config to decide which exporters and subsystems to start
+- Sibling: [Domain-Specific Tracing Instrumentation Expansion](./domain-tracing-expansion.md) — the Tier-2 per-domain gating scheme layered on top of this mechanism
+- Source: `src/Typhon.Engine/Observability/public/TelemetryConfig.cs`, `src/Typhon.Engine/Profiler/public/ProfilerOptions.cs`, `src/Typhon.Engine/Profiler/internals/ProfilerBootstrap.cs`
+
+<!-- Deep dive: claude/design/Profiler/profiler-user-manual.md §3, claude/design/Profiler/typhon-profiler.md §9 -->
+<!-- ADR: claude/adr/019-runtime-telemetry-toggle.md -->

--- a/doc/feature-set/Profiler/profiler-lifecycle-bootstrap.md
+++ b/doc/feature-set/Profiler/profiler-lifecycle-bootstrap.md
@@ -1,0 +1,80 @@
+# Profiler Session Lifecycle & Zero-Code Bootstrap
+> Turn profiling on with a config file — no startup/shutdown code, and no lost trace on crash or exit.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+A profiler needs someone to start its consumer thread, initialize exporters in the right order, and guarantee
+the trace is finalized even if the host forgets to tear it down — or crashes. Getting that sequencing right
+(CPU sampler before session metadata, exporters ready before the first batch, trace header patched exactly
+once) is boilerplate no application developer should have to write per host. Typhon eliminates it: dropping a
+config file next to the executable is enough to get a fully working trace, safely finalized on every exit path.
+
+## ⚙️ How it works (in brief)
+`ProfilerBootstrap` runs automatically at engine load and again inside `TyphonRuntime.Create`: it reads the
+merged configuration, builds the exporters, starts the optional CPU sampler, composes session metadata from the
+live runtime, and calls `TyphonProfiler.Start`. Teardown is wired to the engine storage's disposal so the trace
+finalizes on ordinary shutdown; `AppDomain.ProcessExit`/`UnhandledException` handlers act as a backup for hosts
+that skip disposal or crash. `TyphonProfiler.Start`/`Stop` are idempotent, so redundant calls from the bootstrap,
+the safety net, and an explicit host call never conflict.
+
+## 💻 Usage
+```csharp
+// 1. Drop next to the executable (or set TYPHON__TELEMETRY__* env vars) — no code required:
+// typhon.telemetry.json
+// {
+//   "Typhon": { "Telemetry": { "Enabled": true,
+//       "Profiler": { "Enabled": true, "Trace": "session.typhon-trace" } } }
+// }
+
+using Typhon.Engine;
+
+// 2. Build the runtime as usual — profiling self-wires inside Create() because the config above is active.
+var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+
+// ...run the workload; every built-in call site (transactions, B+Trees, page cache, WAL, checkpoints, ECS)
+// emits automatically — no tracing calls needed in application code...
+
+// 3. Ordinary shutdown finalizes the trace automatically (engine storage disposal fires it). No explicit
+// Stop() call is required, but the host may end the session earlier if it wants to:
+TyphonProfiler.Stop();
+```
+
+| Signal | Effect |
+|---|---|
+| `Typhon.Telemetry.Enabled` / `Profiler.Enabled` = `false` | Bootstrap is a no-op; zero runtime cost |
+| Engine storage disposed (normal shutdown) | Primary teardown — trace finalized deterministically |
+| `AppDomain.ProcessExit` / terminating unhandled exception | Backup teardown for hosts that never dispose |
+| `TyphonProfiler.Stop()` called explicitly | Early, host-initiated teardown (idempotent) |
+
+## ⚠️ Guarantees & limits
+- Zero host code required for the common case — a `typhon.telemetry.json` file plus `TyphonRuntime.Create` is
+  the entire integration surface.
+- `TyphonProfiler.Start`/`Stop` are idempotent: a double-start is a no-op, a double-stop is a no-op — safe
+  under restart-after-crash or a redundant safety-net firing.
+- Bootstrap failures (port already in use, unwritable trace path) are caught and logged to stderr; the host
+  keeps running without profiling rather than crashing.
+- The process-exit safety net does **not** catch `TerminateProcess`/`taskkill /F`/`SIGKILL`,
+  `StackOverflowException`, or access violations — the OS reaps the process before managed code runs. Only a
+  clean shutdown or a caught, terminating unhandled exception finalizes the trace.
+- ProcessExit handlers are budget-capped by the CLR (~2 s); a hung consumer or exporter thread can be cut
+  short, in which case the trailing block of the trace may be lost.
+- Session metadata (systems, archetypes, component types, tracks, resource graph) is captured once at start
+  and is immutable for the lifetime of the session.
+- `AttachExporter`/`DetachExporter` (advanced, low-level API) are only valid while the profiler is stopped —
+  mutating exporters while running throws `InvalidOperationException`.
+
+## 🧪 Tests
+- [ProfilerSessionMetadataBuilderTests](../../../test/Typhon.Engine.Tests/Profiler/ProfilerSessionMetadataBuilderTests.cs) — session metadata composition (systems/archetypes/component types derived from `RuntimeOptions`); per the fixture's own remarks, the full `ProfilerBootstrap.TryStart` self-wiring path gates on a `static readonly` flag and can't be unit-tested in isolation, so this covers the part that can be
+- [FileExporterIntegrationTests](../../../test/Typhon.Engine.Tests/Profiler/FileExporterIntegrationTests.cs) — exercises `TyphonProfiler.Start`/`Stop` end-to-end (start, emit, stop-finalizes) as part of the file-export round-trip
+
+## 🔗 Related
+- Sibling: [Configuration & Performance Tuning](./profiler-configuration-tuning.md) — the config this bootstrap reads to decide which exporters and subsystems to start
+- Sibling: [Trace Export](./trace-export/README.md) — the exporters this bootstrap builds and attaches before starting the session
+- Source: `src/Typhon.Engine/Profiler/public/TyphonProfiler.cs`, `src/Typhon.Engine/Profiler/internals/ProfilerBootstrap.cs`
+
+<!-- Deep dive: claude/design/Profiler/profiler-user-manual.md §2, claude/design/Profiler/typhon-profiler.md §6 -->
+<!-- Overview: claude/overview/09-observability.md -->

--- a/doc/feature-set/Profiler/query-definition-export.md
+++ b/doc/feature-set/Profiler/query-definition-export.md
@@ -1,0 +1,83 @@
+# Query Definition & Execution Export
+> Every View/EcsQuery describes its shape once, then tags each run so you can trace it back to the code that issued it.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+The query span chain (parse, plan, index scan, filter, sort, pagination) already tells you *how* a query ran, but
+not *which* logical query it was, *where in your code* it was declared, or *who else* is running the same one.
+Without a stable identity you can't group executions by definition, spot two systems accidentally holding
+structurally-identical-but-distinct `View`s, or jump from a slow execution back to the `.Query<T>()` / `.ToView()`
+call site that created it.
+
+## ⚙️ How it works (in brief)
+Every `View` and `EcsQuery` gets a process-wide, monotonic instance id at construction (`ViewId` / `EcsQueryId`).
+The first time a query with a given id executes in a session, its structural shape — filters, sort, target
+archetype, primary index — is written once as a definition record; every later execution of the same instance
+just carries the id, so the trace never repeats the shape. Construction and execution-terminal call sites
+(`.Query<T>()`, `.ToView()`, `.Count()`, `.Any()`, …) capture the caller's file/line/method at compile time via
+`[CallerFilePath]`/`[CallerLineNumber]`/`[CallerMemberName]` — no stack walk, no runtime cost. Scheduler-driven
+`View.Refresh` calls (no user call site) fall back to the owning system as attribution. Capture is gated behind
+the `Query` telemetry category, so it costs nothing when profiling is off.
+
+## 💻 Usage
+```csharp
+using Typhon.Engine;
+
+// Definition-site attribution is automatic — no extra arguments to pass.
+var query = tx.Query<Ant>()
+    .With<Position>()
+    .Where<Position>(a => a.Energy > 50);
+
+// Execution-site attribution is captured at the terminal call:
+int hungryAnts = query.Count();     // caller file/line/method recorded with this execution
+bool anyLeft   = query.Any();
+
+// A View records its own construction site once, then each execution keeps its own site:
+var view = tx.Query<Ant>().ToView();
+view.Refresh(tx);                   // scheduler-driven refresh falls back to the owning system
+```
+
+```jsonc
+// typhon.telemetry.json — enable the Query category to capture definitions + per-execution args
+{
+  "Typhon": {
+    "Profiler": {
+      "Enabled": true,
+      "Query": { "Enabled": true }
+    }
+  }
+}
+```
+
+| Config key | Default | Enables |
+|---|---|---|
+| `Typhon:Profiler:Query:Enabled` | `false` | Query parse/plan/execute spans, `QueryDefinitionDescribe`, and per-execution `QueryArgs` |
+
+## ⚠️ Guarantees & limits
+- **Definitions dedup per session, not per execution.** One `QueryDefinitionDescribe` record per distinct
+  `View`/`EcsQuery` instance, no matter how many times it runs; the threshold *values* of each run are captured
+  separately as per-execution args, so two runs with different thresholds still share one definition.
+- **No result-set capture.** Only what was asked and how it executed is recorded — not the entity IDs returned.
+- **Immediate call site only, not a call stack.** Both construction and execution attribution are the single
+  line that invoked the API, matching the [Source Attribution](./source-attribution.md) model.
+- **Zero cost when disabled** — gated behind `TelemetryConfig.QueryActive`; JIT-eliminated like every other
+  profiler subsystem.
+- **Backward-compatible wire format** — trace files from before this feature still decode; the new fields simply
+  decode as absent.
+- **Partial status** — the Workbench-side Query Catalog / Plan Tree / Execution Inspector panels this data feeds
+  are built but system ownership isn't wired yet (definitions currently show no owning system), the "triggered
+  at" execution-site link isn't surfaced in the Execution Inspector, and polymorphic queries don't yet break out
+  per-archetype-subtree stats in that view.
+
+## 🧪 Tests
+- [EcsQueryIdTests](../../../test/Typhon.Engine.Tests/Querying/EcsQueryIdTests.cs) — `EcsQuery<T>.EcsQueryId` is monotonic and unique under concurrent construction
+- [QuerySourceLocationTests](../../../test/Typhon.Engine.Tests/Querying/QuerySourceLocationTests.cs) — `[CallerFilePath]`/`[CallerLineNumber]`/`[CallerMemberName]` substitution at user call sites, stored on the constructed `View`/`EcsQuery`
+- [QueryDefinitionDescribeOnceTests](../../../test/Typhon.Engine.Tests/Profiler/QueryDefinitionDescribeOnceTests.cs) — "describe each query identity exactly once per session" dedup semantics on `QueryDefinitionDescribeTracker`
+
+## 🔗 Related
+- Sibling features: [Span Source Attribution](./source-attribution.md), [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md)
+- Source: `src/Typhon.Engine/Profiler/internals/QueryDefinitionDescribeTracker.cs`, `src/Typhon.Engine/Profiler/internals/QuerySourceStringInterner.cs`, `src/Typhon.Engine/Profiler/internals/QueryEcsViewEvents.cs`, `src/Typhon.Engine/Profiler/internals/EcsQueryEvents.cs`, `src/Typhon.Engine/Ecs/public/EcsQuery.cs`, `src/Typhon.Engine/Querying/public/ViewBase.cs`
+
+<!-- Deep dive: claude/design/Profiler/11-query-definition-export.md, claude/design/Profiler/07-tracing-instrumentation/07-query-ecs-view.md -->
+<!-- Overview: claude/overview/05-query.md -->

--- a/doc/feature-set/Profiler/source-attribution.md
+++ b/doc/feature-set/Profiler/source-attribution.md
@@ -1,0 +1,87 @@
+# Span Source Attribution (Go-to-Source)
+> Every span you see in the Workbench knows the exact file, line, and method that emitted it — one click away.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+A flame graph tells you *what* ran and *how long* it took, but not *where in your code* it came from. Without
+attribution, tracking a slow `BTreeInsert` or `TransactionCommit` span back to the call site means grepping the
+codebase by hand. Source attribution closes that gap: selecting any span in the Workbench shows its emission
+`file:line · method` and offers a one-click jump into your editor, plus an inline read-only preview — no manual
+searching, no extra instrumentation to write.
+
+This is **call-site attribution, not call-stack attribution** — it identifies the single line that emitted the
+span, not the full caller chain. (Full call stacks are covered separately by CPU sampling's Call Tree view.)
+
+## ⚙️ How it works (in brief)
+
+At build time, every `TyphonEvent.BeginXxx(...)` call site in the engine is discovered and assigned a
+deterministic `ushort` id (sorted by file/line/column, so the same site gets the same id on every build). A
+C# 14 compiler interceptor silently redirects each call to carry that id along — no change to the code you write.
+At runtime the id rides in the span's header and, when the field is non-zero, costs two extra bytes on the wire.
+A companion manifest (built once, shipped with the trace) maps each id back to `file`, `line`, and `method`, so
+the Workbench never needs your source tree to decode it — only to display and open it.
+
+User-registered ECS systems get the same treatment through a different route: their registration delegate is
+resolved via the assembly's portable PDB at scheduler build time, so `MoveAllAnts` or similar callback systems
+show their own source, not the scheduler's dispatch site.
+
+## 💻 Usage
+
+There is nothing to call — attribution is automatic for every existing profiler span once a trace is captured:
+
+```csharp
+// Nothing new here — this is any already-instrumented engine call, e.g. inside a custom index or system.
+// Attribution rides along for free: no BeginXxxWithSiteId, no extra parameter, no opt-in call.
+using var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+runtime.Start();
+
+// Open the resulting .typhon-trace (or a live session) in the Workbench, select any span —
+// e.g. a BTree.Insert or Transaction.Commit — and the detail panel shows:
+//   Source: BTree.Insert.cs:1125 · BTree.Insert(...)
+//     [Open in editor]   [Show inline]
+```
+
+Editor handoff and workspace-root resolution are configured once in the Workbench, not in engine code:
+
+| Option (Workbench → Options → Editor/Profiler) | Default | Effect |
+|---|---|---|
+| Editor kind | VS Code | Which app `Open in editor` launches — VS Code, Cursor, Rider, Visual Studio (Windows), or a custom argv template |
+| Workspace root | Auto-detected (`.git` walk-up from CWD) | Base directory the trace's repo-relative paths are resolved against |
+
+## ⚠️ Guarantees & limits
+
+- **Near-zero recording cost.** The id is a literal `ushort` baked into IL by the interceptor — no dictionary
+  lookup, no reflection, no allocation on the hot path. With telemetry off, the code is JIT-eliminated entirely.
+- **Two bytes on the wire per span**, only when the id is non-zero. Manifest itself is written once per
+  file/session (a few hundred sites, tens of KB), not per span.
+- **Engine spans only.** The generator attributes call sites inside `Typhon.Engine`; sites outside it resolve to
+  the "unknown source" sentinel (id `0`) and simply show no Source row. There is no user-facing custom-span API
+  yet (see the *Custom Application-Defined Spans* feature), so this currently covers Typhon's built-in span set.
+- **User-registered systems are best-effort.** Resolution depends on a portable PDB being available next to the
+  assembly (or discoverable by name/version on hosts that report no path, e.g. Godot Mono). Missing PDB or a
+  purely synthesized method yields no Source row — the same fallback as id `0`.
+- **Backward-compatible wire format.** Older trace files without the manifest still decode; they simply carry no
+  source rows.
+- **Not stack attribution.** One call site per span, not a full caller chain.
+- **Build-configuration sensitive.** Site ids and inlining differ between Debug and Release builds. Fine for
+  viewing a single trace; don't diff site ids across configurations — join on `(file, line, method)` instead if
+  you need cross-run comparison.
+
+## 🧪 Tests
+
+- [SourceLocationGeneratorTests](../../../test/Typhon.Engine.Tests/Profiler/SourceLocationGeneratorTests.cs) — the emitted `SourceLocations` table is well-formed: non-empty, deterministic ordering, repo-relative paths, IDs starting at 1, no duplicates
+- [SourceLocationManifestRoundTripTests](../../../test/Typhon.Engine.Tests/Profiler/SourceLocationManifestRoundTripTests.cs) — manifest write/read round-trip in the trace trailer, including header offset patching
+- [SystemSourceResolverByTokenTests](../../../test/Typhon.Engine.Tests/Profiler/SystemSourceResolverByTokenTests.cs) — resolving a user-registered system by `(module, metadataToken)` (the CPU-sample-frame path, no live `MethodInfo`) plus a regression guard on the existing delegate-based path
+
+## 🔗 Related
+
+- Sibling features: [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md), [Custom Application-Defined Spans](./custom-named-spans.md)
+- Source: `src/Typhon.Engine/Profiler/internals/SystemSourceResolver.cs`, `src/Typhon.Engine/Profiler/internals/RuntimeSourceLocationManifest.cs`, `src/Typhon.Generators/SourceLocationGenerator.cs`, `src/Typhon.Generators/TraceEventGenerator.cs`
+
+<!-- Deep dive: claude/design/Profiler/10-profiler-source-attribution.md, claude/design/Profiler/11-cpu-sampling-integration.md §7 -->
+<!-- Overview: claude/overview/09-observability.md -->

--- a/doc/feature-set/Profiler/trace-export/README.md
+++ b/doc/feature-set/Profiler/trace-export/README.md
@@ -1,0 +1,59 @@
+# Trace Export
+> Attach durable file capture and/or a live TCP feed to the same profiler session — pick one, both, or neither.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Profiler](../README.md)
+
+## 🎯 What it solves
+
+Capturing a profiler session is only useful if the bytes actually get somewhere. Some investigations need a
+complete, durable record to pore over after the fact — a crash, a rare stall, a regression that only shows up
+after hours of load. Others need to watch a process *right now* — a live load test, a running server you can't
+restart to reproduce. Trace export gives both without forcing a choice: the same event stream can be written to
+disk, streamed to a live viewer, or both, and a slow or misbehaving sink can never stall the engine or take
+another sink down with it.
+
+## ⚙️ How it works (in brief)
+
+Every attached sink implements `IProfilerExporter`. When the profiler session starts, each attached exporter
+gets its own dedicated OS thread and its own bounded queue; the consumer thread drains the per-thread ring
+buffers, sorts records into batches, and hands each batch — refcounted, one physical buffer shared across every
+sink — to every attached exporter's queue. A sink that falls behind only drops its own newest batch; it never
+blocks the consumer or any other sink. Typhon ships two built-in sinks: a file writer for offline analysis and a
+TCP streamer for live attach. Both are selected declaratively through `typhon.telemetry.json` — no exporter
+construction or profiler start/stop calls are required in application code (see
+[Profiler Session Lifecycle & Zero-Code Bootstrap](../profiler-lifecycle-bootstrap.md)).
+
+## Sub-features
+
+| Sub-feature | Use it for |
+|---|---|
+| [File-based trace export (.typhon-trace)](./file-trace-export.md) | Post-mortem: a complete, replayable binary file for offline analysis in the Workbench trace viewer |
+| [Live TCP streaming export](./live-tcp-trace-export.md) | Real-time: attach the Workbench directly to a running process and watch ticks as they happen |
+
+## ⚠️ Guarantees & limits
+
+- **Per-exporter failure isolation** — each exporter owns a dedicated OS thread and its own bounded queue (64
+  batches, ~16 MB of slack for the two built-ins); a slow disk or a stalled TCP client cannot stall the profiler
+  consumer thread or any other attached exporter.
+- **Drop-newest on backpressure** — when an exporter's queue is full, the batch that just failed to enqueue is
+  discarded (not one already queued); the batch's refcount is released immediately so the shared pool never
+  leaks regardless of how many sinks drop it.
+- **Both sinks can run at once** — setting a trace path and a live port in the same config attaches both
+  exporters to the same session; every record reaches both independently.
+- **Attach/detach only while stopped** — exporters are fixed for the lifetime of a running session; there is no
+  API to add or remove a sink while the profiler is capturing.
+- **Two production sinks ship today** — `IProfilerExporter` is a public extension point, but file and live-TCP
+  are the only sinks the engine builds and wires automatically.
+
+## 🧪 Tests
+
+- [FileExporterIntegrationTests](../../../../test/Typhon.Engine.Tests/Profiler/FileExporterIntegrationTests.cs) — file sink attached to a real session, start/emit/stop lifecycle
+- [TcpExporterIntegrationTests](../../../../test/Typhon.Engine.Tests/Profiler/TcpExporterIntegrationTests.cs) — TCP sink attached to a real session, Init/Block frame round-trip
+
+## 🔗 Related
+
+- Source: [`src/Typhon.Engine/Profiler/public/IProfilerExporter.cs`](../../../../src/Typhon.Engine/Profiler/public/IProfilerExporter.cs), [`ExporterQueue.cs`](../../../../src/Typhon.Engine/Profiler/public/ExporterQueue.cs)
+- Sub-features: [File-based trace export](./file-trace-export.md), [Live TCP streaming export](./live-tcp-trace-export.md)
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §6.3-6.5, §7, claude/design/Profiler/profiler-user-manual.md §2, §4 -->
+<!-- Overview: claude/overview/09-observability.md -->

--- a/doc/feature-set/Profiler/trace-export/file-trace-export.md
+++ b/doc/feature-set/Profiler/trace-export/file-trace-export.md
@@ -1,0 +1,81 @@
+# File-Based Trace Export (.typhon-trace)
+> Write the whole session to a versioned binary file for offline post-mortem analysis in the Workbench.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Profiler](../README.md)
+
+## 🎯 What it solves
+
+Some bugs only show up after hours of load, or only once, or only right before a crash — you can't always be
+watching live when the interesting moment happens. File export gives you a complete, durable record of a
+session that you can open later, pan and zoom across the whole timeline, hand to a teammate, or attach to a bug
+report, without needing the original process to still be running.
+
+## ⚙️ How it works (in brief)
+
+`FileExporter` owns one `.typhon-trace` v3 binary file for the session: a header plus system/archetype/component
+tables written at start, then one LZ4-compressed block per drained batch (capped at 256 KB uncompressed,
+matching the batch size). At session stop it appends optional trailer sections — source-location manifest, CPU
+samples, interned query strings — and rewrites the header with their offsets. The file is chosen by setting a
+trace path in configuration; the Workbench trace viewer reads it directly and builds a sidecar cache alongside
+it the first time it's opened.
+
+## 💻 Usage
+
+```csharp
+// typhon.telemetry.json — zero code:
+// { "Typhon": { "Telemetry": { "Enabled": true,
+//     "Profiler": { "Enabled": true, "Trace": "session.typhon-trace" } } } }
+
+using Typhon.Engine;
+
+var runtime = TyphonRuntime.Create(dbe, schedule =>   // profiler self-wires from config
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+// ... run the workload — every built-in call site emits automatically ...
+TyphonProfiler.Stop();   // optional; ordinary engine shutdown finalizes the file automatically
+```
+
+Computing the path in code (e.g. one file per run) instead of a fixed JSON value:
+
+```csharp
+services.AddTyphonProfiler(cfg => cfg with
+{
+    TraceFilePath = $"trace-{DateTime.UtcNow:yyyyMMdd-HHmmss}.typhon-trace"
+});
+var provider = services.BuildServiceProvider();
+// pass serviceProvider: provider to TyphonRuntime.Create so ProfilerBootstrap picks up the override above
+```
+
+| Config key | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:Trace` | unset (no file export) | Path the `.typhon-trace` file is written to; setting it attaches a `FileExporter` for the session |
+
+## ⚠️ Guarantees & limits
+
+- **Complete only after a clean stop** — the file becomes fully self-contained (final block + trailer sections)
+  once `TyphonProfiler.Stop()` runs, which ordinary engine shutdown does automatically; a process kill before
+  that can leave the trailer or the last block missing.
+- **Immutable once written** — never edit a `.typhon-trace` in place: the Workbench keys its sidecar cache off a
+  fingerprint over the file's mtime, length, and first/last 4 KB, so any in-place edit forces (and invalidates)
+  a rebuild. Copying, renaming, or moving the file is always safe.
+- **Bounded, non-blocking handoff** — the exporter's queue holds up to 64 batches (~16 MB); a stalled disk drops
+  the newest batch rather than stalling the profiler consumer thread or any other attached exporter.
+- **Single writer per file** — one `FileExporter` instance owns the stream; don't point two sessions at the same
+  path concurrently.
+- **Trailer sections are best-effort** — a CPU-sample or query-string encoding failure is caught and logged; it
+  never costs the rest of the trace, which stays fully readable without that section.
+- **Unbounded file size** — a long-running session keeps appending compressed blocks indefinitely; rotation and
+  retention are the operator's responsibility, not the exporter's.
+
+## 🧪 Tests
+
+- [FileExporterIntegrationTests](../../../../test/Typhon.Engine.Tests/Profiler/FileExporterIntegrationTests.cs) — start/emit/stop round-trips every typed event through the written `.typhon-trace`, plus CPU-sample trailer embedding and header offset patching
+
+## 🔗 Related
+
+- Source: [`src/Typhon.Engine/Profiler/internals/FileExporter.cs`](../../../../src/Typhon.Engine/Profiler/internals/FileExporter.cs)
+- Parent feature: [Trace Export](./README.md)
+- Sibling: [Live TCP Streaming Export](./live-tcp-trace-export.md) — the other trace-export sink; both can attach to the same session at once
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §4.6, §7.1, claude/design/Profiler/profiler-user-manual.md §9.1 -->

--- a/doc/feature-set/Profiler/trace-export/live-tcp-trace-export.md
+++ b/doc/feature-set/Profiler/trace-export/live-tcp-trace-export.md
@@ -1,0 +1,71 @@
+# Live TCP Streaming Export
+> Stream a running session over TCP so the Workbench can watch a process tick-by-tick, right now.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Profiler](../README.md)
+
+## 🎯 What it solves
+
+Waiting for a process to exit — or crash — before you can look at its trace doesn't work when you're chasing a
+live stall, watching memory climb during a soak test, or want to see a load test's behavior as it happens. Live
+export lets a Workbench viewer attach directly to a running process's socket and see events arrive as they're
+produced, with no file round-trip and no restart required.
+
+## ⚙️ How it works (in brief)
+
+`TcpExporter` listens on one TCP port and accepts a single client at a time. On connect it sends an Init frame
+(the same header + metadata tables as the file format) and then a stream of Block frames, one per drained batch,
+LZ4-compressed the same way as file export. It also re-sends a small catch-up frame — currently-claimed thread
+names — about once a second, so a viewer that attaches mid-session still gets correct lane labels. Sends are
+non-blocking: a frame that can't be written immediately is dropped rather than stalling the exporter thread. On
+profiler stop, a Shutdown frame closes the session cleanly.
+
+## 💻 Usage
+
+```csharp
+// typhon.telemetry.json — zero code:
+// { "Typhon": { "Telemetry": { "Enabled": true,
+//     "Profiler": { "Enabled": true, "Live": 9100, "LiveWaitMs": 5000 } } } }
+
+using Typhon.Engine;
+
+var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+// LiveWaitMs > 0 blocks Create() until the first viewer connects (or the timeout elapses).
+// ... run the workload; in the Workbench: File → Connect Live → "localhost:9100" ...
+```
+
+| Config key | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:Live` | unset (no live export) | TCP port to listen on; any non-numeric value falls back to port 9100 |
+| `Typhon:Profiler:LiveWaitMs` | `0` (don't wait) | Milliseconds `TyphonRuntime.Create` blocks waiting for the first viewer to attach before returning |
+
+## ⚠️ Guarantees & limits
+
+- **Single client only** — a second connection attempt while a viewer is attached is rejected outright; run a
+  second session on a different `Live` port if you need a second observer.
+- **No persistence** — bytes never delivered over this socket cannot be replayed; a live-only session has no
+  equivalent of the file's completeness. Set both `Trace` and `Live` together to keep a durable copy while also
+  watching live.
+- **Drop-on-backpressure, not stall** — a slow client causes individual frames to be dropped
+  (`SocketError.WouldBlock`) rather than backing up the profiler consumer thread; expect gaps in a chronically
+  slow viewer's feed rather than delay.
+- **Silent disconnect handling** — if the viewer's connection drops, the engine keeps running and simply accepts
+  the next client; there's no application-visible error.
+- **`LiveWaitMs` only gates startup once** — it blocks `TyphonRuntime.Create` for the *first* connection; a later
+  reconnect after the viewer disconnects does not re-block anything.
+- **Plain TCP, no platform dependency** — works identically on Windows/Linux/macOS, unlike the ETW-based
+  off-CPU scheduling extension.
+
+## 🧪 Tests
+
+- [TcpExporterIntegrationTests](../../../../test/Typhon.Engine.Tests/Profiler/TcpExporterIntegrationTests.cs) — Init/Block frame round-trip over a loopback socket, plus `LiveWaitMs`/live-connect-timeout blocking-vs-non-blocking connect behavior
+
+## 🔗 Related
+
+- Source: [`src/Typhon.Engine/Profiler/internals/TcpExporter.cs`](../../../../src/Typhon.Engine/Profiler/internals/TcpExporter.cs)
+- Parent feature: [Trace Export](./README.md)
+- Sibling: [File-Based Trace Export (.typhon-trace)](./file-trace-export.md) — the other trace-export sink; both can attach to the same session at once
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §4.7, §7.2, claude/design/Profiler/08-profiler-live-replay-unification.md, claude/design/Profiler/profiler-user-manual.md §4.4 -->

--- a/doc/feature-set/Profiler/typed-event-capture-pipeline.md
+++ b/doc/feature-set/Profiler/typed-event-capture-pipeline.md
@@ -1,0 +1,80 @@
+# Typed-Event Capture Pipeline
+> Any-thread, ~25-50ns, zero-allocation event capture that costs nothing when the profiler is off.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+Diagnosing latency spikes and throughput regressions in a microsecond-budget engine requires seeing what every thread did, at the granularity of individual transactions, B+Tree operations, and page-cache hits — without the instrumentation itself becoming the bottleneck. String-keyed loggers, boxed `object[]` params, and `Activity`-based tracing all allocate or synchronize on the hot path, which is unacceptable inside a commit or a query loop. Typhon needs first-class visibility into its own engine internals that a developer can leave compiled in permanently and switch on only when needed, at effectively zero standing cost.
+
+## ⚙️ How it works (in brief)
+
+Every instrumented call site opens a typed, ref-struct "event" (one per operation kind — transaction commit, B+Tree insert, page fetch, etc.) via a `TyphonEvent.BeginXxx` factory, optionally sets a few fields, and disposes it when the operation ends. Disposal encodes the record directly into the calling thread's own ring buffer — no locks, no CAS, because each thread is the sole producer for its slot. A dedicated consumer thread wakes on a fixed cadence, drains every active thread's ring, timestamp-sorts the merged records (spans close out of start-time order because they're written on `Dispose`), and slices the result into batches for whatever exporters are attached. A per-thread spillover pool absorbs bursts that would otherwise overflow a slot's primary ring. When the profiler is disabled, the gate check is the first statement of every factory against a `static readonly bool`, so the JIT deletes the entire call — this is the mechanism the rest of the Profiler area's instrumentation (GC tracing, gauges, CPU sampling, etc.) is built on top of.
+
+## 💻 Usage
+
+This pipeline is engine-embedded: ~230 call sites across transactions, the B+Tree, page cache, WAL, checkpoint, and ECS already emit through it, so most applications never write capture code — they only flip it on. A `typhon.telemetry.json` next to your executable is enough:
+
+```csharp
+// typhon.telemetry.json (loaded from the working directory or the assembly directory at startup)
+// {
+//   "Typhon": {
+//     "Telemetry": { "Enabled": true, "Profiler": { "Enabled": true } }
+//   }
+// }
+
+// No profiler code required — TyphonRuntime.Create self-wires capture + a default exporter
+// from that config file the moment the runtime is built.
+var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Sim").CallbackSystem("Tick", ctx => RunGameLogic(ctx));
+});
+```
+
+This is what one of those built-in call sites looks like under the hood (the same `BeginXxx`/`Dispose` shape every instrumented operation uses):
+
+```csharp
+var scope = TyphonEvent.BeginTransactionCommit(tsn);
+scope.ComponentCount = componentInfos.Count;   // optional field — sets a payload bit, not required
+try
+{
+    // ... commit body ...
+    scope.ConflictDetected = hasConflict;
+}
+finally
+{
+    scope.Dispose();   // encodes + publishes the record to this thread's ring
+}
+```
+
+| Option (`Typhon:Telemetry:*`) | Default | Effect |
+|---|---|---|
+| `Enabled` | `false` | Master telemetry gate; forces every subsystem below off regardless of its own flag |
+| `Profiler.Enabled` | `false` | Producer gate for this pipeline; `false` makes every `BeginXxx` fold to `return default;` at JIT time |
+
+## ⚠️ Guarantees & limits
+
+- **Any-thread, ~25-50 ns per span/instant** on the hot path — no allocation, no lock, no `Interlocked` (single-producer-per-slot design).
+- **Zero cost when disabled** — the `ProfilerActive` gate is a `static readonly bool` checked first in every factory; RyuJIT dead-code-eliminates the rest of the call.
+- **Drop-newest, never blocks** — a full ring (after spillover is exhausted) or a full exporter queue drops the newest record and counts it; the producer thread is never stalled waiting for capture to catch up.
+- **Capped concurrency** — up to 256 live thread slots tracked at once; beyond that, new threads' events are dropped rather than growing the registry unboundedly.
+- **Unique, ordering-free span IDs** — each span ID encodes its slot index plus a per-slot counter that is never reset, so IDs stay unique for the process lifetime without cross-thread coordination.
+- **Consumer reorders for you** — spans publish on `Dispose` (end time), not start time, so nesting can write records out of chronological order; the consumer thread re-sorts by start timestamp before handing batches to exporters.
+- **Fixed drain cadence** — the consumer thread drains on a configurable interval (default 1 ms); this is capture-side latency before a record is even eligible for export, independent of exporter speed.
+- **Not the export path** — this feature only gets events into sorted, batched form in memory; turning that into a `.typhon-trace` file or a live TCP stream is a separate exporter feature.
+
+## 🧪 Tests
+
+- [TraceRecordRingTests](../../../test/Typhon.Engine.Tests/Profiler/Events/TraceRecordRingTests.cs) — reserve/publish/drain, size rounding, overflow, wrap-sentinel handling, SPSC producer/consumer correctness under real concurrency
+- [TraceRecordChainTests](../../../test/Typhon.Engine.Tests/Profiler/Events/TraceRecordChainTests.cs) — the spillover chain (`TraceRecordRing.Next`, `ThreadSlot.ChainHead`/`ChainTail`) that absorbs bursts overflowing a slot's primary ring
+- [BeginFactoryParameterTests](../../../test/Typhon.Engine.Tests/Profiler/BeginFactoryParameterTests.cs) — per-kind `BeginXxx` factory field assignment, and the suppressed/disabled-gate short-circuit that returns `default`
+
+## 🔗 Related
+
+- Sibling: [Built-in Engine Instrumentation Catalog](./builtin-subsystem-instrumentation.md) — the ~230 call sites across the engine that emit through this pipeline
+- Sibling: [Configuration & Performance Tuning](./profiler-configuration-tuning.md) — the `ProfilerActive` gate every `BeginXxx` factory checks first
+- Sibling: [Trace Export](./trace-export/README.md) — where the sorted, batched records this pipeline produces get exported to a file or live feed
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §3-6, claude/overview/09-observability.md -->
+<!-- Design: claude/design/Profiler/typhon-event-emission-refactor.md, claude/design/Profiler/typhon-event-hand-written-holdouts.md -->
+<!-- ADRs: 047 — Typed-Event Profiler Architecture (claude/adr/047-typed-event-profiler-architecture.md), 049 — Wire Format in Profiler Library (claude/adr/049-wire-format-in-profiler-library.md), 050 — Typed-Event Source Generator (claude/adr/050-typed-event-source-generator.md) -->

--- a/doc/feature-set/Profiler/unmanaged-allocation-tracing.md
+++ b/doc/feature-set/Profiler/unmanaged-allocation-tracing.md
@@ -1,0 +1,84 @@
+# Unmanaged Memory Allocation Tracing
+> See every native (unmanaged) allocation and free on the profiler timeline, tagged by subsystem.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Profiler](./README.md)
+
+## 🎯 What it solves
+
+Typhon keeps hot-path data off the managed heap deliberately — page cache buffers, WAL staging buffers, the
+transient store, and other large regions are allocated as native memory. That's good for GC pressure, but it
+also makes native allocation churn invisible to normal .NET tooling: a leak or an unexpected size spike in
+native memory won't show up in a heap snapshot. This feature puts every native allocate/free directly on the
+profiler timeline, correlated with whatever engine activity triggered it, so you can see growth, churn, and
+who's responsible without attaching a separate native memory profiler.
+
+## ⚙️ How it works (in brief)
+
+Every engine subsystem that needs native memory allocates it through one funnel: a pinned, aligned memory
+block backed by `NativeMemory`. That funnel's construct and dispose paths each emit a `MemoryAllocEvent`
+instant carrying the direction (alloc/free), a subsystem source tag, the size, and the running total after
+the operation — one instrumentation point, 100% coverage of native traffic, no per-subsystem work needed.
+Ordinary managed byte-array allocations are tracked separately and never move the native total. Arena/pool/
+`ArrayPool`/stackalloc-site tracing is a follow-on effort — see Guarantees & limits.
+
+## 💻 Usage
+
+Nothing to call for Typhon's own internal allocations — flip the config flag and every native block the
+engine creates is traced automatically:
+
+```json
+// typhon.telemetry.json next to your executable
+{
+  "Typhon": {
+    "Telemetry": { "Enabled": true },
+    "Profiler": {
+      "Enabled": true,
+      "MemoryAllocations": { "Enabled": true }
+    }
+  }
+}
+```
+
+`IMemoryAllocator`/`PinnedMemoryBlock` are `internal` to `Typhon.Engine` — there is no public entry point for
+application code to route its own native allocations through this funnel today; every traced allocation is one
+the engine itself made on your behalf (page cache, WAL, transient store, etc.), not something host code opts
+into.
+
+| Option | Default | Effect |
+|---|---|---|
+| `Typhon:Profiler:MemoryAllocations:Enabled` | `false` | Emits a `MemoryAllocEvent` instant on every native alloc/free; populates the Memory — Unmanaged gauge track |
+
+## ⚠️ Guarantees & limits
+
+- **100% coverage of native memory traffic** — every subsystem allocates unmanaged memory through the same
+  funnel, so this single instrumentation point sees all of it: page cache, WAL staging, WAL commit buffer,
+  transient store, and anything else built on it.
+- **Managed allocations are excluded by design** — ordinary `byte[]` array allocations are tracked in a
+  separate running total and never inflate the native/unmanaged numbers; the two are kept visually distinct
+  in the viewer.
+- **Source-tagged** — each record carries a `u16` tag identifying which subsystem made the allocation (WAL
+  staging, page cache, transient store, WAL commit buffer, or unattributed), so the viewer can colour-code and
+  aggregate markers per subsystem.
+- **Alloc/free are symmetric** — a free event carries the same source tag as its matching alloc, so per-tag
+  totals reconcile correctly over the trace.
+- **Independently gated** — its own config flag, separate from GC tracing and gauges; costs nothing when off
+  (JIT-eliminated), and a few nanoseconds per alloc/free plus ~19 bytes on the wire when on.
+- **Resolved once at startup** — like every profiler sub-flag, read at class load; editing the JSON after the
+  process starts requires a restart to take effect.
+- **Not yet covered**: arena/pool allocations, `ArrayPool<byte>` rentals — only the
+  pinned-native-block funnel is instrumented today. Planned as a separate reserved event-kind range; won't
+  change this feature's wire format.
+- **Viewer**: markers appear on the Memory — Unmanaged gauge track alongside a running-total area, a
+  dashed peak-reference line, and a live-blocks count.
+
+## 🧪 Tests
+
+- [MemoryAllocatorInstrumentationTests](../../../test/Typhon.Engine.Tests/Memory/MemoryAllocatorInstrumentationTests.cs) — pinned-byte/live-block counters, source-tag propagation, managed-vs-pinned accounting separation (the counter half the gauge track reads; the gated event-emit half is off by default in tests)
+
+## 🔗 Related
+
+- Sibling features: [GC Event Tracing](./gc-event-tracing.md), [Configuration & Performance Tuning](./profiler-configuration-tuning.md), [Typed-Event Capture Pipeline](./typed-event-capture-pipeline.md)
+- Source: `src/Typhon.Engine/Foundation/Memory/internals/{MemoryAllocator,PinnedMemoryBlock,MemoryBlockBase}.cs`, `src/Typhon.Engine/Profiler/internals/InstantEvents.cs`, `src/Typhon.Profiler/MemoryAllocEnums.cs`
+
+<!-- Deep dive: claude/design/Profiler/typhon-profiler.md §6.7, claude/design/Profiler/06-profiler-feature-roadmap.md §3.2 -->
+<!-- User manual: claude/design/Profiler/profiler-user-manual.md §3.1, §5.3, §8.3 -->

--- a/doc/feature-set/Querying/README.md
+++ b/doc/feature-set/Querying/README.md
@@ -1,0 +1,25 @@
+# Querying
+> The query and view engine: a single archetype-rooted fluent API (`tx.Query<T>()`) parses C# lambda predicates — indexed-field, opaque, OR-disjunctive, spatial, or FK-join — into selectivity-driven execution plans run through a batched streaming pipeline. Persistent Views cache a query's matching entity set and refresh it in microseconds via lock-free commit-time change capture instead of full re-query; point-in-time history and parameterized view pooling are still on the roadmap.
+
+> 🔬 **Recommended:** read [in-depth-overview/09-querying.md](../../in-depth-overview/09-querying.md) (Chapter 09: Querying, which also carries a short Subscriptions section) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Fluent Query API & Predicate Parsing](fluent-query-api/README.md) | Archetype-rooted fluent builder that parses C# lambdas into index-driven plans, with structural/enabled-bit constraints, OR disjunction, and FK navigation joins | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Indexed Field Predicates (WhereField)](fluent-query-api/wherefield-indexed-predicate.md) | Expression-parsed predicate that drives a targeted B+Tree scan and powers incrementally-maintained reactive views | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Opaque Post-Filter Predicates (Where)](fluent-query-api/where-opaque-postfilter.md) | Arbitrary per-entity C# delegate evaluated after a broad archetype scan, for logic the index system can't express | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [OR Disjunction (DNF Predicates)](fluent-query-api/or-disjunction.md) | `\|\|` in a `WhereField` predicate, normalized to Disjunctive Normal Form and evaluated as independent branches | ✅ Implemented | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [Foreign-Key Navigation Joins (L4)](fluent-query-api/fk-navigation-joins.md) | Join across an entity-reference field — filter source entities by predicates on the target entity they point to | ✅ Implemented | 🟣 Advanced |
+| [Result Ordering & Pagination](ordering-pagination.md) | Sorted, paged query results driven directly off a B+Tree index scan — no full-scan-then-sort | ✅ Implemented | 🔵 Core |
+| [Persistent Views — Incremental Refresh & Delta Tracking](persistent-views.md) | TSN-anchored persistent Views (`ToView()`) refreshed via lock-free MPSC ring-buffer change capture at commit time, exposing Added/Removed/Modified deltas | 🚧 Partial | 🔵 Core |
+| [Spatial Query Predicates](spatial-predicates.md) | R-Tree-backed AABB, radius, and ray filters attached directly to a fluent ECS query | ✅ Implemented | 🟣 Advanced |
+| [Execution Planning & Pipeline Execution](execution-planning-pipeline.md) | Picks the most selective index as the scan driver and streams results into the caller's collection | ✅ Implemented | 🟣 Advanced |
+| [Statistics Infrastructure (HLL / MCV / Histogram)](statistics-infrastructure.md) | Background-maintained per-field statistics feeding the selectivity estimator, refreshed by a tunable polling worker thread | ✅ Implemented | 🟣 Advanced |
+| [ViewFactory — Parameterized Queries & View Pooling](view-factory-pooling.md) | Reusable query templates with a Rent/Return view pool, to remove per-session view setup cost | 📋 Planned | 🟣 Advanced |
+| [Temporal Queries (Point-in-Time Read & Revision History)](temporal-queries.md) | Opt-in per-component history retention enabling reads of past state and full revision timelines | 📋 Planned | 🟣 Advanced |
+
+## Internal Features
+
+*No internal-only features in this category — every feature above is reached directly through `tx.Query<T>()`/`IView`, `[Index]`/`[SpatialIndex]` schema attributes, or a documented config knob (`StatisticsOptions`), so nothing here is engine-only machinery.*

--- a/doc/feature-set/Querying/execution-planning-pipeline.md
+++ b/doc/feature-set/Querying/execution-planning-pipeline.md
@@ -1,0 +1,71 @@
+# Execution Planning & Pipeline Execution
+> Picks the most selective index as the scan driver and streams results into your collection — no full-table scans, minimal allocation.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Querying](./README.md)
+
+## 🎯 What it solves
+
+A query with two or more indexed predicates can be answered by scanning any one of them and filtering the rest — but scanning the wrong one (or the first one written) means touching far more entities than the answer actually contains. Execution planning chooses which predicate to physically scan based on how selective it is, so a query like "Level >= 50 AND Gold > 10000" scans the rarer condition first and never reads the component data for entities the cheaper filter would have rejected anyway.
+
+## ⚙️ How it works (in brief)
+
+Every `Execute`, `ExecuteOrdered`, `Count`, `Any`, and `ToView()` call with an indexed `WhereField` predicate builds an execution plan: each predicate's cardinality is estimated from index statistics (most-common-values / histogram / approximate distinct-count, falling back to exact B+Tree counts or uniform distribution when no statistics have been built yet), predicates are ordered by ascending estimated cardinality, and the narrowest one that can bound a key range becomes the primary scan — its bounds become the index iteration range. The remaining predicates become an ordered filter chain, evaluated per candidate with short-circuit on first failure. Matching entity IDs stream straight into the caller-supplied `HashSet<EntityId>` / `List<EntityId>`, and `Skip`/`Take` stop the scan as soon as enough results are collected. `ToView()` builds the plan once and reuses it for every later incremental refresh and overflow-recovery rescan.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+public struct Player
+{
+    [Index] public int Level;
+    [Index] public int Gold;
+}
+
+[Archetype(10)]
+public class PlayerArch : Archetype<PlayerArch>
+{
+    public static readonly Comp<Player> Data = Register<Player>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+
+// Two indexed predicates — the planner picks whichever is more selective as the scan driver
+var richVeterans = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level > 50 && p.Gold > 10000)
+    .Execute();                                   // → HashSet<EntityId>
+
+// Inspect the chosen plan on a view (diagnostic / tuning use)
+using var view = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level > 50 && p.Gold > 10000)
+    .ToView();
+
+Console.WriteLine(view.ExecutionPlan);
+// "Index scan Field[1] [10001..2147483647] → Filters: Field[0] GreaterThan 50 (est: 1200)"
+```
+
+## ⚠️ Guarantees & limits
+
+- Planning runs fresh on every call for one-shot terminals (`Execute`/`ExecuteOrdered`/`Count`/`Any`); `ToView()` builds it once via `view.ExecutionPlan` and reuses the cached plan for every subsequent refresh and overflow rescan.
+- Selectivity is an estimate (statistics-backed when available, exact-count/uniform fallback otherwise) — a bad estimate degrades plan quality, never correctness.
+- Multiple predicates on the *same* indexed field (e.g., `Gold >= 100 && Gold < 5000`) intersect into one tighter scan range rather than being treated as separate filters.
+- `!=` predicates can never become the primary scan — they cannot bound a range. Every `WhereField` predicate needs at least one `==`/`<`/`<=`/`>`/`>=` comparison the planner can narrow on; an all-`!=` predicate currently yields no results (zero for `Count()`) instead of falling back to a broad scan, so pair it with a narrowing condition.
+- `OrderByField`/`OrderByFieldDescending` pins the primary scan to that field — overriding pure selectivity-driven choice — so ordered results come out pre-sorted with no separate sort pass; predicates on the ordered field still narrow the scan range.
+- `Count()` uses a dedicated fused path when an indexed predicate is present: results are counted in place during the index scan, no `HashSet`/`List` is materialized.
+- OR predicates (multi-branch `WhereField`) get one independently-built plan per DNF branch, unioned at execution; `view.ExecutionPlan` exposes only the first branch.
+- Diagnostics are read-only — `ExecutionPlan`/`ToString()` describe the chosen plan; there is no public API to force a different index or override the planner's choice.
+
+## 🧪 Tests
+
+- [PlanBuilderAndExecutorTests](../../../test/Typhon.Engine.Tests/Data/Query/PlanBuilderAndExecutorTests.cs) — selectivity-ascending predicate ordering, tie-breaking, `OrderBy`-pins-primary-scan, `ExecutionPlan.ToString()` diagnostics
+- [PipelineExecutorCombinedPathTests](../../../test/Typhon.Engine.Tests/Data/Query/PipelineExecutorCombinedPathTests.cs) — fused `Count()` path, dual-bound range scans, and MVCC-snapshot-isolated plan execution on Versioned/SV storage
+- [FieldEvaluatorTests](../../../test/Typhon.Engine.Tests/Data/Query/FieldEvaluatorTests.cs) — the compiled `FieldEvaluator` struct's per-`CompareOp`/`KeyType` correctness that the hot-path filter chain runs
+
+## 🔗 Related
+
+- Related feature: [Indexed Field Predicates (WhereField)](./fluent-query-api/wherefield-indexed-predicate.md)
+- Related feature: [Result Ordering & Pagination](./ordering-pagination.md)
+- Related feature: [Persistent Views](./persistent-views.md)
+
+<!-- Deep dive: claude/overview/05-query.md §5.3 Selectivity Estimator, §5.4 Execution Planning, §5.5 Pipeline Executor -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/04-query-planning.md — selectivity estimator chain, statistics maintenance, plan-building algorithm -->
+<!-- ADR: claude/adr/040-btree-leaf-enumerator.md — range-enumerator API backing primary-stream iteration -->

--- a/doc/feature-set/Querying/fluent-query-api/README.md
+++ b/doc/feature-set/Querying/fluent-query-api/README.md
@@ -1,0 +1,48 @@
+# Fluent Query API & Predicate Parsing
+> Archetype-rooted fluent query builder that parses C# lambdas into index-driven plans — structural constraints, indexed/opaque predicates, OR disjunction, and FK navigation joins, all off one entry point.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Querying](../README.md)
+
+## 🎯 What it solves
+
+Application code needs a single, type-safe entry point for finding entities — "has Inventory but not Frozen", "Level ≥ 50", "players in guilds with Level ≥ 10" — without ever hand-rolling a B+Tree scan, an expression-tree walker, or a ring-buffer registration. `tx.Query<TArchetype>()` is that entry point: archetype/component constraints, enabled-bit checks, field predicates (indexed or opaque), OR disjunction, FK joins, ordering, pagination, and reactive materialization all compose off the same fluent builder, rooted at the transaction that will see the results.
+
+## ⚙️ How it works (in brief)
+
+`tx.Query<TArchetype>()` returns a mutable `ref`-friendly struct that borrows the `Transaction` and resolves the archetype's polymorphic subtree (the archetype plus all descendants, by default — use `tx.QueryExact<TArchetype>()` to skip descendants) into a bitmask at construction. Fluent calls narrow that mask (`With<T>`/`Without<T>`/`Exclude<TArchetype>`) or add per-entity constraints (`Enabled<T>`/`Disabled<T>`, field predicates, spatial predicates). `WhereField<T>(Expression<Func<T,bool>>)` walks the lambda's *expression tree* and decomposes it into `FieldPredicate` structs — flattening `&&` chains and, when `||` is present, normalizing to Disjunctive Normal Form (DNF). A one-shot terminal (`Execute`/`ExecuteOrdered`/`Count`/`Any`) consumes the parsed predicate immediately; `ToView()` instead compiles it into a `FieldEvaluator[]` array and wires up a persistent, incrementally-refreshed `EcsView<TArchetype>`.
+
+## Sub-features
+
+| Sub-feature | Use it when... |
+|---|---|
+| [Indexed Field Predicates (WhereField)](./wherefield-indexed-predicate.md) | The field has `[Index]` and you want the fastest scan path, ordering/pagination, or a reactive `ToView()` |
+| [Opaque Post-Filter Predicates (Where)](./where-opaque-postfilter.md) | The condition needs arbitrary C# logic, multiple fields at once, or a non-indexed field |
+| [OR Disjunction (DNF Predicates)](./or-disjunction.md) | Your predicate needs `\|\|` — across an indexed field comparison or a mixed AND/OR group |
+| [Foreign-Key Navigation Joins (L4)](./fk-navigation-joins.md) | You need to filter or join across an entity-reference field (e.g. `Player.GuildId → Guild`) |
+
+## ⚠️ Guarantees & limits
+
+- Queries are **polymorphic by default** — `tx.Query<TArchetype>()` matches the archetype and every descendant; `tx.QueryExact<TArchetype>()` is exact-archetype-only.
+- `With<T>`/`Without<T>`/`Exclude<TArchetype>` filter at the **archetype mask level**, not per-entity component presence; `Enabled<T>`/`Disabled<T>` test per-entity enabled bitmaps (at most 4 of each, backed by a `ushort` bitmap — exceeding it throws `InvalidOperationException`).
+- At most one spatial predicate (`WhereNearby`/`WhereInAABB`/`WhereRay`) per query; composes with `WhereField`/`Where` but not with a second spatial call.
+- `Execute()` returns an unordered `HashSet<EntityId>`; `ExecuteOrdered()` requires `OrderByField`/`OrderByFieldDescending` on an indexed field (itself requiring `WhereField`) and returns a `List<EntityId>`. `Count()`/`Any()` ignore `Skip`/`Take` and throw if either is set.
+- `WhereField` predicates must reference `[Index]`-carrying fields; unsupported syntax (method calls, arithmetic, field-to-field comparisons) throws `NotSupportedException` immediately inside `WhereField`, while a resolvable-but-unindexed field throws `InvalidOperationException` at the first terminal call.
+- Supported operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, combined with `&&`, `||`, `!` (De Morgan's law applied at parse time). String-typed fields (`String64`) aren't supported in `WhereField`/`OrderByField` — use `.Where(lambda)` instead.
+- `ToView()` rejects `OrderBy`/`Skip`/`Take` (a view is unordered) and rejects mixing `WhereField` with a spatial predicate or a chained `.Where(...)`.
+- `NavigateField<TSource, TTarget>(fkSelector)` starts a separate FK-join query path (`EcsNavigationQueryBuilder`) — its predicates compose with the source archetype mask but not with the OR/spatial forms above.
+- Parsing is a one-time cold-path cost (~100µs) per query/view construction; the compiled `FieldEvaluator[]` is what runs on the hot path.
+
+## 🧪 Tests
+
+- [EcsQueryTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EcsQueryTests.cs) — archetype-mask With/Without/Exclude, Enabled/Disabled bitmaps, Count/Any, foreach, and unsupported-clause-combo guards
+
+## 🔗 Related
+
+- Sibling: [Query System (EcsQuery)](../../Ecs/query-system.md) — the Ecs-category entry point this whole category is the deep-dive extension of
+- Source: [src/Typhon.Engine/Ecs/public/EcsQuery.cs](../../../../src/Typhon.Engine/Ecs/public/EcsQuery.cs)
+- Sub-features: [Indexed Field Predicates (WhereField)](./wherefield-indexed-predicate.md), [Opaque Post-Filter Predicates (Where)](./where-opaque-postfilter.md), [OR Disjunction (DNF Predicates)](./or-disjunction.md), [Foreign-Key Navigation Joins (L4)](./fk-navigation-joins.md)
+
+<!-- Deep dive: claude/overview/05-query.md §5.1, §5.2, §5.9, §5.10, §5.12 -->
+<!-- Deep dive: claude/design/Querying/QueryEngine.md -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/02-predicates.md -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/10-predicate-taxonomy.md -->

--- a/doc/feature-set/Querying/fluent-query-api/fk-navigation-joins.md
+++ b/doc/feature-set/Querying/fluent-query-api/fk-navigation-joins.md
@@ -1,0 +1,80 @@
+# Foreign-Key Navigation Joins (L4)
+> Join across an entity-reference field — filter source entities by predicates on the target entity they point to.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Querying](../README.md)
+
+**Assumes:** [Indexed Field Predicates (WhereField)](./wherefield-indexed-predicate.md)
+
+## 🎯 What it solves
+
+ECS data is naturally hierarchical — a `Player` points at its `Guild` via a `GuildId` field, and "players in guilds with `Level >= 10`" is a routine query shape. Reading every player, dereferencing its guild, and checking the guild's field by hand works once; keeping that filtered set live as either side changes (a player switches guilds, a guild levels up) is the part application code shouldn't have to re-implement. Navigation joins give you that as one fluent call, with both one-shot and reactive forms, on top of the existing FK index instead of a generic join algorithm.
+
+## ⚙️ How it works (in brief)
+
+`tx.Query<TSourceArch>().NavigateField<TSource, TTarget>(fkSelector)` returns an `EcsNavigationQueryBuilder` bound to the FK field; `.Where((source, target) => ...)` takes a two-parameter lambda whose predicates are split by which parameter they reference — source-side and target-side filters can be mixed freely. The result set always contains **source** entity IDs (the side you queried from), never target IDs. `Execute()`/`Count()`/`Any()` choose source-first or target-first traversal based on selectivity; `ToView()` produces a `NavigationView` that registers with **both** the source and target component tables' change-capture registries, so it refreshes on either a source FK change (player switches guilds — 1:1 re-evaluation) or a target field change (guild levels up — fans out via the FK's reverse index to every referencing source).
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+public struct Player
+{
+    [Index(AllowMultiple = true), ForeignKey(typeof(Guild))]
+    public long GuildId;
+    [Index(AllowMultiple = true)]
+    public int Active;
+}
+
+[Component("Game.Guild", 1)]
+public struct Guild
+{
+    [Index(AllowMultiple = true)]
+    public int Level;
+}
+
+using var tx = dbe.CreateQuickTransaction();
+
+// One-shot: source EntityIds whose guild satisfies the target predicate
+var members = tx.Query<PlayerArch>()
+    .NavigateField<Player, Guild>(p => p.GuildId)
+    .Where((p, g) => p.Active == 1 && g.Level >= 10)
+    .Execute();                                  // → HashSet<EntityId> (Player ids)
+
+int count = tx.Query<PlayerArch>()
+    .NavigateField<Player, Guild>(p => p.GuildId)
+    .Where((p, g) => g.Level >= 10)
+    .Count();
+
+// Reactive: refreshes on either a GuildId change or a target Guild.Level change
+using var view = tx.Query<PlayerArch>()
+    .NavigateField<Player, Guild>(p => p.GuildId)
+    .Where((p, g) => g.Level >= 10)
+    .ToView();                                   // → ViewBase (NavigationView<Player, Guild>)
+
+foreach (var playerId in view) { /* player is in a guild with Level >= 10 */ }
+```
+
+## ⚠️ Guarantees & limits
+
+- The FK field must be `long`, decorated with `[ForeignKey(typeof(TTarget))]`, and indexed as `[Index(AllowMultiple = true)]` (the reverse lookup needs the multi-value index). Violating any of these throws `InvalidOperationException` naming the field and the missing requirement.
+- `NavigateField<TSource, TTarget>` must be called before `.Where(...)` on the navigation builder — there is no separate ordering violation to guard against since `Where` only exists on the returned navigation builder.
+- `ToView()` requires at least one **target**-side predicate — without it, target deletions wouldn't be detected and the view would go stale; source-only filters throw `InvalidOperationException`. `Execute()`/`Count()`/`Any()` have no such requirement.
+- The view/result set holds **source** entity IDs only; to read the target, dereference the FK field yourself (`tx.Open(id).TryRead<Player>(out var p)` then `tx.Open(EntityId.FromRaw(p.GuildId))`).
+- `ExecuteOrdered()` is not supported on navigation queries — join results have no natural ordering.
+- Navigation combined with OR predicates (`||` inside the navigation `.Where(...)`) is not supported — L4 and L3 don't currently compose.
+- Reverse-navigation fan-out (a target field change re-evaluating every referencing source) costs one FK-index lookup plus one read per referencing source entity — proportional to how many sources point at the changed target, not to the total table size.
+
+## 🧪 Tests
+
+- [EcsNavigationTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EcsNavigationTests.cs) — source+target predicate combination, `Count()`, and `ToView()` incremental refresh on either side
+- [StatisticsRebuildTests](../../../../test/Typhon.Engine.Tests/Data/Query/StatisticsRebuildTests.cs) — `NavigationView_ToView_NoTargetPredicates_Throws` / `NavigationQuery_OneShot_NoTargetPredicates_Works`: the target-predicate requirement is `ToView()`-only
+
+## 🔗 Related
+
+- Parent feature: [Fluent Query API & Predicate Parsing](./README.md)
+- Sibling: [Indexed Field Predicates (WhereField)](./wherefield-indexed-predicate.md) — the FK field's reverse-lookup index the join scans
+- Sibling: [OR Disjunction (DNF Predicates)](./or-disjunction.md) — L4 navigation and L3 OR predicates don't currently compose
+
+<!-- Deep dive: claude/design/Querying/ViewSystem/02-predicates.md §L4 Navigation Join -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/05-view-types.md §NavigationView -->
+<!-- Deep dive: claude/overview/05-query.md §5.10 Navigation Views -->

--- a/doc/feature-set/Querying/fluent-query-api/or-disjunction.md
+++ b/doc/feature-set/Querying/fluent-query-api/or-disjunction.md
@@ -1,0 +1,62 @@
+# OR Disjunction (DNF Predicates)
+> `||` in a `WhereField` predicate, normalized to Disjunctive Normal Form and evaluated as independent branches.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Querying](../README.md)
+
+**Assumes:** [Indexed Field Predicates (WhereField)](./wherefield-indexed-predicate.md)
+
+## 🎯 What it solves
+
+Real filters are rarely a single AND chain — "high level OR in this faction", "(active AND high-level) OR admin". Hand-rolling that as separate queries unioned in application code works for one-shot reads, but breaks down for a reactive `ToView()`: each branch's membership has to be tracked independently, because a field going IN on one branch can keep an entity in the view even while another branch's field goes OUT. OR disjunction support means you write the natural boolean C# expression and the engine handles branch bookkeeping for you, for both one-shot queries and persistent views.
+
+## ⚙️ How it works (in brief)
+
+`WhereField<T>(p => p.Level > 50 || p.Faction == 1)` is parsed into Disjunctive Normal Form (DNF) — an OR of AND-clauses — at query-build time. `!` is pushed to the leaves via De Morgan's law before normalization (`!(A && B)` → `!A || !B`), and `AND(OR(A,B), C)` distributes into `OR(AND(A,C), AND(B,C))`. The result is `FieldPredicate[][]`: each outer entry is one branch, each inner array is that branch's AND-clause. One-shot terminals (`Execute`/`Count`/`Any`) run each branch as an independent index-driven plan and union the results into one `HashSet<EntityId>` — deduplication is free. `ToView()` instead enters **OR mode**: `EcsView<TArchetype>` tracks, per entity, a 16-bit bitmap of which branches currently hold; the entity is in the view whenever any bit is set, so on a per-field change only the branches referencing that field are re-evaluated.
+
+## 💻 Usage
+
+```csharp
+// One-shot: OR across two field comparisons — union of both branches, deduplicated
+var result = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level > 50 || p.Faction == 1)
+    .Execute();                                  // → HashSet<EntityId>
+
+// Mixed AND/OR — DNF: [[Level>50, Faction==1], [Rarity>=4]]
+using var view = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => (p.Level > 50 && p.Faction == 1) || p.Rarity >= 4)
+    .ToView();                                   // → EcsView<PlayerArch> in OR mode (2 branches)
+
+// NOT — De Morgan applied at parse time, zero runtime cost
+var negated = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => !(p.Level > 50 && p.Faction == 1))   // → Level <= 50 || Faction != 1
+    .Execute();
+
+// Chained WhereField calls cross-product as AND-of-OR
+var crossed = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.A > 1 || p.B > 2)   // 2 branches
+    .WhereField<Player>(p => p.C > 3 || p.D > 4)   // 2 branches
+    .Execute();                                    // → cross-product: 4 DNF branches
+```
+
+## ⚠️ Guarantees & limits
+
+- **Maximum 16 DNF branches.** Each entity's branch membership is tracked in a `ushort` bitmap (one bit per branch). Exceeding 16 throws `InvalidOperationException` naming the actual branch count.
+- **Exponential blowup risk:** ANDing multiple OR-pairs multiplies branch count — `(A||B) && (C||D) && (E||F)` is already 2×2×2 = 8 branches; chaining `WhereField` calls that each contain OR cross-products the same way. Restructure as separate queries (unioned in application code) or reduce ANDed OR-pairs if you hit the cap.
+- `ExecuteOrdered()` is **not supported** with OR predicates — merging multiple independently-ordered index scans isn't implemented; sort the unordered `Execute()` result yourself if needed.
+- In OR-mode views, a component read only happens when a changed field crosses a branch's predicate boundary (matching → not-matching or vice versa) — not on every change to a tracked field.
+- Memory cost for an OR-mode view: ~2 bytes per tracked entity for the branch bitmap, on top of the normal entity-set cost.
+- Cross-component OR (branches spanning two different component types within one archetype) is not supported — all branches must resolve against the same `WhereField<T>` component.
+
+## 🧪 Tests
+
+- [ExpressionParserTests](../../../../test/Typhon.Engine.Tests/Data/Query/ExpressionParserTests.cs) — DNF normalization: De Morgan's law, double/triple negation, branch flattening, the 16-branch cap
+- [EcsOrViewTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EcsOrViewTests.cs) — OR-mode `ToView()`: union-of-branches population, per-branch field-crossing in/out, last-branch-fails removal
+
+## 🔗 Related
+
+- Parent feature: [Fluent Query API & Predicate Parsing](./README.md)
+- Sibling: [Indexed Field Predicates (WhereField)](./wherefield-indexed-predicate.md) — OR disjunction is the `||` extension of a `WhereField` predicate
+- Sibling: [Foreign-Key Navigation Joins (L4)](./fk-navigation-joins.md) — OR predicates inside a navigation `.Where(...)` aren't supported
+
+<!-- Deep dive: claude/design/Querying/ViewSystem/02-predicates.md §L3, DNF Normalization Algorithm -->
+<!-- Deep dive: claude/overview/05-query.md §5.9 OR Disjunction -->

--- a/doc/feature-set/Querying/fluent-query-api/where-opaque-postfilter.md
+++ b/doc/feature-set/Querying/fluent-query-api/where-opaque-postfilter.md
@@ -1,0 +1,61 @@
+# Opaque Post-Filter Predicates (Where)
+> Arbitrary per-entity C# predicate evaluated after a broad archetype scan — for logic the index system can't express.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Querying](../README.md)
+
+## 🎯 What it solves
+
+Some filtering logic isn't a single indexed-field comparison: it combines several fields with custom logic, calls into application code, or targets a field that has no index at all. `Where<T>(Func<T, bool> predicate)` accepts any compiled C# delegate and applies it as a per-entity post-filter, trading the index-driven speed of `WhereField` for unrestricted expressiveness — useful for one-shot queries where simplicity matters more than scan cost, or whenever the condition genuinely can't be reduced to an indexed comparison.
+
+## ⚙️ How it works (in brief)
+
+`Where<T>` takes an ordinary `Func<T, bool>` — a compiled delegate, not a parsed expression tree — and chains it into a per-entity filter; multiple `Where` calls AND together. Execution always broad-scans the archetype mask's candidate entities, opens each one (`Transaction.Open` + `TryRead<T>`), and evaluates the delegate — there is no index lookup and no key-only short-circuit. Because the predicate is opaque, the engine cannot determine which fields it depends on, so it cannot wire commit-time change capture for it: an `EcsView` built from `Where` alone falls back to a full re-query (pull mode) on every `Refresh()` instead of an incremental ring-buffer drain.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+public struct Player
+{
+    public int Level;
+    public int Faction;
+}
+
+[Archetype(10)]
+public class PlayerArch : Archetype<PlayerArch>
+{
+    public static readonly Comp<Player> Data = Register<Player>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+
+// Arbitrary per-entity logic — no index involved, evaluated via Transaction.Open + TryRead
+var matched = tx.Query<PlayerArch>()
+    .Where<Player>(p => SomeOpaqueRule(p.Level, p.Faction))
+    .Execute();                                   // → HashSet<EntityId>
+
+// Pull-mode view: re-evaluates the full archetype scan on every Refresh()
+using var view = tx.Query<PlayerArch>()
+    .Where<Player>(p => p.Level > 50)
+    .ToView();                                    // → EcsView<PlayerArch> (pull mode)
+```
+
+## ⚠️ Guarantees & limits
+
+- No index requirement — works on any field, indexed or not, and accepts any computation expressible as `Func<T, bool>`.
+- Cannot be combined with `WhereField` for `ToView()`: an incremental view's predicate must come entirely from `WhereField`. Mixing throws `InvalidOperationException` ("fold the condition into WhereField, or drop WhereField to build a pull view from `.Where(...)`").
+- Cost is O(archetype candidate count) per `Execute()` and per `Refresh()` — every mask-matching entity is opened and read, regardless of how selective the predicate turns out to be.
+- An `EcsView` built from `Where` alone is always **pull mode**: full re-query on each `Refresh()`, no ring-buffer delta tracking, no boundary-crossing short-circuit.
+- Multiple `.Where<T>()` calls chain as AND only — there is no OR composition across separate `.Where` calls (express OR inside the single lambda instead).
+- `ExecuteOrdered()` requires `WhereField` and ignores `.Where(...)`; combining the two throws `InvalidOperationException`.
+
+## 🧪 Tests
+
+- [EcsQueryTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EcsQueryTests.cs) — `Where_*`: field-delegate filtering, empty/all-match edges, two-component combination, foreach, and pull-mode view refresh
+
+## 🔗 Related
+
+- Parent feature: [Fluent Query API & Predicate Parsing](./README.md)
+- Sibling: [Indexed Field Predicates (WhereField)](./wherefield-indexed-predicate.md) — the index-driven counterpart; use it when the field is indexed and only fall back to opaque `Where` otherwise
+
+<!-- Deep dive: claude/overview/05-query.md §5.1 ("Where vs WhereField") -->

--- a/doc/feature-set/Querying/fluent-query-api/wherefield-indexed-predicate.md
+++ b/doc/feature-set/Querying/fluent-query-api/wherefield-indexed-predicate.md
@@ -1,0 +1,84 @@
+# Indexed Field Predicates (WhereField)
+> Expression-parsed predicate that drives a targeted B+Tree scan and powers incrementally-maintained reactive views.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Querying](../README.md)
+
+## 🎯 What it solves
+
+Filtering entities by reading every archetype member's component is wasteful when the field already has a secondary index — the matching set can usually be found directly from the index without touching most entities. `WhereField` lets you express a field comparison as ordinary C# (`p => p.Level >= 50`) while the engine compiles it into an index-driven scan plan. Just as important: because the predicate is understood structurally (not an opaque delegate), it can also drive a persistent `EcsView` that updates itself incrementally as data changes, instead of re-scanning everything on every refresh.
+
+## ⚙️ How it works (in brief)
+
+`WhereField<T>(Expression<Func<T, bool>> predicate)` parses the lambda's *expression tree* (not a compiled delegate) into one or more field predicates, normalized to Disjunctive Normal Form when it contains `||`. Unsupported syntax — method calls, arithmetic between fields, field-to-field comparisons — is rejected immediately as the lambda is parsed. Whether the referenced field actually carries `[Index]` is checked later, the moment a terminal operation (`Execute`/`Count`/`Any`/`ExecuteOrdered`/`ToView`) resolves the predicate against the component's schema — before any B+Tree access, never a silent broad scan. At execution, the planner consults index statistics (histogram / most-common-values / HyperLogLog) to pick the most selective predicate as the primary B+Tree scan stream and applies the rest as ordered filters. Multiple `WhereField` calls AND together (cross-producting any DNF branches). Because the predicate decomposes into key comparisons, an `EcsView` built from it can re-evaluate membership from the before/after key values delivered at commit — no component read needed on the common path.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+public struct Player
+{
+    [Index]
+    public int Level;
+    [Index(AllowMultiple = true)]
+    public int Faction;
+}
+
+[Archetype(10)]
+public class PlayerArch : Archetype<PlayerArch>
+{
+    public static readonly Comp<Player> Data = Register<Player>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+
+// One-shot: matching EntityIds, index-driven scan
+var rarePlayers = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level >= 50)
+    .Execute();                                  // → HashSet<EntityId>
+
+// Zero-allocation aggregation — fused index streaming, no collection built
+int count = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level >= 50)
+    .Count();
+
+// Ordering + pagination (OrderByField requires WhereField to identify the component table)
+var topPlayers = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level >= 10)
+    .OrderByFieldDescending<Player, int>(p => p.Level)
+    .Skip(20).Take(10)
+    .ExecuteOrdered();                            // → List<EntityId>
+
+// Reactive: incremental view, refreshed via ring-buffer deltas, not a full re-scan
+using var view = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level > 50 || p.Faction == 1)
+    .ToView();                                    // → EcsView<PlayerArch> (OR mode: 2 DNF branches)
+```
+
+## ⚠️ Guarantees & limits
+
+- The predicate's field must carry `[Index]` (B+Tree secondary index) — a field that resolves but isn't indexed throws `InvalidOperationException` naming the field, raised at the first terminal call, not inside `WhereField` itself.
+- Operators: `==`, `!=`, `>`, `<`, `>=`, `<=`, combined with `&&` / `||` / `!` (De Morgan applied at parse time); method calls, arithmetic on fields, and field-to-field comparisons throw `NotSupportedException` immediately inside `WhereField`.
+- String-typed fields (`String64`) have no key-type mapping for predicates — referencing one throws `NotSupportedException` at the first terminal call; use `.Where(lambda)` for string-field filtering instead.
+- OR expressions normalize to DNF capped at **16 branches**; exceeding it throws `InvalidOperationException` — restructure as multiple queries or fewer ANDed OR-pairs (each ANDed OR-pair multiplies the branch count).
+- `ToView()` on a `WhereField` query is the only path that yields an incrementally-maintained `EcsView` (ring-buffer delta refresh, O(1) typical cost per change); `Where` (opaque) forces full-rescan pull mode instead.
+- `ExecuteOrdered()` requires `OrderByField`/`OrderByFieldDescending` on an indexed field and does not support multi-branch (OR) predicates.
+- Multiple `WhereField` calls on the same query cross-product as AND-of-OR — chaining ANDed OR-pairs grows DNF branches multiplicatively against the 16-branch cap.
+- Entities spawned (but not yet committed) in the same transaction have no index entry yet; `Execute`/`Count`/`Any` still see them via a deferred-compiled fallback predicate so read-your-own-writes holds, even though the targeted scan itself can't find them.
+
+## 🧪 Tests
+
+- [EcsQueryTargetedScanTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EcsQueryTargetedScanTests.cs) — targeted B+Tree scan vs. broad-scan equivalence, `Count`/`Any`, `ExecuteOrdered` guard throws
+- [TransientIndexTests](../../../../test/Typhon.Engine.Tests/Data/ECS/TransientIndexTests.cs) — `WhereField` index-driven scan on the Transient storage discipline, with a non-primary filter
+- [EcsHardeningTests](../../../../test/Typhon.Engine.Tests/Data/ECS/EcsHardeningTests.cs) — `Query_WhereField_SeesPendingSpawns`: deferred-compiled fallback so uncommitted spawns are still visible
+
+## 🔗 Related
+
+- Parent feature: [Fluent Query API & Predicate Parsing](./README.md)
+- Sibling: [Query System (EcsQuery)](../../Ecs/query-system.md) — the Ecs-category entry point this whole category is the deep-dive extension of
+- Sibling: [Execution Planning & Pipeline Execution](../execution-planning-pipeline.md) — consumes `WhereField` predicates to pick the primary scan
+- Sibling: [Result Ordering & Pagination](../ordering-pagination.md) — `OrderByField` requires a preceding `WhereField` to identify the table
+- Sibling: [Lookup and Range-Scan Operations](../../Indexing/lookup-and-range-scan.md) — `WhereField` compiles down to an index range scan
+
+<!-- Deep dive: claude/overview/05-query.md §5.1, §5.2, §5.9 -->
+<!-- Deep dive: claude/design/Querying/QueryEngine.md -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/10-predicate-taxonomy.md (L1-L4) -->

--- a/doc/feature-set/Querying/ordering-pagination.md
+++ b/doc/feature-set/Querying/ordering-pagination.md
@@ -1,0 +1,73 @@
+# Result Ordering & Pagination
+> Sorted, paged query results driven directly off a B+Tree index scan — no full-scan-then-sort.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Querying](./README.md)
+
+## 🎯 What it solves
+
+Leaderboards, inventory lists, and any paginated UI need results in a specific order, a small slice of which is shown at a time. Scanning every match, sorting it in memory, then slicing off a page wastes I/O and CPU on rows the caller throws away — and gets worse as the table grows. Result Ordering & Pagination instead walks the indexed field in sorted order and stops once the requested page is filled, so a "page 3 of 50,000 leaderboard entries" query touches roughly what it returns, not the whole table.
+
+## ⚙️ How it works (in brief)
+
+`OrderByField`/`OrderByFieldDescending` designate an indexed field on the component identified by a preceding `WhereField` call; when it's the same field the predicate narrowed, the planner reuses that already-narrowed index range as the iteration order directly — no separate sort step. `Skip`/`Take` bound how much of that ordered stream is materialized. `ExecuteOrdered()` is the only terminal that honors this ordering, returning a `List<EntityId>`; `Execute()`, `Count()`, and `Any()` ignore `OrderByField`/`Skip`/`Take` entirely. Queries spanning a polymorphic archetype subtree still come back as one globally ordered list — matching archetypes are merged transparently.
+
+## 💻 Usage
+
+```csharp
+// Page 3 of a Level-descending leaderboard (entries 21-30)
+var page = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level >= 50)
+    .OrderByFieldDescending<Player, int>(p => p.Level)
+    .Skip(20)
+    .Take(10)
+    .ExecuteOrdered();                       // → List<EntityId>, Level descending
+
+foreach (var id in page)
+{
+    var entity = tx.Open(id);
+    if (entity.TryRead<Player>(out var player))
+    {
+        Render(player);
+    }
+}
+
+// Unconditional sort: WhereField still required to identify the component table —
+// an always-true comparison on the order field works fine.
+var allByLevel = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Level >= int.MinValue)
+    .OrderByField<Player, int>(p => p.Level)
+    .ExecuteOrdered();
+```
+
+| Method | Requires | Effect |
+|---|---|---|
+| `OrderByField<T,TKey>` | preceding `WhereField<T>` | Ascending iteration order on an indexed field of `T` |
+| `OrderByFieldDescending<T,TKey>` | preceding `WhereField<T>` | Descending iteration order |
+| `Skip(n)` | preceding `OrderByField`/`OrderByFieldDescending` | Drops the first `n` ordered results |
+| `Take(n)` | preceding `OrderByField`/`OrderByFieldDescending` | Caps the result count at `n` |
+| `ExecuteOrdered()` | `OrderByField` + `WhereField` | Materializes the ordered, paged `List<EntityId>` |
+
+## ⚠️ Guarantees & limits
+
+- **`WhereField` is mandatory** — it identifies the component table `OrderByField` resolves against; calling `OrderByField`, `Skip`, or `Take` without it throws `InvalidOperationException`.
+- **Order field must be indexed** — `OrderByField`/`OrderByFieldDescending` reject non-indexed fields at call time, not at execution.
+- **`Skip`/`Take` require an order first** — paging an unordered result set would have no defined meaning, so both throw `InvalidOperationException` if `OrderByField` hasn't been set.
+- **Not supported on `ToView()`** — Views are unordered live sets; chaining `OrderByField`/`Skip`/`Take` before `.ToView()` throws. Re-run `ExecuteOrdered()` per refresh cycle for "paged + live" use cases.
+- **Not supported with OR predicates** — a `WhereField` with `||` produces multiple independently-planned branches; merging them into one global order isn't implemented. Restructure as a single AND predicate, or run one ordered query per branch.
+- **Not supported with spatial predicates or `.Where(lambda)`** — `WhereNearby`/`WhereInAABB`/`WhereRay` and the opaque post-filter are both unordered scans; sort the result client-side instead.
+- **`Count()`/`Any()` ignore `Skip`/`Take`** — they report the full match count / existence regardless of paging; use `ExecuteOrdered().Count` for a paged count.
+- **No chained `.Where(lambda)`** — fold any extra condition into the `WhereField` expression; `ExecuteOrdered()` throws if an opaque filter is attached.
+
+## 🧪 Tests
+
+- [EcsQueryTargetedScanTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsQueryTargetedScanTests.cs) — ascending/descending `ExecuteOrdered`, `Skip`/`Take` windowing, and the `OrderBy`/`Skip`-without-prerequisite guard throws
+- [SimdKwayMergeTests](../../../test/Typhon.Engine.Tests/Data/ECS/SimdKwayMergeTests.cs) — k-way merge across a polymorphic archetype subtree stays globally ordered under `Skip`/`Take`
+
+## 🔗 Related
+
+- Sibling: [Indexed Field Predicates (WhereField)](fluent-query-api/wherefield-indexed-predicate.md) — `OrderByField` requires a preceding `WhereField` to identify the component table
+- Sibling: [Execution Planning & Pipeline Execution](execution-planning-pipeline.md) — `OrderByField` pins the primary scan, overriding pure selectivity-driven choice
+
+<!-- Deep dive: claude/overview/05-query.md §5.1 EcsQuery API (OrderBy/Skip/Take in the fluent API) -->
+<!-- Deep dive: claude/overview/05-query.md §5.4 Execution Planning (OrderBy constraint on index selection) -->
+<!-- Deep dive: claude/overview/05-query.md §5.12 ECS Query API (full query operations table) -->

--- a/doc/feature-set/Querying/persistent-views.md
+++ b/doc/feature-set/Querying/persistent-views.md
@@ -1,0 +1,86 @@
+# Persistent Views — Incremental Refresh & Delta Tracking
+> A live, indexed query result set that updates itself in microseconds instead of being re-run every tick.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Querying](./README.md)
+
+**Assumes:** [Indexed Field Predicates (WhereField)](./fluent-query-api/wherefield-indexed-predicate.md)
+
+## 🎯 What it solves
+
+Game loops and UI panels routinely need to know "which entities currently match this condition" once per tick — active quests, nearby enemies, low-health units. Re-running the query every tick against the full table wastes CPU on entities that didn't change, and that cost grows with table size, not with how much actually moved. Persistent Views hold the matching entity set across ticks and update only the entities affected by commits since the last refresh, turning a per-tick cost proportional to table size into one proportional to the number of changes.
+
+## ⚙️ How it works (in brief)
+
+`ToView()` on an indexed-field query (`WhereField`) builds the initial entity set once via the same selectivity-driven execution plan as a one-shot query, then registers the view to receive change notifications for every field it depends on. At commit time, the field-update path that already touches old/new values for the B+Tree index also pushes a small delta record (entity, before-key, after-key) into the view's lock-free multi-producer/single-consumer ring buffer — no extra scan, no polling. `Refresh(tx)` drains that buffer up to the transaction's snapshot, re-evaluates only the changed entities' predicates, and updates the entity set plus an Added/Removed/Modified delta. If the buffer fills up between refreshes (too many changes, too long a gap), the view self-heals by falling back to one full re-query using its cached execution plan, then resumes incremental mode.
+
+## 💻 Usage
+
+```csharp
+using var view = tx.Query<ItemArch>()
+    .WhereField<ItemData>(i => i.Rarity >= 3)
+    .ToView();                                  // → EcsView<ItemArch>, populated immediately
+
+// Game loop
+while (running)
+{
+    using var refreshTx = dbe.CreateQuickTransaction();
+    view.Refresh(refreshTx);
+
+    var delta = view.GetDelta();
+    foreach (var pk in delta.Added)    SpawnVisual(pk);
+    foreach (var pk in delta.Removed)  DespawnVisual(pk);
+    foreach (var pk in delta.Modified) UpdateVisual(pk);
+    view.ClearDelta();
+
+    // Or iterate the current full entity set
+    foreach (var id in view.GetEntityEnumerator()) { /* ... */ }
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `ToView(bufferCapacity:)` | 4096 (power of 2) | Ring buffer slot count; larger absorbs bigger inter-refresh bursts before overflowing, at ~35 bytes/slot unmanaged memory |
+
+`EcsView<TArchetype>` picks its refresh strategy from the predicate shape at `ToView()` time:
+
+| Mode | Created when | Refresh cost |
+|---|---|---|
+| Incremental | Single `WhereField` branch | O(changes since last refresh) |
+| OR | `WhereField` with `\|\|` (multiple branches, max 16) | O(changes), per-entity branch bitmap |
+| Pull | No `WhereField` (opaque `Where` or no predicate) | O(full result set), every call — correct, but not incremental |
+
+## ⚠️ Guarantees & limits
+
+- **Indexed fields only.** Every field in the view's predicate must be `[Index]`-annotated — that's what gives commit-time change capture for free. Non-indexed fields are rejected at `ToView()` time; use `.Where(lambda)` one-shot queries for those instead.
+- **No held transaction.** A view tracks a TSN watermark, not an open transaction — it never blocks MVCC cleanup, however long it lives.
+- **Refresh is explicit and consumer-controlled.** Views never update themselves; call `Refresh(tx)` whenever the caller wants to observe the latest committed state up to `tx`'s snapshot.
+- **Delta is net change since `ClearDelta()`**, not a raw log — an entity that enters and leaves between two `ClearDelta()` calls produces no event; one that leaves and re-enters reports as Modified.
+- **`ViewDelta`/`GetDelta()` is zero-allocation** and references the view's internal state directly; it is only valid until the next `ClearDelta()`.
+- **Overflow is graceful, not fatal.** A full ring buffer sets `HasOverflow`; the next `Refresh()` rebuilds the entity set from the cached execution plan and computes Added/Removed from the diff — but per-field Modified granularity for that cycle is lost.
+- **AND, OR, and plain-scan (pull) predicates are all supported** by the same `EcsView<TArchetype>` type — the refresh mode is selected automatically from the predicate shape; OR predicates are capped at 16 DNF branches.
+- **Not ordered.** A view is an unordered live set; `OrderByField`/`Skip`/`Take` are rejected on `ToView()`. Re-run `ExecuteOrdered()` per cycle if you need a sorted/paged snapshot.
+- **Must be disposed.** `view.Dispose()` deregisters it from change notifications and frees its unmanaged ring buffer; un-drained entries are discarded.
+- **Cost profile:** commit-time notification is sub-microsecond per (changed field, watching view); draining ~100-200 changes on refresh is single-digit microseconds.
+- **SingleVersion/Transient views are not fully validated yet.** Views over these storage modes are designed to observe state only as of the last tick boundary (after `WriteTickFence` drains ring buffers), but this wiring is still partial — treat tick-boundary consistency for SV/Transient views as unvalidated until it's closed out. Views over `Versioned` components are fully validated. This is the reason this feature is marked Partial rather than Implemented.
+
+## 🧪 Tests
+
+- [EcsIncrementalViewTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsIncrementalViewTests.cs) — incremental refresh (field crosses in/out), `GetDelta` Added/Removed/Modified, `CompactDelta` net-change collapsing, overflow recovery via full re-query, Pull-mode fallback
+- [EcsOrViewTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsOrViewTests.cs) — OR mode per-entity branch bitmap, entity stays in view while any branch matches
+- [EcsViewTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsViewTests.cs) — base `ToView`/`Refresh` mechanics, `Contains`, delta clearing, dispose semantics
+- [ViewChangeCaptureTests](../../../test/Typhon.Engine.Tests/Data/Query/ViewChangeCaptureTests.cs) — commit-time ring-buffer delta entries (before/after keys, multi-field changes, disposed-view skip)
+- [ViewRegistryTests](../../../test/Typhon.Engine.Tests/Data/Query/ViewRegistryTests.cs) — view registration/deregistration bookkeeping behind commit-time change notification
+- [EcsViewMultiFieldTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsViewMultiFieldTests.cs) — two ANDed `WhereField` predicates on one view: per-field crossing only re-evaluates that predicate
+
+## 🔗 Related
+
+- Related feature: [Fluent Query API & Predicate Parsing](./fluent-query-api/README.md)
+- Also documented as: [Reactive Views (EcsView)](../Ecs/reactive-views.md) in the Ecs category — same feature, since `ToView()` is called on an `EcsQuery`; this page is canonical.
+- Sibling: [Published Views](../Subscriptions/published-views/README.md) — registers a View as a subscribable target for connected clients
+
+<!-- Deep dive: claude/overview/05-query.md §5.6 Persistent Views, §5.7 Delta Tracking, §5.8 View Registry -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/README.md — full design series (overview, internals, view types, concurrency) -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/03-internals.md — ring buffer layout, change capture, refresh/overflow algorithms -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/07-concurrency.md — MPSC correctness, disposal safety -->
+<!-- Deep dive: claude/design/Ecs/09-implementation-plan.md §Umbrella 4 — SV/Transient tick-boundary wiring, the gap behind the Partial status -->
+<!-- ADR: claude/adr/042-view-system-architecture.md — TSN-anchored design rationale (see 2026-05-11 supersession note for current type names) -->

--- a/doc/feature-set/Querying/spatial-predicates.md
+++ b/doc/feature-set/Querying/spatial-predicates.md
@@ -1,0 +1,71 @@
+# Spatial Query Predicates
+> R-Tree-backed AABB, radius, and ray filters attached directly to a fluent ECS query.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Querying](./README.md)
+
+## 🎯 What it solves
+
+Game-server and simulation workloads constantly ask spatial questions — "what's in this room", "what's within aggro range", "what does this ray hit" — that a B+Tree field index cannot answer efficiently. Brute-force scanning every entity's position component to test bounds is O(n) per query and falls apart well before 10K entities at 60Hz. Spatial Query Predicates give `EcsQuery` three index-driven spatial filters (AABB overlap, radius/sphere, ray intersection) that run against a dedicated R-Tree instead of a linear scan, and compose with the rest of the query builder (archetype constraints, field predicates, opaque post-filters).
+
+## ⚙️ How it works (in brief)
+
+Mark the field that defines an entity's bounds with `[SpatialIndex]`; the engine maintains an R-Tree per component table, updated as entities spawn, move, and despawn. `WhereInAABB<T>`, `WhereNearby<T>`, and `WhereRay<T>` attach one spatial predicate to the query — the tree (not a table scan) produces the candidate set, which is then narrowed by archetype mask, any `.Where()`/`.WhereField()` predicate chained onto the same query (AND semantics), and visibility. Only one spatial predicate is allowed per query; static (rarely-moving) and dynamic entities are indexed in separate trees but queried transparently together.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1)]
+public struct Position
+{
+    [SpatialIndex(margin: 0.5f)]
+    public float X, Y, Z;
+}
+
+using var t = dbe.CreateQuickTransaction();
+
+// AABB overlap — entities whose Position bounds intersect the box
+var inRoom = t.Query<UnitArch>()
+    .WhereInAABB<Position>(minX: 0, minY: 0, minZ: 0, maxX: 50, maxY: 0, maxZ: 50)
+    .Execute();                                          // → HashSet<EntityId>
+
+// Radius — entities within range of a point
+var nearby = t.Query<UnitArch>()
+    .WhereNearby<Position>(centerX: 10, centerY: 0, centerZ: 10, radius: 15)
+    .Without<Dead>()
+    .Execute();
+
+// Ray — first-hit-style candidate set along a direction
+var hit = t.Query<UnitArch>()
+    .WhereRay<Position>(originX: 0, originY: 1, originZ: 0, dirX: 1, dirY: 0, dirZ: 0, maxDist: 100)
+    .Any();
+```
+
+| Constructor arg (`[SpatialIndex]`) | Default | Effect |
+|---|---|---|
+| `margin` | required | Fat-AABB enlargement; absorbs small moves without a tree update |
+| `cellSize` | `0` (auto) | Bucket size for the static/bulk-loaded tree variant |
+| `Mode` | `SpatialMode.Dynamic` | `Static` skips per-tick update maintenance for rarely-moving entities |
+| `Category` | `uint.MaxValue` | Archetype-level bitmask; lets a per-cluster broadphase skip whole archetype clusters that don't overlap the query |
+
+## ⚠️ Guarantees & limits
+
+- **One spatial predicate per query** — a second `WhereNearby`/`WhereInAABB`/`WhereRay` call throws `InvalidOperationException`; run separate queries and combine in application code.
+- **Composable with `Where`/`WhereField`** — both are applied as an AND post-filter over the spatial candidate set, not a second index probe.
+- **Archetype-mask filtered** — results respect `.With<T>()`/`.Without<T>()`/`.Exclude<T>()` the same as any other query.
+- **Not supported on `foreach`** — iterating the query directly only applies the archetype scan + `.Where()`; a spatial predicate throws. Call `.Execute()` (or `.Any()`/`.Count()`) instead.
+- **Not supported with `WhereField` on `ToView()`** — a reactive view cannot combine an indexed field predicate with a spatial predicate; a spatial-only (or spatial + opaque `Where`) view falls back to full re-query (pull mode) on every `Refresh()`, not incremental delta tracking.
+- **Not supported with `ExecuteOrdered`** — spatial predicates don't carry an ordering; use `Execute()` and sort in application code if needed.
+- **Sub-microsecond at 10K entities**; ~600µs total spatial budget at 100K entities for a 60Hz tick (3.6% of frame).
+- **kNN-style "nearest N" is not exposed** at this layer — only set-membership filters (AABB/radius/ray).
+
+## 🧪 Tests
+
+- [SpatialEcsIntegrationTests](../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialEcsIntegrationTests.cs) — `WhereInAABB`/`Count`/`Any`, composition with `Where`/`WhereField`, and the one-spatial-predicate-per-query guard
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Ecs/public/EcsQuery.cs](../../../src/Typhon.Engine/Ecs/public/EcsQuery.cs)
+- Sibling: [Spatial Query API (AABB / Radius / Ray / Frustum / kNN / Count)](../Spatial/spatial-query-api.md) — the underlying R-Tree query algorithms this feature exposes through the fluent builder
+
+<!-- Deep dive: claude/overview/05-query.md (§5.12 ECS Query API — spatial predicates) -->
+<!-- Deep dive: claude/adr/044-spatial-rtree-architecture.md (R-Tree architecture, fat-AABB update strategy, category filtering) -->

--- a/doc/feature-set/Querying/statistics-infrastructure.md
+++ b/doc/feature-set/Querying/statistics-infrastructure.md
@@ -1,0 +1,71 @@
+# Statistics Infrastructure (HLL / MCV / Histogram)
+> Background-maintained per-field statistics that let the query planner see data skew instead of guessing uniform distribution.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Querying](./README.md)
+
+## 🎯 What it solves
+
+Execution planning needs to know roughly how many entities a predicate will match before running it, so it can pick the most selective index as the scan driver. Without real distribution data, the planner can only assume every value is equally likely — fine for uniform data, wrong for the skew that's the norm in game data (most players are low level, one faction has 80% of the population, item rarity is heavily weighted toward "common"). A skewed field with no statistics gets the same cardinality estimate for a hot value and a rare one, leading the planner to pick the wrong primary scan stream. Statistics Infrastructure gives the planner real distribution data — refreshed automatically, off the commit path — so plan quality holds even on skewed fields.
+
+## ⚙️ How it works (in brief)
+
+Each `[Index]`-annotated field optionally carries three structures: a HyperLogLog sketch (approximate distinct-value count), a Most-Common-Values table (exact frequencies for the top 100 values), and a 100-bucket equi-width histogram (range distribution). A dedicated low-priority background thread polls periodically, and for each table whose mutation count has crossed a threshold since the last rebuild, it runs a single chunk-based scan that (re)builds all three structures and atomically swaps them in — concurrent queries never see a torn read. Large tables are page-sampled and the counts scaled back up, bounding scan time regardless of table size. Until the first rebuild happens (or if the worker is disabled), the planner transparently falls back to exact B+Tree counts and uniform-distribution math — query correctness never depends on statistics existing.
+
+## 💻 Usage
+
+```csharp
+// Opt in at engine startup — null (default) means no worker thread, no overhead
+services.AddDatabaseEngine(o => o.Statistics = new StatisticsOptions
+{
+    MutationThreshold = 1000,    // rebuild a table after this many index mutations
+    PollIntervalMs = 5000,       // worker poll interval
+    MinEntitiesForRebuild = 100, // skip tiny tables
+    SamplingMinEntities = 10000, // full scan below this; page-sampled above
+});
+
+[Component("Game.Player", 1)]
+public struct Player
+{
+    [Index] public int Level;   // statistics build automatically once mutations accrue
+    [Index] public int Faction;
+}
+
+// No statistics-specific API to call — once enabled, AdvancedSelectivityEstimator
+// picks up MCV/Histogram automatically inside execution planning:
+var veterans = tx.Query<PlayerArch>()
+    .WhereField<Player>(p => p.Faction == 1 && p.Level > 50)
+    .Execute();                                   // → HashSet<EntityId>, plan benefits silently
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `MutationThreshold` | 1000 | Index mutations on a table before the next poll triggers a rebuild |
+| `PollIntervalMs` | 5000 | Background worker poll interval; floor-clamped to 100ms |
+| `MinEntitiesForRebuild` | 100 | Tables smaller than this are skipped (not worth the scan) |
+| `SamplingMinEntities` | 10000 | Below this: full scan; above: page-granularity sampling |
+| `Enabled` | `true` | Master on/off switch (separate from leaving `Statistics` null) |
+
+## ⚠️ Guarantees & limits
+
+- **Opt-in, zero default overhead.** `DatabaseEngineOptions.Statistics` is `null` by default — no worker thread, no scans, no memory cost unless explicitly configured.
+- **Zero commit-path cost.** The only hook on the write path is a non-atomic `int` increment per mutation; the rebuild scan itself runs entirely on the background thread.
+- **No public API to read statistics directly.** HLL/MCV/Histogram are internal to the selectivity estimator — there is nothing to query or inspect from application code; their only observable effect is plan quality (see [Execution Planning & Pipeline Execution](./execution-planning-pipeline.md)).
+- **Staleness is bounded, not zero.** Statistics reflect the data as of the last rebuild — up to `MutationThreshold` mutations plus one `PollIntervalMs` tick stale. A stale estimate degrades plan quality, never correctness.
+- **No incremental maintenance.** Rebuilds are full (or sampled) re-scans, not deltas — HyperLogLog has no removal operation, so incremental updates would accumulate ghost values from deleted/updated entities.
+- **Per-field memory cost when built:** ~4KB (HLL) + ~1.8KB (MCV) + ~0.4KB (Histogram) ≈ 6.2KB per indexed field, allocated lazily on first rebuild.
+- **One table's rebuild failure doesn't block others** — the worker logs the last exception (diagnostic only) and keeps polling the rest of the registered tables.
+- `String64`-keyed indexes are excluded from statistics — only fixed-width numeric key types are supported.
+
+## 🧪 Tests
+
+- [StatisticsRebuildTests](../../../test/Typhon.Engine.Tests/Data/Query/StatisticsRebuildTests.cs) — background worker lifecycle, mutation-threshold-triggered rebuild, atomic torn-read-free swap, sampling, and the `String64`-field skip
+- [HyperLogLogTests](../../../test/Typhon.Engine.Tests/Data/Query/HyperLogLogTests.cs) — HLL cardinality estimate accuracy (unique, skewed, and merged sketches)
+- [MostCommonValuesTests](../../../test/Typhon.Engine.Tests/Data/Query/MostCommonValuesTests.cs) — MCV top-100 identification on Zipf-skewed data, exact-count lookup hit/miss
+
+## 🔗 Related
+
+- Related feature: [Execution Planning & Pipeline Execution](./execution-planning-pipeline.md)
+
+<!-- Deep dive: claude/overview/05-query.md §5.11 Statistics Infrastructure -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/04-query-planning.md — selectivity estimator chain, statistics structures, rebuild/worker algorithms -->
+<!-- ADR: claude/adr/043-advanced-statistics-selectivity.md — why HLL/MCV/histogram, why background rebuild over inline/incremental maintenance -->

--- a/doc/feature-set/Querying/temporal-queries.md
+++ b/doc/feature-set/Querying/temporal-queries.md
@@ -1,0 +1,63 @@
+# Temporal Queries (Point-in-Time Read & Revision History)
+> Opt-in per-component history retention enabling reads of past state and full revision timelines.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Querying](./README.md)
+
+## 🎯 What it solves
+
+MVCC keeps multiple revisions of a component alive only as long as some active transaction can still see them — as soon as nothing needs an old revision, it's reclaimed. There is no way today to ask "what was this entity's position 5 seconds ago?" or "show me the full edit history of this trade record." Use cases like gameplay replay/rewind, undo-redo, audit trails, and debugging "how did we get into this state" all need state that normal MVCC visibility intentionally discards.
+
+## ⚙️ How it works (in brief)
+
+You opt a component into retention with `[TemporalRetention(KeepCount = N)]` (or the runtime equivalent); components without it are unaffected and behave exactly as today. Retained components keep their last N committed revisions instead of discarding them as soon as MVCC visibility allows, and two read APIs work against that history: a point-in-time read for a specific transaction sequence number, and a full chronological enumeration. Both APIs are callable on any component, but only return useful results once retention is configured — without it, history is gone before you can query it.
+
+## 💻 Usage
+
+```csharp
+// Illustrative only — design complete, not implemented yet.
+// [Component]
+// [TemporalRetention(KeepCount = 50)]
+// public struct PlayerPosition
+// {
+//     [Field] public float X;
+//     [Field] public float Y;
+//     [Field] public float Z;
+// }
+//
+// // Point-in-time read
+// if (tx.ReadEntityAtVersion<PlayerPosition>(entityId, targetTSN, out var pastPos))
+// {
+//     Rewind(pastPos);
+// }
+//
+// // Full revision history, oldest to newest
+// foreach (var snapshot in tx.GetRevisionHistory<PlayerPosition>(entityId))
+// {
+//     Console.WriteLine($"TSN {snapshot.TSN}: {snapshot.Component}");
+// }
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `TemporalRetention.KeepCount` | none (opt-in) | Keeps the N most recent committed revisions per entity |
+| `TemporalRetention.KeepFor` / `MaxRevisions` | none (Phase 3) | Time-windowed retention with optional hard cap — deferred, needs a TSN↔DateTime mapping table |
+| `dbe.ConfigureRetention<T>(...)` | n/a | Runtime override of the attribute-declared policy |
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** No code under `src/Typhon.Engine/Querying` or elsewhere defines `[TemporalRetention]`, `ReadEntityAtVersion`, or `GetRevisionHistory` today; this is a complete design awaiting a build slot.
+- **Opt-in, per component type.** Components without `[TemporalRetention]` keep today's lightweight revision chain — zero structural or performance overhead.
+- **Not microsecond-latency.** Designed for ~150ns-1.2µs point-in-time reads (chain-length dependent) and multi-microsecond periodic compaction — a different, slower tier than normal MVCC reads (~100ns), by design.
+- **`KeepCount(N)` only at first ship.** Time-based `KeepFor` retention is deferred to a later phase pending a TSN↔DateTime mapping table; an approximate tick-rate conversion was explicitly rejected because GC is destructive and irreversible.
+- **Retention never overrides active-transaction visibility.** An open transaction's snapshot is never pruned out from under it, regardless of retention policy — retention can only extend the garbage-collection window, never shrink it.
+- **Page cache cost is real.** Each retained revision consumes page cache pages; e.g. `KeepCount(50)` across 10K entities is estimated at ~7.5 MB / ~940 pages — size your cache budget accordingly.
+- **Universal API, conditional usefulness.** `ReadEntityAtVersion`/`GetRevisionHistory` compile and run against any component, but without retention configured they reliably miss (history already reclaimed).
+
+## 🔗 Related
+
+- Related feature: [Persistent Views](./persistent-views.md) — a different live-data mechanism (current-state delta tracking, not history)
+- Sibling: [Temporal (Point-in-Time) Index Query](../Indexing/temporal-index-query.md) — the index-side counterpart reconstructing past key membership from version history
+
+<!-- Deep dive: claude/design/Querying/temporal-queries.md — full design (retention model, chunk directory layout, compaction algorithm, phased implementation plan) -->
+<!-- Research: claude/research/Querying/TemporalQueries.md -->
+<!-- ADR: claude/adr/003-mvcc-snapshot-isolation.md, claude/adr/023-circular-buffer-revision-chains.md -->

--- a/doc/feature-set/Querying/view-factory-pooling.md
+++ b/doc/feature-set/Querying/view-factory-pooling.md
@@ -1,0 +1,69 @@
+# ViewFactory — Parameterized Queries & View Pooling
+> Reusable query templates with a Rent/Return view pool — planned, to remove per-session view setup cost.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Querying](./README.md)
+
+## 🎯 What it solves
+
+Server workloads with high session churn — a player logging in and out of a game server, a client opening and closing a UI panel — repeatedly construct the *same* view (same predicate shape, different parameter values: this player's zone, this player's level threshold) and then tear it down minutes later. Building a [Persistent View](./persistent-views.md) today re-parses the predicate expression, re-extracts field dependencies, and allocates a fresh ring buffer every time, even though the query shape never changes between sessions. None of that is necessary work — only the parameter values and the resulting entity set are session-specific.
+
+## ⚙️ How it works (in brief)
+
+A `ViewFactory` is built once at startup from a parameterized predicate — a lambda over both the component and a user-defined parameter struct (e.g., `(p, prm) => p.Zone == prm.ZoneId && p.Level > prm.MinLevel`). Expression parsing, field-dependency extraction, and evaluator compilation happen exactly once, at `Build()`. Per session, `Rent(tx, params)` either pulls an idle view from the factory's pool or allocates a new one, binds the parameter struct's concrete values into the cached evaluator template, re-registers the view for commit-time change notifications, and runs the initial population — all without re-parsing anything. `Return(view)` deregisters it and pushes it back onto the pool (capped at `MaxPooled`) for the next session to reuse; `view.Dispose()` is a safety-net equivalent of `Return()`. `Rebind(tx, newParams)` lets a long-lived view switch parameters mid-session without leaving the pool.
+
+## 💻 Usage
+
+```csharp
+// Illustrative only — design complete (claude/design/Querying/ViewSystem/phase-4.md),
+// not yet implemented; none of this compiles against today's API.
+
+struct SessionParams
+{
+    public int ZoneId;
+    public int MinLevel;
+}
+
+// At startup (once)
+var factory = dbe.QueryFactory<Player, SessionParams>()
+    .Where((p, prm) => p.Zone == prm.ZoneId && p.Level > prm.MinLevel)
+    .Build(maxPooled: 32);
+
+// Per player login
+ViewBase view = factory.Rent(tx, new SessionParams { ZoneId = 3, MinLevel = 1 });
+
+// Per tick
+view.Refresh(tx);
+var delta = view.GetDelta();
+// ...
+view.ClearDelta();
+
+// Per player logout
+factory.Return(view);   // or view.Dispose() — equivalent safety net
+
+// Server shutdown — all sessions must have returned their views first
+factory.Dispose();      // throws if any view is still rented
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `Build(maxPooled:)` | `Environment.ProcessorCount` | Cap on idle pooled views; pool grows on demand up to this, trims excess on `Return` |
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** Design is complete (Phase 4); no `ViewFactory`, `QueryFactoryBuilder`, or `db.QueryFactory<…>()` exists in the codebase today. Names and shapes above are a design sketch, subject to change.
+- Planned cold-path savings: expression parsing, field-dependency extraction, and evaluator compilation move from per-session (~80–160 µs) to once at `Build()`; a pool-hit `Rent()` additionally skips ring-buffer allocation (~5–10 µs).
+- Initial population cost on `Rent`/`Rebind` is **not** eliminated — re-querying against new parameter values is unavoidable and expected to dominate (~100 µs–10 ms depending on result set size).
+- Planned arities: 1- and 2-component predicates (`QueryFactory<T, TParams>`, `QueryFactory<T1, T2, TParams>`); N≥3 needs prior `QueryBuilder` extensions and is out of scope for this phase.
+- Pooled views sit deregistered and idle (zero commit-time cost) but keep their ring buffer allocated — bounded by `MaxPooled`, not by inter-session activity.
+- Parameter rebinding is explicit only — the factory does not detect or react to parameter changes on its own; the caller must call `Rebind()`.
+- `Rent()`/`Return()` are planned to be thread-safe (callable from login/logout handlers on any thread); `Refresh()`/`Rebind()` remain single-consumer, same as a plain view.
+- `Dispose()` on a factory is planned to throw if any rented view has not been returned — sessions must log out before shutdown.
+
+## 🔗 Related
+
+- Related feature: [Persistent Views — Incremental Refresh & Delta Tracking](./persistent-views.md) — the underlying view mechanism `ViewFactory` pools and parameterizes
+- Sibling: [Reactive Views (EcsView)](../Ecs/reactive-views.md) — the Ecs-category view type `ViewFactory` will pool and parameterize
+
+<!-- Deep dive: claude/design/Querying/ViewSystem/phase-4.md — full design (parameterized predicates, pooling, state machine, concurrency, cost analysis) -->
+<!-- Deep dive: claude/design/Querying/ViewSystem/README.md — view system design series this phase builds on -->
+<!-- Overview: claude/overview/05-query.md — architectural reference -->

--- a/doc/feature-set/README.md
+++ b/doc/feature-set/README.md
@@ -1,0 +1,438 @@
+# Typhon Feature Catalog
+
+> Documentation for every feature in `src/Typhon.Engine`, tagged **Public** (usable by application developers embedding Typhon) or **Internal** (engine machinery, for contributors). Each entry covers what it's for, what problem it solves, and how it works. Scoped to the engine itself — Workbench, TyphonShell, and Patate (apps built on Typhon) are out of scope.
+
+> 📖 **New to Typhon?** This catalog is the *reference* — every feature, one page each, organized for lookup. If you want to *learn* Typhon end-to-end, start with the **[User Guide](../guide/README.md)** instead: a 6-chapter, read-as-you-go tutorial with a runnable example project. Come back here once you know what you're looking for.
+
+> 🔬 **Want to understand *why*, not just *how*?** This catalog tells you what each feature does and how to use it — not the mechanism underneath. The **[In-Depth Overview](../in-depth-overview/README.md)** goes deeper: structures, invariants, and design trade-offs. That's useful whether you're embedding Typhon and want to reason about what it actually guarantees (durability, MVCC, the runtime model), or reading the engine's code for the first time — it's not contributor-only. A 14-chapter reference mirroring `src/Typhon.Engine/`'s folder layout; each category README below links to its corresponding chapter.
+
+**Who it's for:** application developers embedding Typhon get a task-oriented "what exists and how do I use it" reference — the [Public](#public--what-you-can-use) index is a complete, self-contained reading list; stop there. Engine contributors who need the machinery behind those features continue into [Internal](#internal--engine-internals-for-contributors).
+
+**Learning level:** every Public feature page is tagged 🟢 **Start Here** (needed for the simplest working app), 🔵 **Core** (what most production apps reach for), or 🟣 **Advanced** (specific use cases only) — see its badge line. Category tables below are ordered accordingly, easiest first.
+
+**How to navigate:** skim the [category table](#categories) below — its Scope column flags whether a category is mostly Public, Internal-only, or a real mix of both — then drill into a category's README for its full feature list, or a feature page for usage details and code samples. Or jump straight to [Public](#public--what-you-can-use) or [Internal](#internal--engine-internals-for-contributors) below and Ctrl-F for a feature name.
+
+## Categories
+
+| Category | What it covers | Scope | README |
+|---|---|---|---|
+| Foundation | Lock-free primitives, epoch memory safety, deadlines/timeouts, pinned allocators, and hash maps every other layer is built on. | Mixed | [→](Foundation/README.md) |
+| Storage | The memory-mapped page cache, allocation hierarchy (occupancy → segments → chunks), and pluggable backends underlying every persisted structure. | Mixed | [→](Storage/README.md) |
+| Durability | WAL v2, the append-before-publish commit pipeline, checkpointing, and crash recovery — Typhon's crash-safety guarantees. | Mixed | [→](Durability/README.md) |
+| Schema | Attribute-driven component/field declaration, FieldId stability, validation, and automatic/user-defined schema evolution. | Mixed | [→](Schema/README.md) |
+| Revision | The per-component MVCC revision-chain subsystem — storage, snapshot visibility, conflict baselines, and GC/crash scrub. | Mixed | [→](Revision/README.md) |
+| Ecs | The archetype-based entity/component data model — CRUD, storage modes, queries, views, relationships, collections, clusters. | Public | [→](Ecs/README.md) |
+| Indexing | Concurrent B+Tree secondary indexes — key-width variants, lookup/range scan, versioned (MVCC) index history, diagnostics. | Mixed | [→](Indexing/README.md) |
+| Spatial | R-Tree spatial indexing, spatial query predicates, trigger volumes, and cluster-based tiered simulation dispatch. | Mixed | [→](Spatial/README.md) |
+| Querying | The fluent query builder, execution planning, statistics, and incrementally-refreshed persistent Views. | Public | [→](Querying/README.md) |
+| Transactions | The three-tier execution model (Engine → UoW → Transaction) — durability modes/discipline, commit/rollback, conflict resolution. | Public | [→](Transactions/README.md) |
+| Subscriptions | Server-driven, View-based client state replication over TCP — published Views, delta encoding, wire transport. | Public | [→](Subscriptions/README.md) |
+| Runtime | The DAG-scheduled tick loop that dispatches systems — scheduling, system types, spatial-tier dispatch, overload management. | Public | [→](Runtime/README.md) |
+| Resources | The runtime resource graph tracking every engine resource's metrics, budgets, snapshots, and exhaustion handling. | Mixed | [→](Resources/README.md) |
+| Observability | Zero-overhead telemetry gating, distributed tracing, OpenTelemetry metrics export, and health/alerting. | Public | [→](Observability/README.md) |
+| Errors | The unified exception hierarchy, error codes, timeouts, resource-exhaustion handling, and the zero-allocation Result type. | Public | [→](Errors/README.md) |
+| Profiler | The embedded, zero-allocation typed-event profiler and its trace export/inspection tooling. | Mixed | [→](Profiler/README.md) |
+| Hosting | DI extension methods to bootstrap a DatabaseEngine and its services into an IServiceCollection. | Public | [→](Hosting/README.md) |
+
+## Public — What You Can Use
+
+Every Public feature, one line each — the application-facing surface, complete on its own. Sub-features are indented under their parent with `↳`.
+
+### Foundation
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Deadline & Timeout Propagation | Monotonic absolute-deadline timeouts bundled with cooperative cancellation, threaded through every Unit-of-Work via the 24-byte UnitOfWorkContext to eliminate timeout accumulation across nested calls. | ✅ Implemented | 🔵 Core | [→](Foundation/deadline-timeout-propagation.md) |
+
+### Storage
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Transient Store (heap-backed) | Pinned heap blocks standing in for the page cache, so Transient components get raw-memory speed through the same segment code — tune via TransientOptions. | ✅ Implemented | 🔵 Core | [→](Storage/pluggable-storage-backend/transient-store.md) |
+| Database File Locking & Lifecycle | Two-layer protection against concurrent multi-process opens — OS FileShare.Read plus an advisory .lock sidecar with stale/live/cross-machine PID detection — plus create/open/delete lifecycle handling. | ✅ Implemented | 🔵 Core | [→](Storage/file-locking-lifecycle.md) |
+| Memory-Mapped Page Cache & Clock-Sweep Eviction | 8 KiB pages, 4-state lifecycle, clock-sweep eviction with sequential-allocation optimization, async I/O, and backpressure handling. | ✅ Implemented | 🟣 Advanced | [→](Storage/page-cache.md) |
+| Page Integrity — CRC32C, Seqlock Snapshots & A/B Page Pairing | Hardware CRC32C page checksums, seqlock-protected checkpoint snapshots, and A/B slot pairing for structural pages that can't be rebuilt. | ✅ Implemented | 🟣 Advanced | [→](Storage/page-integrity.md) |
+| Variable-Sized Buffer Storage (VSBS) | Linked-chunk-chain storage for variable-length, reference-counted buffers — backs multi-value B+Tree index entries and per-element-type ComponentCollection\<T\> pools. | ✅ Implemented | 🟣 Advanced | [→](Storage/vsbs.md) |
+| Storage Introspection & Integrity Diagnostics | Read-only APIs exposing segment/page topology and auditing occupancy-vs-segment consistency, powering the Workbench Database File Map. | ✅ Implemented | 🟣 Advanced | [→](Storage/storage-introspection.md) |
+| Page Compression (Future) | Planned LZ4-style compression adapter for cold/historical data, string-heavy tables, and backups — deliberately not implemented in v1 so hot real-time paths stay within microsecond latency targets. | 📋 Planned | 🟣 Advanced | [→](Storage/page-compression-future.md) |
+
+### Durability
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Durability Modes | Per-Unit-of-Work control over when WAL records become crash-safe — pick latency vs. data-at-risk per workload. | ✅ Implemented | 🟢 Start Here | [→](Durability/durability-modes/README.md) |
+| &nbsp;&nbsp;↳ Committed Durability Discipline | Zero-loss, atomic writes on Typhon's cheapest component layout (SingleVersion) without paying for an MVCC revision chain. | ✅ Implemented | 🟣 Advanced | [→](Durability/durability-modes/committed-discipline.md) |
+| Write-Ahead Log (WAL v2 logical records) | The single source of durability truth: logical (EntityId, ComponentTypeId) records, one codec, a sequential CRC-chained log. | ✅ Implemented | 🟣 Advanced | [→](Durability/wal-v2.md) |
+| Commit Pipeline (append-before-publish) | Transaction.Commit's VALIDATE→PREPARE→BUILD→APPEND→PUBLISH→WAIT ordering guarantees nothing is visible before its WAL record is appended, and publish never rolls back. | ✅ Implemented | 🟣 Advanced | [→](Durability/commit-pipeline.md) |
+| Checkpoint v2 (SnapshotStore pipeline) | Background pipeline that consolidates dirty data pages into the data file, advances CheckpointLSN only over pages it actually wrote, and recycles WAL segments. | ✅ Implemented | 🟣 Advanced | [→](Durability/checkpoint-v2/README.md) |
+| Crash Recovery (RecoveryDriver) | On open, scans the WAL's durably-committed prefix and replays it idempotently, in strict LSN order, through the engine's own write primitives. | ✅ Implemented | 🟣 Advanced | [→](Durability/crash-recovery/README.md) |
+| Page Checksums & Seqlock Snapshots | CRC32C torn-page detection on every page, paired with a lock-free seqlock so checkpoints snapshot live pages without blocking writers. | ✅ Implemented | 🟣 Advanced | [→](Durability/page-checksums-seqlock.md) |
+| BulkLoad Write Path | An opt-in, exclusive, throughput-first session API that skips per-row WAL and brackets the whole bulk with a BulkBegin/BulkEnd manifest pair plus a synchronous checkpoint barrier. | 🚧 Partial | 🟣 Advanced | [→](Durability/bulk-load.md) |
+| Durability Health & Introspection | DurabilityHealth (Ok/Degraded/Fatal) and checkpoint/WAL-writer cycle counters via the Resource Graph let an operator observe the subsystem without reaching into internals. | ✅ Implemented | 🟣 Advanced | [→](Durability/durability-introspection.md) |
+| Point-in-Time Incremental Backup | Forward-incremental .pack backups scoped to changed pages; restore reassembles a base and heals it through crash recovery's RecoveryDriver. | 📋 Planned | 🟣 Advanced | [→](Durability/pit-backup.md) |
+
+### Schema
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Component & Field Declaration | Attribute-driven declaration of blittable component structs ([Component], [Field], [Index]) reflected into DBComponentDefinition at registration time. | ✅ Implemented | 🟢 Start Here | [→](Schema/component-field-declaration.md) |
+| FieldId Stability | Persistent, name-based FieldId assignment (auto-assign once, match by name on reopen) so adding/removing/reordering fields never breaks index identity; PreviousName handles renames. | ✅ Implemented | 🔵 Core | [→](Schema/fieldid-stability.md) |
+| Schema Validation (SchemaDiff) | On every reopen, diffs persisted vs. runtime schema, classifies every change by compatibility level, and fails loudly before any user transaction runs on unresolvable mismatches. | ✅ Implemented | 🔵 Core | [→](Schema/schema-validation.md) |
+| Compatible Schema Evolution (Auto-Migration) | Automatically migrates entities at startup for field add/remove/reorder and lossless type widenings by allocating a new stride segment while preserving ChunkIds so indexes need no rebuild. | ✅ Implemented | 🔵 Core | [→](Schema/compatible-evolution/README.md) |
+| &nbsp;&nbsp;↳ Migration Execution Strategy | Migration runs eagerly and synchronously at database open — before any user transaction — with progress events and an offline dry-run check. | ✅ Implemented | 🟣 Advanced | [→](Schema/compatible-evolution/migration-execution-strategy.md) |
+| User-Defined Migration Functions | Register pure transform functions for breaking schema changes, with automatic multi-step chain resolution across revisions. | ✅ Implemented | 🟣 Advanced | [→](Schema/migration-functions.md) |
+| Offline Schema Inspection & Dry-Run Validation | Read a database's persisted schema, or simulate a code upgrade against it, without opening it for real. | ✅ Implemented | 🟣 Advanced | [→](Schema/schema-inspection-dryrun.md) |
+| Migration Progress Tracking | OnMigrationProgress event stream (Analyzing → AllocatingSegments → MigratingEntities → … → Complete) for observing long-running eager migrations in production. | ✅ Implemented | 🟣 Advanced | [→](Schema/migration-progress-tracking.md) |
+| Schema History Audit Log | Append-only audit trail recording every applied schema change for production auditing, queried via dbe.GetSchemaHistory(). | ✅ Implemented | 🟣 Advanced | [→](Schema/schema-history-audit.md) |
+
+### Revision
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Revision Append & Chain Growth | Every write to a Versioned component creates a new immutable revision instead of overwriting the old one — Spawn allocates, Write\<T\>() appends, Destroy tombstones. | ✅ Implemented | 🔵 Core | [→](Revision/revision-append-write-path.md) |
+| MVCC Snapshot Visibility | Reads resolve to the latest revision committed at-or-before the reader's transaction TSN, with read-your-own-writes and explicit RevisionReadStatus outcomes. | ✅ Implemented | 🔵 Core | [→](Revision/mvcc-snapshot-visibility.md) |
+| Write-Conflict Baseline Tracking | Every chain append records the new and prior revision as the comparison baseline used by commit-time conflict detection and ConcurrencyConflictHandlers. | ✅ Implemented | 🟣 Advanced | [→](Revision/optimistic-conflict-baseline.md) |
+| Revision Garbage Collection & Compaction | Bounded-memory chain cleanup keyed off MinTSN, preserving a sentinel for in-flight readers and collapsing fully-dead chains to trigger entity removal. | ✅ Implemented | 🟣 Advanced | [→](Revision/revision-gc-compaction.md) |
+
+### Ecs
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Entity & Archetype Model | Structured 64-bit entity identity, C# class-hierarchy archetypes, and typed zero-copy component handles — the schema backbone of every other ECS feature. | ✅ Implemented | 🟢 Start Here | [→](Ecs/entity-archetype-model.md) |
+| Entity Lifecycle & CRUD API | Zero-copy EntityRef accessor for Spawn, Open, Read, Write, Destroy, Enable/Disable — the sole entity manipulation API. | ✅ Implemented | 🟢 Start Here | [→](Ecs/entity-lifecycle-crud/README.md) |
+| &nbsp;&nbsp;↳ Generated Multi-Component Accessors | Source-generated zero-copy Refs/MutRefs structs reading or writing every archetype component in one call. | ✅ Implemented | 🔵 Core | [→](Ecs/entity-lifecycle-crud/generated-multi-component-accessors.md) |
+| &nbsp;&nbsp;↳ Batch & SoA Spawn | Bulk entity creation — shared-value batches or per-entity SoA spans — amortizing per-call overhead across thousands of entities. | ✅ Implemented | 🔵 Core | [→](Ecs/entity-lifecycle-crud/batch-soa-spawn.md) |
+| &nbsp;&nbsp;↳ Enable/Disable Components | O(1) per-component bit-flip toggle — data preserved, not freed, with its own MVCC snapshot isolation independent of the component's StorageMode. | ✅ Implemented | 🔵 Core | [→](Ecs/entity-lifecycle-crud/enable-disable-components.md) |
+| Storage Modes | Pick durability and write cost per component type — from microsecond ACID to nanosecond scratch memory, in one engine. | ✅ Implemented | 🟢 Start Here | [→](Ecs/storage-modes/README.md) |
+| &nbsp;&nbsp;↳ Versioned | Full MVCC snapshot isolation and zero-loss durability for data that can never be lost or read torn. | ✅ Implemented | 🟢 Start Here | [→](Ecs/storage-modes/storage-mode-versioned.md) |
+| &nbsp;&nbsp;↳ SingleVersion (Tick-Fence Durable) | In-place writes at near-zero cost, durable to the last completed game tick. | ✅ Implemented | 🔵 Core | [→](Ecs/storage-modes/storage-mode-singleversion.md) |
+| &nbsp;&nbsp;↳ Transient (Heap-Only) | Heap-only component storage for scratch data that should never touch disk. | ✅ Implemented | 🔵 Core | [→](Ecs/storage-modes/storage-mode-transient.md) |
+| &nbsp;&nbsp;↳ Committed Durability Discipline | Zero-loss, atomic commits on the SingleVersion layout — without paying for a Versioned revision chain. | ✅ Implemented | 🟣 Advanced | [→](Ecs/storage-modes/storage-mode-committed.md) |
+| Query System (EcsQuery) | Three-tier constraint evaluation with planner-chosen broad or targeted scan, indexed predicates, FK joins, and spatial filters. | ✅ Implemented | 🟢 Start Here | [→](Ecs/query-system.md) |
+| Reactive Views (EcsView) | Persistent, incrementally-maintained query results that refresh in microseconds instead of re-scanning every tick. | 🚧 Partial | 🔵 Core | [→](Ecs/reactive-views.md) |
+| Entity Relationships | Typed EntityLink\<T\> references plus declarative cascade delete and reactive FK joins. | ✅ Implemented | 🔵 Core | [→](Ecs/entity-relationships.md) |
+| Component Collections | Per-entity variable-length lists — owned data or entity-reference lists — without breaking fixed-size component layout. | ✅ Implemented | 🔵 Core | [→](Ecs/component-collections.md) |
+| Schema Versioning & Migration | Detects struct/archetype layout drift at database open and migrates data automatically or via your own functions. | 🚧 Partial | 🔵 Core | [→](Ecs/schema-versioning-migration.md) |
+| Entity Clusters (Batched SoA Storage) | GPU-inspired batched SoA storage that turns per-entity hashmap/page lookups into sequential array scans. | ✅ Implemented | 🟣 Advanced | [→](Ecs/entity-clusters.md) |
+
+### Indexing
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Secondary Index Storage Modes | An indexed field is either unique or AllowMultiple; the choice drives the on-disk value representation and which mutation API path is used. | ✅ Implemented | 🔵 Core | [→](Indexing/secondary-index-storage-modes/README.md) |
+| &nbsp;&nbsp;↳ Unique (Single-Value) Secondary Index | One key maps to exactly one entity — the B+Tree value is a chunk-id directly, no buffer indirection. | ✅ Implemented | 🔵 Core | [→](Indexing/secondary-index-storage-modes/unique-secondary-index.md) |
+| &nbsp;&nbsp;↳ Multi-Value Secondary Index (AllowMultiple) | Many entities share one key — the B+Tree value is a growable HEAD buffer of chunk-ids, at a fixed +4-byte-per-entity cost. | ✅ Implemented | 🔵 Core | [→](Indexing/secondary-index-storage-modes/multi-value-secondary-index.md) |
+| Lookup and Range-Scan Operations | Lock-free point lookups and ordered range scans over any secondary index, MVCC-correct at your transaction's snapshot. | ✅ Implemented | 🔵 Core | [→](Indexing/lookup-and-range-scan.md) |
+| Index Handle Resolution (IndexRef) | Opaque, zero-allocation handle to a PK or secondary index, resolved once on the cold path via GetPKIndexRef/GetIndexRef and reused on the hot path with O(1) schema-evolution staleness checks. | ✅ Implemented | 🟣 Advanced | [→](Indexing/index-ref-resolution.md) |
+| Versioned (HEAD/TAIL) Secondary Indexes for MVCC | AllowMultiple indexes maintain a HEAD buffer (current set) plus an append-only TAIL of version transitions so index membership stays correct across updates and deletes. | ✅ Implemented | 🟣 Advanced | [→](Indexing/versioned-secondary-indexes.md) |
+| Transaction-Local Index Overlay (Read-Your-Own-Writes) | Planned per-transaction overlay so index lookups see that transaction's own uncommitted writes. | 📋 Planned | 🟣 Advanced | [→](Indexing/transaction-local-index-overlay.md) |
+
+### Spatial
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Spatial Architecture Overview | Explains how the per-component R-Tree and the engine-wide spatial grid are two independent mechanisms, and which feature to read next. | ✅ Implemented | 🟢 Start Here | [→](Spatial/spatial-architecture-overview.md) |
+| Field Attribute & Schema Integration | Declare a component field as spatially indexed via [SpatialIndex], validated against schema rules at registration time. | ✅ Implemented | 🔵 Core | [→](Spatial/spatial-field-attribute/README.md) |
+| &nbsp;&nbsp;↳ Storage-Mode Compatibility (SingleVersion / Versioned) | The same [SpatialIndex] field works on both storage modes -- only when the tree catches up differs. | ✅ Implemented | 🔵 Core | [→](Spatial/spatial-field-attribute/spatial-storage-mode-compat.md) |
+| Spatial Query API (AABB / Radius / Ray / Frustum / kNN / Count) | Query entry points over the per-component R-Tree: engine-internal SpatialQuery\<T\> plus the public fluent EcsQuery WhereNearby/WhereInAABB/WhereRay. | ✅ Implemented | 🔵 Core | [→](Spatial/spatial-query-api.md) |
+| Spatial Grid Configuration & Tier Control | Engine-wide grid sizing plus the per-cell SimTier control surface for multi-resolution simulation. | ✅ Implemented | 🔵 Core | [→](Spatial/spatial-grid-config.md) |
+| Static / Dynamic Tree Separation | A spatial field lands in one of two independent trees -- tick-fence-exempt static, or fat-AABB-maintained dynamic -- chosen once at schema time. | ✅ Implemented | 🟣 Advanced | [→](Spatial/spatial-rtree-index/spatial-rtree-static-dynamic.md) |
+| Fat-AABB Incremental Update | Margin-enlarged bounds absorb small moves for ~25ns, with no tree mutation. | ✅ Implemented | 🟣 Advanced | [→](Spatial/fat-aabb-update.md) |
+| Category Filtering | Bitmask pruning skips whole subtrees and clusters before geometry tests -- AND-conjunctive at the R-Tree, any-bit-overlap at the cluster broadphase. | ✅ Implemented | 🟣 Advanced | [→](Spatial/spatial-category-filtering.md) |
+| Spatially-Coherent Entity Clustering | Every entity in a cluster shares one grid cell, so spatial bookkeeping is per-cluster, not per-entity. | ✅ Implemented | 🟣 Advanced | [→](Spatial/spatial-coherent-clustering.md) |
+| Tiered Simulation Dispatch | One simulation tier per spatial cell, four dispatch frequencies, zero per-entity distance checks. | ✅ Implemented | 🟣 Advanced | [→](Spatial/tiered-simulation-dispatch.md) |
+| Checkerboard Dispatch | Opt-in two-phase Red/Black cluster partitioning for systems that write across cell boundaries, dispatched as one DAG node with two internal phases. | ✅ Implemented | 🟣 Advanced | [→](Spatial/checkerboard-dispatch.md) |
+
+> Note: Static/Dynamic Tree Separation is a sub-feature of the (Internal) Spatial R-Tree Index — see the [Internal](#internal--engine-internals-for-contributors) section below for the tree itself.
+
+### Querying
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Fluent Query API & Predicate Parsing | Archetype-rooted fluent builder that parses C# lambdas into index-driven plans, with structural/enabled-bit constraints, OR disjunction, and FK navigation joins. | ✅ Implemented | 🟢 Start Here | [→](Querying/fluent-query-api/README.md) |
+| &nbsp;&nbsp;↳ Indexed Field Predicates (WhereField) | Expression-parsed predicate that drives a targeted B+Tree scan and powers incrementally-maintained reactive views. | ✅ Implemented | 🔵 Core | [→](Querying/fluent-query-api/wherefield-indexed-predicate.md) |
+| &nbsp;&nbsp;↳ Opaque Post-Filter Predicates (Where) | Arbitrary per-entity C# delegate evaluated after a broad archetype scan, for logic the index system can't express. | ✅ Implemented | 🟢 Start Here | [→](Querying/fluent-query-api/where-opaque-postfilter.md) |
+| &nbsp;&nbsp;↳ OR Disjunction (DNF Predicates) | `\|\|` in a WhereField predicate, normalized to Disjunctive Normal Form and evaluated as independent branches. | ✅ Implemented | 🟣 Advanced | [→](Querying/fluent-query-api/or-disjunction.md) |
+| &nbsp;&nbsp;↳ Foreign-Key Navigation Joins (L4) | Join across an entity-reference field — filter source entities by predicates on the target entity they point to. | ✅ Implemented | 🟣 Advanced | [→](Querying/fluent-query-api/fk-navigation-joins.md) |
+| Result Ordering & Pagination | Sorted, paged query results driven directly off a B+Tree index scan — no full-scan-then-sort. | ✅ Implemented | 🔵 Core | [→](Querying/ordering-pagination.md) |
+| Persistent Views — Incremental Refresh & Delta Tracking | TSN-anchored persistent Views (ToView()) refreshed via lock-free MPSC ring-buffer change capture at commit time, exposing Added/Removed/Modified deltas. | 🚧 Partial | 🔵 Core | [→](Querying/persistent-views.md) |
+| Spatial Query Predicates | R-Tree-backed AABB, radius, and ray filters attached directly to a fluent ECS query. | ✅ Implemented | 🟣 Advanced | [→](Querying/spatial-predicates.md) |
+| Execution Planning & Pipeline Execution | Picks the most selective index as the scan driver and streams results into the caller's collection. | ✅ Implemented | 🟣 Advanced | [→](Querying/execution-planning-pipeline.md) |
+| Statistics Infrastructure (HLL / MCV / Histogram) | Background-maintained per-field statistics feeding the selectivity estimator, refreshed by a tunable polling worker thread. | ✅ Implemented | 🟣 Advanced | [→](Querying/statistics-infrastructure.md) |
+| ViewFactory — Parameterized Queries & View Pooling | Reusable query templates with a Rent/Return view pool, to remove per-session view setup cost. | 📋 Planned | 🟣 Advanced | [→](Querying/view-factory-pooling.md) |
+| Temporal Queries (Point-in-Time Read & Revision History) | Opt-in per-component history retention enabling reads of past state and full revision timelines. | 📋 Planned | 🟣 Advanced | [→](Querying/temporal-queries.md) |
+
+### Transactions
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Unit of Work (durability boundary) | Middle tier of the three-tier API hierarchy — batches Transactions under a single flush/durability boundary, owning the shared ChangeSet, deadline, and UoW identity. | ✅ Implemented | 🟢 Start Here | [→](Transactions/unit-of-work.md) |
+| Durability Modes (Deferred / GroupCommit / Immediate) | Per-UoW control of WAL flush timing — trade commit latency for the data-at-risk window on crash. | ✅ Implemented | 🟢 Start Here | [→](Transactions/durability-modes/README.md) |
+| &nbsp;&nbsp;↳ Per-Transaction Durability Override | Escalate one critical operation to zero-loss durability without raising the durability mode of the surrounding batch. | ✅ Implemented | 🟣 Advanced | [→](Transactions/durability-modes/durability-override-escalation.md) |
+| Transaction Creation Patterns | Three ways to obtain a Transaction — explicit UoW + CreateTransaction, single-shot quick transaction, or UoW-less read-only snapshot transaction. | ✅ Implemented | 🟢 Start Here | [→](Transactions/transaction-creation-patterns/README.md) |
+| &nbsp;&nbsp;↳ Standard (UnitOfWork + CreateTransaction) | Open a UnitOfWork once and draw as many transactions from it as a batch needs, sharing one durability/flush boundary. | ✅ Implemented | 🟢 Start Here | [→](Transactions/transaction-creation-patterns/transaction-creation-standard.md) |
+| &nbsp;&nbsp;↳ CreateQuickTransaction (single-shot, auto-dispose) | One call fuses a UnitOfWork and its one Transaction into a single disposable for single-shot writes. | ✅ Implemented | 🟢 Start Here | [→](Transactions/transaction-creation-patterns/transaction-creation-quick.md) |
+| &nbsp;&nbsp;↳ CreateReadOnlyTransaction (snapshot reads) | A Transaction with no UnitOfWork, UoW ID, or ChangeSet at all, for pure-read MVCC-snapshot workloads. | ✅ Implemented | 🔵 Core | [→](Transactions/transaction-creation-patterns/transaction-creation-readonly.md) |
+| SingleVersion Durability Discipline (TickFence / Commit) | Per-transaction knob, orthogonal to DurabilityMode, that picks how a SingleVersion write becomes durable. | ✅ Implemented | 🔵 Core | [→](Transactions/durability-discipline/README.md) |
+| &nbsp;&nbsp;↳ TickFence Discipline (Default) | The default, lowest-cost SingleVersion write — durable at the next tick fence, not at commit. | ✅ Implemented | 🔵 Core | [→](Transactions/durability-discipline/durability-discipline-tickfence.md) |
+| &nbsp;&nbsp;↳ Commit Discipline (Variant-A Staging) | Atomic, zero-loss SingleVersion writes — durable and visible together at Commit(), with no revision chain. | ✅ Implemented | 🟣 Advanced | [→](Transactions/durability-discipline/durability-discipline-commit.md) |
+| Commit / Rollback Pipeline (ACID Commit Path) | Transaction.Commit/Rollback overloads implementing the append-before-publish commit pipeline with atomic conflict resolution and always-completing rollback. | ✅ Implemented | 🔵 Core | [→](Transactions/commit-rollback-pipeline.md) |
+| Optimistic Concurrency Conflict Resolution | Pluggable ConcurrencyConflictHandler invoked per conflicting entity during commit, exposing four data views via ConcurrencyConflictSolver; default with no handler is last-writer-wins. | ✅ Implemented | 🔵 Core | [→](Transactions/optimistic-conflict-resolution.md) |
+| Deadline & Cooperative Cancellation | An absolute deadline rides every transaction commit, propagating through every lock and aborting cleanly only before work starts. | ✅ Implemented | 🔵 Core | [→](Transactions/deadline-cancellation.md) |
+| UoW Identity & Crash-Safe Recovery Boundary | Each UoW gets a 15-bit ID from a persistent, back-pressured UowRegistry; on crash, still-Pending UoW IDs are voided so their revisions become instantly invisible with no replay. | ✅ Implemented | 🟣 Advanced | [→](Transactions/uow-identity-crash-recovery.md) |
+| Transaction Lifecycle, Thread Affinity & Pooling | Transaction is single-thread-affine with a fail-fast state machine; TransactionChain provides lock-free CAS-based creation, exclusive-lock removal, 16-instance pooling, and MinTSN tracking for MVCC garbage collection. | ✅ Implemented | 🟣 Advanced | [→](Transactions/transaction-lifecycle-pooling.md) |
+| Bulk Load Session | Opt-in, exclusive write path that batches writes through a recycled Transaction and commits the whole load atomically via a checkpoint barrier. | ✅ Implemented | 🟣 Advanced | [→](Transactions/bulk-load-session.md) |
+
+### Subscriptions
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Published Views | Register a query View as a subscribable target via TyphonRuntime.PublishView, as either one shared instance for all clients or a per-client factory. | ✅ Implemented | 🟢 Start Here | [→](Subscriptions/published-views/README.md) |
+| &nbsp;&nbsp;↳ Shared Views | One View instance, refreshed and diffed once per tick, fanned out to every subscriber. | ✅ Implemented | 🔵 Core | [→](Subscriptions/published-views/shared-views.md) |
+| &nbsp;&nbsp;↳ Per-Client Views | A Func\<ClientContext, ViewBase\> that builds a fresh, parameterized View for each subscriber. | ✅ Implemented | 🔵 Core | [→](Subscriptions/published-views/per-client-views.md) |
+| Subscription Management (SetSubscriptions) | Atomic, idempotent, diff-based API to set a client's full subscription list each tick. | ✅ Implemented | 🟢 Start Here | [→](Subscriptions/subscription-management/README.md) |
+| &nbsp;&nbsp;↳ Server-Driven Subscriptions (v1) | Game code calls SetSubscriptions whenever game state changes; the runtime applies the diff-based transition on the next tick. | ✅ Implemented | 🔵 Core | [→](Subscriptions/subscription-management/subscription-server-driven.md) |
+| &nbsp;&nbsp;↳ Client-Initiated Subscriptions (v2) | Clients request their own subscription changes via an OnClientSubscriptionRequest callback, validated server-side before being applied. | 📋 Planned | 🟣 Advanced | [→](Subscriptions/subscription-management/subscription-client-initiated.md) |
+| Client Connections & Lifecycle | TCP listener thread accepts sockets and assigns each a ConnectionId; ClientContext is the only handle game code touches. | ✅ Implemented | 🔵 Core | [→](Subscriptions/client-connections.md) |
+| Per-Tick Delta Computation & Encoding | After WriteTickFence, the Output phase diffs published Views into Added/Removed/Modified and encodes only the changed component bytes. | ✅ Implemented | 🔵 Core | [→](Subscriptions/delta-computation/README.md) |
+| &nbsp;&nbsp;↳ Component-Level Dirty Encoding (v1) | Modified entities send full bytes for each component whose chunk was dirty this tick; unchanged components are omitted. | ✅ Implemented | 🔵 Core | [→](Subscriptions/delta-computation/delta-encoding-component-dirty.md) |
+| &nbsp;&nbsp;↳ Per-Field Dirty Encoding (v1.1) | Planned output-phase field diffing to shrink Modified payloads to only the bytes of fields that actually changed. | 📋 Planned | 🟣 Advanced | [→](Subscriptions/delta-computation/delta-encoding-per-field-dirty.md) |
+| Subscription Server Configuration | Tunable knobs for the TCP subscription listener: port, max clients, send buffer capacity, backpressure threshold, sync batch size, ring buffer capacity. | ✅ Implemented | 🔵 Core | [→](Subscriptions/server-configuration.md) |
+| Reference C# Client SDK | Typhon.Client connects over TCP, decodes TickDeltaMessages, and maintains a per-View local entity cache that application code reads directly. | ✅ Implemented | 🔵 Core | [→](Subscriptions/reference-client-sdk.md) |
+| Published/System-Input View Separation Guard | Runtime throws if a published View doubles as a system input (or vice versa), since the View's MPSC delta ring buffer can only have one consumer. | ✅ Implemented | 🟣 Advanced | [→](Subscriptions/published-view-isolation.md) |
+| TCP Transport & Wire Format | One length-prefixed, MemoryPack-serialized TickDeltaMessage per client per tick over TCP_NODELAY. | ✅ Implemented | 🟣 Advanced | [→](Subscriptions/wire-transport.md) |
+| Incremental Sync | New subscriptions to large Views sync in tick-sized batches instead of one giant first delta. | ✅ Implemented | 🟣 Advanced | [→](Subscriptions/incremental-sync.md) |
+| Backpressure & Resync Recovery | A full client send buffer drops one tick's delta and triggers an automatic full-state resync — never an unbounded queue. | ✅ Implemented | 🟣 Advanced | [→](Subscriptions/backpressure-resync.md) |
+| Subscription Priority & Overload Throttling | Critical/Normal/Low priority per published View; under overload Normal/Low Views are throttled while Critical Views always go out. | ✅ Implemented | 🟣 Advanced | [→](Subscriptions/priority-overload-throttling.md) |
+| Subscription Telemetry & Tracing | Per-tick OutputPhaseMs/DeltasPushed/OverflowCount counters plus a live per-tick Output-phase trace span. | 🚧 Partial | 🟣 Advanced | [→](Subscriptions/subscription-telemetry.md) |
+
+### Runtime
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Tick-Based Execution Engine | TyphonRuntime — the top-level host that owns the tick loop, creates one UoW per tick and one Transaction per system automatically, and drives startup/crash-recovery/shutdown. | ✅ Implemented | 🔵 Core | [→](Runtime/tick-execution-engine/README.md) |
+| &nbsp;&nbsp;↳ Execution Modes | Today: a fixed-timestep tick loop plus a single-threaded debug variant; event-driven and hybrid request/response modes are designed but not yet built. | 🚧 Partial | 🟣 Advanced | [→](Runtime/tick-execution-engine/execution-modes.md) |
+| &nbsp;&nbsp;↳ Worker Pool & Threading Model | Core allocation between a dedicated tick-metronome thread and a worker pool that executes the system DAG in parallel. | ✅ Implemented | 🟣 Advanced | [→](Runtime/tick-execution-engine/worker-pool-threading.md) |
+| &nbsp;&nbsp;↳ Parallel Tick Fence | Spreads the post-tick WriteTickFence step (cluster migrations, AABB refresh, WAL publish) across the worker pool instead of running it on one thread. | ✅ Implemented | 🟣 Advanced | [→](Runtime/tick-execution-engine/parallel-tick-fence.md) |
+| System Types | Five system base classes a developer picks per piece of game logic — proactive callbacks, reactive entity queries, chunk-parallel non-entity work, multi-stage pipelines, and sub-system grouping. | ✅ Implemented | 🔵 Core | [→](Runtime/system-types/README.md) |
+| &nbsp;&nbsp;↳ CallbackSystem | Proactive system that runs every tick for non-entity work — timers, input draining, global state. | ✅ Implemented | 🔵 Core | [→](Runtime/system-types/callback-system.md) |
+| &nbsp;&nbsp;↳ QuerySystem | Reactive per-entity system that auto-skips when nothing relevant changed, with optional automatic multi-core chunking. | ✅ Implemented | 🔵 Core | [→](Runtime/system-types/query-system.md) |
+| &nbsp;&nbsp;↳ ChunkedCallbackSystem | Fan a CallbackSystem's body out across N workers for SIMD sweeps, reductions, and other non-entity chunkable work. | ✅ Implemented | 🟣 Advanced | [→](Runtime/system-types/chunked-callback-system.md) |
+| &nbsp;&nbsp;↳ PipelineSystem | Reactive multi-stage gather/process/scatter system for bulk entity processing — full execution model pending Patate. | Implemented (chunk-dispatch only) | 🟣 Advanced | [→](Runtime/system-types/pipeline-system.md) |
+| &nbsp;&nbsp;↳ CompoundSystem | Group related sub-systems' registration under one Configure call — one node from the outside, parallel inside. | ✅ Implemented | 🟣 Advanced | [→](Runtime/system-types/compound-system.md) |
+| Declarative System Scheduling (Track → DAG → Phase, Auto-DAG) | Systems declare per-component read/write access and a DAG-local phase; the scheduler auto-derives execution edges and rejects unsafe write/write or stale-read conflicts at Build(). | ✅ Implemented | 🔵 Core | [→](Runtime/declarative-system-scheduling.md) |
+| Parallel Entity Processing (QuerySystem.Parallel) | Automatic multi-core chunking with a reusable PointInTimeAccessor (no per-chunk Transaction for non-Versioned writes) across four dispatch paths selected by Versioned-write × change-filter. | ✅ Implemented | 🟣 Advanced | [→](Runtime/parallel-entity-processing.md) |
+| Reactive Dispatch: Change Filters & Run Conditions | changeFilter limits a system's entity set to dirty ∪ Added by piggybacking on the View's ring buffer; shouldRun gives a zero-cost proactive skip predicate evaluated before any input work. | ✅ Implemented | 🟣 Advanced | [→](Runtime/reactive-dispatch-change-filters.md) |
+| Typed Event Queues | Single-producer ring-buffer queues for inter-system signalling within a tick, enabling reactive cascade chains that early-out cheaply when dormant. | ✅ Implemented | 🟣 Advanced | [→](Runtime/typed-event-queues.md) |
+| Side-Transactions for Immediate Durability | Per-tick CreateSideTransaction(Immediate) lets a system commit economy-critical writes durably mid-tick, independent of and invisible to the main tick UoW's snapshot. | ✅ Implemented | 🟣 Advanced | [→](Runtime/side-transactions.md) |
+| Overload Management | Single-writer overload state machine that escalates/de-escalates through system throttling and tick-rate modulation (TiDi, up to 6x) and fires a critical-overload callback for game-decided player shedding. | 🚧 Partial | 🟣 Advanced | [→](Runtime/overload-management.md) |
+| Telemetry & Runtime Inspection | Always-on, zero-allocation ring buffer of per-tick/per-system telemetry inspectable from game code; a pluggable IRuntimeInspector hook for remote tooling is designed but not implemented. | 🚧 Partial | 🟣 Advanced | [→](Runtime/telemetry-runtime-inspection.md) |
+| Spatial Tiers & Adaptive Dispatch | Per-cluster simulation tiers let systems process near entities every tick and far entities at reduced/amortized/dormant rates, scoping dispatch automatically to the matching clusters. | ✅ Implemented | 🟣 Advanced | [→](Runtime/spatial-tiers-adaptive-dispatch/README.md) |
+| &nbsp;&nbsp;↳ Tier-Filtered & Amortized Dispatch | Scope a system to clusters in matching tier cells, and optionally process just 1/N of them per tick. | ✅ Implemented | 🟣 Advanced | [→](Runtime/spatial-tiers-adaptive-dispatch/tier-filtered-amortized-dispatch.md) |
+| &nbsp;&nbsp;↳ Cluster Dormancy (Sleep/Wake) | Clusters untouched for N ticks sleep and are skipped by every dispatch path, waking within one tick of being written to. | ✅ Implemented | 🟣 Advanced | [→](Runtime/spatial-tiers-adaptive-dispatch/cluster-dormancy.md) |
+| &nbsp;&nbsp;↳ Checkerboard (Red/Black) Dispatch | Two-phase Red/Black parallel dispatch so neighbor-touching systems never race across a cell boundary. | ✅ Implemented | 🟣 Advanced | [→](Runtime/spatial-tiers-adaptive-dispatch/checkerboard-dispatch.md) |
+| Data-Driven Timers / Scheduled Entities | Documented pattern for modeling respawns/expiries as entities with a time-of-expiry component and a CallbackSystem poll; no built-in timer/scheduling infrastructure exists yet. | 📋 Planned | 🟣 Advanced | [→](Runtime/data-driven-timers.md) |
+| Declarative Scheduling — Auto-DAG (RFC 07) | Directory-form restructuring of Declarative System Scheduling (above) into two sub-pages; exists on disk but was never linked from this table until now — see the flagging note below. | ✅ Implemented | 🟣 Advanced | [→](Runtime/declarative-scheduling/README.md) |
+| &nbsp;&nbsp;↳ Track → DAG → Phase Partitioning | Tracks order coarse execution stages, DAGs group independent dependency graphs, phases order systems within one DAG. | ✅ Implemented | 🟣 Advanced | [→](Runtime/declarative-scheduling/track-dag-phase-partitioning.md) |
+| &nbsp;&nbsp;↳ Access Declarations & Build-Time Conflict Detection | Reads/Writes/ReadsFresh/ReadsSnapshot declare what a system touches; Build() derives safe ordering and rejects unsafe overlaps. | ✅ Implemented | 🟣 Advanced | [→](Runtime/declarative-scheduling/access-conflict-detection.md) |
+| Tick Lifecycle & Transaction Management | Restructures content already covered above by Side-Transactions and the tick loop's Parallel Tick Fence into its own directory; exists on disk but was never linked from this table until now — see the flagging note below. | ✅ Implemented | 🟣 Advanced | [→](Runtime/tick-lifecycle/README.md) |
+| &nbsp;&nbsp;↳ Side-Transactions (Immediate Durability) | A transaction you open and commit from inside a tick system that becomes durable on its own, independent of whether the tick's main UoW ever flushes. | ✅ Implemented | 🟣 Advanced | [→](Runtime/tick-lifecycle/side-transactions.md) |
+| &nbsp;&nbsp;↳ Parallel Tick Fence (WriteTickFence) | Spreads the post-tick WriteTickFence step across the worker pool instead of running it serially on one thread. | ✅ Implemented | 🟣 Advanced | [→](Runtime/tick-lifecycle/parallel-tick-fence.md) |
+
+> Flagging note: the last two entries (Declarative Scheduling — Auto-DAG, Tick Lifecycle & Transaction Management) are directory-form restructurings that duplicate content already covered earlier in this table (Declarative System Scheduling; Side-Transactions + Parallel Tick Fence). They exist as real, unlinked doc pages under `Runtime/`; listed here for completeness per the source data, but they likely need consolidating with — or retiring in favor of — their originals rather than living on as permanent duplicates.
+
+### Resources
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Resource Budget Configuration (ResourceOptions) | Startup-time configuration of fixed/growable resource limits (page cache size, max active transactions, WAL ring/segment sizing, shadow buffer, checkpoint thresholds) plus Validate() to check fixed allocations fit the total memory budget. | ✅ Implemented | 🔵 Core | [→](Resources/resource-budgets-options.md) |
+| Exhaustion Policy & ResourceExhaustedException | Typed exception for resource-limit hits; ExhaustionPolicy enum documents intent but isn't a runtime dispatch switch. | 🚧 Partial | 🔵 Core | [→](Resources/exhaustion-policy-handling.md) |
+| DI Registration & Wiring | Register Typhon services into IServiceCollection and have each one self-attach to the resource graph. | ✅ Implemented | 🔵 Core | [→](Resources/resources-di-wiring.md) |
+| Observability Bridge (Resources to OTel/Health/Alerts) | Consumer-side mapping of resource snapshots to OpenTelemetry metrics, health-check thresholds, and alert payloads. | 🚧 Partial | 🟣 Advanced | [→](Resources/observability-bridge-resources.md) |
+
+### Observability
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Telemetry Configuration & Gating | Hierarchical, JSON/env-var-driven static-readonly bool surface (~200 flags) that the JIT dead-code-eliminates when off, gating both Activity tracing and the typed-event Profiler with zero overhead when disabled. | ✅ Implemented | 🟢 Start Here | [→](Observability/telemetry-config-gating.md) |
+| Distributed Tracing (Activity API) | Centralized ActivitySource and OTel-semantic attribute constants for correlating Typhon with a host's own OTLP trace. | 🚧 Partial | 🔵 Core | [→](Observability/distributed-tracing.md) |
+| OpenTelemetry Metrics Export | Observable-pattern OTel Meter exporters that snapshot internal state and expose it as gauges/counters for Prometheus/OTLP scraping. | 🚧 Partial | 🔵 Core | [→](Observability/otel-metrics-export/README.md) |
+| &nbsp;&nbsp;↳ Resource Graph Metrics Bridge | Every Resource System node exposed as a standard OTel Meter for Prometheus/OTLP scraping. | 🚧 Partial | 🟣 Advanced | [→](Observability/otel-metrics-export/resource-graph-metrics-bridge.md) |
+| &nbsp;&nbsp;↳ ECS Metrics Exporter | Per-archetype EntityMap health and per-component-type transient memory as zero-cost OTel gauges. | 🚧 Partial | 🟣 Advanced | [→](Observability/otel-metrics-export/ecs-metrics-exporter.md) |
+| Resource-Aware Health Checks | Framework-agnostic ITyphonHealthCheck (Healthy/Degraded/Unhealthy worst-of-composite) backed by ResourceHealthChecker. | ✅ Implemented | 🔵 Core | [→](Observability/health-checks.md) |
+| Per-Domain Named Metrics Catalog | Documented target list of ~40 fixed-name OTel instruments (typhon.tx.*, typhon.wal.*, typhon.lock.*...) across 8 domains. | 📋 Planned | 🟣 Advanced | [→](Observability/per-domain-metrics-catalog.md) |
+| Threshold-Based Resource Alerting | ResourceAlertGenerator raises Warning/Critical ResourceAlerts on health-state transitions, tracing root cause via a hardcoded wait-dependency graph. | ✅ Implemented | 🟣 Advanced | [→](Observability/threshold-alerting.md) |
+
+### Errors
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| TyphonException Hierarchy & Catalog | Base TyphonException (ErrorCode + virtual IsTransient) rooted hierarchy giving callers three catch granularities, with a living catalog of every concrete exception type and a caller-owns-retry philosophy. | ✅ Implemented | 🔵 Core | [→](Errors/exception-hierarchy.md) |
+| IsTransient Retry Hint | A virtual IsTransient flag on every TyphonException hinting whether a retry might succeed, without the engine ever retrying on the caller's behalf. | ✅ Implemented | 🔵 Core | [→](Errors/transience-hint.md) |
+| Timeout Exceptions & Deadline Propagation | Configurable, finite deadlines (TimeoutOptions, WaitContext) replace infinite-wait lock primitives, converting hangs into typed TyphonTimeoutException subclasses plus a bulk-load checkpoint timeout. | ✅ Implemented | 🔵 Core | [→](Errors/timeout-exceptions-deadlines.md) |
+| Error Code Classification | A numeric TyphonErrorCode per failure, grouped into subsystem ranges (1xxx-8xxx) for logging/metrics dashboards — the exception type, not the code, is what callers catch on. | ✅ Implemented | 🟣 Advanced | [→](Errors/error-codes.md) |
+| Resource Exhaustion Handling | ExhaustionPolicy metadata (FailFast/Wait/Evict/Degrade) documents how the engine reacts when a bounded resource is full — FailFast throws a structured ResourceExhaustedException (IsTransient=true), Wait resources throw a bounded TyphonTimeoutException subclass, never an unbounded hang or InvalidOperationException. | ✅ Implemented | 🟣 Advanced | [→](Errors/resource-exhaustion-handling.md) |
+| Storage & Corruption Exceptions | Typed failures for storage I/O, CRC32C page corruption (unhealable), and another-process database-file-lock detection. | ✅ Implemented | 🟣 Advanced | [→](Errors/storage-corruption-exceptions.md) |
+| Durability (WAL / BulkLoad / Commit) Exceptions | Typed, fail-fast failures from the WAL writer, the commit pipeline's durability wait, and BulkLoad session lifecycle. | ✅ Implemented | 🟣 Advanced | [→](Errors/durability-exceptions.md) |
+| Schema & Constraint Violation Exceptions | Engine-refuses-to-proceed failures for the data model: breaking schema mismatch, migration failure, revision downgrade, duplicate unique key. | ✅ Implemented | 🟣 Advanced | [→](Errors/schema-constraint-exceptions.md) |
+| Runtime/Scheduler Declared-Access Validation | DEBUG-only InvalidAccessException when a system writes a component it never declared via Writes\<T\>()/SideWrites\<T\>(), compiled out in RELEASE. | ✅ Implemented | 🟣 Advanced | [→](Errors/runtime-access-validation.md) |
+
+### Profiler
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| Profiler Session Lifecycle & Zero-Code Bootstrap | TyphonProfiler.Start/Stop (idempotent) manage the consumer/exporter threads and process-exit safety net; ProfilerBootstrap self-wires the whole session from typhon.telemetry.json + TyphonRuntime.Create with no host orchestration required. | ✅ Implemented | 🟢 Start Here | [→](Profiler/profiler-lifecycle-bootstrap.md) |
+| Trace Export | IProfilerExporter fan-out: each attached exporter gets its own OS thread and bounded queue (drop-newest on backpressure, refcounted batches); file and live-TCP sinks cover offline post-mortem and real-time attach. | ✅ Implemented | 🔵 Core | [→](Profiler/trace-export/README.md) |
+| &nbsp;&nbsp;↳ File-Based Trace Export (.typhon-trace) | Write the whole session to a versioned binary file for offline post-mortem analysis in the Workbench. | ✅ Implemented | 🔵 Core | [→](Profiler/trace-export/file-trace-export.md) |
+| &nbsp;&nbsp;↳ Live TCP Streaming Export | Stream a running session over TCP so the Workbench can watch a process tick-by-tick, right now. | ✅ Implemented | 🔵 Core | [→](Profiler/trace-export/live-tcp-trace-export.md) |
+| Configuration & Performance Tuning | typhon.telemetry.json / TYPHON__PROFILER__* env overrides drive independent static-readonly-bool gates per subsystem (JIT-eliminated when off); ProfilerOptions documents the consumer/drain tunables. | ✅ Implemented | 🔵 Core | [→](Profiler/profiler-configuration-tuning.md) |
+| Per-Tick Gauge/Metric Snapshots | One packed record per tick exposes memory, page-cache, WAL, and transaction counters to the trace viewer. | ✅ Implemented | 🔵 Core | [→](Profiler/gauge-snapshots.md) |
+| Custom Application-Defined Spans | Reserved wire-format span kind (NamedSpan, ID 246) for app-defined span names — read/replay support exists, but no producer factory exists in TyphonEvent yet. | 📋 Planned | 🟣 Advanced | [→](Profiler/custom-named-spans.md) |
+| GC Event Tracing | See every .NET garbage collection and EE-suspension pause on the same timeline as your transactions. | ✅ Implemented | 🟣 Advanced | [→](Profiler/gc-event-tracing.md) |
+| Unmanaged Memory Allocation Tracing | See every native (unmanaged) allocation and free on the profiler timeline, tagged by subsystem. | 🚧 Partial | 🟣 Advanced | [→](Profiler/unmanaged-allocation-tracing.md) |
+| Off-CPU Thread Scheduling Capture (Windows) | EtwSchedulingPump emits one ThreadContextSwitch record per closed on-CPU slice via the NT Kernel Logger, showing when and why Typhon threads left the CPU. | ✅ Implemented | 🟣 Advanced | [→](Profiler/offcpu-thread-scheduling.md) |
+| Integrated CPU Sampling (Statistical Call Tree) | In-process EventPipe SampleProfiler captures call stacks for the session, embedded as a trailer section and rendered as a dotTrace-style Call Tree. | ✅ Implemented | 🟣 Advanced | [→](Profiler/cpu-sampling-calltree.md) |
+| Query Definition & Execution Export | Captures every View/EcsQuery's structural definition once per session plus per-execution args and call sites, correlated to the existing query span chain. | 🚧 Partial | 🟣 Advanced | [→](Profiler/query-definition-export.md) |
+| Domain-Specific Tracing Instrumentation Expansion | Two-tier compile-time gated tracing rollout across nine engine domains (Concurrency, Storage, Memory, Data, Query, ECS, Spatial, Scheduler/Runtime, Durability, Subscriptions), zero cost when off. | 🚧 Partial | 🟣 Advanced | [→](Profiler/domain-tracing-expansion.md) |
+
+### Hosting
+
+| Feature | Summary | Status | Level | Link |
+|---|---|---|---|---|
+| DI Engine Bootstrap Chain | Add*() extension methods on IServiceCollection that register and wire the engine's top-level singletons into a working DatabaseEngine. | ✅ Implemented | 🟢 Start Here | [→](Hosting/di-bootstrap-chain/README.md) |
+| &nbsp;&nbsp;↳ Singleton/Scoped/Transient Lifetime Variants | Every Add* with a lifetime choice ships as Add.../AddScoped.../AddTransient... twins sharing one factory delegate. | ✅ Implemented | 🔵 Core | [→](Hosting/di-bootstrap-chain/lifetime-variants.md) |
+| Engine Options Configuration Surface | IOptions\<T\>-based configuration for engine services, set via configure delegates on each Add*() DI call. | ✅ Implemented | 🔵 Core | [→](Hosting/engine-options-configuration/README.md) |
+| &nbsp;&nbsp;↳ Options Validation Hooks | AddOptions\<T\>().Validate(...) is wired on every options type but its predicate is a no-op stub today; ResourceOptions.Validate()/PagedMMFOptions.IsValid are the real, directly-callable fail-fast checks. | 🚧 Partial | 🟣 Advanced | [→](Hosting/engine-options-configuration/options-validation-stubs.md) |
+| Clean-Slate Database File Deletion | EnsureFileDeleted\<TO\>(IServiceProvider) resolves IOptions\<TO\> in a fresh scope and deletes the backing database file it points at. | ✅ Implemented | 🔵 Core | [→](Hosting/ensure-file-deleted.md) |
+| Profiler Launch Override Hook | AddTyphonProfiler(Func\<ProfilerLaunchConfig,ProfilerLaunchConfig\>) lets a host adjust the profiler launch config in code without giving up zero-code defaults. | ✅ Implemented | 🟣 Advanced | [→](Hosting/profiler-launch-override-hook.md) |
+
+## Internal — Engine Internals (for Contributors)
+
+Every Internal feature, one line each — engine machinery with no direct application-facing API. Sub-features are indented under their parent with `↳`. Categories with no Internal-tagged features (Ecs, Querying, Transactions, Subscriptions, Runtime, Observability) are omitted below.
+
+### Foundation
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Reader-Writer & Resource Lifecycle Locks | CAS-only, allocation-free spin-locks every concurrent engine structure embeds for shared/exclusive or lifecycle access. | ✅ Implemented | [→](Foundation/access-control-lock-family/README.md) |
+| &nbsp;&nbsp;↳ AccessControl (full-featured RW lock) | 64-bit reader-writer lock with waiter fairness, in-place promotion, and contention tracking. | ✅ Implemented | [→](Foundation/access-control-lock-family/access-control.md) |
+| &nbsp;&nbsp;↳ AccessControlSmall (compact RW lock) | 32-bit reader-writer lock for thousands of embedded per-node/per-page latches with short critical sections. | ✅ Implemented | [→](Foundation/access-control-lock-family/access-control-small.md) |
+| &nbsp;&nbsp;↳ ResourceAccessControl (3-mode lifecycle lock) | 32-bit Accessing/Modify/Destroy lock where structural growth doesn't block concurrent readers. | ✅ Implemented | [→](Foundation/access-control-lock-family/resource-access-control.md) |
+| Epoch-Based Resource Protection | Lock-free epoch/grace-period scheme that protects in-flight page-cache pages from eviction with 2 obligations per transaction instead of per-page ref-counting. | ✅ Implemented | [→](Foundation/epoch-based-resource-protection.md) |
+| High-Resolution Timers | Self-calibrating sub-millisecond periodic timer services (three-phase Sleep→Yield→Spin wait, drift-free metronome scheduling) used for the deadline watchdog, telemetry flush, and epoch advancement, exposing per-tick jitter metrics. | ✅ Implemented | [→](Foundation/high-resolution-timers/README.md) |
+| &nbsp;&nbsp;↳ Dedicated Timer (HighResolutionTimerService) | A single periodic callback on its own thread, isolated from every other timer in the engine. | ✅ Implemented | [→](Foundation/high-resolution-timers/dedicated-timer.md) |
+| &nbsp;&nbsp;↳ Shared Timer (HighResolutionSharedTimerService) | One thread multiplexing many periodic callbacks, each at its own rate, waking only when the soonest one is due. | ✅ Implemented | [→](Foundation/high-resolution-timers/shared-timer.md) |
+| In-Memory Hash Maps | Open-addressing, pinned-memory hash set/map types with backward-shift deletion and JIT-specialized hashing that replace .NET HashSet/Dictionary/ConcurrentDictionary on hot paths. | ✅ Implemented | [→](Foundation/in-memory-hash-maps/README.md) |
+| &nbsp;&nbsp;↳ Non-Concurrent HashMap\<TKey[, TValue]\> | Single-threaded open-addressing hash set/map replacing HashSet/Dictionary on a hot path, zero per-entry GC pressure. | ✅ Implemented | [→](Foundation/in-memory-hash-maps/non-concurrent-hash-map.md) |
+| &nbsp;&nbsp;↳ ConcurrentHashMap\<TKey[, TValue]\> | Striped, lock-free-read hash set/map replacing ConcurrentDictionary on a shared hot path, per-stripe CAS writes. | ✅ Implemented | [→](Foundation/in-memory-hash-maps/concurrent-hash-map.md) |
+| Page-Backed Linear Hash Map | O(1) exact-match key/value index, persisted in fixed-size chunks, with crash-safe rebuild instead of WAL logging. | ✅ Implemented | [→](Foundation/paged-linear-hash-map.md) |
+| Memory Allocators | Pinned/unmanaged memory primitives that give every page cache, segment, and hash-map structure stable, GC-immune addresses with parent-owned leak tracking. | ✅ Implemented | [→](Foundation/memory-allocators.md) |
+| Concurrent Bitmaps & Collections | Lock-free/CAS-guarded occupancy bitmaps (flat and 3-level) plus a pick/putback slot array for high-contention tracking. | ✅ Implemented | [→](Foundation/concurrent-bitmaps-collections.md) |
+| Hardware-Accelerated CRC32C Checksums | SSE4.2/ARM-intrinsic CRC32C (Castagnoli polynomial) computation with software-table fallback (~1.3µs per 8KB page) — the checksum primitive backing every page-integrity check in storage and durability. | ✅ Implemented | [→](Foundation/crc32c-checksums.md) |
+
+### Storage
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Epoch-Based Page Protection & Dirty-Page Tracking | Epoch-tagged eviction safety plus the ChangeSet/DirtyCounter/ActiveChunkWriters/SlotRefCount protocol that pins modified or pointer-referenced pages until checkpoint write-back. | ✅ Implemented | [→](Storage/epoch-dirty-tracking.md) |
+| Page Allocation & Occupancy Tracking | A 3-level bitmap that allocates and tracks every 8 KiB page in the database file, growing the file automatically as needed. | ✅ Implemented | [→](Storage/page-allocation-occupancy.md) |
+| Segment & Chunk-Based Allocation Engine | Multi-page directories and fixed-size slot allocation — the substrate every component, index, and revision chain is built from. | ✅ Implemented | [→](Storage/segment-chunk-allocation.md) |
+| Pluggable Storage Backend (Persistent vs Transient) | One set of segment/index code, JIT-specialized per backend, so Transient components get heap speed for free. | ✅ Implemented | [→](Storage/pluggable-storage-backend/README.md) |
+| &nbsp;&nbsp;↳ Persistent Store (MMF-backed) | The default backend — every durable component's segments run through the memory-mapped page cache at zero abstraction cost. | ✅ Implemented | [→](Storage/pluggable-storage-backend/persistent-store.md) |
+| String Table Storage | UTF-8 string storage spread across linked fixed-size chunks, for strings too long to hold inline. | ✅ Implemented | [→](Storage/string-table.md) |
+
+> Note: Transient Store (heap-backed), the other child of Pluggable Storage Backend, is Public — see the [Public](#public--what-you-can-use) section above.
+
+### Durability
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| A/B Protected-Page Slot-Pairing | Doublewrite-free torn-write protection for the meta page and segment-directory pages that crash recovery can't re-derive. | ✅ Implemented | [→](Durability/checkpoint-v2/protected-page-pairing.md) |
+| Rebuild of Derived Structures | Indexes, EntityMap, and occupancy are never repaired after a crash — they're discarded and rebuilt wholesale from the recovered primary data. | ✅ Implemented | [→](Durability/crash-recovery/rebuild-derived-structures.md) |
+| Formal Proofs & Invariant Rules | Durability correctness is gated on falsifiable artifacts — invariant rules, TLA+ specs, and a crash-simulation sweep — enforced in CI. | ✅ Implemented | [→](Durability/correctness-proofs.md) |
+
+> Note: A/B Protected-Page Slot-Pairing and Rebuild of Derived Structures are sub-features of Checkpoint v2 and Crash Recovery respectively — both Public parents, listed in the [Public](#public--what-you-can-use) section above.
+
+### Schema
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| tsh Schema Shell Commands | Typhon Shell commands (schema-fields, schema-diff, schema-validate, schema-history, schema-export) exposing persisted-vs-runtime schema comparison and inspection as an interactive CLI on top of the engine schema APIs. | ✅ Implemented | [→](Schema/tsh-schema-commands.md) |
+| System Schema Persistence | Self-referential storage of component/field metadata as engine-internal ECS entities (ComponentR1/FieldR1) inside the database itself, loaded/saved via a minimal single-threaded CRUD layer (no MVCC/WAL) at engine open/create. | ✅ Implemented | [→](Schema/system-schema-persistence.md) |
+| Workbench Per-Session Schema Loading & ALC Reload | Loads schema DLLs into a per-session collectible ALC so Workbench sessions can rebuild/swap binaries without restarting the host, classifying engine schema exceptions into Ready/MigrationRequired/Incompatible and rebinding component IDs by schema name across reloads. | ✅ Implemented | [→](Schema/workbench-schema-loading.md) |
+| Component Family Classification | Classifies a component into a semantic family (Spatial/Combat/AI/Inventory/Rendering/Networking/Input/Misc) via explicit attribute or name heuristic, for stable Workbench Data Flow grouping. | ✅ Implemented | [→](Schema/component-family-classification.md) |
+
+### Revision
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Chain Walk Correctness Under Compaction | The visibility walk scans the whole chain instead of breaking on the first too-new entry, because background GC compaction can reorder entries without changing their TSNs. | ✅ Implemented | [→](Revision/mvcc-visibility-walk.md) |
+| Revision Chain Storage | Per-entity, per-component circular-buffer chunk chain holding every live revision of a Versioned component, allocated on first write and grown on demand. | ✅ Implemented | [→](Revision/revision-chain-storage.md) |
+| Crash-Recovery Chain Scrub & Orphan Sweep | Post-crash recovery step that collapses every Versioned chain to its single committed HEAD and frees unreachable revision-table chunks, guaranteeing pre-crash MVCC history never survives into the recovered base. | ✅ Implemented | [→](Revision/crash-recovery-chain-scrub.md) |
+
+> Note: Chain Walk Correctness Under Compaction is a sub-feature of MVCC Snapshot Visibility, a Public parent listed in the [Public](#public--what-you-can-use) section above.
+
+### Indexing
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Specialized B+Tree Key-Size Variants | Four key-width-specialized B+Tree implementations (16/32/64-bit and String64), automatically selected by an indexed field's CLR type. | ✅ Implemented | [→](Indexing/btree-key-variants.md) |
+| Compound Move/MoveValue (field-update fast path) | Atomic remove+insert for indexed-field updates — one traversal, one lock on the common same-leaf case. | ✅ Implemented | [→](Indexing/compound-move-operations.md) |
+| Temporal (Point-in-Time) Index Query | Reconstructs which entities held a key's value at a past TSN by replaying the index's append-only TAIL history. | 🚧 Partial | [→](Indexing/temporal-index-query.md) |
+| TAIL Retention / Garbage Collection | Bounds TAIL version-history growth via boundary-sentinel-preserving pruning — built and tested, not yet auto-triggered. | 🚧 Partial | [→](Indexing/tail-garbage-collection.md) |
+| Optimistic Lock Coupling (per-node concurrency) | Per-node OLC version latches give lock-free optimistic readers and leaf-only write latching for B+Tree/R-Tree index operations. | ✅ Implemented | [→](Indexing/olc-concurrency.md) |
+| Index Diagnostics & Consistency Checking | Always-on per-instance contention counters plus an on-demand tsh structural walk to diagnose B+Tree contention and validate integrity. | ✅ Implemented | [→](Indexing/btree-diagnostics.md) |
+| B+Tree Node Layout and Capacity Tuning | Cache-line-aware 256-byte B+Tree node layout with per-key-type capacities, tuned through a multi-phase profiling effort. | ✅ Implemented | [→](Indexing/btree-node-layout-tuning.md) |
+| Batched Index Maintenance for Bulk Commits | Commit-path rework that batches secondary-index updates per commit; accessor-reuse has shipped, sorted-key application has not. | 🚧 Partial | [→](Indexing/batched-index-maintenance.md) |
+
+### Spatial
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Spatial R-Tree Index | Page-backed R-Tree attached to a component field, giving sub-microsecond AABB/radius/ray queries shared across every archetype that uses it. | ✅ Implemented | [→](Spatial/spatial-rtree-index/README.md) |
+| Trigger Volumes (Enter / Leave / Stay) | Region entities diffed against the spatial tree(s) each cycle to emit Enter/Leave/Stay events at a configurable per-region frequency. | ✅ Implemented | [→](Spatial/spatial-trigger-volumes.md) |
+| Interest Management (Delta Spatial Queries) | Per-observer "what changed near me" delta queries via an archived dirty-bitmap ring buffer, with full-sync fallback for stale observers. | 🚧 Partial | [→](Spatial/spatial-interest-management.md) |
+| Cluster Spatial Queries | Per-cell broadphase + per-entity narrowphase AABB/Radius queries for cluster-eligible archetypes. | 🚧 Partial | [→](Spatial/cluster-spatial-queries.md) |
+| Cluster Dormancy (Sleep / Wake) | Clusters with no component writes for N ticks sleep and skip dispatch entirely, waking within one tick of being touched. | ✅ Implemented | [→](Spatial/cluster-dormancy.md) |
+
+> Note: Static / Dynamic Tree Separation, the only child of Spatial R-Tree Index, is Public — see the [Public](#public--what-you-can-use) section above.
+
+### Resources
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Resource Tree & Registry | Hierarchical, fail-fast tree of every managed resource (8 fixed subsystem branches under Root) with cascade disposal and path-based navigation. | ✅ Implemented | [→](Resources/resource-tree-registry.md) |
+| Resource Tree Mutation Notifications | NodeMutated event fires on every Added/Removed registration so consumers (e.g. Workbench live tree view) can react without polling. | ✅ Implemented | [→](Resources/resource-tree-mutation-notifications.md) |
+| Metric Reporting (IMetricSource / IMetricWriter) | Pull-based, zero-allocation interface for resources to expose 5 metric kinds — Memory, Capacity, DiskIO, Throughput, Duration — read by the graph on snapshot, not pushed on the hot path. | ✅ Implemented | [→](Resources/metric-reporting.md) |
+| Owner-Aggregates Granularity Strategy | Architectural rule for what becomes a resource-tree node vs. what owning components aggregate and report on its behalf. | ✅ Implemented | [→](Resources/owner-aggregates-granularity.md) |
+| Debug Properties Drill-Down (IDebugPropertiesProvider) | Ad-hoc, allocation-tolerant dictionary of diagnostic key/value pairs for per-resource drill-down that's too verbose for the structured metric writer. | ✅ Implemented | [→](Resources/debug-properties-drilldown.md) |
+| Snapshot & Query API | On-demand, consistent-enough tree-wide snapshot (IResourceGraph.GetSnapshot) with query helpers — GetSubtreeMemory, FindMostUtilized, FindByType, GetSubtree, GetNode — plus auto-computed throughput rates from the previous snapshot. | ✅ Implemented | [→](Resources/snapshot-query-api/README.md) |
+| &nbsp;&nbsp;↳ Root-Cause Cascade Analysis (FindRootCause) | Trace a high-utilization symptom node back through a known dependency chain to find what's actually backed up. | ✅ Implemented | [→](Resources/snapshot-query-api/root-cause-cascade-analysis.md) |
+
+### Errors
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Result\<TValue,TStatus\> Hot-Path Result Type | Zero-allocation dual-generic result struct for hot-path lookups that expect a miss — no exceptions, no boxing, no branch on access; used internally by B+Tree/MVCC hot paths, not surfaced through Transaction/Query call sites. | ✅ Implemented | [→](Errors/result-type.md) |
+
+### Profiler
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Typed-Event Capture Pipeline | Any-thread ~25-50ns ref-struct span/instant emission into per-thread SPSC ring buffers, drained by a dedicated timestamp-sorting consumer thread; zero allocation, JIT-eliminated when disabled. | ✅ Implemented | [→](Profiler/typed-event-capture-pipeline.md) |
+| Built-in Engine Instrumentation Catalog | Automatic, no-app-code-required span/instant coverage of Scheduler, Transactions, ECS, B+Tree, Page Cache, WAL, Checkpoint, Statistics and Cluster Migration — 37+ wire-stable event kinds decoded by a shared TraceEventDecoder. | ✅ Implemented | [→](Profiler/builtin-subsystem-instrumentation.md) |
+| Span Source Attribution (Go-to-Source) | Every span optionally carries a compile-time-deterministic source location for one-click editor handoff and inline preview in the Workbench. | ✅ Implemented | [→](Profiler/source-attribution.md) |
+| Lock-Contention Forensics (Deep Diagnostics) | Post-mortem visibility into which threads waited on which locks, for how long, and why. | 📋 Planned | [→](Profiler/lock-contention-diagnostics.md) |
+
+### Hosting
+
+| Feature | Summary | Status | Link |
+|---|---|---|---|
+| Pluggable WAL I/O Backend (IWalFileIO seam) | AddDatabaseEngine resolves an optional internal IWalFileIO from the container so tests/benchmarks run the full WAL + checkpoint pipeline with zero disk I/O; the interface and implementations are internal, unreachable from application code. | ✅ Implemented | [→](Hosting/wal-io-injection-seam.md) |
+
+## See also
+
+This catalog favors practical orientation over deep internals: what a feature does, why it exists, and how to use it (Public), or just enough of how it fits together to orient a contributor (Internal). For other angles on the same engine:
+
+- [`doc/in-depth-overview/`](../in-depth-overview/README.md) — implementation-level walkthroughs of engine internals (struct layouts, algorithms), organized to mirror `src/Typhon.Engine/`'s folder structure.
+- [`doc/guide/`](../guide/README.md) — a hands-on, task-oriented tutorial for building an application on Typhon end to end, without engine internals.

--- a/doc/feature-set/Resources/README.md
+++ b/doc/feature-set/Resources/README.md
@@ -1,0 +1,27 @@
+# Resources
+> A runtime resource graph that tracks every significant engine resource (storage, transactions, durability, allocation, synchronization, timers, runtime, profiler) in a fixed 8-branch hierarchical tree, lets components report metrics/budgets/debug detail through a handful of pull-based interfaces, and exposes point-in-time snapshots with query and root-cause helpers for diagnostics, monitoring, and exhaustion handling.
+
+> 🔬 **Recommended:** read [in-depth-overview/13-resources.md](../../in-depth-overview/13-resources.md) (Chapter 13: Resources) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Resource Budget Configuration (ResourceOptions)](resource-budgets-options.md) | Startup-time configuration of fixed/growable resource limits (page cache size, max active transactions, WAL ring/segment sizing, shadow buffer, checkpoint thresholds) plus `Validate()` to check fixed allocations fit the total memory budget | ✅ Implemented | 🔵 Core |
+| [Exhaustion Policy & ResourceExhaustedException](exhaustion-policy-handling.md) | Typed exception for resource-limit hits; `ExhaustionPolicy` enum documents intent but isn't a runtime dispatch switch | 🚧 Partial | 🔵 Core |
+| [DI Registration & Wiring](resources-di-wiring.md) | Register Typhon services into `IServiceCollection` and have each one self-attach to the resource graph | ✅ Implemented | 🔵 Core |
+| [Observability Bridge (Resources to OTel/Health/Alerts)](observability-bridge-resources.md) | Consumer-side mapping of resource snapshots to OpenTelemetry metrics, health-check thresholds, and alert payloads | 🚧 Partial | 🟣 Advanced |
+
+## Internal Features
+
+> Engine machinery for contributors — the resource graph's own plumbing (tree structure, metric/debug reporting interfaces, and the raw snapshot/query surface) that the public features above are built on. Application code doesn't call these directly; Typhon's own tooling (Workbench, tsh) does.
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Resource Tree & Registry](resource-tree-registry.md) | Hierarchical, fail-fast tree of every managed resource (8 fixed subsystem branches under Root) with cascade disposal and path-based navigation | ✅ Implemented |
+| [Resource Tree Mutation Notifications](resource-tree-mutation-notifications.md) | `NodeMutated` event fires on every Added/Removed registration so consumers (e.g. Workbench live tree view) can react without polling | ✅ Implemented |
+| [Metric Reporting (IMetricSource / IMetricWriter)](metric-reporting.md) | Pull-based, zero-allocation interface for resources to expose 5 metric kinds — Memory, Capacity, DiskIO, Throughput, Duration — read by the graph on snapshot, not pushed on the hot path | ✅ Implemented |
+| [Owner-Aggregates Granularity Strategy](owner-aggregates-granularity.md) | Architectural rule for what becomes a resource-tree node vs. what owning components aggregate and report on its behalf | ✅ Implemented |
+| [Debug Properties Drill-Down (IDebugPropertiesProvider)](debug-properties-drilldown.md) | Ad-hoc, allocation-tolerant dictionary of diagnostic key/value pairs for per-resource drill-down that's too verbose for the structured metric writer | ✅ Implemented |
+| [Snapshot & Query API](snapshot-query-api/README.md) | On-demand, consistent-enough tree-wide snapshot (`IResourceGraph.GetSnapshot`) with query helpers — `GetSubtreeMemory`, `FindMostUtilized`, `FindByType`, `GetSubtree`, `GetNode` — plus auto-computed throughput rates from the previous snapshot | ✅ Implemented |
+| &nbsp;&nbsp;↳ [Root-Cause Cascade Analysis (FindRootCause)](snapshot-query-api/root-cause-cascade-analysis.md) | Trace a high-utilization symptom node back through a known dependency chain to find what's actually backed up | ✅ Implemented |

--- a/doc/feature-set/Resources/debug-properties-drilldown.md
+++ b/doc/feature-set/Resources/debug-properties-drilldown.md
@@ -1,0 +1,82 @@
+# Debug Properties Drill-Down (IDebugPropertiesProvider)
+> An ad-hoc, allocation-tolerant key/value dictionary for per-resource diagnostic drill-down.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+
+`IMetricSource` is deliberately narrow — five fixed kinds (Memory, Capacity, DiskIO, Throughput,
+Duration), zero-allocation, read on every snapshot. That shape is right for dashboards and alerts,
+but wrong for "why is *this specific* `ComponentTable` behaving oddly?" questions: per-segment
+chunk counts, page-cache state histograms, schema names, transaction-chain TSNs — detail that's
+too verbose, too shaped-per-type, or too rarely needed to justify a dedicated metric field.
+`IDebugPropertiesProvider` gives any resource a second, looser channel for exactly that detail,
+without growing the structured metric surface or the resource tree itself.
+
+## ⚙️ How it works (in brief)
+
+Any `IResource` may additionally implement `IDebugPropertiesProvider` with one method,
+`GetDebugProperties()`, returning `IReadOnlyDictionary<string, object>`. Unlike `ReadMetrics`,
+this call is allowed to allocate — it's invoked on demand for diagnostics, not on every snapshot
+tick. Keys follow a `Container.Field` dot-convention (e.g. `ComponentSegment.AllocatedChunks`,
+`Contention.MaxWaitUs`); values are primitives or types with meaningful `ToString()`. It is also
+the documented surface for the "Owner Aggregates" pattern: fine-grained primitives that don't get
+their own graph node (segments, latches, banks) report their per-instance breakdown here, while
+their owner reports only the aggregate via `IMetricSource`.
+
+## 💻 Usage
+
+```csharp
+var ct = dbe.GetComponentTable<Player>();
+
+// Direct call on a typed reference
+foreach (var (key, value) in ct.GetDebugProperties())
+{
+    Console.WriteLine($"{key} = {value}");
+}
+// StorageMode = Versioned
+// ComponentSegment.AllocatedChunks = 4096
+// ComponentSegment.Capacity = 8192
+// CompRevTableSegment.AllocatedChunks = 4096
+// DefaultIndexSegment.AllocatedChunks = 256
+// ...
+
+// Or drill into any node reached via the resource tree, without holding a typed reference
+var node = resourceGraph.FindByPath("Storage/ManagedPagedMMF");
+if (node is IDebugPropertiesProvider provider)
+{
+    var props = provider.GetDebugProperties();
+    // PageCache.FreeCount, PageCache.DirtyCount, ClockSweep.MinCounter, Segments.Count, ...
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Optional interface** — most `IResource` types don't implement it; check with
+  `is IDebugPropertiesProvider` before calling on an arbitrary node, or call directly on a known
+  type.
+- **May allocate** — a new `Dictionary<string, object>` per call, including boxing for value
+  types. Not for hot paths or per-tick polling; call on demand for debugging/diagnostics.
+- **No cross-key snapshot consistency** — unlike `IMetricSource.ReadMetrics` (one coherent call
+  per node during a tree walk), `GetDebugProperties()` reads live state directly; individual
+  entries may be momentarily inconsistent with each other under concurrent mutation.
+- **Lock-free by convention, not enforced** — implementations are expected to avoid taking locks
+  so a debug read can't itself become a contention source, but the interface doesn't require it.
+- **No tree-wide snapshot helper ships today** — there is no built-in walker that collects
+  `GetDebugProperties()` across every node; call it per node yourself (directly, or after an
+  `is IDebugPropertiesProvider` check while walking `IResource.Children`).
+- Currently implemented on `ComponentTable`, `ManagedPagedMMF`, `DatabaseEngine`,
+  `TransactionChain`, `MemoryAllocator`, `ConcurrentBitmapL3All`, `PinnedMemoryBlock`,
+  `MemoryBlockArray`, `MemoryBlockBase`, and `StagingBufferPool`.
+
+## 🧪 Tests
+- [OwnerAggregatesTests](../../../test/Typhon.Engine.Tests/Resources/OwnerAggregatesTests.cs) — `ComponentTable.GetDebugProperties()`
+  per-segment breakdown (`ComponentSegment.*`, `CompRevTableSegment.*`, `DefaultIndexSegment.*`, `String64IndexSegment.*` when present),
+  values match live segment state after entity creation
+
+## 🔗 Related
+
+- Source: [`IDebugPropertiesProvider.cs`](../../../src/Typhon.Engine/Resources/public/IDebugPropertiesProvider.cs)
+- Related: [Metric Reporting](./metric-reporting.md) — the structured, zero-allocation counterpart this complements.
+
+<!-- Deep dive: claude/design/Resources/09-resource-observability-implementations.md, claude/design/Resources/05-granularity-strategy.md -->

--- a/doc/feature-set/Resources/exhaustion-policy-handling.md
+++ b/doc/feature-set/Resources/exhaustion-policy-handling.md
@@ -1,0 +1,86 @@
+# Exhaustion Policy & ResourceExhaustedException
+> A typed exception for bounded resources hitting their limit, plus policy metadata that documents — but does not yet drive — the response.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+
+Bounded resources (transaction slots, epoch registry slots, growable segments) eventually run out.
+Applications need a single, typed way to detect "this resource is full" and decide whether to
+retry, back off, or surface an error — instead of catching generic exceptions or timeouts and
+guessing at the cause. `ResourceExhaustedException` is that signal: it names the resource, its
+current usage, and its limit, so callers can react programmatically rather than by parsing a
+message string.
+
+## ⚙️ How it works (in brief)
+
+Each `ResourceNode` records an `ExhaustionPolicy` (`None`, `FailFast`, `Wait`, `Evict`, `Degrade`)
+at construction, describing how that component is *supposed* to behave when full. Today this is
+**diagnostic metadata only** — nothing reads it to dispatch behavior. The actual FailFast paths are
+hand-coded independently at each call site: UoW ID allocation (`UowRegistry.AllocateUowId`),
+segment growth (`ChunkBasedSegment.AllocateChunk`/`AllocateChunks`), and the epoch thread registry
+all throw `ResourceExhaustedException` directly when they hit capacity. Wait/Evict/Degrade
+components (page cache, WAL staging buffers, transaction pooling) implement the described behavior
+in their own code, not through the enum. Treat `ExhaustionPolicy` as documentation you can read off
+a node, not a switch you can hook.
+
+## 💻 Usage
+
+```csharp
+using Typhon.Engine;
+
+try
+{
+    var uowId = uowRegistry.AllocateUowId(); // FailFast: throws if no slot is free
+}
+catch (ResourceExhaustedException ex)
+{
+    // ex.ResourcePath   -> "Execution/UowRegistry/AllocateUowId"
+    // ex.CurrentUsage / ex.Limit / ex.Utilization
+    if (ex.IsTransient)
+    {
+        // Safe to retry after a short backoff — slots free up as other UoWs finish.
+    }
+}
+
+// The deadline-bounded overload waits instead of failing immediately, then throws
+// ResourceExhaustedException only once the deadline expires:
+var wc = WaitContext.FromTimeout(TimeSpan.FromMilliseconds(50));
+var uowId2 = uowRegistry.AllocateUowId(ref wc);
+
+// ExhaustionPolicy is inspectable but purely informational:
+var node = (ResourceNode)registry.FindByPath("Root/Durability/StagingBufferPool");
+Console.WriteLine(node.ExhaustionPolicy); // ExhaustionPolicy.Wait — describes intent, not enforced by this property
+```
+
+## ⚠️ Guarantees & limits
+
+- `ResourceExhaustedException.IsTransient` is always `true` — the resource may self-heal (a slot
+  frees up, a pool drains); callers should treat it as retryable, not fatal.
+- Confirmed FailFast throw sites today: `UowRegistry.AllocateUowId` (with and without a deadline),
+  `ChunkBasedSegment.AllocateChunk`/`AllocateChunks` (segment at max capacity), and the epoch
+  thread registry (`ThrowHelper.ThrowEpochRegistryExhausted`).
+- `ExhaustionPolicy` on `ResourceNode` is **not** enforced anywhere — setting it, or reading it back,
+  has no runtime effect. Don't build logic that branches on a node's `ExhaustionPolicy`; it will not
+  match actual behavior for every component and may not be updated when a component's real strategy
+  changes.
+- `ResourceType`, `CurrentUsage`, and `Limit` are populated by the call site, not derived — a bug at
+  the throw site (e.g. stale usage count) is not caught by the exception type itself.
+- Not all Wait/Evict/Degrade components surface `ResourceExhaustedException` on their slow path —
+  some report exhaustion as a timeout or a boolean return instead; check the specific component's
+  API before assuming a uniform exception contract engine-wide.
+
+## 🧪 Tests
+- [ResourceOptionsTests](../../../test/Typhon.Engine.Tests/Resources/ResourceOptionsTests.cs) — `ExhaustionPolicy` enum values,
+  `ResourceExhaustedException` construction/utilization/message formatting
+- [ExhaustionPolicyTests](../../../test/Typhon.Engine.Tests/Errors/ExhaustionPolicyTests.cs) — real FailFast enforcement at
+  `TransactionPool.CreateTransaction` and `ChunkBasedSegment.AllocateChunk`/`AllocateChunks`, `ResourceNode.ExhaustionPolicy` metadata
+
+## 🔗 Related
+
+- Sibling: [Resource Budget Configuration](./resource-budgets-options.md) — the limits whose exhaustion this feature signals.
+- Sibling: [Resource Exhaustion Handling](../Errors/resource-exhaustion-handling.md) — the application-facing policy enforcement built on this signal (cross-category).
+
+<!-- Deep dive: claude/design/Resources/07-budgets-exhaustion.md -->
+<!-- Design: claude/design/Errors/03-exhaustion-policy.md -->
+<!-- Overview: claude/overview/08-resources.md §on ExhaustionPolicy (D12) -->

--- a/doc/feature-set/Resources/metric-reporting.md
+++ b/doc/feature-set/Resources/metric-reporting.md
@@ -1,0 +1,98 @@
+# Metric Reporting (IMetricSource / IMetricWriter)
+> Zero-cost-until-asked metric collection for every significant engine resource.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+Diagnosing capacity problems, sizing budgets, and wiring OpenTelemetry export all need numeric
+visibility into engine internals — memory used, slots free, I/O volume, op rates, latencies. A
+push/event-based instrumentation model would tax every hot-path operation even when nobody is
+watching. Applications need a way to ask "what's the current state of this resource?" without
+paying for it between asks.
+
+## ⚙️ How it works (in brief)
+Resources with measurable state implement `IMetricSource` alongside their place in the resource
+tree. They maintain plain fields (counters, gauges) as a side effect of normal operation — no
+locks, no `Interlocked` for single-writer counters. When a snapshot is requested, the resource
+graph walks the tree and calls `ReadMetrics(writer)` once per node; the node writes whichever of
+the five metric kinds (Memory, Capacity, DiskIO, Throughput, Duration) are relevant to it. Reads
+are approximate (no synchronization) and per-node atomic only. Fine-grained primitives — latches,
+chunks, segments — are not graph nodes; their owning component aggregates and reports on their
+behalf (Owner Aggregates pattern), keeping the tree at ~50-300 nodes regardless of entity count.
+
+## 💻 Usage
+```csharp
+using Typhon.Engine;
+
+// Implementing IMetricSource on a custom resource node
+public class MyCache : ResourceNode, IMetricSource
+{
+    private long _hits;
+    private long _misses;
+    private long _usedSlots;
+    private readonly long _totalSlots;
+    private long _peakBytes;
+    private long _currentBytes;
+
+    public void ReadMetrics(IMetricWriter writer)
+    {
+        writer.WriteMemory(_currentBytes, _peakBytes);
+        writer.WriteCapacity(_usedSlots, _totalSlots);
+        writer.WriteThroughput(MetricNames.CacheHits, _hits);
+        writer.WriteThroughput(MetricNames.CacheMisses, _misses);
+    }
+
+    public void ResetPeaks() => _peakBytes = _currentBytes;
+}
+
+// Reading a snapshot (e.g. periodic monitoring or a health check)
+ResourceSnapshot snapshot = resourceGraph.GetSnapshot();
+NodeSnapshot pageCache = snapshot.GetNode("Root/Storage/PageCache"); // Nodes[] keys include the "Root/" prefix
+if (pageCache?.Capacity is { } capacity)
+{
+    Console.WriteLine($"PageCache utilization: {capacity.Utilization:P1}");
+}
+foreach (var t in pageCache.Throughput)
+{
+    Console.WriteLine($"{t.Name}: {t.Count}");
+}
+
+resourceGraph.ResetAllPeaks(); // start a new peak-measurement window
+```
+
+| Metric kind | Reports | Typical source |
+|---|---|---|
+| Memory | `AllocatedBytes`, `PeakBytes` | Allocators, caches, buffers |
+| Capacity | `Current`, `Maximum` (`Utilization` derived) | Pools, segments, bitmaps |
+| DiskIO | `ReadOps`/`WriteOps`/`ReadBytes`/`WriteBytes` | PageCache, WAL, checkpoint |
+| Throughput | named `Count` | Hits/misses, commits, inserts |
+| Duration | named `LastUs`/`AvgUs`/`MaxUs` | Flush, checkpoint, commit |
+
+## ⚠️ Guarantees & limits
+- Zero hot-path cost: fields are updated with plain writes (or `Interlocked` only where
+  multi-writer); the read side only runs when a snapshot is taken.
+- `ReadMetrics` targets < 100 ns per node and must not allocate, lock, or call other sources —
+  recursion is handled by the graph during tree walk.
+- Snapshot consistency is per-node atomic, cross-node approximate (nodes are read microseconds
+  apart); a full snapshot over 50-100 nodes costs roughly 2.5-5 μs.
+- `WriteThroughput`/`WriteDuration` names must be static strings (use `MetricNames` constants) —
+  this is a documented convention, not runtime-enforced.
+- High-water marks (`PeakBytes`, `MaxUs`) use plain check-and-write; an occasional lost update
+  under a race is accepted as a diagnostic-grade trade-off.
+- Not every resource implements `IMetricSource` — pure grouping nodes ("Root", "Storage") report
+  nothing of their own; subtree totals are computed by the snapshot query API.
+- Latches, chunks, segments, and other sub-500-instance primitives never become graph nodes — look
+  for their numbers aggregated on the owning `ComponentTable`/cache/allocator instead.
+
+## 🧪 Tests
+- [MetricSourceTests](../../../test/Typhon.Engine.Tests/Resources/MetricSourceTests.cs) — `IMetricWriter`/`IMetricSource` contract,
+  partial-metrics reporting, `GetMetricSources` tree walk (self-inclusion, skipping non-sources, from-root traversal)
+- [MetricTypesTests](../../../test/Typhon.Engine.Tests/Resources/MetricTypesTests.cs) — the 5 metric-kind value types
+  (Memory/Capacity/DiskIO/Throughput/Duration), `CapacityMetrics.Utilization` edge cases, `MetricNames` constants
+
+## 🔗 Related
+- Sibling: [Debug Properties Drill-Down](./debug-properties-drilldown.md) — the allocation-tolerant counterpart for ad-hoc diagnostic detail.
+- Sibling: [Snapshot & Query API](./snapshot-query-api/README.md) — freezes these metrics into a point-in-time snapshot for querying.
+
+<!-- Deep dive: claude/design/Resources/03-metric-source.md, claude/design/Resources/04-metric-kinds.md, claude/design/Resources/05-granularity-strategy.md -->
+<!-- Decision record: claude/adr/032-resource-system-architecture.md (see partial-supersession note — IMetricWriter ships with 5 methods; contention flows through IContentionTarget instead) -->

--- a/doc/feature-set/Resources/observability-bridge-resources.md
+++ b/doc/feature-set/Resources/observability-bridge-resources.md
@@ -1,0 +1,97 @@
+# Observability Bridge (Resources to OTel/Health/Alerts)
+> Turns resource-graph snapshots into OpenTelemetry metrics, a health status, and threshold alerts.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+Monitoring stacks (Prometheus/Grafana, Kubernetes probes, PagerDuty/Slack) don't want to talk to
+the resource graph directly — they want standard metrics, a health enum, and alert payloads with a
+root cause already attached. The Observability Bridge is that adapter layer: it reads
+`ResourceSnapshot`s on a timer and republishes them in the three shapes external tooling expects,
+so applications don't hand-roll polling loops around `IResourceGraph`.
+
+## ⚙️ How it works (in brief)
+The bridge is a pure **consumer** of the resource graph — it owns no counters and defines no tree
+structure, it only reads what components already report. A `ResourceMetricsExporter` snapshots the
+graph on an interval and exposes every metric kind (Memory, Capacity, DiskIO, Throughput, Duration)
+as `System.Diagnostics.Metrics` observable instruments tagged with `resource_path`, so any OTel
+exporter you attach (Prometheus, OTLP, dotnet-counters) picks them up for free. A
+`ResourceHealthChecker` derives a `Healthy`/`Degraded`/`Unhealthy` status from `Capacity.Utilization`
+against per-path thresholds, using a worst-of-all-nodes rule. A `ResourceAlertGenerator` turns a
+threshold breach into a `ResourceAlert` with a root-cause path found via `FindRootCause`. A
+`ResourceMetricsService` wires the three together on one timer and raises events on status
+transitions.
+
+## 💻 Usage
+```csharp
+using Typhon.Engine;
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddSingleton<IResourceGraph>(existingResourceGraph);
+
+services.AddTyphonObservabilityBridge(options =>
+{
+    options.SnapshotInterval = TimeSpan.FromSeconds(1);
+    options.Thresholds["Durability/WALRingBuffer"] = new HealthThresholds(0.60, 0.80);
+});
+
+var provider = services.BuildServiceProvider();
+
+// OTel export: attach any exporter to ResourceMetricsExporter.MeterName ("Typhon.Resources").
+var exporter = provider.GetRequiredService<ResourceMetricsExporter>();
+
+// Health: cheap poll for a liveness probe, or a detailed result for a dashboard.
+ITyphonHealthCheck health = provider.GetRequiredService<ITyphonHealthCheck>();
+HealthStatus status = health.CheckHealth();
+HealthCheckResult detail = health.GetDetailedResult();
+Console.WriteLine($"{detail.Status}: {detail.Description}");
+
+// Alerts: subscribe before starting the timer-driven service.
+var metricsService = provider.GetRequiredService<ResourceMetricsService>();
+metricsService.AlertRaised += (_, alert) =>
+    Console.WriteLine($"[{alert.Severity}] {alert.Title} -> root cause {alert.RootCausePath}");
+metricsService.HealthStatusChanged += (_, e) =>
+    Console.WriteLine($"{e.PreviousStatus} -> {e.NewStatus}");
+metricsService.Start();
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `SnapshotInterval` | 5s | Cadence for both metrics refresh and health/alert evaluation (one timer, not two) |
+| `MetricNamePrefix` | `"typhon.resource"` | Prefix for every OTel instrument name |
+| `ExportMemoryMetrics` / `ExportCapacityMetrics` / `ExportDiskIOMetrics` / `ExportThroughputMetrics` / `ExportDurationMetrics` | `true` | Toggle a metric kind's instruments off entirely |
+| `Thresholds["<path>"]` | `HealthThresholds.Default` (80%/95%) | Per-node degraded/unhealthy utilization cutoffs; `WALRingBuffer` and `TransactionPool` default to `Critical` (60%/80%) |
+
+## ⚠️ Guarantees & limits
+- Read-only consumer: the bridge maintains no counters, defines no tree structure, and does not
+  decide exhaustion policy — it only reads `ResourceSnapshot`s the graph already produces.
+- Metric names are generic per kind (e.g. `typhon.resource.capacity.utilization`) with the node
+  path carried as a `resource_path` tag, not baked into the metric name — keeps OTel/Prometheus
+  cardinality management on the consumer side.
+- Alerts fire only on status **transitions to a worse state** (`AlertRaised`); recovery
+  (`Unhealthy → Degraded → Healthy`) raises `HealthStatusChanged` but never a new alert, to avoid
+  flapping noise.
+- `ResourceAlertGenerator` traces a single root-cause node via `FindRootCause`; it does not (yet)
+  attach cascading-effect/contention-hotspot lists to the alert, despite that being part of the
+  original design intent — treat `ResourceAlert` as symptom + one root cause, not a full blast
+  radius.
+- `ITyphonHealthCheck` is framework-independent by design — there is no built-in ASP.NET Core
+  `IHealthCheck` or Kubernetes probe endpoint; write a thin adapter that calls `CheckHealth()` /
+  `GetDetailedResult()` from your own health-check registration.
+- No built-in Prometheus/OTLP exporter or AlertManager/webhook sender ships in Typhon — the bridge
+  stops at the `Meter` and the `AlertRaised`/`HealthStatusChanged` events; wiring those to an actual
+  sink is application code.
+- `ResourceMetricsService` swallows exceptions from its timer callback to avoid killing the timer
+  thread — a persistently throwing health check degrades silently rather than crashing.
+
+## 🧪 Tests
+- [ObservabilityBridgeTests](../../../test/Typhon.Engine.Tests/Observability/Bridge/ObservabilityBridgeTests.cs) — OTel metric-name
+  building, `ResourceMetricsExporter` instrument registration/gating, `ResourceHealthChecker` threshold tiers, `ResourceAlertGenerator`
+  root-cause attribution and transition-only alerting, `ResourceMetricsService` start/stop/force-update events
+
+## 🔗 Related
+- Sibling: [Resource Graph Metrics Bridge](../Observability/otel-metrics-export/resource-graph-metrics-bridge.md) — the Observability-side view of this same OTel/health/alert exporter (cross-category).
+- Sibling: [Metric Reporting](./metric-reporting.md) — the per-node data this bridge reads on each snapshot.
+
+<!-- Deep dive: claude/design/Resources/08-observability-bridge.md -->

--- a/doc/feature-set/Resources/owner-aggregates-granularity.md
+++ b/doc/feature-set/Resources/owner-aggregates-granularity.md
@@ -1,0 +1,82 @@
+# Owner-Aggregates Granularity Strategy
+> The rule for what becomes a resource-tree node and what gets rolled up into its owner.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+Typhon has thousands of latches, hundreds of thousands of chunks, and millions of entities. A
+resource tree with one node per instance would cost hundreds of MB and tens of milliseconds per
+snapshot, and burying the few decisions an operator can act on under a sea of leaf nodes defeats
+the point of having a tree at all. Application code that walks the resource graph (dashboards,
+health checks, OTel export) needs that tree to stay small and meaningful regardless of how much
+data the engine is holding.
+
+## ⚙️ How it works (in brief)
+This is an architectural rule, not an API to call. A type only gets a graph node if it has a
+distinct lifecycle, operators can act on its metrics, its count is bounded (under ~500), and
+tracking it aids debugging — structs/ref structs are never nodes. Everything that fails the test
+(latches, chunks, segments, revision chains, entities) is **aggregated into its owning node**: the
+owner reports the rolled-up numbers via `IMetricSource`, and exposes a per-child breakdown on
+demand via `IDebugPropertiesProvider`. Latch contention specifically flows up through the
+`IContentionTarget` callback. The target shape is 3 levels deep (System → Subsystem → Component /
+Per-type Instance); a 4th level is added only when a sub-resource has its own distinct metrics or
+resource pool worth isolating.
+
+## 💻 Usage
+You don't call this pattern — you apply it when adding a new internal type. `ComponentTable<T>` is
+the reference example: it owns several segments but exposes only itself as a node.
+
+```csharp
+public class ComponentTable : ResourceNode, IMetricSource, IDebugPropertiesProvider
+{
+    // ComponentSegment, CompRevTableSegment, DefaultIndexSegment, String64IndexSegment, ...
+    // are NOT ResourceNodes — no node per segment, no node per chunk inside them.
+
+    public void ReadMetrics(IMetricWriter writer)
+    {
+        long allocated = (ComponentSegment?.AllocatedChunkCount ?? 0) + (CompRevTableSegment?.AllocatedChunkCount ?? 0);
+        long capacity = (ComponentSegment?.ChunkCapacity ?? 0) + (CompRevTableSegment?.ChunkCapacity ?? 0);
+        writer.WriteCapacity(allocated, capacity); // one Capacity metric for the whole table
+    }
+}
+
+// Consumers see one node, with drill-down available on request:
+var ct = dbe.GetComponentTable<Player>();
+Console.WriteLine(ct.Children.Count); // 0 — segments are not children
+
+var snapshot = resourceGraph.GetSnapshot();
+var node = snapshot.GetNode("Root/DataEngine/ComponentTable_Player");
+Console.WriteLine(node.Capacity.Value.Utilization); // aggregated across all segments
+
+foreach (var (k, v) in ct.GetDebugProperties())     // per-segment breakdown, on demand
+    Console.WriteLine($"{k} = {v}");
+```
+
+| Decision input | Node? | Example |
+|---|---|---|
+| Distinct lifecycle, bounded count (<500), actionable metrics | Yes | `ComponentTable<T>`, `PageCache`, `PrimaryKeyIndex` |
+| struct / ref struct | Never | `AtomicChange`, lock guards |
+| Fine-grained, unbounded, or pure data | No — aggregate into owner | latches, chunks, segments, revision chains, entities |
+
+## ⚠️ Guarantees & limits
+- Not enforced by the compiler or runtime — it's a design rule applied when a new `IResource` is
+  added; review against `claude/design/Resources/05-granularity-strategy.md` §2 before adding a node.
+- Aggregated primitives are invisible to `IResource.Children` / tree walks; their numbers only
+  surface through the owner's `IMetricSource.ReadMetrics` (rolled-up) and `IDebugPropertiesProvider`
+  (per-child breakdown, allocates, call on demand — not every tick).
+- Keeps the tree at roughly 50-400 nodes regardless of entity/chunk/latch count (a full snapshot
+  stays in the few-μs range, see metric-reporting.md); a 4th tree level is justified only when a
+  sub-resource has metrics or a resource pool genuinely distinct from its parent's — not for symmetry.
+- `ComponentTable_SegmentsAreNotChildren` and related tests assert this invariant for the ECS
+  storage path; a regression there (a segment gaining a node) is a design violation, not a feature.
+
+## 🧪 Tests
+- [OwnerAggregatesTests](../../../test/Typhon.Engine.Tests/Resources/OwnerAggregatesTests.cs) — `ComponentTable` has zero graph
+  children while its `IMetricSource.ReadMetrics` aggregates segment capacity/allocation totals
+
+## 🔗 Related
+- Companion features: [`metric-reporting.md`](./metric-reporting.md) (the rolled-up surface), [`debug-properties-drilldown.md`](./debug-properties-drilldown.md) (the per-child drill-down)
+- Tests: [`test/Typhon.Engine.Tests/Resources/OwnerAggregatesTests.cs`](../../../test/Typhon.Engine.Tests/Resources/OwnerAggregatesTests.cs)
+
+<!-- Deep dive: claude/design/Resources/05-granularity-strategy.md -->
+<!-- Decision record: claude/adr/032-resource-system-architecture.md (Decision 3 — Owner Aggregates Pattern) -->

--- a/doc/feature-set/Resources/resource-budgets-options.md
+++ b/doc/feature-set/Resources/resource-budgets-options.md
@@ -1,0 +1,85 @@
+# Resource Budget Configuration (ResourceOptions)
+> Startup-time sizing of every fixed/growable resource limit, with a Validate() sanity check.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+Typhon's memory-bound components (page cache, WAL ring/segments, shadow buffer) must be sized
+before the engine starts — there's no GC to grow them lazily, and getting it wrong either wastes
+memory or causes runtime exhaustion under load. Applications need one place to declare these
+limits, in domain units (pages, transactions, bytes), and a way to catch a misconfiguration —
+fixed allocations that don't fit the declared memory budget — at startup instead of in production.
+
+## ⚙️ How it works (in brief)
+`ResourceOptions` is a plain settings object hung off `DatabaseEngineOptions.Resources`. Each
+property maps to one bounded resource's limit (page cache pages, max active transactions, WAL ring
+bytes, WAL segment count/size, shadow buffer pages, checkpoint thresholds) and ships with a sane
+default. Components never see this object directly — each receives only its own limit at
+construction. Calling `Validate()` sums the resources that are allocated immediately at startup
+(page cache, WAL ring + segments, shadow buffer) and throws if that total exceeds
+`TotalMemoryBudgetBytes`. Growable resources (active transaction count, index nodes, query
+buffers) are intentionally excluded — they're bounded by runtime caps, not upfront allocation.
+
+## 💻 Usage
+```csharp
+using Typhon.Engine;
+
+// DatabaseEngine's constructor is internal — set the budget through the DI extension (see DI
+// Registration & Wiring) or directly on DatabaseEngineOptions if you already have one.
+services.AddDatabaseEngine(opt =>
+{
+    opt.Resources = new ResourceOptions
+    {
+        PageCachePages = 262144,              // 2 GB (8 KB/page)
+        MaxActiveTransactions = 1000,
+        WalRingBufferSizeBytes = 8 << 20,     // 8 MB
+        WalMaxSegments = 4,
+        WalMaxSegmentSizeBytes = 64L << 20,   // 64 MB each
+        ShadowBufferPages = 512,              // 4 MB
+        TotalMemoryBudgetBytes = 4L << 30,    // 4 GB ceiling for fixed allocations
+    };
+
+    // Throws InvalidOperationException if fixed allocations exceed TotalMemoryBudgetBytes.
+    opt.Resources.Validate();
+});
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `PageCachePages` | 256 (2 MB) | Page cache size; fixed at startup |
+| `MaxPageCachePages` | 16384 (128 MB) | Reserved for future dynamic cache sizing; not enforced today |
+| `MaxActiveTransactions` | 1000 | `CreateTransaction` throws `ResourceExhaustedException` beyond this |
+| `TransactionPoolSize` | 16 | Pooled `Transaction` objects; pool miss allocates new (Degrade) |
+| `WalRingBufferSizeBytes` | 8 MB | Commit threads block once the ring drains slower than it fills |
+| `WalBackPressureThreshold` | 0.8 | Fraction of ring capacity where back-pressure kicks in |
+| `WalMaxSegmentSizeBytes` / `WalMaxSegments` | 64 MB / 4 | WAL segment file sizing; exhausting all forces a checkpoint |
+| `CheckpointMaxDirtyPages` | 10000 | Dirty-page threshold that forces an early checkpoint |
+| `CheckpointIntervalMs` | 30000 | Idle checkpoint cadence |
+| `ShadowBufferPages` | 512 (4 MB) | CoW backup buffer; writers block when full |
+| `TotalMemoryBudgetBytes` | 4 GB | Ceiling checked by `Validate()` against fixed allocations |
+
+## ⚠️ Guarantees & limits
+- Set once at construction; there is no supported way to change `ResourceOptions` after the engine
+  starts — resizing requires a restart.
+- `Validate()` only checks **fixed** allocations (page cache + WAL ring + WAL segments + shadow
+  buffer). Growable resources (transactions, index nodes, query buffers) are not part of the check
+  — they're capped at runtime instead, so a passing `Validate()` is not a guarantee against all
+  exhaustion.
+- `CalculateFixedAllocationBytes()` / `CalculateAvailableBudgetBytes()` let you inspect the
+  breakdown and headroom before or after `Validate()`.
+- Each component receives only its own limit (constructor injection) — there is no way to read
+  another component's budget back out of a live engine via this type.
+- The exhaustion policy each limit triggers (FailFast, Wait, Evict, Degrade) is fixed per-component
+  and not configurable here — see the resource graph's `ExhaustionPolicy` metadata for what happens
+  when a given limit is hit.
+
+## 🧪 Tests
+- [ResourceOptionsTests](../../../test/Typhon.Engine.Tests/Resources/ResourceOptionsTests.cs) — defaults, `Validate()` pass/fail against
+  the memory budget, `CalculateFixedAllocationBytes`/`CalculateAvailableBudgetBytes`, `DatabaseEngineOptions.Resources` wiring
+
+## 🔗 Related
+- Sibling: [Exhaustion Policy & ResourceExhaustedException](./exhaustion-policy-handling.md) — what happens when a configured limit is hit.
+- Sibling: [DI Registration & Wiring](./resources-di-wiring.md) — where `ResourceOptions` is threaded into constructed services.
+- Source: `src/Typhon.Engine/Resources/public/ResourceOptions.cs`
+
+<!-- Deep dive: claude/design/Resources/07-budgets-exhaustion.md, claude/overview/08-resources.md §8.7 -->

--- a/doc/feature-set/Resources/resource-tree-mutation-notifications.md
+++ b/doc/feature-set/Resources/resource-tree-mutation-notifications.md
@@ -1,0 +1,70 @@
+# Resource Tree Mutation Notifications
+> Live add/remove events from the resource graph — no polling required.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+Tools that display the resource tree (Workbench's live tree view, a custom monitor) need to know
+the moment a node appears or disappears — a new `ComponentTable`, a dropped segment, a closed
+session. Polling the tree on a timer is wasteful and laggy. The Resource Tree Registry already
+self-registers/unregisters every node; this feature surfaces those topology changes as an event
+so consumers can update incrementally instead of re-walking the tree.
+
+## ⚙️ How it works (in brief)
+`IResourceRegistry.NodeMutated` is a plain `event Action<ResourceMutationEventArgs>`. It fires once
+per `RegisterChild`/`RemoveChild` call that actually changes membership — a duplicate add (same
+`Id` already present) is a no-op and raises nothing. The event args carry only the minimal
+identification needed to act (`Kind`, `NodeId`, `ParentId`, `Type`, `Timestamp`), not a graph copy.
+Each subscriber runs inside its own try/catch on the raising side, so a throwing handler cannot
+break delivery to the others or to the registry itself.
+
+## 💻 Usage
+```csharp
+using Typhon.Engine;
+
+IResourceRegistry registry = services.GetRequiredService<IResourceRegistry>();
+
+registry.NodeMutated += args =>
+{
+    switch (args.Kind)
+    {
+        case ResourceMutationKind.Added:
+            Console.WriteLine($"+ {args.ParentId}/{args.NodeId} ({args.Type})");
+            break;
+        case ResourceMutationKind.Removed:
+            Console.WriteLine($"- {args.ParentId}/{args.NodeId} ({args.Type})");
+            break;
+    }
+};
+
+// ... later, when no longer interested:
+// registry.NodeMutated -= handler;
+```
+
+Typhon Workbench's live tree view is the reference consumer: `ResourceGraphStream` subscribes once
+per session, coalesces bursts into ~10 frames/second, and pushes them to the browser over SSE so
+the tree updates without a refresh.
+
+## ⚠️ Guarantees & limits
+- Fires only on actual membership changes: `Added` when `RegisterChild` adds a new `Id`, `Removed`
+  when `RemoveChild` finds and removes one. Re-registering an existing `Id` is a silent no-op.
+- `ResourceMutationKind.Mutated` is reserved for a future state-change notification — not emitted
+  today.
+- Handlers must not throw: the registry invokes each subscriber in its own try/catch and swallows
+  exceptions to protect the others. Don't rely on exceptions propagating out of a handler.
+- Handlers must not mutate the graph (register/remove nodes) from inside the callback — re-entrant
+  raises are not supported.
+- Delivery is synchronous and in-process, on the calling thread (the thread that constructed or
+  disposed the node) — there is no built-in batching or cross-thread marshalling; consumers that
+  need rate-limiting (e.g. a UI) must coalesce themselves, as `ResourceGraphStream` does.
+- Carries identifiers only (`NodeId`, `ParentId`, `Type`), not a node reference or full subtree —
+  look up the actual node via `IResourceRegistry.FindByPath` if more detail is needed.
+
+## 🧪 Tests
+- [ResourceRegistryMutationTests](../../../test/Typhon.Engine.Tests/Resources/ResourceRegistryMutationTests.cs) — Added/Removed events,
+  duplicate-register no-op, throwing-subscriber isolation, unsubscribe stops delivery
+
+## 🔗 Related
+- Catalog: [Resource Tree Registry](./resource-tree-registry.md)
+
+<!-- Design: claude/design/Resources/10-di-and-public-surface.md §3 -->

--- a/doc/feature-set/Resources/resource-tree-registry.md
+++ b/doc/feature-set/Resources/resource-tree-registry.md
@@ -1,0 +1,71 @@
+# Resource Tree Registry
+> The hierarchical map of every significant engine resource — self-registering nodes, no orphans, cascade disposal.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+
+Typhon manages dozens of distinct resource kinds — page cache, WAL, transactions, component tables, allocators, bitmaps — each with its own lifecycle. Without a common structure there is no single place to ask "what does the engine currently own?", no consistent teardown ordering, and no stable address space for diagnostics or metrics to hang off of. The Resource Tree Registry gives every tracked resource exactly one parent, one place in a navigable tree, and a guaranteed disposal path.
+
+## ⚙️ How it works (in brief)
+
+`ResourceRegistry` creates a `Root` node plus eight fixed subsystem nodes (`Storage`, `DataEngine`, `Durability`, `Allocation`, `Synchronization`, `Timer` — with a `Timer/Dedicated` sub-node, `Runtime`, `Profiler`) at construction. Any `IResource` — typically a generic `ResourceNode`, sometimes a domain type implementing the interface directly — registers itself with an explicit parent in its constructor; passing `null` throws immediately (`NullReferenceException`, since the constructor dereferences the parent before any explicit check), so there is no orphan bucket to hide bugs in. Resources are addressed by name-only `Id` (type comes from `ResourceType`), giving clean paths like `Root/DataEngine/Player/PrimaryKey`. Disposing a node cascades depth-first to its children (a node can opt out via `DisposeWithParent = false` when something else owns its lifecycle), and `ResourceRegistry.Dispose()` walks subsystems in an explicit dependency order rather than relying on unspecified dictionary enumeration. A `NodeMutated` event fires on every add/remove for live observers such as the Workbench.
+
+## 💻 Usage
+
+```csharp
+services.AddResourceRegistry(); // DI: IResourceRegistry singleton, one per process
+
+// or construct directly:
+var registry = new ResourceRegistry(new ResourceRegistryOptions { Name = "Typhon" });
+
+// subsystem nodes already exist
+var storage = registry.Storage;
+var durability = registry.GetSubsystem(ResourceSubsystem.Durability);
+
+// any IResource self-registers under an explicit parent
+var pageCache = new ResourceNode("PageCache", ResourceType.Cache, registry.Storage);
+
+// or register an externally-constructed IResource under a subsystem
+registry.Register(myCustomResource, ResourceSubsystem.Allocation);
+
+// path lookup, both directions
+var node = registry.FindByPath("Root/Storage/PageCache");
+var path = pageCache.GetPath(); // "Root/Storage/PageCache" (ResourceExtensions)
+
+// react to topology changes
+registry.NodeMutated += args =>
+{
+    if (args.Kind == ResourceMutationKind.Added)
+        Console.WriteLine($"{args.ParentId} gained {args.NodeId} ({args.Type})");
+};
+
+registry.Dispose(); // cascades subsystem-by-subsystem in dependency order
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `ResourceRegistryOptions.Name` | `"DefaultResourceRegistry"` | Diagnostic label for the registry instance |
+
+## ⚠️ Guarantees & limits
+
+- One `IResourceRegistry` per process; multiple `DatabaseEngine` instances are siblings under the same registry, not separate trees.
+- No orphan container: every `IResource` requires a non-null parent at construction — a null parent faults at the exact call site (`NullReferenceException` today), not on a later traversal.
+- Cascade disposal is depth-first; `ResourceRegistry.Dispose()` tears down subsystems in a fixed order (`Profiler` → `Runtime` → `DataEngine` → `Durability` → `Storage` → `Allocation` → `Synchronization` → `Timer` → `Root` as a safety net) because `DataEngine`'s graceful shutdown reads `Storage`/`Durability`/`Synchronization` during its own teardown.
+- `Children` enumeration is a point-in-time snapshot (`ConcurrentDictionary.Values`) — fine for diagnostics, not a substitute for linearizable state.
+- `NodeMutated` subscribers must not throw (the registry isolates each handler) and must not mutate the graph from inside the handler — re-entrant raises are not supported.
+- Per-node overhead (~150–200 bytes) and registration cost are one-time, by design — the tree targets components and per-type instances (e.g. one node per `ComponentTable<T>`), not per-entity or per-latch granularity; fine-grained primitives aggregate into their owning node instead of getting their own.
+
+## 🧪 Tests
+
+- [ResourceTreeTests](../../../test/Typhon.Engine.Tests/Resources/ResourceTreeTests.cs) — subsystem structure, registration, ancestors/descendants, path lookup (`GetPath`/`FindByPath`), thread-safe concurrent registration
+- [ResourceRegistryDisposeOrderTests](../../../test/Typhon.Engine.Tests/Resources/ResourceRegistryDisposeOrderTests.cs) — cascade disposal ordering (`DataEngine` tears down before `Storage`/`Durability`/`Synchronization`)
+
+## 🔗 Related
+
+- Sibling: [Resource Tree Mutation Notifications](./resource-tree-mutation-notifications.md) — live add/remove events built on this registry.
+- Sibling: [DI Registration & Wiring](./resources-di-wiring.md) — how services attach to this tree via DI.
+
+<!-- Overview: claude/overview/08-resources.md §8.2 -->
+<!-- Design: claude/design/Resources/01-registry.md -->
+<!-- Design: claude/design/Resources/02-registry-examples.md -->

--- a/doc/feature-set/Resources/resources-di-wiring.md
+++ b/doc/feature-set/Resources/resources-di-wiring.md
@@ -1,0 +1,56 @@
+# DI Registration & Wiring
+> Register Typhon services into `IServiceCollection` and have each one self-attach to the resource graph.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Resources](./README.md)
+
+## 🎯 What it solves
+
+Every managed Typhon service (storage, durability, allocation, synchronization, timers) needs a place in the resource graph to report metrics, budgets, and exhaustion state. Wiring this by hand — constructing each service, finding its parent subsystem node, registering it — is repetitive and easy to get wrong (wrong parent, missed registration, wrong lifetime). The DI extensions fold registry attachment into the same call that registers the service with `Microsoft.Extensions.DependencyInjection`, so a host gets a fully wired resource tree from `IServiceCollection` calls alone.
+
+## ⚙️ How it works (in brief)
+
+`AddResourceRegistry` (plus `AddScopedResourceRegistry` / `AddTransientResourceRegistry`) registers `IResourceRegistry` → `ResourceRegistry`, binding an optional `ResourceRegistryOptions` configure callback through `IOptions<T>`. Sibling extensions — `AddMemoryAllocator`, `AddManagedPagedMMF`, `AddEpochManager`, `AddHighResolutionSharedTimer`, `AddDeadlineWatchdog`, `AddDatabaseEngine` — each resolve `IResourceRegistry` inside their factory and pass the matching subsystem node (`rr.Storage`, `rr.Synchronization`, `rr.Timer`, …) into the constructed service, so registration with the graph happens as a side effect of normal DI resolution. Most extensions have `Add…` (singleton), `AddScoped…`, and `AddTransient…` variants for tests and short-lived hosts. Call order among the `Add…` calls themselves doesn't matter — standard `IServiceCollection` resolution is lazy, keyed by type, at `BuildServiceProvider` / first resolve, not at `Add…` time — but every dependency a service needs (`AddDatabaseEngine` needs the allocator, watchdog, epoch manager, and `ManagedPagedMMF`) must have been added to the collection by then, or the first resolve throws.
+
+## 💻 Usage
+
+```csharp
+var services = new ServiceCollection();
+
+services
+    .AddResourceRegistry(opt => opt.Name = "MyHost")        // IResourceRegistry singleton
+    .AddMemoryAllocator()                                    // attaches under registry.Allocation
+    .AddHighResolutionSharedTimer()                          // attaches under registry.Timer
+    .AddEpochManager()                                       // attaches under registry.Synchronization
+    .AddDeadlineWatchdog()                                   // uses the shared timer + registry
+    .AddManagedPagedMMF(opt => opt.DatabaseName = "db")      // attaches under registry.Storage
+    .AddDatabaseEngine();                                    // attaches under registry.DataEngine
+
+var sp = services.BuildServiceProvider();
+var registry = sp.GetRequiredService<IResourceRegistry>();
+var engine = sp.GetRequiredService<DatabaseEngine>();
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `AddResourceRegistry` / `AddScopedResourceRegistry` / `AddTransientResourceRegistry` | n/a | Pick the `IResourceRegistry` lifetime; singleton is the production case |
+| `ResourceRegistryOptions.Name` | `"DefaultResourceRegistry"` | Diagnostic label for the registry instance |
+| `AddManagedPagedMMF` / `AddScopedManagedPagedMemoryMappedFile` / `AddTransientManagedPagedMemoryMappedFile` | n/a | Pick the `ManagedPagedMMF` lifetime |
+| `AddEpochManager` / `AddScopedEpochManager` / `AddTransientEpochManager` | n/a | Pick the `EpochManager` lifetime |
+| `AddDatabaseEngine` / `AddScopedDatabaseEngine` / `AddTransientDatabaseEngine` | n/a | Pick the `DatabaseEngine` lifetime |
+
+## ⚠️ Guarantees & limits
+
+- All extensions are additive `IServiceCollection` calls returning `this`, so they chain fluently and compose with any other DI setup in the host.
+- Each extension resolves `IResourceRegistry` (and its other dependencies) lazily inside its factory delegate — nothing is constructed at `Add…` time, only at `BuildServiceProvider`/resolve time. Forgetting `AddResourceRegistry` (or a required dependency like the epoch manager or shared timer) surfaces as a standard DI resolution failure, not a silent gap in the resource tree.
+- Resource-graph attachment is not optional or toggleable per service: any service built through these extensions always registers under its subsystem node. There is no "construct without registering" escape hatch via DI — use the service's constructor directly if a tree-less instance is needed (e.g. tests that pass an explicit `IResourceRegistry` mock).
+- `AddOptions<T>().Validate(...)` hooks exist on these extensions but are currently placeholders (`// TODO Add validation logic`) — invalid option values are not yet rejected at registration time.
+- Options validation/binding follows standard `Microsoft.Extensions.Options` semantics (`IOptions<T>` resolved once per factory invocation); nothing Typhon-specific changes that contract.
+
+## 🔗 Related
+
+- Sibling: [Resource Tree Registry](./resource-tree-registry.md) — the tree these DI extensions attach services into.
+- Sibling: [Resource Budget Configuration](./resource-budgets-options.md) — options object threaded into constructed services via these extensions.
+- Source: [src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs](../../../src/Typhon.Engine/Hosting/public/TyphonBuilderExtensions.cs)
+- Source: [src/Typhon.Engine/Resources/public/ResourceRegistry.cs](../../../src/Typhon.Engine/Resources/public/ResourceRegistry.cs)
+
+<!-- Design: claude/design/Resources/10-di-and-public-surface.md -->

--- a/doc/feature-set/Resources/snapshot-query-api/README.md
+++ b/doc/feature-set/Resources/snapshot-query-api/README.md
@@ -1,0 +1,88 @@
+# Snapshot & Query API
+> Pull a consistent-enough, point-in-time snapshot of the whole resource tree, then query it for memory, capacity, and rate answers.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Resources](../README.md)
+
+## 🎯 What it solves
+
+Diagnosing "why is the engine slow" or "what's using all the memory" by reading individual component counters
+means hand-correlating dozens of fields across dashboards. `IResourceGraph.GetSnapshot()` freezes every
+[metric-reporting](../metric-reporting.md) node's values into one object, so an operator or health-check can ask
+tree-wide questions — total memory under a subsystem, which node is closest to capacity, what's the current
+op/sec rate — against a single, stable structure instead of live, moving counters.
+
+## ⚙️ How it works (in brief)
+
+`GetSnapshot()` walks the resource tree once, calls `ReadMetrics()` on every node that implements
+`IMetricSource`, and returns an immutable `ResourceSnapshot` whose `Nodes` dictionary is keyed by full path
+(e.g. `"Root/Storage/PageCache"`). `GetSnapshot(IResource subtreeRoot)` does the same walk starting partway
+down the tree, for when you already know which subsystem to inspect. `ResourceSnapshot`'s query methods
+(`GetSubtreeMemory`, `FindMostUtilized`, `GetNode`, `FindByType`, `GetSubtree`) run entirely against the frozen
+`Nodes` dictionary — no further tree walk, safe to call from any thread. `Rates` is computed automatically by
+comparing the new snapshot's `Throughput` counters against the previous one the same `IResourceGraph` instance
+took; it's `null` on the very first call.
+
+## 💻 Usage
+
+```csharp
+using Typhon.Engine;
+
+IResourceGraph resourceGraph = new ResourceGraph(registry); // or resolve via DI (IResourceGraph)
+
+// Full tree snapshot — call on demand, or every 1-5s for monitoring/health checks.
+ResourceSnapshot snapshot = resourceGraph.GetSnapshot();
+
+// Path-based lookup — full paths are rooted at "Root/...".
+NodeSnapshot pageCache = snapshot.GetNode("Root/Storage/PageCache");
+if (pageCache?.Capacity is { } capacity)
+    Console.WriteLine($"PageCache: {capacity.Utilization:P0} ({capacity.Current}/{capacity.Maximum})");
+
+// Memory attribution — sum AllocatedBytes across every node under a subtree.
+long dataEngineBytes = snapshot.GetSubtreeMemory("Root/DataEngine");
+
+// Bottleneck detection — single worst node, or every node above a threshold.
+NodeSnapshot bottleneck = snapshot.FindMostUtilized();
+foreach (NodeSnapshot hot in snapshot.FindMostUtilized(0.9))
+    Console.WriteLine($"{hot.Path}: {hot.Capacity!.Value.Utilization:P0}");
+
+// Targeted subtree snapshot — skips everything outside Durability.
+IResource durability = resourceGraph.FindByPath("Durability");
+ResourceSnapshot durabilitySnap = resourceGraph.GetSnapshot(durability);
+
+// Throughput rates — null on the first snapshot this IResourceGraph instance ever took.
+if (snapshot.Rates is { } rates)
+{
+    double hitsPerSec = rates.GetRate("Root/Storage/PageCache", "CacheHits");
+    Console.WriteLine($"Cache hits/sec: {hitsPerSec:F0}");
+}
+
+resourceGraph.ResetAllPeaks(); // start a fresh peak-measurement window across all metric sources
+```
+
+## ⚠️ Guarantees & limits
+
+- Per-node atomic, cross-node approximate: each `ReadMetrics()` call reads one node's fields together, but
+  different nodes may be read microseconds apart — no global lock blocks live traffic during a snapshot.
+- Cost is ~50 ns/node; a typical 50-100 node tree costs ~2.5-5 μs to snapshot, with no allocations beyond the
+  returned snapshot's own arrays/dictionary.
+- `Nodes` keys are full paths including the `"Root/"` prefix; `GetSubtreeMemory`/`GetSubtree` match on exact
+  segment boundaries (`"Storage"` matches `"Storage"` and `"Storage/PageCache"`, never `"StorageX"`).
+- `FindMostUtilized()`, `GetNode()`, and `FindByType()` return `null`/empty rather than throwing when nothing
+  has `Capacity` metrics or nothing matches — no exceptions for "not found".
+- `GetSnapshot(subtreeRoot)` computes `Rates` against the last *full-tree* snapshot, but does not itself become
+  the new rate baseline — only `GetSnapshot()` (the full-tree overload) updates it.
+- A `ResourceSnapshot` is a plain immutable object — hold onto one for historical comparison, or pass it across
+  threads freely; nothing about it ties back to live engine state.
+
+## 🧪 Tests
+
+- [ResourceSnapshotTests](../../../../test/Typhon.Engine.Tests/Resources/ResourceSnapshotTests.cs) — snapshot capture, subtree scoping,
+  `GetSubtreeMemory`/`FindMostUtilized`/`FindByType`/`GetSubtree`, throughput rate computation, thread-safe concurrent `GetSnapshot` calls
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Resources/public/IResourceGraph.cs](../../../../src/Typhon.Engine/Resources/public/IResourceGraph.cs), [src/Typhon.Engine/Resources/public/ResourceGraph.cs](../../../../src/Typhon.Engine/Resources/public/ResourceGraph.cs), [src/Typhon.Engine/Resources/public/ResourceSnapshot.cs](../../../../src/Typhon.Engine/Resources/public/ResourceSnapshot.cs)
+- Sub-features: [Root-Cause Cascade Analysis (FindRootCause)](./root-cause-cascade-analysis.md)
+- Sibling: [Metric Reporting](../metric-reporting.md) — the per-node data this API freezes into a snapshot.
+
+<!-- Deep dive: claude/design/Resources/06-snapshot-api.md, claude/overview/08-resources.md §8.8 -->

--- a/doc/feature-set/Resources/snapshot-query-api/root-cause-cascade-analysis.md
+++ b/doc/feature-set/Resources/snapshot-query-api/root-cause-cascade-analysis.md
@@ -1,0 +1,72 @@
+# Root-Cause Cascade Analysis (FindRootCause)
+> Trace a high-utilization symptom node back through a known dependency chain to find what's actually backed up.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Resources](../README.md)
+
+## 🎯 What it solves
+
+A node at 95% capacity might be the actual bottleneck, or it might just be stuck waiting on something else
+further down the chain — e.g. `TransactionPool` stalls because the WAL ring buffer can't drain fast enough, not
+because the pool itself is undersized. Without traversal, an operator has to know Typhon's internal wait
+relationships by heart and check each candidate by hand. `FindRootCause` automates that one hop at a time.
+
+## ⚙️ How it works (in brief)
+
+`ResourceSnapshot.FindRootCause(symptomPath, highUtilizationThreshold = 0.8)` checks whether the symptom node's
+`Capacity.Utilization` exceeds the threshold; if so, it looks up the node in a small, hardcoded
+*architectural-knowledge* table of wait dependencies and follows the edge to whichever dependency is both above
+the same threshold and most utilized. It repeats from there until a node has no further high-utilization
+dependency, and returns that node — the chain's end is reported as the root cause. The table reflects how
+Typhon's subsystems interact by design, not anything observed at runtime.
+
+## 💻 Usage
+
+```csharp
+ResourceSnapshot snapshot = resourceGraph.GetSnapshot();
+
+NodeSnapshot symptom = snapshot.GetNode("Root/DataEngine/TransactionPool");
+if (symptom?.Capacity is { Utilization: > 0.8 })
+{
+    // Accepts the path with or without the "Root/" prefix.
+    NodeSnapshot rootCause = snapshot.FindRootCause("DataEngine/TransactionPool");
+    Console.WriteLine($"Root cause: {rootCause.Path} ({rootCause.Capacity?.Utilization:P0})");
+    // → "Root cause: Root/Durability/WALRingBuffer (93%)"
+}
+
+// Stricter threshold — only chase dependencies that are themselves above 90% utilization.
+NodeSnapshot strict = snapshot.FindRootCause("DataEngine/TransactionPool", highUtilizationThreshold: 0.9);
+```
+
+## ⚠️ Guarantees & limits
+
+- The dependency table is fixed architectural knowledge baked into `ResourceSnapshot`, not derived from runtime
+  call graphs or actual wait events. It currently has 4 edges: `DataEngine/TransactionPool` →
+  `Durability/WALRingBuffer`; `Durability/WALRingBuffer` → `Durability/WALSegments`; `Storage/PageCache` →
+  `Storage/ManagedPagedMMF`; `Backup/ShadowBuffer` → `Backup/SnapshotStore`.
+- Coverage is partial by construction: a node with no entry on the left side of the table returns itself
+  immediately, even if it's genuinely blocked on something architecturally — this is a curated heuristic, not a
+  complete dependency graph.
+- Two of the four edges (`Backup/*`) reference paths that don't exist in the current resource tree; a lookup
+  through them simply finds nothing and the chain stops there — no exception.
+- A dependency is only followed when **both** the current node and the candidate are above
+  `highUtilizationThreshold` — a saturated node whose blocker is calm (e.g. 60% with an 0.8 threshold) is
+  reported as the root cause itself; the chain doesn't continue past a dependency that isn't itself under
+  pressure.
+- Traversal is cycle-safe (visited-set guard) though the shipped table is acyclic; cost is O(chain length) —
+  in practice 1-2 hops — with no extra `ReadMetrics()` calls, since it reads only the already-frozen snapshot.
+- Scoped to `Capacity.Utilization` only. Lock/latch contention isn't part of this surface — see
+  `IContentionTarget` for wait-time telemetry, which aggregates separately per owning component.
+
+## 🧪 Tests
+
+- [ResourceOptionsTests](../../../../test/Typhon.Engine.Tests/Resources/ResourceOptionsTests.cs) — `FindRootCause` region: chain
+  tracing through multiple hops, custom/default threshold behavior, missing-node and `Root/`-prefix handling, most-utilized-dependency
+  selection
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Resources/public/ResourceSnapshot.cs](../../../../src/Typhon.Engine/Resources/public/ResourceSnapshot.cs)
+- Parent feature: [Snapshot & Query API](./README.md)
+- Sibling: [Threshold-Based Resource Alerting](../../Observability/threshold-alerting.md) — `FindRootCause` is the shared root-cause tracing machinery behind both (cross-category).
+
+<!-- Deep dive: claude/design/Resources/06-snapshot-api.md §5 FindRootCause, claude/design/Resources/07-budgets-exhaustion.md -->

--- a/doc/feature-set/Revision/README.md
+++ b/doc/feature-set/Revision/README.md
@@ -1,0 +1,21 @@
+# Revision
+> The per-component MVCC revision-chain subsystem: stores every live version of a `Versioned`-mode component in a compact on-disk circular buffer, appends rather than overwrites on every write, and resolves snapshot-isolated reads against that chain by transaction TSN. The same chain backs commit-time conflict detection and is reclaimed — by live garbage collection and by post-crash scrub — once no active transaction can still see an old version.
+
+> 🔬 **Recommended:** read [in-depth-overview/05-revision.md](../../in-depth-overview/05-revision.md) (Chapter 05: Revision (MVCC)) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Revision Append & Chain Growth](revision-append-write-path.md) | Every write to a `Versioned` component creates a new immutable revision instead of overwriting the old one — `Spawn` allocates, `Write<T>()` appends, `Destroy` tombstones | ✅ Implemented | 🔵 Core |
+| [MVCC Snapshot Visibility](mvcc-snapshot-visibility.md) | Reads resolve to the latest revision committed at-or-before the reader's transaction TSN, with read-your-own-writes and explicit `RevisionReadStatus` outcomes (Success/NotFound/SnapshotInvisible/Deleted) | ✅ Implemented | 🔵 Core |
+| [Write-Conflict Baseline Tracking](optimistic-conflict-baseline.md) | Every chain append records the new and prior revision as the comparison baseline used by commit-time conflict detection and `ConcurrencyConflictHandler`s | ✅ Implemented | 🟣 Advanced |
+| [Revision Garbage Collection & Compaction](revision-gc-compaction.md) | Bounded-memory chain cleanup keyed off `MinTSN`, preserving a sentinel for in-flight readers and collapsing fully-dead chains to trigger entity removal | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Revision Chain Storage](revision-chain-storage.md) | Per-entity, per-component circular-buffer chunk chain holding every live revision of a `Versioned` component, allocated on first write and grown on demand | ✅ Implemented |
+| [Chain Walk Correctness Under Compaction](mvcc-visibility-walk.md) (part of [MVCC Snapshot Visibility](mvcc-snapshot-visibility.md)) | The visibility walk scans the whole chain instead of breaking on the first too-new entry, because background GC compaction can reorder entries without changing their TSNs | ✅ Implemented |
+| [Crash-Recovery Chain Scrub & Orphan Sweep](crash-recovery-chain-scrub.md) | Post-crash recovery step that collapses every `Versioned` chain to its single committed HEAD and frees unreachable revision-table chunks, guaranteeing pre-crash MVCC history never survives into the recovered base | ✅ Implemented |

--- a/doc/feature-set/Revision/crash-recovery-chain-scrub.md
+++ b/doc/feature-set/Revision/crash-recovery-chain-scrub.md
@@ -1,0 +1,91 @@
+# Crash-Recovery Chain Scrub & Orphan Sweep
+> After a crash, every Versioned component's revision history collapses back to its single committed value.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Revision](./README.md)
+
+## 🎯 What it solves
+
+A live `Versioned` component can carry several historical revisions on disk at once, kept around so
+snapshot-isolated readers that started before the latest write still see a consistent value. That reasoning
+stops applying the instant the process crashes: every in-flight reader is gone, so there is no snapshot left to
+protect. Left untouched, the surviving chains would carry pre-crash MVCC history into the recovered database —
+and on top of that, an operation interrupted mid-allocation (a revision or content chunk claimed but never
+linked into a chain) leaves chunks marked allocated that nothing references at all. Both classes of leftover
+need to be gone before the recovered database is trusted as a base, or storage grows unbounded and stale
+history becomes indistinguishable from live data.
+
+## ⚙️ How it works (in brief)
+
+After the WAL window is applied, recovery walks every Versioned component table's revision chains and
+collapses each one to its single highest-TSN **committed** element, freeing every other revision's content
+chunk and every overflow chunk the chain had grown. A chain with no committed survivor (every element was
+either voided or belonged to a transaction that never durably committed) collapses to one invisible element
+instead, so the entity still reads as deleted rather than left in an ambiguous state. Once every chain is down
+to its single root chunk, a second pass scans the table's revision and content chunk pools and frees anything
+still marked allocated that no surviving chain root or its head value reaches — the chunks an interrupted
+pre-crash operation leaked. Chain root locations never move, which is exactly what lets the EntityMap rebuild —
+a separate, earlier step keyed off the same chain-root scan — run safely before this scrub, and what gives the
+secondary-index rebuild that follows the scrub a stable, already-correct address for every entity.
+
+## 💻 Usage
+
+This is an internal recovery step, not something application code calls — it runs automatically as part of
+opening a database that crashed (WAL files present), right after the WAL window is applied and before secondary
+B+Tree indexes are rebuilt. (The EntityMap is rebuilt separately, *before* WAL apply, off the same chain-root
+scan — see Guarantees.)
+
+```csharp
+using Typhon.Engine;
+
+// Recovery — including the scrub — completes before this call returns. There is
+// no separate API, flag, or step to trigger it.
+var engine = serviceProvider.GetRequiredService<DatabaseEngine>();
+
+// Observable effect: every Versioned revision chain that survived recovery holds
+// exactly one element, however many updates landed against it before the crash.
+foreach (var seg in engine.EnumerateStorageSegments())
+{
+    if (seg.Kind == StorageSegmentKind.Revision)
+    {
+        Console.WriteLine($"revision table allocChunks={seg.AllocatedChunkCount} " +
+                           $"freeChunks={seg.FreeChunkCount}"); // no pre-crash overflow chunks remain
+    }
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Crash path only.** Runs solely when recovery detects WAL files at open; a clean reopen leaves chains
+  untouched for the regular revision garbage collector to trim lazily.
+- **Exactly one committed survivor per chain** — the highest-TSN element with no in-flight isolation marker.
+  Elements from transactions that never durably committed are discarded along with their content, never kept
+  "just in case."
+- **No-committed-head chains read as deleted, not corrupt** — the chain collapses to a single invisible
+  element rather than vanishing outright; the entity's EntityMap entry and root chunk stay in place (a known,
+  harmless residual, not a leak the orphan sweep will touch).
+- **Cluster HEAD values are unaffected** — the scrub only discards non-head revisions; a cluster archetype's
+  already-correct head slot is never rewritten by this step.
+- **Orphan sweep is per-table and scrub-ordered** — it only reclaims a table's own leaked revision/content
+  chunks, and only after that table's chains are fully scrubbed; running it earlier would treat still-live
+  non-head revisions as orphans and free data that should have survived.
+- **Must run before secondary-index rebuild** — B+Tree indexes are built from the scrubbed chain heads, never
+  from pre-scrub history, so a torn ordering would bake stale or duplicate entries into freshly rebuilt indexes.
+  The EntityMap is the one derived structure rebuilt *before* this scrub (and before WAL apply): it only needs
+  each chain's stable root location plus the entity's primary key, not the chain's post-scrub content, so
+  running it earlier is safe and lets every later recovery phase resolve entities immediately.
+- **No application-facing trigger or inspection API** — entirely internal to crash recovery; the only visible
+  effect is the post-recovery chunk footprint (via `EnumerateStorageSegments`) and the absence of stale
+  revisions on subsequent reads.
+
+## 🧪 Tests
+
+- [DeferredCleanupTests](../../../test/Typhon.Engine.Tests/Data/DeferredCleanupTests.cs) — `Scrub_CollapsesMultiRevisionChain_ToHeadValue_Idempotent` (built directly against `ScrubChainToHead`, verifies the single-committed-HEAD collapse and idempotency) and `SweepOrphans_FreesUnreachableChunks_KeepsReachableData` (frees an interrupted-alloc orphan chunk while keeping the reachable chain root and content intact)
+
+## 🔗 Related
+
+- Related feature: [Crash Recovery (RecoveryDriver)](../Durability/crash-recovery/README.md), [Rebuild of Derived Structures](../Durability/crash-recovery/rebuild-derived-structures.md), [Revision Chain Storage](./revision-chain-storage.md)
+- Source: [`ComponentRevisionManager.ScrubChainToHead` / `SweepTableOrphans` / `EnumerateVersionedChainHeads`](../../../src/Typhon.Engine/Revision/internals/ComponentRevisionManager.cs), [`DatabaseEngine.ScrubVersionedChains`](../../../src/Typhon.Engine/Ecs/public/DatabaseEngine.cs)
+
+<!-- Deep dive: claude/overview/06-durability.md §6.5 — Crash Recovery (RecoveryDriver) -->
+<!-- Design: claude/design/Durability/MinimalWal/03-recovery.md §6 — Phase 4 SCRUB + orphan sweep -->
+<!-- Rules: claude/rules/durability.md — RB-02 (rebuild ordering), RB-03 (chain scrub postcondition), RB-05 (TSN resumption) -->

--- a/doc/feature-set/Revision/mvcc-snapshot-visibility.md
+++ b/doc/feature-set/Revision/mvcc-snapshot-visibility.md
@@ -1,0 +1,97 @@
+# MVCC Snapshot Visibility
+> Reads resolve to the one revision that was committed at-or-before your transaction's snapshot — never a partial or future write.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Revision](./README.md)
+
+## 🎯 What it solves
+
+A multi-writer, multi-reader database needs a precise answer to "what value does *this* read see?" that holds
+regardless of what other transactions are doing concurrently. Without it, readers could observe half-committed
+writes, see data appear or disappear depending on timing, or get inconsistent answers across two reads of the
+same entity within one transaction. Snapshot visibility gives every read path — `Transaction.QueryRead`,
+`EntityAccessor.Open`/`OpenMut`, and the lock-free `PointInTimeAccessor` — one deterministic outcome per call,
+expressed as an explicit status rather than an ambiguous null or stale value.
+
+## ⚙️ How it works (in brief)
+
+Every transaction (and every `PointInTimeAccessor` snapshot) is stamped with a TSN at creation. A read for a
+`Versioned` component resolves against that fixed TSN: among the component's committed revisions, it picks the
+latest one at-or-before the TSN, ignoring anything still mid-commit or committed afterward. Internally this
+collapses to four outcomes — found, never created, created-but-not-yet-visible, or tombstoned — but the
+higher-level APIs you call (`QueryRead`, `Open`, `Read`/`TryRead`) flatten these into a `bool` or a thrown
+`InvalidOperationException`, since most callers don't need to distinguish "doesn't exist" from "not visible yet"
+from "deleted". A transaction's own uncommitted writes are invisible through this same path; they're served
+instead from a per-transaction write cache, so a transaction always reads back what it just wrote without
+waiting for its own commit.
+
+## 💻 Usage
+
+```csharp
+using var ro = dbe.CreateReadOnlyTransaction();          // TSN frozen at creation
+if (ro.QueryRead<Stats>(heroId.RawValue, out var stats))  // resolves the revision visible at ro.TSN
+{
+    Evaluate(stats);
+}
+// false covers: component never existed, exists but not committed by ro.TSN, or tombstoned — callers
+// don't need to tell these apart for a plain existence check.
+
+using var uow = dbe.CreateUnitOfWork();
+using var tx = uow.CreateTransaction();
+ref var s = ref tx.OpenMut(heroId).Write(Hero.Stats);
+s.Hp -= 10;                                                // uncommitted — invisible to every other reader
+ref readonly var seen = ref tx.Open(heroId).Read(Hero.Stats);
+// seen.Hp reflects the write above: read-your-own-writes via tx's local cache, not the chain walk
+tx.Commit();
+```
+
+```csharp
+// PointInTimeAccessor: same visibility rule, no transaction/locking overhead — for parallel query workers
+using var snapshot = PointInTimeAccessor.Create(dbe);
+var worker = snapshot.GetWorkerAccessor(0);
+var entity = worker.Open(heroId);                          // throws if not found/visible at snapshot.TSN
+ref readonly var hp = ref entity.Read(Hero.Stats);
+```
+
+| API | Not-found / not-yet-visible / deleted |
+|-----|----------------------------------------|
+| `QueryRead<T>` | returns `false` |
+| `TryOpen` / `TryRead<T>` | returns `false` |
+| `Open` / `OpenMut` | throws `InvalidOperationException` |
+
+## ⚠️ Guarantees & limits
+
+- **Stable snapshot** — a transaction's (or `PointInTimeAccessor`'s) TSN never advances on its own, so repeated
+  reads of the same entity return the same revision for the transaction's whole lifetime, no matter what commits
+  in the meantime.
+- **No dirty reads** — a revision from a transaction still mid-commit is invisible to every other reader; there
+  is no window where a partial write is observable.
+- **Read-your-own-writes** — the writing transaction sees its own uncommitted changes via a local cache, while
+  every other transaction still sees the prior committed revision.
+- **Explicit, not silent, "deleted"** — a tombstoned entity reports as not-found through the collapsed bool/throw
+  APIs, same as never having existed; callers needing to distinguish the two (e.g. `UpdateComponent` writing a
+  new revision over a tombstone) use the lower-level chain metadata internally — this isn't exposed as public API.
+- **`PointInTimeAccessor` reads only** — it can write `SingleVersion`/`Transient` components but throws on
+  `Versioned` writes; use a `Transaction` when you need to mutate `Versioned` data.
+- Visibility is resolved purely from each revision's commit state and TSN — crash recovery guarantees that by
+  the time any transaction runs, only durably-committed revisions exist in the chain, so this rule needs no
+  special case for "did this survive the last crash".
+- **Correct under compaction** — resolution scans the whole chain rather than stopping at the first too-new
+  entry, because background revision GC can reorder entries physically without changing their TSNs; a
+  single-entry, all-committed chain (the common steady-state case) short-circuits this scan entirely, resolving
+  without taking the chain's read lock.
+
+## 🧪 Tests
+
+- [EcsSpawnMvccTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsSpawnMvccTests.cs) — `Write_Versioned_OtherTx_SeesOldData` (no dirty reads), `Write_Versioned_ReadAfterWrite_SeesNewData`/`Read_PendingSpawn_UsesDirectLocation` (read-your-own-writes), `Read_Versioned_UsesRevisionChain`
+- [PointInTimeAccessorTests](../../../test/Typhon.Engine.Tests/Data/PointInTimeAccessorTests.cs) — same visibility rule through the lock-free `PointInTimeAccessor` path (`ReadVersionedComponent_ReturnsCorrectValue`, `OpenDestroyedEntity_TryOpenReturnsFalse`)
+- [ChaosStressTests](../../../test/Typhon.Engine.Tests/Data/ChaosStressTests.cs) — `RevisionChain_RapidUpdatesWithLongReaders` asserts a held snapshot never observes a value change while concurrent writers hammer the same entity
+
+## 🔗 Related
+
+- Related feature: [Revision Chain Storage](./revision-chain-storage.md) (the layout this walks), [Revision Append & Chain Growth](./revision-append-write-path.md)
+- Sub-feature: [Chain Walk Correctness Under Compaction](./mvcc-visibility-walk.md) (why the walk can't break on the first too-new entry)
+- Sibling: [Storage Mode: Versioned](../Ecs/storage-modes/storage-mode-versioned.md) — Versioned mode is the ECS-facing side of this revision chain
+- Source: [`RevisionReadStatus`](../../../src/Typhon.Engine/Revision/public/RevisionReadStatus.cs), [`RevisionChainReader.WalkChain`](../../../src/Typhon.Engine/Transactions/internals/RevisionWalker.cs), [`RevisionEnumerator`](../../../src/Typhon.Engine/Revision/internals/RevisionEnumerator.cs), [`PointInTimeAccessor`](../../../src/Typhon.Engine/Ecs/public/PointInTimeAccessor.cs)
+
+<!-- Deep dive: claude/design/Revision/02-mvcc-visibility.md, claude/overview/04-data.md -->
+<!-- ADR: claude/adr/003-mvcc-snapshot-isolation.md -->

--- a/doc/feature-set/Revision/mvcc-visibility-walk.md
+++ b/doc/feature-set/Revision/mvcc-visibility-walk.md
@@ -1,0 +1,58 @@
+# Chain Walk Correctness Under Compaction
+> The visibility walk scans a `Versioned` component's whole revision chain rather than stopping at the first too-new entry — because background revision GC can reorder entries physically without changing their TSNs.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Revision](./README.md)
+
+## 🎯 What it solves
+
+[MVCC Snapshot Visibility](./mvcc-snapshot-visibility.md) promises that a read resolves the latest revision
+committed at-or-before the reader's TSN. The naive way to implement that — walk the chain in physical order,
+stop at the first entry whose TSN exceeds the reader's snapshot — is wrong on Typhon's revision chain: cleanup
+compaction can relocate a later-committed revision into an earlier physical slot than an older one, so the
+chain's physical order and its commit-TSN order can diverge. A walk that breaks early can therefore skip the
+revision a reader was actually entitled to see, returning a stale or wrong value with no error.
+
+## ⚙️ How it works (in brief)
+
+`RevisionChainReader.WalkChain` always processes every live entry in the chain — never breaking on the first
+`TSN > transactionTSN` it meets — and keeps the highest-TSN entry that is both committed (`!IsolationFlag`) and
+at-or-before the reader's TSN, voided entries skipped along the way. An entry's `IsolationFlag` stays set until
+its writing transaction calls `Commit`, which is what makes an uncommitted entry invisible to every reader,
+including the writer's own later reads through this same path (read-your-own-writes is served separately, from
+a per-transaction cache, not from the chain). One fast path exists: a single-entry, already-committed chain — the
+common steady state for an entity not under concurrent write contention — resolves directly off the chain header
+without constructing the full walk or taking the chain's read lock at all.
+
+## 💻 Usage
+
+There's no separate API for this — it's the resolution step inside every `Versioned` read (`QueryRead`, `Open`,
+`PointInTimeAccessor`; see [MVCC Snapshot Visibility](./mvcc-snapshot-visibility.md) for those call sites). What's
+observable from the outside is purely a correctness property: a snapshot read keeps returning the right value
+across concurrent writes *and* concurrent cleanup, with no window where compaction running in the background
+causes a read to regress to an older or wrong revision.
+
+## ⚠️ Guarantees & limits
+
+- **No break-on-first-too-new** — the walk always covers the full chain; a later-slotted revision with a lower
+  TSN than an earlier-slotted one (a relocation artifact of cleanup) is never mistaken for "we've gone too far".
+- **Latest-by-TSN wins among visible candidates** — ties cannot occur (TSNs are unique per commit), so resolution
+  is always deterministic.
+- **Read cost scales with chain length** — a hot component with many outstanding revisions (e.g. a long-lived
+  reader holding old ones alive) makes every read on it walk further; this is exactly what the revision garbage
+  collector bounds by reclaiming entries no live snapshot can still need.
+- **Single-entry fast path takes no lock** — the steady-state case (no overflow chunk, already committed) reads
+  the header and one element directly, skipping `RevisionEnumerator` construction and the shared-lock acquire
+  that the general walk needs to stay consistent against concurrent compaction.
+
+## 🧪 Tests
+
+- [ChaosStressTests](../../../test/Typhon.Engine.Tests/Data/ChaosStressTests.cs) — `RevisionChainDepth_DeepChainWithCleanup` and `SentinelRevision_StaggeredReaderRelease` interleave writes with staggered/out-of-order reader release so background compaction runs concurrently with reads, then assert every reader still resolves its own snapshot correctly (no regression to a stale or wrong revision)
+
+## 🔗 Related
+
+- Parent feature: [MVCC Snapshot Visibility](./mvcc-snapshot-visibility.md)
+- Sibling: [Revision Garbage Collection & Compaction](./revision-gc-compaction.md) — the background compactor whose relocations this walk must tolerate
+- Source: [`RevisionChainReader.WalkChain`](../../../src/Typhon.Engine/Transactions/internals/RevisionWalker.cs), [`RevisionEnumerator`](../../../src/Typhon.Engine/Revision/internals/RevisionEnumerator.cs)
+
+<!-- Deep dive: claude/design/Revision/02-mvcc-visibility.md §5 — The chain is not TSN-sorted -->
+<!-- ADR: claude/adr/003-mvcc-snapshot-isolation.md -->

--- a/doc/feature-set/Revision/optimistic-conflict-baseline.md
+++ b/doc/feature-set/Revision/optimistic-conflict-baseline.md
@@ -1,0 +1,88 @@
+# Write-Conflict Baseline Tracking
+> Every revision append remembers the value it replaced, so commit-time conflict detection and resolution have something to compare against.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Revision](./README.md)
+
+## 🎯 What it solves
+
+Typhon's optimistic concurrency model (no locks during execution, ADR-003) needs a cheap way to answer two
+questions at commit time: "did anyone else commit a newer value for this entity's component since I read mine?"
+and, if so, "what was my baseline, what did the other transaction write, and what was I about to write?" Without
+a tracked baseline, conflict detection would have no fixed point of comparison, and a `ConcurrencyConflictHandler`
+that wants to rebase a delta (rather than just overwrite) would have nothing to rebase from. Background revision
+GC also physically reshuffles chain entries during compaction, so a transaction's cached position can go stale
+between read and commit — that staleness has to be caught, not silently produce a wrong result.
+
+## ⚙️ How it works (in brief)
+
+Every chain append (`AddCompRev`) records two coordinates: the new revision just written (`Cur`) and the revision
+it superseded (`Prev`), each as a `(chunk id, revision index)` pair. At commit, this `Cur` baseline is compared
+against the chain's authoritative state — a monotonic per-entity commit counter, immune to index reshuffling —
+to decide whether a conflict occurred. If a `ConcurrencyConflictHandler` is registered and a conflict fires, the
+baseline pair resolves the four data views (`ReadData`, `CommittedData`, `CommittingData`, `ToCommitData`) handed
+to the handler. Because compaction can shift indices between read and commit, the cached index is re-validated
+against its (unique) content-chunk id — `FindRevisionIndexByChunkId` — and repaired before it's trusted; without
+a handler, conflicts fall back to plain index-order comparison.
+
+## 💻 Usage
+
+The baseline itself is internal — application code interacts with it only through `Transaction.Commit`'s optional
+handler, which receives the resolved comparison views:
+
+```csharp
+using var t1 = dbe.CreateQuickTransaction();
+t1.Open(entityId).Read(CompAArch.A);                       // baseline snapshot
+ref var w1 = ref t1.OpenMut(entityId).Write(CompAArch.A);
+w1 = new CompA(90);                                         // intended write, delta = -10
+
+// Meanwhile another transaction read the same baseline, set A=130, and committed first.
+
+void ConflictHandler(ref ConcurrencyConflictSolver solver)
+{
+    var read = solver.ReadData<CompA>();           // 100 — our original snapshot
+    var committed = solver.CommittedData<CompA>();  // 130 — the other transaction's committed value
+    var committing = solver.CommittingData<CompA>(); // 90  — our intended write
+
+    var delta = committing.A - read.A;              // -10
+    solver.ToCommitData<CompA>().A = committed.A + delta; // rebase: 130 + (-10) = 120
+}
+
+t1.Commit(ConflictHandler);   // result: A == 120, not 90 (ours) or 130 (theirs)
+```
+
+| Resolution helper | Effect |
+|---|---|
+| `TakeRead<T>()` | Discard all changes, revert to the read snapshot |
+| `TakeCommitted<T>()` | Accept the other transaction's value |
+| `TakeCommitting<T>()` | Keep your own value (also the default if the handler is a no-op) |
+| (write `ToCommitData<T>()` directly) | Custom resolution, e.g. delta rebase as above |
+
+## ⚠️ Guarantees & limits
+
+- Without a handler, conflict resolution is "last writer wins" — the committing transaction's value always
+  replaces the prior one; no exception is raised.
+- With a handler, conflict detection uses a monotonic per-entity commit counter, not revision indices — it cannot
+  be fooled by background compaction reordering the chain between your read and your commit.
+- Stale cached positions caused by concurrent compaction are transparently repaired before use; if an entry is
+  ever truly unrecoverable (a hard invariant violation, not expected in practice) commit throws rather than
+  resolving against wrong data.
+- The handler runs under the entity's per-component revision-chain exclusive lock, so detection, resolution, and
+  publish are one atomic region — no second writer can interleave between "you see the conflict" and "your
+  resolution becomes visible".
+- Baseline tracking is per `(transaction, entity, component)` and only meaningful across the lifetime of one
+  transaction — it is not a general-purpose diff/version API.
+- Applies only to `StorageMode.Versioned` components — `SingleVersion`/`Committed`-discipline writes have no
+  revision chain to compare against (see [Committed Durability Discipline](../Ecs/storage-modes/storage-mode-committed.md)).
+
+## 🧪 Tests
+
+- [ConcurrencyConflictTests](../../../test/Typhon.Engine.Tests/Data/ConcurrencyConflictTests.cs) — the canonical suite: no-conflict pass-through, no-handler last-wins, handler-based delta rebase/`TakeCommitted`/`TakeRead`, multi-entity (all-conflict and partial-conflict) handler dispatch, concurrent-thread rebase race
+
+## 🔗 Related
+
+- Related feature: [Revision Append & Chain Growth](./revision-append-write-path.md) (where Prev/Cur are first set), [MVCC Snapshot Visibility](./mvcc-snapshot-visibility.md)
+- Sibling: [Optimistic Conflict Resolution](../Transactions/optimistic-conflict-resolution.md) — the `Transaction.Commit` handler surface that consumes this baseline
+- Source: [`ComponentRevisionManager.AddCompRev`/`FindRevisionIndexByChunkId`](../../../src/Typhon.Engine/Revision/internals/ComponentRevisionManager.cs), [`Transaction.DetectAndResolveConflict`](../../../src/Typhon.Engine/Transactions/public/Transaction.cs), [`ConcurrencyConflictSolver`](../../../src/Typhon.Engine/Transactions/public/ConcurrencyConflictSolver.cs)
+
+<!-- Deep dive: claude/design/Revision/01-revision-chain-storage.md, claude/design/Revision/03-revision-gc-compaction.md §3 -->
+<!-- ADR: claude/adr/003-mvcc-snapshot-isolation.md -->

--- a/doc/feature-set/Revision/revision-append-write-path.md
+++ b/doc/feature-set/Revision/revision-append-write-path.md
@@ -1,0 +1,86 @@
+# Revision Append & Chain Growth
+> Every write to a `Versioned` component creates a new immutable revision instead of overwriting the old one.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Revision](./README.md)
+
+## 🎯 What it solves
+
+Snapshot isolation requires that a transaction reading a `Versioned` component keeps seeing the value as of its
+own snapshot, even while other transactions concurrently write newer values. Overwriting a component in place
+would tear those reads and destroy the history that conflict detection and AS-OF / point-in-time queries depend
+on. Every `Spawn`, `Write<T>()`, and `Destroy` on a `Versioned` component therefore produces a brand-new,
+immutable revision instead of mutating the previous one — older readers keep a valid, untouched value to read.
+
+## ⚙️ How it works (in brief)
+
+`Spawn` allocates an entity's first revision directly. Every subsequent `Write<T>()` is copy-on-write: it
+appends a new revision to that component's per-entity chain — a small circular buffer that grows into 64-byte
+overflow chunks automatically once it fills, with no size limit you need to plan for up front. `Destroy` appends
+a tombstone revision (no payload) rather than deleting anything immediately. Each new revision is stamped with
+the writing transaction's TSN and Unit-of-Work id and marked provisional — invisible to every other transaction
+— until commit publishes it. The prior revision is left exactly as it was; nothing is freed at write time.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Stats", 1)]                 // StorageMode.Versioned is the default
+struct Stats { public int Hp; public int Mana; }
+
+[Archetype(7)]
+partial class Hero : Archetype<Hero>
+{
+    public static readonly Comp<Stats> Stats = Register<Stats>();
+}
+
+using var uow = dbe.CreateUnitOfWork();
+using var tx = uow.CreateTransaction();
+
+var id = tx.Spawn<Hero>(Hero.Stats.Set(new Stats { Hp = 100, Mana = 50 }));   // revision #1
+tx.Commit();
+
+// Each write below appends a new revision — concurrent snapshot readers are unaffected.
+for (var i = 0; i < 5; i++)
+{
+    using var hitUow = dbe.CreateUnitOfWork();
+    using var hitTx = hitUow.CreateTransaction();
+    ref var stats = ref hitTx.OpenMut(id).Write(Hero.Stats);   // copy-on-write: new revision appended
+    stats.Hp -= 10;                                            // chain grows into an overflow chunk past 3 entries
+    hitTx.Commit();
+}
+
+using var deathUow = dbe.CreateUnitOfWork();
+using var deathTx = deathUow.CreateTransaction();
+deathTx.Destroy(id);          // appends a tombstone revision per Versioned component the entity carries
+deathTx.Commit();
+```
+
+## ⚠️ Guarantees & limits
+
+- A write never blocks or invalidates a concurrent reader: the previous revision is untouched, so any
+  transaction already holding it keeps a valid value for the rest of its lifetime.
+- Chain growth is fully automatic — applications never size or manage the revision chain; the first 3 revisions
+  fit in the entity's root storage, every 5 beyond that grow the chain by one more chunk.
+- A new revision is provisional (invisible to other transactions) until the writing transaction commits; a
+  rolled-back transaction's revisions are voided, not left dangling.
+- Revisions are append-only and not reclaimed by the write path itself — the chain keeps growing with every
+  write until garbage collection trims revisions no longer needed by any active snapshot (see Related).
+- Appending briefly takes the entity's per-component revision-chain lock; under sustained timeout (default via
+  `TimeoutOptions.Current.RevisionChainLockTimeout`) the write throws `LockTimeoutException` rather than
+  blocking indefinitely.
+- Only `StorageMode.Versioned` components use this path — `SingleVersion` and `Transient` components write
+  in place and never allocate a revision (see [Committed Durability Discipline](../Durability/durability-modes/committed-discipline.md)
+  for the cheaper alternative when isolation isn't needed).
+
+## 🧪 Tests
+
+- [EcsSpawnMvccTests](../../../test/Typhon.Engine.Tests/Data/ECS/EcsSpawnMvccTests.cs) — `Spawn_Versioned_RevisionChainCreated` (chunk allocated on `Spawn`), `Write_Versioned_CopyOnWrite_NewChunk`/`Write_CreatedEntity_NoCopyOnWrite` (append vs. same-tx reuse), rollback frees the chunk (`Spawn_Versioned_Rollback_FreesRevisionChunk`, `Write_Versioned_Rollback_FreesNewChunk`)
+- [TransactionTests](../../../test/Typhon.Engine.Tests/Data/TransactionTests.cs) — `ComponentRevisionTortureTest` drives 100 mixed commit/rollback writes against one entity and asserts the accumulated revision count, then compacts to 1 after the blocking reader completes
+
+## 🔗 Related
+
+- Related feature: [Revision Chain Storage](./revision-chain-storage.md) (the layout this populates), [MVCC Snapshot Visibility](./mvcc-snapshot-visibility.md), [Write-Conflict Baseline Tracking](./optimistic-conflict-baseline.md) (Prev/Cur are first set here), [Revision Garbage Collection & Compaction](./revision-gc-compaction.md)
+- Source: [`ComponentRevisionManager.AddCompRev`/`AllocCompRevStorage`/`GrowChain`](../../../src/Typhon.Engine/Revision/internals/ComponentRevisionManager.cs), [`Transaction.Spawn`/`Transaction.Destroy`](../../../src/Typhon.Engine/Transactions/public/Transaction.ECS.cs), [`EntityRef.Write`](../../../src/Typhon.Engine/Ecs/public/EntityRef.cs)
+
+<!-- Deep dive: claude/design/Revision/01-revision-chain-storage.md, claude/design/Revision/README.md -->
+<!-- ADR: claude/adr/003-mvcc-snapshot-isolation.md -->
+<!-- Overview: claude/overview/04-data.md §4.5–4.6 -->

--- a/doc/feature-set/Revision/revision-chain-storage.md
+++ b/doc/feature-set/Revision/revision-chain-storage.md
@@ -1,0 +1,72 @@
+# Revision Chain Storage (on-disk layout)
+> The fixed-size, append-friendly layout that holds every live revision of a `Versioned` component on disk.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Revision](./README.md)
+
+## 🎯 What it solves
+
+MVCC needs somewhere to put the multiple concurrently-live revisions a `Versioned` component can accumulate while older snapshots still depend on them. That history has to be cheap to append to on every commit, cheap to walk on every read, and bounded in size so a hot entity doesn't grow without limit. A naive per-revision allocation (or a single growable array per entity) would fragment storage and make both append and reclaim expensive. Revision Chain Storage is the physical layout that makes append, walk, and reclaim all O(1)-ish operations instead of O(n) ones.
+
+## ⚙️ How it works (in brief)
+
+Each entity's component history for a given `Versioned` component type lives in a singly-linked chain of fixed 64-byte chunks — a circular buffer, so the oldest slot is reused once a chunk fills and its entries are no longer needed. The first chunk carries a small header (lock, item/chain counts, owning entity's primary key, a monotonic commit counter) plus a handful of revision entries; once those fill up, the chain grows by linking in additional 64-byte overflow chunks. Each revision entry is tiny — just enough to point at the actual component payload (stored separately, sized to the component) and to record when and by which transaction it was written. Capacity per chunk is derived from the entry's struct size at compile/runtime, not hardcoded, so the layout self-adjusts if the entry ever changes shape.
+
+## 💻 Usage
+
+This is a storage primitive, not something application code allocates or walks directly — it exists transparently under any `Versioned` component (the default storage mode), created on first write and grown automatically as revisions accumulate:
+
+```csharp
+[Component("Game.Health", 1)]                 // StorageMode.Versioned is the default
+struct Health { public int Current; public int Max; }
+
+[Archetype(7)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Health> Health = Register<Health>();
+}
+
+using var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+var soldier = tx.Spawn<Unit>(Unit.Health.Set(new Health { Current = 100, Max = 100 }));
+tx.Commit();                                   // allocates the entity's first revision-chain chunk
+
+using var hit = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+hit.OpenMut(soldier).Write(Unit.Health).Current -= 25;
+hit.Commit();                                  // appends a new revision entry into the same chain
+```
+
+Read-only introspection of the storage footprint goes through the same segment enumeration as every other structure:
+
+```csharp
+foreach (var seg in dbe.EnumerateStorageSegments())
+{
+    if (seg.Kind == StorageSegmentKind.Revision)
+    {
+        Console.WriteLine($"revision table root={seg.RootPageIndex} stride={seg.Stride} " +
+                           $"allocChunks={seg.AllocatedChunkCount} freeChunks={seg.FreeChunkCount}");
+    }
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Every chunk is exactly 64 bytes (one cache line); chunk capacity (3 entries in the first chunk, 5 per overflow chunk today) is computed from the entry struct's size, not hardcoded — a layout change flows through automatically.
+- One revision-chain chunk is the fixed minimum cost of a `Versioned` component per entity, even if it's never updated again after creation.
+- A short revision history (up to the first chunk's capacity) needs no overflow allocation at all — this is the steady state most entities should stay in; the revision garbage collector (see GC entry) is what keeps long-lived entities from drifting out of it.
+- The chain is singly-linked and circular by design: appending past capacity links a new chunk rather than copying existing entries, and reclaiming the oldest slot is an index bump, not a deallocation.
+- A component payload (`ComponentChunkId == 0`) inside a revision entry means a tombstone — a delete, not a missing record — so older snapshots can still resolve what an entity looked like before it was deleted.
+- Layout details (header/entry field order, packed bit layout) are internal and not part of the application-facing API surface; only the aggregate footprint is exposed, via `EnumerateStorageSegments`.
+
+## 🧪 Tests
+
+- [CompRevStorageElementTests](../../../test/Typhon.Engine.Tests/Data/CompRevStorageElementTests.cs) — layout-level unit tests: `Sizeof_Is12Bytes`, `ChunkCapacity_Root_Is3`/`ChunkCapacity_Overflow_Is5`, bitfield independence of `TSN`/`IsolationFlag`/`UowId`/`ComponentChunkId`, `Void`/`IsVoid` tombstone semantics
+
+## 🔗 Related
+
+- Deep dive: [doc/in-depth-overview/05-revision.md](../../in-depth-overview/05-revision.md)
+- Related feature: [Revision Append & Chain Growth](./revision-append-write-path.md) (what populates this layout),
+  [MVCC Snapshot Visibility](./mvcc-snapshot-visibility.md) (the reader that walks this chain)
+- Sibling: [Storage Mode: Versioned](../Ecs/storage-modes/storage-mode-versioned.md) — Versioned mode is the ECS-facing side of this on-disk layout
+- Source: [`ComponentRevisionManager`](../../../src/Typhon.Engine/Revision/internals/ComponentRevisionManager.cs), [`CompRevStorageHeader`/`CompRevStorageElement`](../../../src/Typhon.Engine/Ecs/public/ComponentTable.cs), [`RevisionEnumerator`](../../../src/Typhon.Engine/Revision/internals/RevisionEnumerator.cs)
+
+<!-- Deep dive: claude/design/Revision/01-revision-chain-storage.md, claude/overview/04-data.md §4.6 Revision Chains -->
+<!-- ADR: claude/adr/023-circular-buffer-revision-chains.md, claude/adr/027-even-sized-hot-path-structs.md -->

--- a/doc/feature-set/Revision/revision-gc-compaction.md
+++ b/doc/feature-set/Revision/revision-gc-compaction.md
@@ -1,0 +1,100 @@
+# Revision Garbage Collection & Compaction
+> Automatic, bounded-memory reclamation of old MVCC revisions once no active transaction can see them.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Revision](./README.md)
+
+## 🎯 What it solves
+
+Every overwrite of a `Versioned` component appends a new revision rather than mutating in place, so snapshot
+reads keep working while the write happens. Left unchecked, that history grows forever — a hot entity updated
+thousands of times would carry thousands of dead revisions, inflating storage and slowing every read that has
+to walk past them to find the visible one. Revision GC reclaims revisions as soon as they're provably
+unreachable, so chain length and storage footprint track *live* MVCC demand instead of cumulative write
+history.
+
+## ⚙️ How it works (in brief)
+
+GC is keyed off `MinTSN`, the oldest transaction snapshot still active — only revisions older than `MinTSN` are
+candidates for reclamation, since some open transaction may still need to resolve a read against them. When the
+transaction holding the oldest snapshot completes, the engine compacts every chain it touched right away. If a
+different (non-tail) transaction commits while an older one is still running, its cleanup is queued instead of
+done immediately, and runs automatically once that older transaction finally completes. Either way, one
+revision is always kept alive at the boundary — so a transaction reading at exactly `MinTSN` still resolves
+correctly — and once every revision in a chain collapses to a single "deleted" marker, the entity itself is
+removed.
+
+## 💻 Usage
+
+GC requires no application code — it runs transparently as a side effect of transaction completion:
+
+```csharp
+using var tx1 = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+var unit = tx1.Spawn<Unit>(Unit.Health.Set(new Health { Current = 100, Max = 100 }));
+tx1.Commit();
+
+// A long-running reader holds back the cleanup cutoff while updates accumulate.
+using var reader = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+reader.OpenRead(unit, Unit.Health);
+
+for (var i = 0; i < 50; i++)
+{
+    using var writer = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+    writer.OpenMut(unit).Write(Unit.Health).Current -= 1;
+    writer.Commit();                    // each commit queues cleanup, blocked by `reader`
+}
+
+reader.Dispose();                       // reader was the tail — its disposal compacts every queued chain
+```
+
+The only application-facing knobs are queue-health thresholds, set via `DatabaseEngineOptions.DeferredCleanup`
+at construction; queue depth and throughput are readable back through the engine's diagnostics surface:
+
+```csharp
+var options = new DatabaseEngineOptions
+{
+    DeferredCleanup = new DeferredCleanupOptions
+    {
+        HighWaterMark     = 100_000,    // log a warning once this many entities are queued (default)
+        CriticalThreshold = 1_000_000,  // log a critical warning past this point (default)
+        MaxCleanupBatchSize = 1000,     // entities reclaimed per deferred-cleanup pass (default)
+    },
+};
+
+var props = dbe.GetDebugProperties();
+Console.WriteLine($"pending={props["DeferredCleanup.QueueSize"]} processed={props["DeferredCleanup.ProcessedTotal"]}");
+```
+
+## ⚠️ Guarantees & limits
+
+- A revision is never reclaimed while a transaction could still need it — the cutoff is the oldest live
+  snapshot (`MinTSN`), not a timer or a fixed chain-length limit.
+- Reclamation is eventual, not instant, when a long-running transaction holds `MinTSN` back: writes against a
+  hot entity keep accumulating queued cleanup work, bounded and deduplicated per entity, until that transaction
+  completes.
+- A deleted entity's chain isn't removed immediately — it keeps a single "deleted" marker alive until no
+  transaction could possibly observe the entity again, so concurrent readers reliably see "deleted" rather than
+  "never existed".
+- Compaction never changes what a transaction can observe — it only discards copies that are already provably
+  invisible to every active and future transaction.
+- This applies to `Versioned`-mode components only; `SingleVersion`/`Transient` storage has no revision chain
+  to reclaim (see [Storage Modes](../Ecs/storage-modes/README.md)).
+- Cost is proportional to chain length at the moment of reclamation — short chains (the common case) compact in
+  low single-digit microseconds; long chains (entities updated heavily while a reader stalls them) cost more,
+  but only once, when the blocking transaction finally completes.
+
+## 🧪 Tests
+
+- [DeferredCleanupTests](../../../test/Typhon.Engine.Tests/Data/DeferredCleanupTests.cs) — tail-blocked cleanup on commit/dispose/rollback, queue dedup and TSN-bucket migration, partial-queue processing with sentinel preservation, matches the doc's own Usage sample almost line for line
+- [ChaosStressTests](../../../test/Typhon.Engine.Tests/Data/ChaosStressTests.cs) — `RevisionChainDepth_DeepChainWithCleanup` (500+ revisions reclaimed as staggered readers release oldest-first), `SentinelRevision_StaggeredReaderRelease` (reverse-order release stresses the sentinel boundary when `nextMinTSN` doesn't match the first kept entry's TSN)
+
+## 🔗 Related
+
+- Related feature: [Revision Chain Storage](./revision-chain-storage.md) (the layout this reclaims space within),
+  [MVCC Snapshot Visibility](./mvcc-snapshot-visibility.md) (the reader the sentinel revision protects)
+- Sibling: [Chain Walk Correctness Under Compaction](./mvcc-visibility-walk.md) — the visibility-side counterpart that tolerates this compactor's relocations
+- Source: [`ComponentRevisionManager.CleanUpUnusedEntriesCore`](../../../src/Typhon.Engine/Revision/internals/ComponentRevisionManager.cs),
+  [`DeferredCleanupManager`](../../../src/Typhon.Engine/Ecs/internals/DeferredCleanupManager.cs),
+  [`DeferredCleanupOptions`](../../../src/Typhon.Engine/Ecs/public/DeferredCleanupOptions.cs)
+
+<!-- Deep dive: claude/design/Revision/03-revision-gc-compaction.md, claude/overview/04-data.md §4.9 GC & Space Reclamation -->
+<!-- ADR: claude/adr/035-deferred-cleanup-hybrid-gc.md -->

--- a/doc/feature-set/Runtime/README.md
+++ b/doc/feature-set/Runtime/README.md
@@ -1,0 +1,35 @@
+# Runtime
+> The Runtime is Typhon's game-server execution layer: a DAG-scheduled, multi-threaded tick loop that dispatches developer-defined systems against the ECS data layer and automates their UoW/Transaction lifecycle. Systems declare phase and read/write access so the scheduler derives safe parallel execution automatically, scope dispatch to spatial simulation tiers, and skip entirely when nothing relevant changed. An overload detector and always-on per-tick telemetry let the server degrade gracefully under a load spike — throttling systems, slowing the tick rate, or signalling game code to shed load — instead of falling over.
+
+> 🔬 **Recommended:** read [in-depth-overview/10-runtime.md](../../in-depth-overview/10-runtime.md) (Chapter 10: Runtime) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Tick-Based Execution Engine](tick-execution-engine/README.md) | `TyphonRuntime` — the top-level host that owns the tick loop, creates one UoW per tick and one Transaction per system automatically, and drives startup/crash-recovery/shutdown | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Execution Modes](tick-execution-engine/execution-modes.md) | Today: a fixed-timestep tick loop plus a single-threaded debug variant; event-driven and hybrid request/response modes are designed but not yet built | 🚧 Partial | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [Worker Pool & Threading Model](tick-execution-engine/worker-pool-threading.md) | Core allocation between a dedicated tick-metronome thread and a worker pool that executes the system DAG in parallel | ✅ Implemented | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [Parallel Tick Fence](tick-execution-engine/parallel-tick-fence.md) | Spreads the post-tick `WriteTickFence` step (cluster migrations, AABB refresh, WAL publish) across the worker pool instead of running it on one thread — tuned via `RuntimeOptions` | ✅ Implemented | 🟣 Advanced |
+| [Declarative System Scheduling (Track → DAG → Phase, Auto-DAG)](declarative-system-scheduling.md) | Systems declare per-component read/write access and a DAG-local phase; the scheduler auto-derives execution edges and rejects unsafe write/write or stale-read conflicts at `Build()` | ✅ Implemented | 🔵 Core |
+| [System Types](system-types/README.md) | Five system base classes a developer picks per piece of game logic — proactive callbacks, reactive entity queries, chunk-parallel non-entity work, multi-stage pipelines, and sub-system grouping | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [CallbackSystem](system-types/callback-system.md) | Proactive system that runs every tick for non-entity work — timers, input draining, global state | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [QuerySystem](system-types/query-system.md) | Reactive per-entity system that auto-skips when nothing relevant changed, with optional automatic multi-core chunking | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [ChunkedCallbackSystem](system-types/chunked-callback-system.md) | Fan a CallbackSystem's body out across N workers for SIMD sweeps, reductions, and other non-entity chunkable work | ✅ Implemented | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [PipelineSystem](system-types/pipeline-system.md) | Reactive multi-stage gather/process/scatter system for bulk entity processing — full execution model pending Patate | ✅ Implemented (chunk-dispatch only) | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [CompoundSystem](system-types/compound-system.md) | Group related sub-systems' registration under one `Configure` call — one node from the outside, parallel inside | ✅ Implemented | 🟣 Advanced |
+| [Parallel Entity Processing (QuerySystem.Parallel)](parallel-entity-processing.md) | Automatic multi-core chunking with a reusable `PointInTimeAccessor` (no per-chunk Transaction for non-Versioned writes) across four dispatch paths selected by Versioned-write × change-filter | ✅ Implemented | 🟣 Advanced |
+| [Reactive Dispatch: Change Filters & Run Conditions](reactive-dispatch-change-filters.md) | `changeFilter` limits a system's entity set to dirty ∪ Added by piggybacking on the View's ring buffer; `shouldRun` gives a zero-cost proactive skip predicate evaluated before any input work | ✅ Implemented | 🟣 Advanced |
+| [Typed Event Queues](typed-event-queues.md) | Single-producer ring-buffer queues for inter-system signalling within a tick, enabling reactive cascade chains that early-out cheaply when dormant | ✅ Implemented | 🟣 Advanced |
+| [Side-Transactions for Immediate Durability](side-transactions.md) | Per-tick `CreateSideTransaction(Immediate)` lets a system commit economy-critical writes durably mid-tick, independent of and invisible to the main tick UoW's snapshot | ✅ Implemented | 🟣 Advanced |
+| [Overload Management](overload-management.md) | Single-writer overload state machine that escalates/de-escalates through system throttling and tick-rate modulation (TiDi, up to 6x) and fires a critical-overload callback for game-decided player shedding | 🚧 Partial | 🟣 Advanced |
+| [Telemetry & Runtime Inspection](telemetry-runtime-inspection.md) | Always-on, zero-allocation ring buffer of per-tick/per-system telemetry inspectable from game code; a pluggable `IRuntimeInspector` hook for remote tooling is designed but not implemented | 🚧 Partial | 🟣 Advanced |
+| [Spatial Tiers & Adaptive Dispatch](spatial-tiers-adaptive-dispatch/README.md) | Per-cluster simulation tiers let systems process near entities every tick and far entities at reduced/amortized/dormant rates, scoping dispatch automatically to the matching clusters | ✅ Implemented | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [Tier-Filtered & Amortized Dispatch](spatial-tiers-adaptive-dispatch/tier-filtered-amortized-dispatch.md) | Scope a system to clusters in matching tier cells, and optionally process just 1/N of them per tick | ✅ Implemented | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [Cluster Dormancy (Sleep/Wake)](spatial-tiers-adaptive-dispatch/cluster-dormancy.md) | Clusters untouched for N ticks sleep and are skipped by every dispatch path, waking within one tick of being written to | ✅ Implemented | 🟣 Advanced |
+| &nbsp;&nbsp;↳ [Checkerboard (Red/Black) Dispatch](spatial-tiers-adaptive-dispatch/checkerboard-dispatch.md) | Two-phase Red/Black parallel dispatch so neighbor-touching systems never race across a cell boundary | ✅ Implemented | 🟣 Advanced |
+| [Data-Driven Timers / Scheduled Entities](data-driven-timers.md) | Documented pattern for modeling respawns/expiries as entities with a time-of-expiry component and a `CallbackSystem` poll; no built-in timer/scheduling infrastructure exists yet | 📋 Planned | 🟣 Advanced |
+
+## Internal Features
+
+*No internal-only engine machinery documented separately in this category — every feature file above is directly reached from application code (`TyphonRuntime`, `SystemBuilder`, `TickContext`, `RuntimeOptions`, `Transaction`). The DAG deriver, overload detector, dormancy reporter, and access validator that back these features are implementation detail behind them, not separately catalogued.*

--- a/doc/feature-set/Runtime/data-driven-timers.md
+++ b/doc/feature-set/Runtime/data-driven-timers.md
@@ -1,0 +1,100 @@
+# Data-Driven Timers / Scheduled Entities
+> Model respawns, expiries, and cooldowns as queryable entities — no separate timer subsystem.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](./README.md)
+
+## 🎯 What it solves
+
+Game servers need scheduled work — respawns, buff/cooldown expiry, auction timeouts, periodic
+events — that fires by passage of time rather than by data change. A dedicated timer/scheduler
+subsystem (heap of callbacks, wheel timer, etc.) duplicates machinery Typhon already has: storage,
+transactions, indexes, queries. It also loses the properties those give you for free — a timer
+living outside the entity model isn't transactional, isn't crash-recoverable, and isn't
+queryable ("show me all pending respawns") without bespoke code.
+
+## ⚙️ How it works (in brief)
+
+A timer is an ordinary entity: an archetype carrying a time-of-expiry field plus whatever payload
+the timer needs (player id, item id, …). A dedicated `CallbackSystem` runs every tick and queries
+for entities whose expiry field has passed `now`, processes them, and destroys (one-shot) or
+re-arms (repeating) the timer entity. Because expiry is driven by wall-clock or tick-count passage
+— not by a write to the entity — this must be a proactive `CallbackSystem` poll, not a reactive
+`changeFilter`/View trigger: nothing writes to the timer component when it silently expires, so a
+change-tracking mechanism would never see the event.
+
+## 💻 Usage
+
+```csharp
+// 1. A payload component + your own expiry component (any unmanaged struct works;
+//    Typhon does not ship a built-in ScheduleAt type today).
+public struct ScheduleAt
+{
+    public long ExpiresAtTicks;   // Stopwatch.GetTimestamp()-based
+    public bool IsExpired(long nowTicks) => nowTicks >= ExpiresAtTicks;
+    public static ScheduleAt After(TimeSpan delay) =>
+        new() { ExpiresAtTicks = Stopwatch.GetTimestamp() + (long)(delay.TotalSeconds * Stopwatch.Frequency) };
+}
+
+public struct RespawnData
+{
+    public EntityId PlayerId;
+}
+
+[Archetype(300)]
+public class RespawnTimer : Archetype<RespawnTimer>
+{
+    public static readonly Comp<ScheduleAt> Timer = Register<ScheduleAt>();
+    public static readonly Comp<RespawnData> Data = Register<RespawnData>();
+}
+
+// 2. Schedule a respawn from any system, inside its Transaction:
+var timer = ScheduleAt.After(TimeSpan.FromSeconds(30));
+var data = new RespawnData { PlayerId = deadPlayerId };
+tx.Spawn<RespawnTimer>(RespawnTimer.Timer.Set(in timer), RespawnTimer.Data.Set(in data));
+
+// Cancel by destroying the timer entity:
+tx.Destroy(respawnTimerId);
+
+// 3. A CallbackSystem polls and fires expired timers every tick:
+var dag = schedule.PublicTrack.DeclareDag("Game");
+dag.CallbackSystem("ProcessRespawns", ctx =>
+{
+    var now = Stopwatch.GetTimestamp();
+    foreach (var id in ctx.Transaction.Query<RespawnTimer>()
+                 .Where<ScheduleAt>(t => t.IsExpired(now))
+                 .Execute())
+    {
+        var entity = ctx.Transaction.Open(id);
+        var data = entity.Read(RespawnTimer.Data);
+        RespawnPlayer(ctx.Transaction, data.PlayerId);
+        ctx.Transaction.Destroy(id);   // one-shot: remove after firing
+    }
+}, after: "Input");
+```
+
+## ⚠️ Guarantees & limits
+
+- **Transactional, crash-durable, queryable, cancellable** — these come for free from being a
+  normal entity: rollback undoes scheduling, recovery restores it per the archetype's storage
+  mode, `tx.Query<RespawnTimer>().Execute()` lists pending timers, `tx.Destroy(id)` cancels one.
+- **No built-in scheduler** — this is a documented pattern, not Typhon infrastructure. You write
+  the `ScheduleAt`-style component, the `CallbackSystem` poll loop, and the re-arm/destroy logic.
+- **Current query cost is a broad scan, not an index seek** — `EcsQuery<T>.Where<T>` evaluates the
+  predicate per entity via `Transaction.Open` + `TryRead`; targeted (index-first) scan isn't wired
+  up yet. An index-backed range query (`ExpiresAtTicks <= now`) is the eventual goal but cost
+  today scales with the archetype's entity count, not the expired subset.
+- **Pick storage mode per timer cost/criticality**: `SV` for high-frequency, loss-tolerant timers
+  (respawns, cooldowns — a tick of loss on crash is invisible); `Versioned` for timers that must
+  never silently vanish (auction expiry, trade lockouts).
+- Repeating timers must be re-armed explicitly (`ExpiresAtTicks += interval`) by your processing
+  code — there is no automatic repeat semantics.
+
+## 🔗 Related
+
+- Related feature: [Declarative System Scheduling](./declarative-system-scheduling.md) (CallbackSystem, `shouldRun`)
+- Related feature: [Reactive Dispatch / Change Filters](./reactive-dispatch-change-filters.md) (why this pattern uses a poll, not a filter)
+- Related feature: [Query System](../Ecs/query-system.md)
+- Related feature: [Storage Mode — SingleVersion](../Ecs/storage-modes/storage-mode-singleversion.md), [Storage Mode — Versioned](../Ecs/storage-modes/storage-mode-versioned.md)
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md §Schedule Components (Timer Pattern) -->
+<!-- Deep dive: claude/design/Runtime/README.md (decision R15) -->

--- a/doc/feature-set/Runtime/declarative-scheduling/README.md
+++ b/doc/feature-set/Runtime/declarative-scheduling/README.md
@@ -1,0 +1,56 @@
+# Declarative Scheduling — Auto-DAG (RFC 07)
+> Systems declare phase and read/write access; the scheduler derives the DAG and rejects unsafe overlaps at Build().
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Manual dependency wiring (`.After()` edges on every system) doesn't scale: adding a new writer of a
+component means auditing every existing system that touches it, and a missed edge is a silent race —
+nondeterministic behavior that only reproduces under load. It also leaves cores idle, because a
+hand-written DAG is only as parallel as the developer bothered to make it. Declarative access turns
+"who reads/writes what" into an explicit fact the scheduler can act on, so overlapping writes and
+ambiguous reads become a `Build()`-time error instead of a production bug.
+
+## ⚙️ How it works (in brief)
+
+Every system declares a phase (its position in a DAG-local ordering) and a read/write set on
+`SystemBuilder` — `Reads<T>()`, `Writes<T>()`, `ReadsFresh<T>()`, `ReadsSnapshot<T>()`, plus
+event-queue and named-resource variants. At `Build()`, the scheduler groups systems by phase, derives
+a DAG edge for every access relationship it can prove is safe (e.g. a fresh reader runs after its
+writer), and throws — with a copy-paste-ready fix — for relationships it can't (two writers of the
+same component, same phase, no declared order). The derived graph is an ordinary dependency DAG; the
+any-worker, claim-on-CAS dispatch loop that executes it at runtime is unchanged by this RFC — only how
+the DAG gets *built* changed.
+
+## Sub-features
+
+| Sub-feature | Use it when... |
+|---|---|
+| [Track → DAG → Phase Partitioning](./track-dag-phase-partitioning.md) | Structuring the schedule itself — grouping systems into independent DAGs, ordering coarse execution stages, declaring a DAG's phase sequence |
+| [Access Declarations & Build-Time Conflict Detection](./access-conflict-detection.md) | Declaring what one system reads/writes so the scheduler can order it safely and parallelize it against everything else |
+
+## ⚠️ Guarantees & limits
+
+- `W×W` (two writers of the same component, same phase) and ambiguous `R×W` (plain `Reads<T>()`
+  against a same-phase writer) are `Build()`-time errors with copy-paste-ready suggestions — never
+  silent races.
+- Access tracking is component-level, not field-level — `Writes<T>()` means "touches any field of T."
+- `.After()` / `.Before()` remain as the escape hatch for non-access ordering constraints, and as the
+  required disambiguation tool for an intentional same-phase `W×W`.
+- A DEBUG-only assertion checks every `EntityRef.Write<T>()` against the executing system's declared
+  `Writes`/`SideWrites` set; `[Conditional("DEBUG")]` strips the call entirely in RELEASE — zero
+  production overhead.
+- This is declaration, not inference — Typhon never inspects a system body to detect its actual
+  reads/writes. An undeclared access is simply invisible to the scheduler (and, in DEBUG, only the
+  write side is cross-checked at runtime).
+- `Build()` validation has no suppress switch — it's a one-shot startup cost; a false positive should
+  be fixed by correcting the declaration, not disabled.
+
+## 🔗 Related
+
+- Sub-features: [Track → DAG → Phase Partitioning](./track-dag-phase-partitioning.md), [Access Declarations & Build-Time Conflict Detection](./access-conflict-detection.md)
+
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md -->
+<!-- Deep dive: claude/rules/runtime-scheduling.md -->
+<!-- Deep dive: claude/adr/052-track-dag-partitioning-hierarchy.md -->

--- a/doc/feature-set/Runtime/declarative-scheduling/access-conflict-detection.md
+++ b/doc/feature-set/Runtime/declarative-scheduling/access-conflict-detection.md
@@ -1,0 +1,99 @@
+# Access Declarations & Build-Time Conflict Detection
+> Reads/Writes/ReadsFresh/ReadsSnapshot declare what a system touches; Build() derives safe ordering and rejects unsafe overlaps.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Two systems in the same phase writing the same component, or a system reading data with no stated
+opinion on whether it wants this-tick or previous-tick values, are both silent races today and
+correctness bugs in production. Declared access makes "who touches what" an explicit, checkable fact
+instead of something a developer has to remember to verify by hand every time a new system is added.
+
+## ⚙️ How it works (in brief)
+
+On `SystemBuilder`, a system declares `Reads<T>()` / `Writes<T>()` for components, `WritesEvents` /
+`ReadsEvents` for event queues, and `WritesResource` / `ReadsResource` for named non-component
+resources. Two read variants resolve same-phase write conflicts explicitly: `ReadsFresh<T>()` orders
+the reader after any same-phase writer (sees this tick's value), `ReadsSnapshot<T>()` orders it before
+(sees the previous tick's value — and is only legal on `Versioned` components, since there's no MVCC
+history to freeze to on `SingleVersion`/`Transient`). Plain `Reads<T>()` is legal only when no
+same-phase writer of `T` exists. At `Build()`, the deriver walks each DAG's systems phase by phase:
+same-phase write/write and ambiguous read/write overlaps throw with a fix suggestion; every other
+access pair derives a DAG edge. Across phases the deriver is conflict-driven, not all-to-all — a
+phase-N+1 system only waits on a phase-N system it genuinely conflicts with, so unrelated systems still
+overlap even though phase order remains the human-readable contract.
+
+## 💻 Usage
+
+```csharp
+private struct Position { public float X, Y; }
+private struct Velocity { public float X, Y; }
+
+class MovementSystem : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Movement").Phase(Phase.Simulation)
+        .Input(() => _movingUnits).Parallel()
+        .Reads<Velocity>().Writes<Position>();
+
+    protected override void Execute(TickContext ctx)
+    {
+        foreach (var id in ctx.Entities)
+        {
+            var entity = ctx.Accessor.OpenMut(id);
+            ref var pos = ref entity.Write(Unit.Position);
+            pos.X += entity.Read(Unit.Velocity).X * ctx.DeltaTime;
+        }
+    }
+}
+
+class ClampSystem : QuerySystem
+{
+    // Same phase, same component as Movement — the W×W must be disambiguated or Build() throws (AC-01).
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Clamp").Phase(Phase.Simulation).After("Movement")
+        .Writes<Position>();
+    // Execute(...) elided.
+}
+
+class RenderSystem : QuerySystem
+{
+    // Different (later) phase — observes this tick's clamped Position via the derived cross-phase edge.
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Render").Phase(Phase.Output)
+        .ReadsFresh<Position>();
+    // Execute(...) elided.
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- `Build()`-time errors, with copy-paste-ready suggestions, for: same-phase `W×W` with no declared
+  order; same-phase plain `Reads<T>()` against a writer of `T`; resource `W×W` with no declared order;
+  two systems in one phase both declaring `ExclusivePhase()`, or one declaring it while sharing the
+  phase with anyone else.
+- `ReadsSnapshot<T>()` requires `T` to be `Versioned` — `Build()` rejects it on `SingleVersion` or
+  `Transient` components (no MVCC history to freeze to).
+- Cross-phase `ReadsSnapshot<T>()` against an earlier-phase writer degrades to fresh semantics: phase
+  order already forces "writer first," so there's nothing earlier left to freeze to. This is a
+  documented, intentional deviation from the intra-phase meaning.
+- `SideWrites<T>()` (writes via a `DurabilityMode.Immediate` side-transaction) is surfaced to tooling
+  but intentionally does **not** participate in scheduler ordering.
+- A DEBUG-only check (`SystemAccessValidator`) throws `InvalidAccessException` when `EntityRef.Write<T>()`
+  runs from a system that didn't declare `Writes<T>`/`SideWrites<T>` — silently skipped for systems
+  with zero declarations (migration window) and compiled out entirely in RELEASE.
+- Conflict checks consult only direct `.After()`/`.Before()` adjacency, not transitive reachability —
+  a chain `A.Before(B).Before(C)` does not implicitly resolve an `A`/`C` write conflict; each pair
+  needs its own edge.
+- Access is the unit of truth for derivation, not actual runtime behavior — Typhon never inspects what
+  a system body really touches; an undeclared access is simply invisible to the scheduler.
+
+## 🔗 Related
+
+- Parent feature: [Declarative Scheduling — Auto-DAG (RFC 07)](./README.md)
+- Sibling: [Track → DAG → Phase Partitioning](./track-dag-phase-partitioning.md) — the phase/DAG structure this access derivation runs within.
+- Sibling: [Runtime/Scheduler Declared-Access Validation](../../Errors/runtime-access-validation.md) — the DEBUG-only runtime check that cross-verifies these declarations.
+
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md -->
+<!-- Deep dive: claude/rules/runtime-scheduling.md (AC-01..AC-05, ED-01..ED-05f, DV-01..DV-03) -->

--- a/doc/feature-set/Runtime/declarative-scheduling/track-dag-phase-partitioning.md
+++ b/doc/feature-set/Runtime/declarative-scheduling/track-dag-phase-partitioning.md
@@ -1,0 +1,87 @@
+# Track → DAG → Phase Partitioning
+> Tracks order coarse execution stages, DAGs group independent dependency graphs, phases order systems within one DAG.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+A tick needs more structure than one flat system list. The engine's own bookkeeping (the post-tick
+Fence) must run as a unit after the whole app; an app may want to split unrelated work (gameplay vs.
+debug tooling) into independently-built graphs that don't accidentally couple; and within one
+subsystem there's usually a coarse natural ordering (Input → Simulation → Output). Track → DAG →
+Phase gives each of those three needs its own explicit, structural level instead of overloading a
+single list with per-system flags.
+
+## ⚙️ How it works (in brief)
+
+A `RuntimeSchedule` owns an ordered list of `Track`s: built-in **Engine-Pre**, **Public** (the app's
+default track), and **Engine-Post** (holds the engine's Fence DAG), with app tracks declared via
+`DeclareTrack(...)` slotting in between Public and Engine-Post. Track order is execution order — every
+DAG in track *N* completes before any DAG in track *N+1* begins. Each `Track` holds one or more
+independent `Dag`s (`Track.DeclareDag(name)`); DAGs in the same track have no ordering relationship
+with each other. Each `Dag` declares its own ordered `Phase[]` list via `.Phases(...)` (or gets a
+single implicit phase if it declares none) — phases are DAG-local, so two DAGs may reuse the same
+phase name without coupling. A system lands in a phase via `b.Phase(...)` in `Configure`, or in the
+DAG's default phase if it never calls it.
+
+## 💻 Usage
+
+```csharp
+var schedule = RuntimeSchedule.Create(new RuntimeOptions { WorkerCount = 8 });
+
+// One DAG on the built-in Public track, with its own phase order.
+var game = schedule.PublicTrack.DeclareDag("Game")
+    .Phases(Phase.Input, Phase.Simulation, Phase.Output)
+    .DefaultPhase(Phase.Simulation);
+
+class ReadInputSystem : CallbackSystem
+{
+    protected override void Configure(SystemBuilder b) => b.Name("ReadInput").Phase(Phase.Input);
+    protected override void Execute(TickContext ctx) { /* ... */ }
+}
+
+game.Add(new ReadInputSystem());
+game.Add(new MovementSystem());   // Configure: b.Name("Movement") — lands in Phase.Simulation (the default)
+game.Add(new RenderSystem());     // Configure: b.Name("Render").Phase(Phase.Output)
+
+// A second, independent app track + DAG — runs only after every Public-track DAG has completed.
+var debugTrack = schedule.DeclareTrack("Debug");
+debugTrack.DeclareDag("DebugOverlay").Add(new DebugDrawSystem());
+
+using var scheduler = schedule.Build(registry.Runtime);
+scheduler.Start();
+```
+
+| Level | Declared with | Ordering rule |
+|---|---|---|
+| Track | `RuntimeSchedule.DeclareTrack(name, tags...)` | Declaration order = execution order; a coarse barrier between tracks |
+| DAG | `Track.DeclareDag(name)` | DAGs in the same track are independent of each other |
+| Phase | `Dag.Phases(...)` + `b.Phase(...)` | DAG-local total order; unset systems land in the DAG's default phase |
+
+## ⚠️ Guarantees & limits
+
+- Declaring a DAG is mandatory — there is no default-DAG convenience; every system belongs to exactly
+  one named `Dag`.
+- A DAG that declares no phases gets a single implicit phase — fine for a trivial DAG ordered entirely
+  by `.After()`/`.Before()`.
+- Phases are DAG-local: there is no engine-global phase namespace, and the same phase name reused in
+  two different DAGs does not couple them.
+- App track names may not start with the reserved `Engine-` prefix, may not duplicate an existing
+  track name, and may not carry the reserved `engine` tag — those mark the built-in Engine-Pre /
+  Engine-Post tracks only.
+- `.After()` / `.Before()` and access-conflict derivation never cross a DAG boundary — `Build()`
+  rejects a cross-DAG dependency edge outright.
+- The Engine-Post track (the Fence) is dispatched from the post-tick hook rather than the in-tick
+  track loop, because it depends on serial tick-fence prep finishing first. The "track order =
+  execution order" contract still holds — only the trigger differs.
+- `DagScheduler.UserSystems` / `SystemCount` exclude systems on `engine`-tagged tracks so tooling
+  counts stay app-focused; `AllSystemCount` includes them.
+
+## 🔗 Related
+
+- Parent feature: [Declarative Scheduling — Auto-DAG (RFC 07)](./README.md)
+- Sibling: [Access Declarations & Build-Time Conflict Detection](./access-conflict-detection.md) — the per-system read/write declarations that combine with phase order to derive DAG edges.
+
+<!-- Deep dive: claude/adr/052-track-dag-partitioning-hierarchy.md -->
+<!-- Deep dive: claude/overview/13-runtime.md §Track → DAG → Phase → System partitioning -->
+<!-- Deep dive: claude/rules/runtime-scheduling.md (PS-01, PR-01..PR-03) -->

--- a/doc/feature-set/Runtime/declarative-system-scheduling.md
+++ b/doc/feature-set/Runtime/declarative-system-scheduling.md
@@ -1,0 +1,85 @@
+# Declarative System Scheduling (Track → DAG → Phase, Auto-DAG)
+> Systems declare read/write access and a phase; the scheduler derives the DAG and rejects unsafe conflicts at Build().
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Runtime](./README.md)
+
+## 🎯 What it solves
+Hand-wired `.After()` edges don't scale: adding a new writer of a component means auditing every
+existing system that touches it, and a missed edge is a silent race — nondeterministic behavior
+that only reproduces under load. Manual DAGs also under-parallelize, because a hand-written graph
+is only as concurrent as the developer bothered to make it, leaving cores idle. Declarative access
+turns "who reads/writes what" into an explicit, checkable fact instead of tribal knowledge.
+
+## ⚙️ How it works (in brief)
+Systems register under a `Track → Dag → Phase` hierarchy: tracks run in strict execution order
+(all DAGs of track N finish before track N+1 starts), DAGs are independent dependency graphs, and
+each DAG declares its own ordered phase sequence. Each system declares a phase (`b.Phase(...)`)
+and an access set (`b.Reads<T>()`, `b.Writes<T>()`, `b.ReadsFresh<T>()`, `b.ReadsSnapshot<T>()`,
+plus event-queue and named-resource variants) on `SystemBuilder`. At `Build()`, the scheduler
+groups systems by phase, derives a DAG edge for every access relationship it can prove safe, and
+hard-errors — with a fix suggestion — for the ones it can't (two same-phase writers of a
+component, or a plain `Reads<T>()` against a same-phase writer). `.After()` / `.Before()` remain
+as the disambiguation tool for that error and as an escape hatch for ordering that isn't
+access-driven. Across phases, edges are conflict-driven rather than all-to-all, so independent
+systems in adjacent phases can run concurrently instead of waiting on an unrelated straggler.
+
+## 💻 Usage
+```csharp
+var schedule = RuntimeSchedule.Create(new RuntimeOptions { BaseTickRate = 60, WorkerCount = 8 });
+
+var dag = schedule.PublicTrack.DeclareDag("Game")
+    .Phases(Phase.Input, Phase.Simulation, Phase.Output, Phase.Cleanup)
+    .DefaultPhase(Phase.Simulation);
+
+dag.Add(new MovementSystem());    // Configure(): b.Name("Movement").Phase(Phase.Simulation).Writes<Position>();
+dag.Add(new RenderSyncSystem());  // Configure(): b.Name("RenderSync").Phase(Phase.Output).ReadsFresh<Position>();
+
+using var scheduler = dag.Build(parentResource);
+```
+
+A system declaring a same-phase write conflict must disambiguate explicitly:
+```csharp
+protected override void Configure(SystemBuilder b) => b
+    .Name("Clamp")
+    .Phase(Phase.Simulation)
+    .Writes<Position>()
+    .After("Movement");   // both write Position in Simulation — Build() requires this edge
+```
+
+| Declaration | Effect |
+|---|---|
+| `Reads<T>()` | Plain read; legal only if no same-phase writer of `T` exists |
+| `ReadsFresh<T>()` | Ordered after same-phase writers of `T` — sees this-tick value |
+| `ReadsSnapshot<T>()` | Ordered before same-phase writers of `T` — sees previous-tick value (requires Versioned `T`) |
+| `Writes<T>()` | Mutates `T`; two same-phase writers require `.After()` / `.Before()` |
+| `ExclusivePhase()` | System runs alone in its phase |
+
+## ⚠️ Guarantees & limits
+- `W×W` (two same-phase writers of a component) and ambiguous `R×W` (plain `Reads<T>()` against a
+  same-phase writer) are `Build()`-time errors naming both systems — never silent races.
+- Access tracking is component-level, not field-level — `Writes<T>()` covers any field of `T`.
+- `ReadsSnapshot<T>()` requires `T` to use Versioned storage; SingleVersion/Transient components
+  have no prior-tick history to freeze to and are rejected at `Build()`.
+- Phases order systems within one DAG only. Cross-DAG ordering is structural (track sequence), not
+  access-derived — `.After()` / `.Before()` spanning DAGs is rejected at `Build()`.
+- Cross-phase edges are conflict-driven, not all-to-all: a straggler in phase N no longer gates
+  every system in phase N+1, only the ones with a declared data dependency on it.
+- `Build()` validation has no suppress switch — a false positive is fixed by correcting the
+  declaration, not disabling the check.
+- DEBUG builds assert every `EntityRef.Write<T>()` against the executing system's declared writes;
+  RELEASE strips the check (`[Conditional("DEBUG")]`) for zero production overhead.
+
+## 🧪 Tests
+
+- [AccessDagDerivationTests](../../../test/Typhon.Engine.Tests/Runtime/AccessDagDerivationTests.cs) — W×W same-phase throws, `.After()`/`.Before()` disambiguation, `ReadsFresh`/`ReadsSnapshot` edge derivation, `ReadsSnapshot` on SingleVersion rejected
+- [SystemBuilderFluentTests](../../../test/Typhon.Engine.Tests/Runtime/SystemBuilderFluentTests.cs) — `Reads`/`Writes`/`ReadsFresh`/`ReadsSnapshot` declaration API, dedup, `Before`/`After` cycle detection
+- [SystemAccessValidatorTests](../../../test/Typhon.Engine.Tests/Runtime/SystemAccessValidatorTests.cs) — DEBUG-only assert that `EntityRef.Write<T>()` matches the system's declared writes
+
+## 🔗 Related
+- Parent feature: [Runtime](./README.md)
+- Sibling: [Declarative Scheduling — Auto-DAG (RFC 07)](./declarative-scheduling/README.md) — near-duplicate catalog entry for the same Track→DAG→Phase access-declaration system, filed under its own sub-category.
+
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md -->
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md -->
+<!-- Deep dive: claude/rules/runtime-scheduling.md -->
+<!-- Deep dive: claude/adr/052-track-dag-partitioning-hierarchy.md -->

--- a/doc/feature-set/Runtime/overload-management.md
+++ b/doc/feature-set/Runtime/overload-management.md
@@ -1,0 +1,81 @@
+# Overload Management
+> Single-writer state machine that throttles systems and slows the tick rate so a load spike degrades instead of crashing.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](./README.md)
+
+## 🎯 What it solves
+Game servers face sudden, unpredictable load spikes — a crowd converges on one point, an explosion destroys thousands of entities, a bot swarm hits the AI pipeline. Without a built-in response, an overloaded tick loop either falls further and further behind (unbounded latency) or the process falls over. Overload Management gives the Runtime a standing policy for "what to do when a tick takes too long" so the server degrades in a controlled, reversible way instead of crashing or freezing.
+
+## ⚙️ How it works (in brief)
+Every tick, the scheduler measures the overrun ratio (actual tick duration vs. the base-rate budget) and event-queue growth, and feeds both into a single-writer state machine (`OverloadDetector`, running on the tick driver thread). Sustained overrun escalates through levels; sustained headroom de-escalates. Escalation is fast (5 consecutive overrun ticks by default), de-escalation is slow (20 consecutive under-run ticks) — this asymmetric hysteresis prevents oscillation. At `SystemThrottling` and above, low-priority systems marked shed-able stop running and normal-priority systems with a throttle divisor run less often; `Critical`/`High`-priority systems are never touched. If overrun persists, the Runtime slows the whole simulation in integer multiples of the base tick (`TickRateModulation`, up to 6x) so physics `dt` stays constant. As a last resort it fires a callback so game code can shed load itself (e.g. disconnect spectators); the Runtime never disconnects players on its own.
+
+## 💻 Usage
+```csharp
+protected override void Configure(SystemBuilder b) => b
+    .Name("AmbientFx")
+    .Priority(SystemPriority.Low)
+    .CanShed(true);                 // disabled entirely once overload hits SystemThrottling+
+
+protected override void Configure(SystemBuilder b) => b
+    .Name("AI")
+    .Priority(SystemPriority.Normal)
+    .ThrottledTickDivisor(3);       // runs every 3rd tick under overload instead of every tick
+
+// Physics stays Priority.Critical (default throttle/shed knobs left untouched) — never shed or skipped.
+
+// Tune detection thresholds and the tick-rate floor at runtime creation:
+using var runtime = TyphonRuntime.Create(dbe, schedule => { /* ... */ }, new RuntimeOptions
+{
+    Overload = new OverloadOptions
+    {
+        OverrunThreshold = 1.2f,    // tick must run 20% over budget to count as "overrunning"
+        EscalationTicks = 5,        // consecutive overrunning ticks before escalating
+        DeescalationTicks = 20,     // consecutive headroom ticks before de-escalating
+        MinTickRateHz = 10,         // floor for TickRateModulation (60Hz base -> up to 6x)
+    },
+});
+
+// Last resort: game code decides who/what to shed.
+runtime.OnCriticalOverload += rt =>
+{
+    // e.g. disconnect spectators, migrate players, split the zone
+};
+
+// Inspect current state from anywhere in game code:
+var level = runtime.CurrentOverloadLevel; // OverloadLevel.Normal / SystemThrottling / ScopeReduction / TickRateModulation / PlayerShedding
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `OverloadOptions.OverrunThreshold` | 1.2 | Ratio (actual/target) above which a tick counts as overrunning |
+| `OverloadOptions.DeescalationRatio` | 0.6 | Ratio below which a tick counts toward de-escalation |
+| `OverloadOptions.EscalationTicks` | 5 | Consecutive overrunning ticks required to escalate |
+| `OverloadOptions.DeescalationTicks` | 20 | Consecutive headroom ticks required to de-escalate |
+| `OverloadOptions.MinTickRateHz` | 10 | Hard floor for the modulated tick rate (caps the multiplier ladder) |
+| `OverloadOptions.QueueGrowthTicks` | 5 | Consecutive ticks of growing event-queue depth that also counts as an escalation signal (0 disables) |
+| `SystemBuilder.Priority` | `Normal` | `Critical`/`High` never throttled or shed; `Normal` throttled via divisor; `Low` shed if `CanShed` |
+| `SystemBuilder.CanShed` | `false` | Whether a `Low`-priority system is disabled entirely once any overload level is active |
+| `SystemBuilder.ThrottledTickDivisor` | 1 | Run-every-Nth-tick divisor applied to `Normal`-priority systems once any overload level is active |
+
+## ⚠️ Guarantees & limits
+- **Reversible and asymmetric** — every level can de-escalate; escalation reacts in ~5 ticks, de-escalation waits ~20, by design (prevents flapping under noisy load).
+- **`Critical`/`High`-priority systems are never throttled or shed** by this mechanism, at any overload level — protect your core simulation systems (physics, combat) by priority, not by hoping the detector spares them.
+- **System throttling/shedding is level-agnostic today** — `SystemThrottling`, `ScopeReduction`, and `TickRateModulation` all apply the same `CanShed`/`ThrottledTickDivisor` rules; there is no additional effect specific to `ScopeReduction` yet.
+- **Per-system entity budgets (`EntityBudget`, `DeferralMode`) are defined but not enforced** — the types exist for the planned Level 2 scope-reduction feature; setting them today has no runtime effect.
+- **Tick-rate modulation is integer-multiple only** (1/2/3/4/6x, capped by `MinTickRateHz`) — physics `dt` per step stays constant, avoiding floating-point drift; clients must be told the active multiplier separately (this feature does not push it to clients).
+- **`OverrunThreshold`/`DeescalationRatio` are evaluated against the base-rate (1x) budget**, even while running under a higher multiplier — see the Telemetry feature for how `OverrunRatio` is computed.
+- **Player shedding is a signal, not an action** — `TyphonRuntime.OnCriticalOverload` fires once on entering `PlayerShedding`; the Runtime takes no action on its own, all mitigation is game-defined.
+- **Single-writer state machine** — `OverloadDetector.Update` runs only on the tick driver thread once per tick; no synchronization is needed and none should be added around it.
+
+## 🧪 Tests
+
+- [OverloadTests](../../../test/Typhon.Engine.Tests/Runtime/OverloadTests.cs) — `OverloadDetectorTests` (pure state-machine escalation/de-escalation hysteresis, tick-rate multiplier ladder) and `OverloadThrottleTests` (`ThrottledTickDivisor`, `CanShed`, telemetry recording)
+
+## 🔗 Related
+- Related feature: [Telemetry & Runtime Inspection](./telemetry-runtime-inspection.md)
+- Related feature: [Declarative System Scheduling](./declarative-system-scheduling.md)
+- Sibling: [Subscription Priority & Overload Throttling](../Subscriptions/priority-overload-throttling.md) — how the same overload signal reprioritizes View delivery to players.
+
+<!-- Deep dive: claude/design/Runtime/03-overload.md -->
+<!-- Deep dive: claude/overview/13-runtime.md — Overrun handling -->
+<!-- Deep dive: claude/overview/13-runtime.md — Overload Management -->

--- a/doc/feature-set/Runtime/parallel-entity-processing.md
+++ b/doc/feature-set/Runtime/parallel-entity-processing.md
@@ -1,0 +1,94 @@
+# Parallel Entity Processing (QuerySystem.Parallel)
+> Multi-core entity chunking that skips per-chunk Transaction overhead for non-Versioned writes.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](./README.md)
+
+## 🎯 What it solves
+
+A game server with dozens of cores but only a handful of systems can't get throughput from DAG-level
+parallelism alone — most of the win has to come from splitting one system's entity set across workers.
+Doing that naively (materialize the full entity list, give every chunk its own `Transaction`) burns
+cycles on list-copying and per-chunk Transaction setup/commit before any game logic runs. Parallel
+entity processing removes both costs for the common case (writing non-`Versioned` components), so
+`b.Parallel()` scales a `QuerySystem` without changing its `Execute` loop.
+
+## ⚙️ How it works (in brief)
+
+The runtime picks one of four dispatch paths from two facts about the system: whether it has a
+`ChangeFilter` and whether it declares `WritesVersioned()`. Non-Versioned systems get a reusable
+`PointInTimeAccessor` (PTA) — attached once per tick to a fresh MVCC snapshot — and each worker gets its
+own `EntityAccessor` from it, so entity access has no per-entity dictionary lookup and no Transaction
+commit. Unfiltered non-Versioned systems go further: the entity set is never materialized into an array
+— each chunk iterates a contiguous slice of the View's underlying hash map directly. Filtered systems
+(and any system writing `Versioned` components) materialize a list instead — dirty-only when filtered,
+full-set otherwise — and Versioned writers get a real per-chunk `Transaction`, since the PTA cannot
+perform copy-on-write.
+
+| Path | Selected when | Prepare cost | Chunk entity access |
+|------|---------------|--------------|----------------------|
+| 1 — Full, non-Versioned | no `ChangeFilter`, no `WritesVersioned()` | O(1) — no list built | `ctx.Accessor` (PTA), zero-copy hash-map slice |
+| 2 — Filtered, non-Versioned | `ChangeFilter` set, no `WritesVersioned()` | O(dirty count) | `ctx.Accessor` (PTA), pooled slice |
+| 3 — Full, Versioned | no `ChangeFilter`, `WritesVersioned()` | O(entity count) | `ctx.Transaction`, pooled slice |
+| 4 — Filtered, Versioned | `ChangeFilter` set, `WritesVersioned()` | O(dirty count) | `ctx.Transaction`, pooled slice |
+
+## 💻 Usage
+
+```csharp
+public class MovementSystem : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Movement")
+        .Input(() => activeUnitsView)
+        .Parallel();                       // Path 1: no ChangeFilter, no WritesVersioned
+
+    protected override void Execute(TickContext ctx)
+    {
+        foreach (var id in ctx.Entities)
+        {
+            var entity = ctx.Accessor.OpenMut(id);     // PTA — no per-entity dictionary lookup
+            ref var pos = ref entity.Write<EcsPosition>();
+            pos.X += entity.Read<EcsVelocity>().X * ctx.DeltaTime;
+        }
+    }
+}
+
+// Path 4 (filtered + Versioned write): same Configure, plus
+// .ChangeFilter(typeof(EcsBuffs)).WritesVersioned()
+// — Execute then uses ctx.Transaction.OpenMut(id) instead of ctx.Accessor.
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `b.Parallel()` | off | Enables chunking; required for any of the four paths |
+| `b.ChangeFilter(...)` | none | Narrows the dispatched set to dirty/Added entities (Paths 2/4) |
+| `b.WritesVersioned()` | off | Switches chunk access from `ctx.Accessor` to a per-chunk `ctx.Transaction` (Paths 3/4) |
+| `b.ChunksPerWorker(factor)` | `1.0` | Oversubscribes chunk count beyond worker count, range `[1.0, 64.0]` |
+
+## ⚠️ Guarantees & limits
+
+- `ctx.Accessor` reads all storage modes (Versioned via MVCC chain walk, SingleVersion/Transient
+  direct) and writes SingleVersion/Transient, but **throws on a Versioned write** — declare
+  `WritesVersioned()` instead.
+- `ctx.Accessor` cannot Spawn, Destroy, Commit, or Rollback — structural changes need an upstream
+  non-parallel system.
+- Path 1 vs. a per-chunk `Transaction`: ~2.2x lower per-chunk overhead (PTA ~380µs/chunk vs.
+  Transaction ~850µs/chunk) — only declare `WritesVersioned()` when actually needed.
+- All workers in a tick see the same frozen MVCC snapshot (one TSN per `Attach()`); the PTA is reused
+  across ticks and across all non-Versioned parallel systems with zero steady-state allocation.
+- Scaling is good up to one CCD's worth of cores; cross-CCD `EntityMap` access flattens the curve on
+  multi-CCD hardware (measured: ~89% efficiency at 8 workers, ~42% at 16 on a 2-CCD part).
+- The DAG, not the runtime, guarantees chunks across different parallel systems don't race.
+- Out of scope: Spawn/Destroy inside a parallel chunk; cross-system pipelining (next system's chunk K
+  starting before this system fully completes).
+
+## 🧪 Tests
+
+- [ParallelQueryTests](../../../test/Typhon.Engine.Tests/Runtime/ParallelQueryTests.cs) — all four dispatch paths (`ParallelQuery_NonVersioned_ChunkReceivesAccessor`, `ParallelQuery_WritesVersioned_ChunkReceivesTransaction`), chunk partitioning, chunk-throw isolation
+- [ChunksPerWorkerTests](../../../test/Typhon.Engine.Tests/Runtime/ChunksPerWorkerTests.cs) — `ChunksPerWorker` oversubscription factor vs. worker-count cap and entity-count cap
+
+## 🔗 Related
+
+- Sibling feature: [QuerySystem](./system-types/query-system.md)
+
+<!-- Deep dive: claude/design/Runtime/06-parallel-efficiency.md -->
+<!-- Deep dive: claude/overview/13-runtime.md — QuerySystem.Parallel, PointInTimeAccessor -->

--- a/doc/feature-set/Runtime/reactive-dispatch-change-filters.md
+++ b/doc/feature-set/Runtime/reactive-dispatch-change-filters.md
@@ -1,0 +1,95 @@
+# Reactive Dispatch: Change Filters & Run Conditions
+> Skip systems that have nothing to do — proactively via a predicate, reactively via dirty-entity tracking.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](./README.md)
+
+## 🎯 What it solves
+In a large persistent world, most entities are unchanged on most ticks. Running every system's full
+loop every tick — re-checking health regen on units that took no damage, re-pathing NPCs that haven't
+moved — burns CPU on work with no observable effect. Game logic also has conditions that gate a whole
+system regardless of entity state (zone mode, feature flags, debug toggles). Without a cheap way to
+express both, developers either pay the full per-entity cost every tick or hand-rewrite "did anything
+change?" checks per system — repetitive and easy to get subtly wrong.
+
+## ⚙️ How it works (in brief)
+Two independent gates run before a system does any real work. `shouldRun` is a zero-arg predicate
+checked first, before the system's View is even refreshed — false means skip immediately, no input
+cost paid at all. `changeFilter` is checked second (QuerySystem/PipelineSystem only): it narrows the
+view's `Input` so the system gets only the View's `Added` entities plus entities whose listed
+component types were written since the last tick (`dirtySet ∪ Added`), and the system is skipped
+entirely if that set is empty and no consumed event queue has events. The dirty set is built as a
+side effect of the View's normal refresh — draining its existing ring buffer of writes — so there is
+no extra write-path cost; the only added cost is one membership check per ring-buffer entry already
+being processed.
+
+## 💻 Usage
+```csharp
+public class HealthRegen : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("HealthRegen")
+        .Input(() => unitsView)
+        .ChangeFilter(typeof(EcsHealth))   // OR logic — runs only if Health changed (or unit is new)
+        .After("InputDrain");
+
+    protected override void Execute(TickContext ctx)
+    {
+        // ctx.Entities == dirtySet ∪ Added — not the full View
+        foreach (var id in ctx.Entities)
+        {
+            ref var hp = ref ctx.Transaction.OpenMut(id).Write<EcsHealth>();
+            hp.Current = Math.Min(hp.Current + 1, hp.Max);
+        }
+    }
+}
+
+public class PvPCombatSystem : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("PvPCombat")
+        .Input(() => combatView)
+        .ShouldRun(() => zoneState.Mode == ZoneMode.PvP)   // evaluated before any input work
+        .After("Movement");
+
+    protected override void Execute(TickContext ctx) { /* ... */ }
+}
+
+// Lambda shorthand — both gates available on the registration overloads too
+dag.QuerySystem("GameRules", ctx => { foreach (var id in ctx.Entities) { /* ... */ } },
+    input: () => activeEntitiesView,
+    changeFilter: [typeof(EcsHealth), typeof(EcsStatus)],
+    shouldRun: () => !gameState.IsPaused,
+    after: "Combat");
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `b.ShouldRun(() => bool)` | none | Proactive gate, evaluated before View refresh / input cost. All system types. |
+| `b.ChangeFilter(params Type[])` | none | Reactive gate, narrows entity set to `dirtySet ∪ Added`. Requires `b.Input(...)`. |
+
+## ⚠️ Guarantees & limits
+- Evaluation order is fixed: `shouldRun` first → View refresh (if any) → event-queue/`changeFilter`
+  empty check → dispatch. A false `shouldRun` never pays View refresh or filter cost.
+- `changeFilter` is OR logic across listed types — an entity qualifies if *any* listed component was
+  written, not all.
+- `changeFilter` requires `Input`; `Build()` rejects it on a `CallbackSystem` or any system without a
+  View — there is no entity set to narrow.
+- Skip cost is ~200-300ns in both cases; `shouldRun` predicates must be cheap, thread-safe, and
+  side-effect-free — they run on whichever worker thread dispatches the system, with no synchronization.
+- If the View's ring buffer overflows, the dirty-tracking falls back to a full re-scan and treats every
+  entity in the View as dirty for that tick — correct but conservative, not a silent miss.
+- A system can combine `shouldRun`, `changeFilter`, and consumed event queues; it executes if
+  `shouldRun` passes AND (the filtered entity set is non-empty OR a consumed queue has events).
+- A `QuerySystem`/`PipelineSystem` with *neither* `changeFilter` nor consumed events runs every tick
+  its predecessors allow — there's no reactive trigger to gate it.
+
+## 🧪 Tests
+
+- [ChangeFilterTests](../../../test/Typhon.Engine.Tests/Runtime/ChangeFilterTests.cs) — `dirtySet ∪ Added` narrowing, OR logic across multiple filtered types, no-filter runs every tick
+- [ShouldRunTests](../../../test/Typhon.Engine.Tests/Runtime/ShouldRunTests.cs) — proactive gate evaluated before View refresh, successors still dispatch on skip, dynamic per-tick predicate
+
+## 🔗 Related
+- Sibling feature: [QuerySystem](./system-types/query-system.md)
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md — Change-Filtered System Inputs -->
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md — System Run Conditions -->

--- a/doc/feature-set/Runtime/side-transactions.md
+++ b/doc/feature-set/Runtime/side-transactions.md
@@ -1,0 +1,81 @@
+# Side-Transactions for Immediate Durability
+> Commit economy-critical writes durably mid-tick, independent of the tick's main UoW.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](./README.md)
+**Assumes:** [Durability Modes (Deferred / GroupCommit / Immediate)](../Transactions/durability-modes/README.md)
+
+## 🎯 What it solves
+
+The tick's main UoW uses Deferred durability — a single WAL flush at tick end, so a crash mid-tick
+loses the whole tick. That's fine for position or health (recomputed next tick), but not for a
+trade, a purchase, or a loot drop: losing those is a player-visible, often irreversible, problem.
+Side-transactions give a system a way to commit specific writes with stronger durability than the
+tick around it, without restructuring the tick's UoW or slowing down everything else in it.
+
+## ⚙️ How it works (in brief)
+
+`ctx.CreateSideTransaction(...)` opens a new `Transaction` with its own durability mode, separate
+from the system's main `ctx.Transaction`. It is short-lived: do the writes, `Commit()`, dispose.
+Because it gets its own TSN, the calling system's main `Transaction` — whose snapshot was already
+fixed — does not see the side-transaction's result; only systems that start later in the tick
+(higher TSN) can. Side-transactions committed against each other (e.g. two trades in sequence) see
+one another in commit order. The caller fully owns the side-transaction's lifecycle — the runtime
+does not auto-commit or auto-dispose it the way it does for `ctx.Transaction`.
+
+## 💻 Usage
+
+```csharp
+protected override void Execute(TickContext ctx)
+{
+    var buyer = ctx.Transaction.Open(trade.BuyerId);
+    var seller = ctx.Transaction.Open(trade.SellerId);
+    if (!ValidateTrade(buyer, seller, trade))
+    {
+        return;
+    }
+
+    using var tradeTx = ctx.CreateSideTransaction(DurabilityMode.Immediate);
+    var buyerMut = tradeTx.OpenMut(trade.BuyerId);
+    var sellerMut = tradeTx.OpenMut(trade.SellerId);
+
+    ref var bw = ref buyerMut.Write(Player.Wallet);
+    ref var sw = ref sellerMut.Write(Player.Wallet);
+    bw.Gold -= trade.Price;
+    sw.Gold += trade.Price;
+
+    tradeTx.Commit(); // FUA WAL flush — durable now, even if the rest of the tick is lost
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `mode` (`DurabilityMode`) | `Immediate` | `Immediate` blocks `Commit()` until the WAL record is on stable media (~15-85µs); `Deferred`/`GroupCommit` are also accepted but defeat the point of a side-transaction |
+| `discipline` (`DurabilityDiscipline`) | `TickFence` | Only matters for `SingleVersion`-layout components; pass `Commit` for atomic, zero-loss, no-revision-chain writes without full MVCC. No effect on `Versioned` components (always commit-scoped) |
+
+## ⚠️ Guarantees & limits
+
+- A committed side-transaction survives a crash even if the enclosing tick's UoW never flushes.
+- The calling system's `ctx.Transaction` never observes a side-transaction's writes (its snapshot
+  TSN was fixed before the side-tx committed) — use a [typed event queue](./typed-event-queues.md)
+  to hand data to a later system in the same tick instead of relying on transaction visibility.
+- Subsequent systems in the tick (new `Transaction`, higher TSN) can see committed side-tx writes,
+  but this is incidental ordering, not a contract — don't depend on it across DAG reorderings.
+- The caller must `Commit()` and dispose the side-transaction explicitly; nothing rolls it into the
+  main tick's UoW lifecycle.
+- `Immediate` durability costs ~15-85µs per commit (FUA) versus ~0.1ms for the *entire* tick's
+  Deferred flush — use it only for the operations that need it, not as a default.
+- Declare side-tx writes with `SystemBuilder.SideWrites<T>()` so tooling (Schema Inspector,
+  Profiler) can report them; this declaration is informational only and does not affect scheduler
+  ordering or add DAG edges.
+
+## 🧪 Tests
+
+- [SideTransactionTests](../../../test/Typhon.Engine.Tests/Runtime/SideTransactionTests.cs) — independent commit survives the enclosing tick, invisible to the calling system's own `ctx.Transaction`, caller owns lifecycle
+
+## 🔗 Related
+
+- Related feature: [Typed Event Queues](./typed-event-queues.md)
+- Sibling: [Side-Transactions (Immediate Durability)](./tick-lifecycle/side-transactions.md) — same feature, separately written up under the tick-lifecycle grouping; not a duplicate to merge, kept for now.
+
+<!-- Deep dive: claude/design/Runtime/01-tick-lifecycle.md §Immediate Side-Transactions -->
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md §Q12 -->

--- a/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/README.md
+++ b/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/README.md
@@ -1,0 +1,65 @@
+# Spatial Tiers & Adaptive Dispatch
+> Per-cluster simulation tiers let systems run near entities every tick and far entities at reduced/amortized/dormant rates.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+A 10M-entity world can't run every system at full frequency for every entity — distance-based detail
+reduction is mandatory, but a per-entity distance check every tick costs O(N) before any tiering even
+pays off. Game code needs a cheap, engine-owned way to say "this spatial region gets full simulation,
+that one gets a fraction of it, that other one barely runs at all" — and have every system, view, and
+parallel dispatch path downstream honor that classification automatically, at cluster granularity, with
+no per-system spatial bookkeeping.
+
+## ⚙️ How it works (in brief)
+
+Game code assigns one of four `SimTier` flags (`Tier0`..`Tier3`) to each spatial grid cell, once per
+tick, via `TickContext.SpatialGrid`. At tick start the engine rebuilds — per cluster-eligible archetype,
+skipped whenever nothing changed — a compact list of active clusters grouped by tier
+(`TierClusterIndex`). Three runtime mechanisms read that index to scope dispatch: a system's `Tier(...)`
+filter restricts it to matching clusters and can add `CellAmortize(N)` to process only `1/N` of them per
+tick; `Checkerboard()` splits a tier-filtered cluster set into two conflict-free Red/Black dispatch
+phases for systems that touch neighboring cells; and per-cluster dormancy puts clusters that haven't
+been written to in a configurable number of ticks to sleep, removing them from every dispatch path at
+zero cost until something wakes them. All three compose — a system can be tier-filtered, amortized, and
+checkerboard-dispatched at once, and dormancy filters out sleeping clusters underneath all of them.
+
+## Sub-features
+
+| Sub-feature | Use it when... |
+|---|---|
+| [Tier-Filtered & Amortized Dispatch](./tier-filtered-amortized-dispatch.md) | A system should only run against near/far cells, or should spread coarse-tier work across several ticks instead of doing it all at once |
+| [Cluster Dormancy (Sleep/Wake)](./cluster-dormancy.md) | A large share of clusters go idle for long stretches (empty regions, parked units) and shouldn't be dispatched at all while quiet |
+| [Checkerboard (Red/Black) Dispatch](./checkerboard-dispatch.md) | A parallel system reads/writes neighboring cells (diffusion, propagation) and needs conflict-free dispatch without going single-threaded |
+
+## ⚠️ Guarantees & limits
+
+- All three mechanisms operate on cluster lists, not per-entity checks — the cost of tiering scales with
+  active cluster count, never with entity count.
+- One tick of staleness end to end — a cell's tier change, a migration, or a dormancy wake all take
+  effect at the *next* tick's dispatch, never the current one (`BuildTierIndexesAtTickStart` runs before
+  any system in the tick).
+- `TierClusterIndex` rebuild is dual-invalidated (grid tier version + per-archetype cluster-set version)
+  — a stationary camera with no migrations pays two integer compares per archetype, not a re-scan.
+- Composing tier filtering, amortization, checkerboard, and dormancy is additive and engine-managed —
+  game code never has to intersect cluster sets by hand.
+- `TickContext.TierBudgetMetrics` exposes per-tier wall-clock cost and entity counts from the previous
+  tick so a `TierAssignment`-style system can adapt tier boundaries to the actual frame budget instead of
+  fixed radii.
+
+## 🧪 Tests
+
+- [TierDispatchTests](../../../../test/Typhon.Engine.Tests/Runtime/TierDispatchTests.cs) — `TierClusterIndex` rebuild/staleness, tier-filtered dispatch, `CellAmortize`, `AmortizedDeltaTime`
+- [DormancyTests](../../../../test/Typhon.Engine.Tests/Runtime/DormancyTests.cs) — sleep-threshold counter, wake on write/heartbeat, dispatch skips sleeping clusters
+- [CheckerboardTests](../../../../test/Typhon.Engine.Tests/Runtime/CheckerboardTests.cs) — Red/Black two-phase split, no-overlap, composition with tier filtering and dormancy
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Runtime/public/SimTier.cs](../../../../src/Typhon.Engine/Runtime/public/SimTier.cs), [TierBudgetMetrics.cs](../../../../src/Typhon.Engine/Runtime/public/TierBudgetMetrics.cs)
+- Also cataloged from the spatial-grid side: [Spatial category](../../Spatial/README.md) — [Tiered Simulation Dispatch](../../Spatial/tiered-simulation-dispatch.md), [Cluster Dormancy](../../Spatial/cluster-dormancy.md), [Checkerboard Dispatch](../../Spatial/checkerboard-dispatch.md) cover the same mechanisms from the cell/grid-configuration angle
+- Sub-features: [Tier-Filtered & Amortized Dispatch](./tier-filtered-amortized-dispatch.md), [Cluster Dormancy (Sleep/Wake)](./cluster-dormancy.md), [Checkerboard (Red/Black) Dispatch](./checkerboard-dispatch.md)
+
+<!-- Deep dive: claude/overview/13-runtime.md §Spatial Tiers & Multi-Resolution Dispatch -->
+<!-- Deep dive: claude/rules/spatial.md (modules TierClusterIndex, Dormancy, Checkerboard Partition) -->
+<!-- ADR: claude/adr/046-spatial-tiers-architecture.md -->

--- a/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/checkerboard-dispatch.md
+++ b/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/checkerboard-dispatch.md
@@ -1,0 +1,83 @@
+# Checkerboard (Red/Black) Dispatch
+> Two-phase Red/Black parallel dispatch so neighbor-touching systems never race across a cell boundary.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Parallel dispatch normally hands different clusters to different worker threads with no ordering between
+them. That's fine when a system only touches the entity it's iterating, but systems that read or write
+neighboring cells too — pheromone diffusion, heat propagation — would race if two face-adjacent cells
+ran on different workers at the same instant. Without engine support, the only safe fallback is running
+such a system single-threaded, which throws away parallelism for exactly the systems most likely to be
+expensive (full-grid passes).
+
+## ⚙️ How it works (in brief)
+
+Each cell is colored Red or Black from the parity of its grid coordinates, `(cellX + cellY) % 2`. No two
+orthogonally-adjacent cells share a color, so the engine can dispatch all Red clusters in parallel, wait
+for them to finish, then dispatch all Black clusters in parallel — a system that only touches
+face-adjacent neighbors never observes a half-written neighbor. This is implemented as a single DAG node
+with two internal phases, not two DAG nodes: after the Red phase's chunks all complete, the scheduler's
+cleanup hook signals "re-dispatch," the same node runs again scoped to Black, and only then do successors
+fire. From the DAG's perspective — and from every other system's perspective — checkerboard dispatch is
+invisible structure inside one node.
+
+## 💻 Usage
+
+```csharp
+var game = schedule.PublicTrack.DeclareDag("Game");
+
+game.QuerySystem("Pheromone_Diffuse", ctx =>
+{
+    // Safe to read/write neighboring cells' data — no other worker is touching an adjacent cell
+    // during this phase.
+    foreach (var id in ctx.Entities)
+    {
+        ref var pher = ref ctx.Accessor.OpenMut(id).Write(Pheromone.Data);
+        pher.Value = Diffuse(pher.Value, NeighborSamples(ctx, id));
+    }
+},  input: () => pheromoneView,
+    tier: SimTier.Near,
+    parallel: true,
+    checkerboard: true);
+
+// Equivalent class-based form (SystemBuilder):
+// protected override void Configure(SystemBuilder b) => b.Name("Pheromone_Diffuse").Tier(SimTier.Near).Parallel().Checkerboard();
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `checkerboard:` (`QuerySystem`) / `b.Checkerboard()` (`SystemBuilder`) | `false` | Split the filtered cluster list into Red/Black and dispatch as two sequential parallel phases within one DAG node |
+
+## ⚠️ Guarantees & limits
+
+- Requires `parallel: true` — `Build()` rejects `checkerboard: true` without it, at schedule build time,
+  not at first tick.
+- Incompatible with `ChunkedParallel` — combining the two throws at build time.
+- Composes with `tier:` / `CellAmortize` and dormancy — the split runs over whichever cluster set those
+  filters already produced; sleeping clusters are excluded before coloring, same as for any other
+  tier-filtered system.
+- Red ∪ Black is always the full filtered cluster set with no overlap — every cluster is processed
+  exactly once per tick, never zero times or twice.
+- Protects **face adjacency only** — diagonal neighbors share the same color, so a system reading/writing
+  diagonal cells (not just orthogonal ones) is not protected by the two-phase split.
+- Non-spatial archetypes (no grid, or no cell mapping) degenerate to all clusters in Red and an empty
+  Black phase — the callback still runs twice, but the second call sees no entities.
+- One extra dispatch-prepare and worker barrier per tick versus a single-phase parallel system —
+  negligible unless the per-phase entity work is already very cheap.
+
+## 🧪 Tests
+
+- [CheckerboardTests](../../../../test/Typhon.Engine.Tests/Runtime/CheckerboardTests.cs) — `Checkerboard_TwoPhases_BothExecute`, `Checkerboard_RedBlack_NoOverlap`, `Checkerboard_RequiresParallel_Throws`, `Checkerboard_WithDormancy_SleepingSkipped`
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Runtime/public/TyphonRuntime.cs](../../../../src/Typhon.Engine/Runtime/public/TyphonRuntime.cs) (`SplitCheckerboardClusters`, `OnParallelQueryPrepare`/`OnParallelQueryCleanup` two-phase protocol)
+- Source: [src/Typhon.Engine/Runtime/public/SystemBuilder.cs](../../../../src/Typhon.Engine/Runtime/public/SystemBuilder.cs) (`Checkerboard()`), [Dag.cs](../../../../src/Typhon.Engine/Runtime/public/Dag.cs) (`checkerboard:` parameter)
+- Parent feature: [Spatial Tiers & Adaptive Dispatch](./README.md)
+- Same mechanism, cell/grid-configuration angle: [Spatial category — Checkerboard Dispatch](../../Spatial/checkerboard-dispatch.md)
+
+<!-- Deep dive: claude/overview/13-runtime.md §Checkerboard Dispatch -->
+<!-- ADR: claude/adr/046-spatial-tiers-architecture.md (Decision 6 — one DAG node, two internal phases) -->
+<!-- Rules: claude/rules/spatial.md (module Checkerboard Partition, CB-01, CB-02) -->

--- a/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/cluster-dormancy.md
+++ b/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/cluster-dormancy.md
@@ -1,0 +1,81 @@
+# Cluster Dormancy (Sleep/Wake)
+> Clusters untouched for N ticks sleep and are skipped by every dispatch path, waking within one tick of being written to.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Tier filtering already shrinks the dispatch set for distant regions, but even a coarse tier still
+contains clusters doing nothing tick after tick — idle units, empty cells, parked props. Dormancy goes
+one step further: it lets the runtime notice a cluster has gone quiet and stop dispatching it to *any*
+system against that archetype, tier-filtered or not, until something inside it changes again — without
+game code having to track idle state itself or remember to skip it.
+
+## ⚙️ How it works (in brief)
+
+Each cluster carries a sleep counter, advanced once per tick at the cluster tick fence: a tick with no
+dirty write in the cluster increments it, a tick with one resets it to zero. Once the counter reaches a
+configurable per-archetype threshold, the cluster flips `Active → Sleeping` and every parallel dispatch
+path drops it from its cluster partition at zero per-entity cost. Because a write to a sleeping cluster
+can happen from any worker thread mid-tick, the wake isn't applied inline (that would race on shared
+sleep state) — it's recorded on a `[ThreadStatic]` list and drained single-threaded at the tick fence
+(`Sleeping → WakePending`), then promoted to `Active` at the very start of the next tick, before
+`TierClusterIndex` rebuilds or any system dispatches. End to end that's at most one tick of wake latency.
+An optional heartbeat interval wakes sleeping clusters anyway on a staggered schedule, independent of
+writes, for a periodic idle re-check.
+
+## 💻 Usage
+
+Dormancy is fully automatic from a system author's point of view — once thresholds are set for an
+archetype, no per-system opt-in is needed. Ordinary writes wake a sleeping cluster; every `QuerySystem`
+against the archetype, tier-filtered or not, silently skips clusters that are `Sleeping`:
+
+```csharp
+game.QuerySystem("IdleDrift", ctx =>
+{
+    foreach (var id in ctx.Entities) { /* never dispatched against a sleeping cluster */ }
+}, input: () => antsView, parallel: true, tier: SimTier.Tier2, cellAmortize: 60);
+```
+
+The sleep threshold and heartbeat interval themselves are per-archetype runtime settings
+(`SleepThresholdTicks`, `HeartbeatIntervalTicks`) — there is no public fluent configuration wrapper for
+them yet; today they're set on the archetype's internal cluster runtime state from the host project
+(the same `InternalsVisibleTo` boundary `AntHill.Core` builds under for engine integration), not from
+arbitrary game code.
+
+| Setting | Default | Effect |
+|---|---|---|
+| `SleepThresholdTicks` | `0` (disabled) | Consecutive clean ticks before `Active → Sleeping`; clamped to `[0, 65535]` |
+| `HeartbeatIntervalTicks` | `0` (off) | When `> 0`, sleeping clusters wake on a staggered schedule for a periodic re-check |
+
+## ⚠️ Guarantees & limits
+
+- **Wake is bounded to one tick of latency** — a write at tick T is `WakePending` by T's tick fence and
+  `Active` before any system dispatches at tick T+1; never permanently missed.
+- **Zero overhead when nothing sleeps** — the dormancy filter in dispatch-prepare is skipped entirely
+  while the sleeping count is zero, for every system, every tick.
+- **Filters both tier-filtered and unfiltered systems** — a `SimTier.All` system still skips sleeping
+  clusters; dormancy is not a tier-only mechanism.
+- **Activity means a dirty write, not a spatial-only write** — a field written exclusively through the
+  zero-copy spatial-update path does not mark the cluster dirty, so it neither resets the sleep counter
+  nor wakes a sleeping cluster on its own.
+- **Two wake triggers only**: a dirty write and the heartbeat timer. Proximity-based wake and
+  tier-promotion wake are not implemented — a sleeping cluster promoted to `Tier0` stays asleep, excluded
+  from dispatch, until a write or heartbeat wakes it.
+- **No public per-archetype configuration API yet** — see Usage above; `ClusterSleepState` is the only
+  public surface today.
+
+## 🧪 Tests
+
+- [DormancyTests](../../../../test/Typhon.Engine.Tests/Runtime/DormancyTests.cs) — `SleepAfterThreshold`, `SleepingClusterSkippedInDispatch`, `WakeRequest_Transition`, `HeartbeatWake`, `NoOverhead_WhenNoSleeping`, `SleepCounterReset_OnWrite`
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Runtime/internals/DormancyReporter.cs](../../../../src/Typhon.Engine/Runtime/internals/DormancyReporter.cs) (thread-local deferred wake requests, single-threaded drain)
+- Source: [src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs](../../../../src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs) (`DormancySweep`, `ProcessWakeRequest`, `TransitionWakePendingToActive`)
+- Source: [src/Typhon.Engine/Ecs/public/ClusterSleepState.cs](../../../../src/Typhon.Engine/Ecs/public/ClusterSleepState.cs)
+- Parent feature: [Spatial Tiers & Adaptive Dispatch](./README.md)
+- Same mechanism, full configuration walkthrough: [Spatial category — Cluster Dormancy (Sleep / Wake)](../../Spatial/cluster-dormancy.md)
+
+<!-- Deep dive: claude/overview/13-runtime.md §Cluster Dormancy -->
+<!-- Rules: claude/rules/spatial.md (module Dormancy, DM-01..DM-03) -->

--- a/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/tier-filtered-amortized-dispatch.md
+++ b/doc/feature-set/Runtime/spatial-tiers-adaptive-dispatch/tier-filtered-amortized-dispatch.md
@@ -1,0 +1,86 @@
+# Tier-Filtered & Amortized Dispatch
+> Scope a system to clusters in matching tier cells, and optionally process just 1/N of them per tick.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Not every system should touch every entity every tick. A combat AI needs full fidelity near the camera
+but is wasted work on the far side of the map; a slow-decay or idle-drift update is correct even if it
+only runs once every few seconds for distant entities. Without engine support, a system author would
+have to thread a distance/tier check through every entity loop by hand — exactly the per-entity overhead
+tiering exists to avoid. Tier-filtered dispatch lets a system declare its tier scope once at
+registration; cell amortization lets it additionally spread coarse-tier work across ticks instead of
+doing all of it at once.
+
+## ⚙️ How it works (in brief)
+
+A system declares a `SimTier` filter (default `SimTier.All`, meaning unfiltered — the pre-tiering fast
+path). At dispatch-prepare time the scheduler reads the system's archetype's per-tier cluster list
+(rebuilt once per tick, before any system runs) and restricts the parallel chunk partition to just that
+list — never touching clusters outside the filter. Adding `CellAmortize(N)` further strides that list
+into `N` rotating buckets keyed by `tickNumber % N`, so the system sees `1/N` of its tier's clusters on
+any given tick; `TickContext.AmortizedDeltaTime` is scaled to `DeltaTime × N` so integration math (decay,
+drift, movement) stays correct across the longer effective step. A `View`'s own `WithTier(...)` filter
+applies the same cluster scoping independently, useful for published/subscription views; a system's
+filter and its input view's filter combine by bit-AND.
+
+## 💻 Usage
+
+```csharp
+var game = schedule.PublicTrack.DeclareDag("Game");
+
+// Full fidelity, every tick — Tier 0 cells only.
+game.QuerySystem("CombatAi", ctx =>
+{
+    foreach (var id in ctx.Entities) { /* full-fidelity AI */ }
+}, input: () => antsView, parallel: true, tier: SimTier.Tier0);
+
+// Coarse tier: process 1/60th of Tier 2's clusters per tick, amortizing the integration step.
+game.QuerySystem("IdleDrift", ctx =>
+{
+    foreach (var id in ctx.Entities)
+    {
+        ref var pos = ref ctx.Accessor.OpenMut(id).Write(Ant.Position);
+        pos.X += DriftSpeed * ctx.AmortizedDeltaTime;   // ~1s of drift, once every 60th tick
+    }
+}, input: () => antsView, parallel: true, tier: SimTier.Tier2, cellAmortize: 60);
+
+// Equivalent class-based form (SystemBuilder):
+// protected override void Configure(SystemBuilder b) => b.Name("IdleDrift").Tier(SimTier.Tier2).CellAmortize(60).Parallel();
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `tier:` (`QuerySystem`) / `b.Tier(...)` (`SystemBuilder`) | `SimTier.All` | Restrict dispatch to clusters in matching cells; flags combine (`SimTier.Near` = `Tier0 \| Tier1`) |
+| `cellAmortize:` / `b.CellAmortize(N)` | `0` (off) | Process `1/N` of the tier's clusters per tick, rotating buckets by tick number; requires a non-`All` tier |
+
+## ⚠️ Guarantees & limits
+
+- Filtering operates on cluster lists, never per-entity — a tier-filtered system's chunk partition is
+  built only over its tier's clusters, with zero scanning of clusters outside the filter.
+- `Build()`-time validation rejects `SimTier.None` (would dispatch zero clusters), `CellAmortize > 0`
+  without a non-`All` tier filter, and tier filters on system types other than `QuerySystem`.
+- `CellAmortize` skips whole untouched clusters between buckets — it is bucket rotation, not per-entity
+  modulo, so the 59/60 you skip in a tick are never iterated, not iterated-and-ignored.
+- Multi-tier flag combinations (e.g. `SimTier.Near`, `SimTier.Active`) are merged once per rebuild and
+  cached by flag byte — no per-system merge allocation for repeated combinations.
+- `TickContext.TierBudgetMetrics` (per-tier cost and entity count from the previous tick) is all-zero on
+  the first tick — guard `BudgetMs == 0` before computing a utilization ratio.
+- A system's `Tier(...)` and its input `View.WithTier(...)` combine by bit-AND; a non-overlapping
+  combination throws at dispatch-prepare time rather than silently materializing zero entities.
+
+## 🧪 Tests
+
+- [TierDispatchTests](../../../../test/Typhon.Engine.Tests/Runtime/TierDispatchTests.cs) — `Build_TierNone_Throws`, `Build_CellAmortizeWithoutTier_Throws`, `TierDispatch_Tier0System_SeesOnlyTier0Entities`, `TierDispatch_CellAmortize_ProcessesEachCellExactlyOncePerCycle`, `TierDispatch_AmortizedDeltaTime_EqualsDeltaTimeTimesAmortize`
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Runtime/public/SimTier.cs](../../../../src/Typhon.Engine/Runtime/public/SimTier.cs), [SystemBuilder.cs](../../../../src/Typhon.Engine/Runtime/public/SystemBuilder.cs) (`Tier`, `CellAmortize`), [Dag.cs](../../../../src/Typhon.Engine/Runtime/public/Dag.cs) (`tier:`/`cellAmortize:` parameters)
+- Source: [src/Typhon.Engine/Ecs/internals/TierClusterIndex.cs](../../../../src/Typhon.Engine/Ecs/internals/TierClusterIndex.cs) (per-archetype tier-grouped index, dual invalidation, merge cache)
+- Source: [src/Typhon.Engine/Runtime/public/TyphonRuntime.cs](../../../../src/Typhon.Engine/Runtime/public/TyphonRuntime.cs) (`OnParallelQueryPrepare` tier-scoped partition, `BuildTierIndexesAtTickStart`)
+- Parent feature: [Spatial Tiers & Adaptive Dispatch](./README.md)
+- Same mechanism, cell/grid-configuration angle: [Spatial category — Tiered Simulation Dispatch](../../Spatial/tiered-simulation-dispatch.md)
+
+<!-- Deep dive: claude/overview/13-runtime.md §Tier-Filtered System Dispatch -->
+<!-- Rules: claude/rules/spatial.md (modules TierClusterIndex/TI-01..TI-03, SetCellTier Validation/SC-01) -->

--- a/doc/feature-set/Runtime/system-types/README.md
+++ b/doc/feature-set/Runtime/system-types/README.md
@@ -1,0 +1,69 @@
+# System Types
+> Five system base classes for every shape of per-tick work — proactive, reactive, chunk-parallel, multi-stage, and grouped.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Tick logic comes in fundamentally different shapes: proactive non-entity work (timers, draining input queues,
+global state), reactive per-entity work that should skip entirely when nothing relevant changed, chunkable
+non-entity work that wants worker-pool parallelism without paying for entity machinery, bulk multi-stage entity
+processing, and grouping of related systems into one schedulable unit. Forcing all of this through a single
+system shape means either paying View/Transaction overhead for logic that touches no entities, or hand-rolling
+skip checks and chunk distribution everywhere. The five system types let each piece of logic declare the
+execution shape it actually needs.
+
+## ⚙️ How it works (in brief)
+
+Every system is a class deriving from one of five base types, implementing `Configure(SystemBuilder b)`
+(name, dependencies, input, access declarations) and — except `CompoundSystem` — `Execute(TickContext ctx)`.
+`CallbackSystem` is proactive (runs every tick); `QuerySystem` and `PipelineSystem` are reactive (skip when
+their input has no work); `ChunkedCallbackSystem` is a `CallbackSystem` variant that fans `Execute` out across
+N workers; `CompoundSystem` groups sibling systems' registration under one `Configure` call. Lambda shorthand
+(`dag.CallbackSystem(name, ctx => ..., ...)`, `dag.QuerySystem(...)`, `dag.PipelineSystem(...)`) registers the
+same kinds directly on a `Dag` without a class, for logic too small to justify one. Both styles coexist in the
+same DAG and the same tick; class-based registration is required to use RFC-07 access declarations (`Reads<T>`,
+`Writes<T>`, ...) that drive automatic DAG-edge derivation.
+
+## Sub-features
+
+| Sub-feature | Use it for |
+|-------------|-----------|
+| [CallbackSystem](./callback-system.md) | Proactive non-entity work that must run every tick — timers, input draining, global state |
+| [QuerySystem](./query-system.md) | Reactive per-entity work, single-worker or auto-chunked across cores via `Parallel()` |
+| [ChunkedCallbackSystem](./chunked-callback-system.md) | Chunkable non-entity work (SIMD sweeps, parallel reductions) that doesn't need entity iteration |
+| [PipelineSystem](./pipeline-system.md) | Bulk multi-stage entity processing (gather → process → scatter) — execution model pending Patate |
+| [CompoundSystem](./compound-system.md) | Bundling related sub-systems' registration into a single `Configure` call |
+
+## ⚠️ Guarantees & limits
+
+- `CallbackSystem` (and `ChunkedCallbackSystem`) is the only proactive kind — runs every tick unless
+  `b.ShouldRun(...)` returns false. `QuerySystem` and `PipelineSystem` are reactive.
+- Each dispatched `CallbackSystem`/`QuerySystem` (or chunk, for `Parallel()`) gets its own `Transaction`,
+  created on the executing worker and auto-committed after `Execute` returns — systems never call
+  `Commit()`/`Dispose()` themselves.
+- A thrown exception rolls back that system's own Transaction and skips its successors
+  (`SkipReason.DependencyFailed`); independent DAG branches still execute — one failure doesn't abort the tick.
+- `CompoundSystem.Add(...)` expands each sub-system into its own DAG registration at `dag.Add(compound)` time —
+  there is no aggregate group name; from outside the compound is atomic (all children complete before the
+  compound's successors start), but other systems depend on individual sub-system names, not the group.
+- `Build()` rejects at startup: a lambda/class system with no name, `Parallel()`/`ChangeFilter` without an
+  `Input` View, `ChangeFilter`/`Input` on a `CallbackSystem`, `ChunkedParallel` combined with any entity-context
+  concept, duplicate names, and dependency cycles.
+- `PipelineSystem`'s full gather/process/scatter execution model is not implemented yet — see its sub-feature
+  doc for exactly what works today.
+
+## 🧪 Tests
+
+- [ClassBasedSystemTests](../../../../test/Typhon.Engine.Tests/Runtime/ClassBasedSystemTests.cs) — all five base types registered side-by-side, mixed lambda/class dispatch, name/null validation
+- [ScheduleValidationTests](../../../../test/Typhon.Engine.Tests/Runtime/ScheduleValidationTests.cs) — `Build()`-time rejections shared across system types (duplicate names, invalid `ChunksPerWorker`, `Parallel`/`ChangeFilter` without `Input`)
+
+## 🔗 Related
+
+- Sub-features: [CallbackSystem](./callback-system.md), [QuerySystem](./query-system.md),
+  [ChunkedCallbackSystem](./chunked-callback-system.md), [PipelineSystem](./pipeline-system.md),
+  [CompoundSystem](./compound-system.md)
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md -->
+<!-- Deep dive: claude/overview/13-runtime.md -->
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md -->

--- a/doc/feature-set/Runtime/system-types/callback-system.md
+++ b/doc/feature-set/Runtime/system-types/callback-system.md
@@ -1,0 +1,77 @@
+# CallbackSystem
+> Proactive system that runs every tick for non-entity work — timers, input draining, global state.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Some tick logic has nothing to do with entity iteration and must still run every tick regardless of what
+changed: draining a network input queue, advancing a global clock, flushing pending entity destroys. Routing
+that through an entity-input system would mean creating a View it never uses just to get dispatched.
+`CallbackSystem` is the proactive base type — no View, no `ChangeFilter`, no reactive skip — for logic that the
+runtime should simply invoke once per tick.
+
+## ⚙️ How it works (in brief)
+
+Derive from `CallbackSystem`, implement `Configure(SystemBuilder b)` (name, dependencies, optional
+`ShouldRun`) and `Execute(TickContext ctx)`. The dispatching worker runs `Execute` inline — no entity-prep
+step, no input refresh. The runtime creates a per-system `Transaction` on the same worker before `Execute`
+runs and auto-commits it after; `ctx.Entities` is empty since there is no View input. `ShouldRun` (optional) is
+evaluated once before dispatch — returning false skips the system for this tick while still dispatching
+successors.
+
+## 💻 Usage
+
+```csharp
+public class InputDrain : CallbackSystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("InputDrain")
+        .Priority(SystemPriority.High);
+
+    protected override void Execute(TickContext ctx)
+    {
+        // Drain network command queues, write results into components via ctx.Transaction.
+        var entity = ctx.Transaction.OpenMut(someEntityId);
+        ref var cmd = ref entity.Write<PendingCommand>();
+        // ...
+    }
+}
+
+dag.Add(new InputDrain());
+
+// Lambda shorthand — trivial logic, no class boilerplate
+dag.CallbackSystem("Cleanup", ctx => ctx.FlushDestroys(), after: "InputDrain");
+
+// Conditional proactive system — skips most ticks
+dag.CallbackSystem("ZoneRotation", ctx => RotateZone(ctx),
+    shouldRun: () => zoneState.RotationDue, after: "InputDrain");
+```
+
+## ⚠️ Guarantees & limits
+
+- Proactive — runs every tick unless `b.ShouldRun(...)` (or the lambda's `shouldRun:`) returns false. Cost of a
+  false `ShouldRun`: ~200-300ns, successors still dispatch.
+- No entity input is possible: `Build()` rejects `b.Input(...)` and `b.ChangeFilter(...)` on a `CallbackSystem`.
+- Gets its own `Transaction` per tick (`ctx.Transaction`), created and committed by the runtime — never call
+  `Commit()`/`Dispose()` inside `Execute`.
+- A thrown exception rolls back the system's Transaction and skips its successors
+  (`SkipReason.DependencyFailed`); other DAG branches continue.
+- `b.Parallel()` is not valid on a plain `CallbackSystem` — use `ChunkedCallbackSystem` and `b.ChunkedParallel(N)`
+  for chunk-parallel non-entity work.
+- Registered via `dag.Add(new MySystem())` (class-based) or `dag.CallbackSystem(name, ctx => ..., ...)` (lambda)
+  — both coexist in the same DAG.
+
+## 🧪 Tests
+
+- [ClassBasedSystemTests](../../../../test/Typhon.Engine.Tests/Runtime/ClassBasedSystemTests.cs) — `Add_CallbackSystem_ExecutesEveryTick`, unnamed-system rejection
+- [ScheduleValidationTests](../../../../test/Typhon.Engine.Tests/Runtime/ScheduleValidationTests.cs) — `Build_ChangeFilterOnCallbackSystem_Throws`, `Build_ParallelOnCallbackSystem_Throws` — no entity input/parallel on a plain `CallbackSystem`
+- [ShouldRunTests](../../../../test/Typhon.Engine.Tests/Runtime/ShouldRunTests.cs) — proactive `ShouldRun` gate: skip cost, successors still dispatch, telemetry recording
+
+## 🔗 Related
+
+- Parent feature: [System Types](./README.md)
+- Sibling: [Typed Event Queues](../typed-event-queues.md) — proactive `CallbackSystem` producers/consumers commonly drive event-queue cascades.
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md — Proactive vs Reactive -->
+<!-- Deep dive: claude/overview/13-runtime.md — CallbackSystem -->

--- a/doc/feature-set/Runtime/system-types/chunked-callback-system.md
+++ b/doc/feature-set/Runtime/system-types/chunked-callback-system.md
@@ -1,0 +1,116 @@
+# ChunkedCallbackSystem — Chunk-Parallel Non-Entity Work
+> Fan a CallbackSystem's body out across N workers for SIMD sweeps, reductions, and other non-entity chunkable work.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Some per-tick work is naturally parallel but isn't entity iteration at all — sweeping a flat pheromone grid,
+downsampling an image buffer, reducing an array into a heat accumulator. Routing that through `QuerySystem.Parallel`
+would mean paying for entity-prep machinery (View input, `Accessor`, per-chunk `Transaction`) the work never
+uses. `ChunkedCallbackSystem` gives `CallbackSystem` the same N-way worker fan-out without any of that overhead —
+just a chunk index and count.
+
+## ⚙️ How it works (in brief)
+
+Derive from `ChunkedCallbackSystem` and call `b.ChunkedParallel(chunkCount)` in `Configure`; `Execute` is then
+invoked `chunkCount` times in parallel across workers, each call reading `ctx.ChunkIndex`/`ctx.ChunkCount` to
+compute its own slice of whatever data structure the system owns. There's no `Accessor`, no `Entities`, no
+per-chunk `Transaction` — `TickContext` carries only tick metadata plus the chunk coordinates.
+`ChunkedCallbackSystem<TContext>` adds a typed ambient context (bound once via `scheduler.RegisterContext(ctx)`
+after `Build()`) with two extra hooks evaluated before any worker claims a chunk: `ShouldRun(TContext)` to gate
+the whole system on typed state, and `Prepare(TContext)` to build a per-tick plan and return a dynamic chunk
+count (`0` skips, `>0` dispatches that many chunks, `-1` defers to the static `ChunkedParallel(N)` count).
+
+## 💻 Usage
+
+```csharp
+public sealed class PheroMaxReduce : ChunkedCallbackSystem
+{
+    private readonly float[] _pheromoneGrid;
+    private float[] _heatAccum;
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("PheroMaxReduce")
+        .ReadsResource("PheromoneGrid")
+        .WritesResource("HeatFoodAccum")
+        .ChunkedParallel(chunkCount: 16);
+
+    protected override void Execute(TickContext ctx)
+    {
+        int len = _pheromoneGrid.Length;
+        int start = (int)((long)ctx.ChunkIndex * len / ctx.ChunkCount);
+        int end = (int)((long)(ctx.ChunkIndex + 1) * len / ctx.ChunkCount);
+        for (int i = start; i < end; i++)
+        {
+            _heatAccum[i] = MathF.Max(_heatAccum[i], _pheromoneGrid[i]);
+        }
+    }
+}
+
+dag.Add(new PheroMaxReduce());
+```
+
+Typed variant — a per-tick plan gates the chunk count dynamically:
+
+```csharp
+public sealed class WaveSimulationStep : ChunkedCallbackSystem<SimContext>
+{
+    protected override void Configure(SystemBuilder<SimContext> b) => b
+        .Name("WaveStep")
+        .ChunkedParallel(chunkCount: 8);   // static fallback if Prepare returns -1
+
+    // Evaluated before any worker claims a chunk; false skips the system entirely.
+    protected override bool ShouldRun(SimContext ctx) => ctx.WaveCount > 0;
+
+    // Returns the dynamic chunk count for this tick: 0 = skip, >0 = dispatch, -1 = use the static count.
+    protected override int Prepare(SimContext ctx) => Math.Min(ctx.WaveCount, 32);
+
+    protected override void Execute(TickContext ctx)
+    {
+        // Context property (from the base class) exposes the bound typed context.
+        var slice = Context.GetSlice(ctx.ChunkIndex, ctx.ChunkCount);
+        // ... process slice ...
+    }
+}
+
+var scheduler = dag.Build(parentResource);
+scheduler.RegisterContext(new SimContext(...));   // must run after Build(), before Start()
+scheduler.Start();
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `b.ChunkedParallel(chunkCount)` | n/a (required) | Static chunk count; `Execute` runs this many times in parallel |
+| `Prepare(TContext)` returns `>0` | — | Overrides the static count for this tick only |
+| `Prepare(TContext)` returns `0` | — | Skips the system this tick (successors still dispatch) |
+| `Prepare(TContext)` returns `-1` | default | No opinion — falls back to the static `ChunkedParallel(N)` count |
+
+## ⚠️ Guarantees & limits
+
+- `ChunkedParallel` is mutually exclusive with every entity-context builder method — `Input`, `ChangeFilter`,
+  `WritesVersioned`, `Tier`, `CellAmortize`, `Checkerboard`, `ChunksPerWorker` — `Build()` rejects the
+  combination.
+- Valid only on `CallbackSystem` (and its `ChunkedCallbackSystem`/`ChunkedCallbackSystem<TContext>`
+  subclasses) — not on `QuerySystem` or `PipelineSystem`.
+- A typed system (`ChunkedCallbackSystem<TContext>`) must be bound via `scheduler.RegisterContext<TContext>(ctx)`
+  after `Build()` and before `Start()` — `Start()` throws if a typed system was registered without a matching
+  `RegisterContext` call.
+- `ShouldRun`/`Prepare` run once per system per tick, single-threaded, before any worker claims a chunk — they
+  are not re-entered per chunk and must not block.
+- Each `Execute` invocation runs concurrently with the others for the same system — slicing must be
+  partition-correct (no two chunk indices touching overlapping data); the runtime does not check for overlap.
+- No `Transaction`, no `Accessor`, no `ctx.Entities` — this type is for plain memory/array work, not entity
+  reads/writes. Use `QuerySystem.Parallel` when the work is per-entity.
+
+## 🧪 Tests
+
+- [TypedContextSystemTests](../../../../test/Typhon.Engine.Tests/Runtime/TypedContextSystemTests.cs) — `ChunkedCallbackSystem<TContext>` binding via `RegisterContext`, typed `ShouldRun`/`Prepare` (skip/dispatch/-1 fallback), unbound-system `Start()` throw, untyped variant still works
+
+## 🔗 Related
+
+- Parent feature: [System Types](./README.md)
+- Sibling: [CallbackSystem](./callback-system.md) — the proactive base type this specializes for chunk-parallel non-entity work.
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md — ChunkedCallbackSystem -->
+<!-- Deep dive: claude/overview/13-runtime.md — ChunkedCallbackSystem, Parallel Tick Fence -->

--- a/doc/feature-set/Runtime/system-types/compound-system.md
+++ b/doc/feature-set/Runtime/system-types/compound-system.md
@@ -1,0 +1,71 @@
+# CompoundSystem
+> Group related sub-systems' registration under one `Configure` call — one node from the outside, parallel inside.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Related systems (a pathing system, a behavior-tree system, a steering system that together form "AI") are
+logically one unit, but registering them individually scatters their wiring across the schedule and forces
+every dependent to know about each member by name. `CompoundSystem` lets a group declare its members in one
+place and be depended on as a single name from outside, while still allowing the members to run in parallel
+with each other when their declared access doesn't conflict.
+
+## ⚙️ How it works (in brief)
+
+Derive from `CompoundSystem`, implement `Configure()`, and call `Add(...)` for each `CallbackSystem` or
+`QuerySystem` member (construct them as fields/constructor params so callers can reach into the group for
+testing or telemetry). When the compound is registered with `dag.Add(compound)`, the runtime calls `Configure()`
+and expands each member into its own registration on the same `Dag` — there is no compound-level DAG node;
+members keep whatever name and `.After(...)` dependency they declared themselves. From outside, other systems
+depending on `.After("AI")`-style names should target a specific member's name (e.g. the last stage), since the
+compound itself has no name of its own.
+
+## 💻 Usage
+
+```csharp
+public class AiGroup : CompoundSystem
+{
+    private readonly PathingSystem _pathing = new();
+    private readonly SteeringSystem _steering = new();
+
+    protected override void Configure()
+    {
+        Add(_pathing);
+        Add(_steering);   // declares its own .After("Pathing") if it needs to run after _pathing
+    }
+}
+
+var aiGroup = new AiGroup();
+dag.Add(aiGroup);
+
+dag.CallbackSystem("Cleanup", ctx => ctx.FlushDestroys(), after: "Steering");
+```
+
+## ⚠️ Guarantees & limits
+
+- `Add(...)` accepts `CallbackSystem`, `QuerySystem`, or `PipelineSystem` — but a `PipelineSystem` member hits
+  the same `NotSupportedException` as a top-level `dag.Add(PipelineSystem)` registration (pending Patate).
+- Expansion happens once, at `dag.Add(compound)` time — each member becomes an ordinary registration on the
+  owning `Dag`; there is no runtime concept of "the compound" after `Build()`.
+- No aggregate name: the compound itself is not a DAG node. Internal dependency edges between members
+  (`.After("Pathing")` inside `Configure`) are honored; a dependent outside the group targets a member's own
+  name, not the group's class name.
+- Members schedule by their own declarations — non-conflicting members run in parallel inside the group, exactly
+  as they would if registered individually.
+- All members must have unique names across the *whole* schedule (not just within the compound) — `Build()`
+  rejects duplicates the same way it does for any two systems.
+- A member that throws rolls back only its own Transaction and skips only its own successors; it does not abort
+  sibling members in the same compound unless they have a declared dependency on it.
+
+## 🧪 Tests
+
+- [ClassBasedSystemTests](../../../../test/Typhon.Engine.Tests/Runtime/ClassBasedSystemTests.cs) — `Add_CompoundSystem_ExpandsSubSystems`, `Add_NullCompoundSystem_ThrowsArgumentNull`
+
+## 🔗 Related
+
+- Parent feature: [System Types](./README.md)
+- Sibling: [QuerySystem](./query-system.md) — the most common member type grouped inside a CompoundSystem.
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md — CompoundSystem -->
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md — Q11 Compound systems -->

--- a/doc/feature-set/Runtime/system-types/pipeline-system.md
+++ b/doc/feature-set/Runtime/system-types/pipeline-system.md
@@ -1,0 +1,75 @@
+# PipelineSystem
+> Reactive multi-stage gather/process/scatter system for bulk entity processing — full execution model pending Patate.
+
+**Status:** ✅ Implemented (chunk-dispatch only) · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+`QuerySystem.Parallel` chunks an entity-by-entity loop across workers, but it still pays per-entity overhead
+(View iteration, `EntityRef` indirection) for each access. Truly high-throughput bulk processing — physics over
+thousands of bodies, vectorized batch updates — wants a SoA gather → process → scatter pipeline instead of a
+per-entity loop. `PipelineSystem` is the system type reserved for that shape: multi-worker chunk-parallel
+execution with no `TickContext` entity machinery at all.
+
+## ⚙️ How it works (in brief)
+
+Today, `PipelineSystem` provides fixed-chunk-count parallel dispatch: register a chunk action and a total chunk
+count, and the runtime distributes chunk indices across workers exactly like `ChunkedCallbackSystem` does — no
+`Transaction`, no `Accessor`, no `ctx.Entities`. The full design (View-driven reactive skip, `ChangeFilter`,
+internally-managed per-worker Transactions for the gather/scatter phases) is specified in the design doc but
+**not yet wired**: the lambda registration accepts `input:`/`changeFilter:` parameters for forward
+compatibility, but they are not consumed by the scheduler today, and **class-based registration is rejected
+outright**. The execution model is deferred to the Patate design.
+
+## 💻 Usage
+
+```csharp
+// The only working registration path today — lambda, fixed chunk count, no entity context.
+dag.PipelineSystem("Physics", (chunkIndex, totalChunks) =>
+{
+    // chunkIndex / totalChunks — compute this chunk's slice of whatever data the pipeline owns.
+    // Gather/Process/Scatter against entities would create their own Transaction internally (not provided).
+}, totalChunks: 8, after: "Movement");
+```
+
+```csharp
+// Class-based skeleton — Configure works, but registering it throws today:
+public class RenderPipeline : PipelineSystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Render")
+        .Input(() => renderableView);   // accepted by the builder, not yet consumed
+}
+
+dag.Add(new RenderPipeline());   // throws NotSupportedException — pending Patate design
+```
+
+## ⚠️ Guarantees & limits
+
+- `dag.Add(PipelineSystem)` (class-based) throws `NotSupportedException` — "execution model pending Patate
+  design." Only `dag.PipelineSystem(name, chunkAction, totalChunks, ...)` (lambda) is implemented.
+- The lambda's `chunkAction` receives only `(chunkIndex, totalChunks)` — no `TickContext`, no `Transaction`, no
+  `Accessor`. Any entity access inside the chunk action must create and manage its own `Transaction`.
+- `input:`/`changeFilter:` parameters on the lambda overload are accepted but not wired to dispatch — a
+  registered `PipelineSystem` always runs (subject to `shouldRun`) with the fixed `totalChunks` count; there is
+  no reactive skip yet.
+- `b.Parallel()` is rejected for `PipelineSystem` — it has its own chunk-parallel model (`totalChunks`), not the
+  `QuerySystem` parallel path.
+- A chunk action that throws fails the whole system: remaining chunks are drained without running, successors
+  are skipped (`SkipReason.DependencyFailed`); other DAG branches continue.
+- Inside a `CompoundSystem`, a `PipelineSystem` child hits the same `NotSupportedException` as top-level
+  registration — compounds cannot currently contain a working `PipelineSystem` member.
+
+## 🧪 Tests
+
+- [DagSchedulerTests](../../../../test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs) — `PipelineSystem_AllChunksProcessed`, `PipelineSystem_MultiWorkerDistribution`, `PipelineSystem_ChunksResetEachTick` — the working lambda/fixed-chunk-count dispatch path
+- [ClassBasedSystemTests](../../../../test/Typhon.Engine.Tests/Runtime/ClassBasedSystemTests.cs) — `Add_PipelineSystem_ThrowsNotSupported` — class-based registration rejection
+- [TyphonRuntimeTests](../../../../test/Typhon.Engine.Tests/Runtime/TyphonRuntimeTests.cs) — `PipelineSystem_DoesNotReceiveTransaction` — no `TickContext` entity machinery
+
+## 🔗 Related
+
+- Parent feature: [System Types](./README.md)
+- Sibling: [QuerySystem](./query-system.md) — `QuerySystem.Parallel` is the per-entity-loop alternative this bulk gather/process/scatter shape is reserved for.
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md — PipelineSystem Integration -->
+<!-- Deep dive: claude/overview/13-runtime.md — PipelineSystem -->

--- a/doc/feature-set/Runtime/system-types/query-system.md
+++ b/doc/feature-set/Runtime/system-types/query-system.md
@@ -1,0 +1,115 @@
+# QuerySystem
+> Reactive per-entity system that auto-skips when nothing relevant changed, with optional automatic multi-core chunking.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Runtime](../README.md)
+**Assumes:** [Query System (EcsQuery)](../../Ecs/query-system.md)
+
+## 🎯 What it solves
+
+Most game logic is per-entity (AI, movement, status effects, combat), and in a large persistent world most
+entities are unchanged on any given tick. Re-scanning the full population every tick wastes CPU; hand-rolling
+"did anything I care about change?" checks per system is repetitive and easy to get subtly wrong. `QuerySystem`
+gives per-entity logic a reactive trigger — it runs only when its input has dirty entities or pending events —
+and an opt-in `Parallel()` mode that chunks the entity set across worker threads without changing the
+`Execute` loop body.
+
+## ⚙️ How it works (in brief)
+
+Derive from `QuerySystem`, declare an `Input` View and an optional `ChangeFilter` in `Configure`. At dispatch,
+the View refreshes and the runtime checks: any `ChangeFilter` dirty/Added entity, or any pending event in a
+consumed queue? If neither, the system skips (~200-300ns) and successors still dispatch. Otherwise
+`ctx.Entities` yields `dirtySet ∪ Added` (with a filter) or the full View (without one), and a `Transaction`
+(`ctx.Transaction`) is created for the system to use. Adding `b.Parallel()` splits the filtered set into chunks
+run on different workers — `Execute` is called once per chunk, `ctx.Entities` is that chunk's slice, and entity
+access goes through `ctx.Accessor` by default (a lightweight, thread-safe reader/writer) unless the system
+writes a `Versioned` component, in which case `b.WritesVersioned()` switches each chunk to its own
+`ctx.Transaction`.
+
+## 💻 Usage
+
+```csharp
+// Sequential — runs only on ticks where a Health component changed
+public class HealthRegen : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("HealthRegen")
+        .Input(() => unitsView)
+        .ChangeFilter(typeof(EcsHealth))
+        .After("InputDrain");
+
+    protected override void Execute(TickContext ctx)
+    {
+        foreach (var id in ctx.Entities)
+        {
+            ref var hp = ref ctx.Transaction.OpenMut(id).Write<EcsHealth>();
+            hp.Current = Math.Min(hp.Current + 1, hp.Max);
+        }
+    }
+}
+dag.Add(new HealthRegen());
+
+// Parallel — same loop shape, chunked across workers via ctx.Accessor
+public class MovementSystem : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Movement")
+        .Input(() => activeUnitsView)
+        .After("InputDrain")
+        .Parallel();
+
+    protected override void Execute(TickContext ctx)
+    {
+        foreach (var id in ctx.Entities)
+        {
+            var entity = ctx.Accessor.OpenMut(id);
+            ref var pos = ref entity.Write<EcsPosition>();
+            pos.X += entity.Read<EcsVelocity>().X * ctx.DeltaTime;
+        }
+    }
+}
+dag.Add(new MovementSystem());
+
+// Lambda shorthand
+dag.QuerySystem("GameRules", ctx => { foreach (var id in ctx.Entities) { /* ... */ } },
+    input: () => activeEntitiesView, changeFilter: [typeof(EcsHealth)], after: "Combat");
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `b.Input(() => view)` | required | View providing the entity set; mandatory for any `QuerySystem` |
+| `b.ChangeFilter(...)` | none | Reactive trigger — entity set narrows to `dirtySet ∪ Added`; OR logic across types |
+| `b.Parallel()` | off | Chunk the filtered entity set across workers |
+| `b.WritesVersioned()` | off | Switch chunk access from `ctx.Accessor` to a per-chunk `ctx.Transaction` (required to write `Versioned` data in parallel) |
+| `b.ChunksPerWorker(factor)` | `1.0` | Oversubscribe chunk count (`round(WorkerCount × factor)`), range `[1.0, 64.0]` |
+
+## ⚠️ Guarantees & limits
+
+- Reactive skip: no `ChangeFilter` dirty/Added entities AND no pending consumed-queue events → skip
+  (~200-300ns); a `QuerySystem` with no `ChangeFilter` and no events runs every tick its predecessors allow.
+- `Build()` rejects: no `Input` View, `Parallel()` without `Input`, `ChangeFilter` without `Input`.
+- Sequential systems get one `Transaction` for the whole `Execute` call; `Parallel()` systems get either a
+  per-chunk `ctx.Accessor` (default) or a per-chunk `ctx.Transaction` (`WritesVersioned()`) — chunk Transactions
+  cost markedly more than `ctx.Accessor`, so only declare `WritesVersioned()` when actually writing `Versioned`
+  components.
+- `ctx.Accessor` can read all storage modes and write `SingleVersion`/`Transient` components but throws on a
+  `Versioned` write, and cannot `Spawn`/`Destroy`/`Commit`/`Rollback`.
+- The DAG, not the runtime, guarantees parallel chunks don't race — overlapping writes across parallel systems
+  or chunks are a design error to fix with `.After()`/`.Before()`, not something the runtime detects.
+- Scaling falls off past one CCD's worth of cores on multi-CCD hardware (cross-CCD EntityMap access) — see the
+  parallel-efficiency design doc for measured numbers.
+
+## 🧪 Tests
+
+- [ChangeFilterTests](../../../../test/Typhon.Engine.Tests/Runtime/ChangeFilterTests.cs) — reactive skip when nothing dirty, OR logic across filtered types, `ctx.Entities == dirtySet ∪ Added`
+- [ScheduleValidationTests](../../../../test/Typhon.Engine.Tests/Runtime/ScheduleValidationTests.cs) — `Build()` rejects missing `Input`, `Parallel()`/`ChangeFilter()` without `Input`
+- [ParallelQueryTests](../../../../test/Typhon.Engine.Tests/Runtime/ParallelQueryTests.cs) — `b.Parallel()` chunk dispatch, `ctx.Accessor` vs. `WritesVersioned()` → `ctx.Transaction`
+
+## 🔗 Related
+
+- Parent feature: [System Types](./README.md)
+- Sibling: [Parallel Entity Processing (QuerySystem.Parallel)](../parallel-entity-processing.md) — the four dispatch-path deep dive behind `b.Parallel()` on this system type.
+- Sibling: [Reactive Dispatch: Change Filters & Run Conditions](../reactive-dispatch-change-filters.md) — the `changeFilter`/`shouldRun` mechanics this system type's reactive skip relies on.
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md — QuerySystem.Parallel -->
+<!-- Deep dive: claude/design/Runtime/06-parallel-efficiency.md -->
+<!-- Deep dive: claude/overview/13-runtime.md — QuerySystem, QuerySystem.Parallel -->

--- a/doc/feature-set/Runtime/telemetry-runtime-inspection.md
+++ b/doc/feature-set/Runtime/telemetry-runtime-inspection.md
@@ -1,0 +1,64 @@
+# Telemetry & Runtime Inspection
+> Always-on, zero-allocation per-tick telemetry your game code can read directly — no exporter required.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](./README.md)
+
+## 🎯 What it solves
+Game servers need to know *now*, from inside the process, whether the tick loop is healthy — how long the last tick took, which systems are eating the budget, why a system didn't run. Waiting on an external metrics pipeline is too slow for an admin command or an in-game debug overlay, and too heavyweight if all you want is "did tick N overrun?". This feature gives every tick's vitals to game code as plain structs, with no allocation and no opt-in required.
+
+## ⚙️ How it works (in brief)
+Every tick, the scheduler writes one `TickTelemetry` record plus one `SystemTelemetry` record per system into a pre-allocated circular buffer (`TickTelemetryRing`, default 1024 ticks ≈ 17s at 60Hz). The ring is single-writer (tick driver thread) and safe for concurrent reads — game code, an admin command, or a periodic logger can walk it from any thread. Only the most recent `Capacity` ticks are retained; reading a tick number outside that window throws. A second surface, `IRuntimeInspector`, is designed as a push-based hook (`OnTickStart`/`OnSystemComplete`/`OnTickEnd`) for future remote tooling (REST API, web explorer) — it is not implemented; `RuntimeOptions` has no `Inspector` property today.
+
+## 💻 Usage
+```csharp
+var ring = runtime.Telemetry;
+
+// Inspect the most recent tick
+ref readonly var tick = ref ring.GetTick(ring.NewestTick);
+if (tick.OverrunRatio > 1.2f)
+{
+    logger.LogWarning("Tick {N} overran: {Actual}ms / {Target}ms ({Level}, x{Mul})",
+        tick.TickNumber, tick.ActualDurationMs, tick.TargetDurationMs,
+        tick.CurrentLevel, tick.TickMultiplier);
+}
+
+// Per-system breakdown for that same tick
+foreach (ref readonly var sys in ring.GetSystemMetrics(tick.TickNumber))
+{
+    if (sys.WasSkipped)
+    {
+        Console.WriteLine($"system {sys.SystemIndex} skipped: {sys.SkipReason}");
+    }
+}
+
+// Walk recent history (oldest available -> newest)
+for (var n = ring.OldestAvailableTick; n <= ring.NewestTick; n++)
+{
+    ref readonly var t = ref ring.GetTick(n);
+    // aggregate, plot, export...
+}
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `RuntimeOptions.TelemetryRingCapacity` | 1024 | Ring size (must be a power of 2); trades retention window for memory (~`capacity × (32B + systemCount × 48B)`). |
+
+## ⚠️ Guarantees & limits
+- **Always on, zero allocation** — `Record` copies into pre-allocated slots; there is no opt-in flag and no per-tick GC pressure.
+- **Bounded retention** — only the last `TelemetryRingCapacity` ticks are kept; `GetTick`/`GetSystemMetrics` throw `ArgumentOutOfRangeException` once a tick scrolls out of the window. Read promptly if correlating with an external event (e.g. a player report).
+- **Single writer** — only the tick driver thread calls `Record`; readers get a consistent past-tick snapshot but must not assume the *current* in-flight tick's slot is stable.
+- **`TickTelemetry.OverrunRatio` is base-rate, not throttle-adjusted** — it is always `actual / target-at-1x`, even while `TickMultiplier > 1`. Use it to ask "are we over the engine's nominal budget", not "are we over our currently throttled budget".
+- **`SystemTelemetry.StragglerGapUs` is a placeholder today** — always `0` pending deeper Pipeline integration; don't rely on it for parallel-imbalance analysis yet.
+- **No remote/out-of-process inspection** — `IRuntimeInspector` is designed but unimplemented; there is no REST endpoint or web explorer hook today. All access is in-process (game code, admin commands compiled into the server).
+- **Reading is not free at scale** — `GetSystemMetrics` returns a span over a per-tick array sized to the full system count (engine-internal systems included); iterate only what you need on a hot path.
+
+## 🧪 Tests
+
+- [TickTelemetryRingTests](../../../test/Typhon.Engine.Tests/Runtime/TickTelemetryRingTests.cs) — record/read round-trip, ring-wrap eviction of the oldest tick, out-of-window `GetTick` throws
+
+## 🔗 Related
+- Related feature: [Subscription Telemetry & Tracing](../Subscriptions/subscription-telemetry.md)
+
+<!-- Deep dive: claude/design/Runtime/03-overload.md — Tick Telemetry & Runtime Inspection -->
+<!-- Deep dive: claude/overview/13-runtime.md — Telemetry -->
+<!-- Deep dive: claude/overview/13-runtime.md — Per-tick diagnostics -->

--- a/doc/feature-set/Runtime/tick-execution-engine/README.md
+++ b/doc/feature-set/Runtime/tick-execution-engine/README.md
@@ -1,0 +1,60 @@
+# Tick-Based Execution Engine
+> TyphonRuntime — the single host object that turns a registered system schedule into a running, self-recovering, gracefully-shutting-down server.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+A real-time simulation server needs more than "call my systems every frame" — it needs a process
+lifecycle: spin up worker threads and a drift-free tick clock, recover correctly after a crash
+(replay the WAL, rebuild transient state), and shut down without losing in-flight work or hanging
+on a stuck system. Hand-rolling this lifecycle is exactly the kind of plumbing that's easy to get
+subtly wrong — a worker thread that's never joined, transient state nobody rebuilds after recovery,
+writes lost because shutdown didn't wait for them. `TyphonRuntime` is the one object that owns this
+lifecycle end-to-end, so game code only has to define systems and a couple of lifecycle callbacks.
+
+## ⚙️ How it works (in brief)
+
+`TyphonRuntime.Create(engine, configure, options)` builds a `DagScheduler` from a `RuntimeSchedule`
+the caller populates with systems, then `Start()` launches the worker pool and a dedicated
+`Typhon.TickDriver` thread that fires ticks at a fixed metronome rate (see
+[Worker Pool & Threading Model](./worker-pool-threading.md)). Every tick runs the registered system
+DAG through a runtime-owned UoW/Transaction lifecycle — see
+[Tick Lifecycle & Transaction Management](../tick-lifecycle/README.md) for what happens inside a
+single tick. `OnFirstTick` fires exactly once, before the first tick's systems run, so game code can
+rebuild transient state after crash recovery (the database engine itself replays the WAL during
+`DatabaseEngine` open, before the runtime is even created). `OnShutdown` fires once during
+`Shutdown()`, given a dedicated Immediate-durability transaction so cleanup writes (e.g. persisting
+player state) survive the process exiting. `Dispose()` then tears down worker threads and the
+underlying resources.
+
+## Sub-features
+
+| Sub-feature | What it covers |
+|---|---|
+| [Execution Modes](./execution-modes.md) | The tick-driven dispatch model TyphonRuntime runs today, including single-threaded debug mode |
+| [Worker Pool & Threading Model](./worker-pool-threading.md) | Core allocation between the tick metronome thread and the worker pool, and how each waits |
+| [Parallel Tick Fence](./parallel-tick-fence.md) | How the post-tick `WriteTickFence` step is spread across the worker pool instead of running serially |
+
+## ⚠️ Guarantees & limits
+
+- `Create` does not start anything — systems can be registered and validated before any thread
+  exists. `Start()` is the only call that launches worker threads and the TickDriver.
+- `OnFirstTick` and `OnShutdown` each receive their own `TickContext` with a dedicated `Transaction`
+  — `OnShutdown`'s is Immediate durability, so its writes are crash-safe before `Shutdown()` returns.
+- `Shutdown()` is synchronous: it stops the subscription server, runs `OnShutdown`, then blocks until
+  every worker thread has joined. There is no async/timeout-bounded shutdown overload — a system
+  that deadlocks blocks `Shutdown()` indefinitely.
+- `Dispose()` must run after `Shutdown()` to release worker-pool resources; disposing without
+  shutting down first does not run `OnShutdown`.
+
+## 🧪 Tests
+
+- [TyphonRuntimeTests](../../../../test/Typhon.Engine.Tests/Runtime/TyphonRuntimeTests.cs) — Create/Start/Shutdown lifecycle, `OnFirstTick`/`OnShutdown` durability, transaction handoff to systems
+
+## 🔗 Related
+
+- Related feature: [Tick Lifecycle & Transaction Management](../tick-lifecycle/README.md) — what happens inside one tick (UoW, per-system Transactions, side-transactions)
+- Sub-features: [Execution Modes](./execution-modes.md), [Worker Pool & Threading Model](./worker-pool-threading.md), [Parallel Tick Fence](./parallel-tick-fence.md)
+
+<!-- Deep dive: claude/design/Runtime/01-tick-lifecycle.md, claude/design/Runtime/04-threading-and-modes.md, claude/overview/13-runtime.md -->

--- a/doc/feature-set/Runtime/tick-execution-engine/execution-modes.md
+++ b/doc/feature-set/Runtime/tick-execution-engine/execution-modes.md
@@ -1,0 +1,83 @@
+# Execution Modes
+> Today: a fixed-timestep tick loop (plus a single-threaded debug variant); event-driven and hybrid request/response modes are designed but not yet built.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Tick-Based Execution Engine](./README.md)
+
+## 🎯 What it solves
+
+Game servers split into two broad dispatch shapes: continuous simulation (FPS/MMO/survival — work
+happens every tick whether or not a player acts) and discrete request/response (turn-based/card/idle
+games — work happens only when a player acts). Forcing one shape onto the other either pays a full
+tick's overhead for an idle turn-based game, or bolts a fake tick loop onto something that's
+naturally event-driven. `TyphonRuntime` is designed to host either shape; today only the tick-driven
+shape is implemented.
+
+## ⚙️ How it works (in brief)
+
+`TyphonRuntime.Create` + `Start()` runs a fixed-timestep loop: a dedicated `Typhon.TickDriver` thread
+fires ticks at `RuntimeOptions.BaseTickRate` Hz, and every tick executes the full registered system
+DAG through the runtime-owned UoW/Transaction lifecycle (see
+[Tick Lifecycle & Transaction Management](../tick-lifecycle/README.md)). Setting
+`RuntimeOptions.WorkerCount = 1` collapses the worker pool onto the TickDriver thread itself, running
+every system synchronously in topological order — the same `ShouldRun`/`Prepare`/skip/failure
+machinery as multi-threaded execution, just on one thread. This is a genuine single-threaded
+execution path (not a simulated one), useful for deterministic step-by-step debugging without
+touching any other code.
+
+## 💻 Usage
+
+```csharp
+using var runtime = TyphonRuntime.Create(engine, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Game")
+        .CallbackSystem("Movement", ctx => { /* ... */ })
+        .CallbackSystem("AI", ctx => { /* ... */ }, after: "Movement");
+}, new RuntimeOptions
+{
+    BaseTickRate = 60,   // Hz — the only execution mode implemented today
+});
+
+runtime.Start();   // spins up the worker pool + the Typhon.TickDriver metronome thread
+// ... ticks fire on the metronome until Shutdown() ...
+runtime.Shutdown();
+runtime.Dispose();
+```
+
+```csharp
+// Single-threaded debug mode — identical schedule, deterministic in-order execution on one thread
+using var debugRuntime = TyphonRuntime.Create(engine, configureSchedule,
+    new RuntimeOptions { BaseTickRate = 60, WorkerCount = 1 });
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `RuntimeOptions.BaseTickRate` | 60 | Metronome rate (Hz) for the tick-driven loop |
+| `RuntimeOptions.WorkerCount` | -1 (`Max(1, ProcessorCount - 4)`) | Set to `1` for single-threaded, in-order debug execution |
+
+## ⚠️ Guarantees & limits
+
+- **Only tick-based mode is implemented.** `claude/design/Runtime/04-threading-and-modes.md` also
+  designs an event-driven mode (`ProcessAction` per player action, no tick loop, per-player
+  serialized/cross-player concurrent dispatch) and a hybrid mode (tick loop + in-tick action
+  dispatch), but there is no `ExecutionMode` enum, `ProcessAction`, or `RegisterActionHandler` in the
+  current codebase — every `TyphonRuntime` runs the fixed-timestep tick loop.
+- Request/response workloads (turn-based, card, idle games) must currently be modeled as work
+  processed inside a tick (e.g. drain a queued-actions buffer from a `CallbackSystem`) rather than
+  through a dedicated event-driven dispatch path.
+- The tick rate is fixed at `BaseTickRate` for the runtime's lifetime; only the *internal* multiplier
+  the overload detector applies under load (1×-6×) changes effective cadence — see
+  [Worker Pool & Threading Model](./worker-pool-threading.md).
+- `WorkerCount = 1` still runs the full DAG (all phases, all tracks) — it changes *where* systems
+  run (one thread, in topological order), not *what* runs.
+
+## 🧪 Tests
+
+- [TyphonRuntimeTests](../../../../test/Typhon.Engine.Tests/Runtime/TyphonRuntimeTests.cs) — `SingleThreadedMode_TransactionWorks` proves `WorkerCount = 1` still gives systems a valid Transaction
+- [DagSchedulerTests](../../../../test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs) — `SingleThreadedMode_Works`, `SingleThreadedMode_PipelineSystem_AllChunksProcessed` — deterministic in-order execution of the same DAG
+
+## 🔗 Related
+
+- Parent feature: [Tick-Based Execution Engine](./README.md)
+- Sibling: [Worker Pool & Threading Model](./worker-pool-threading.md)
+
+<!-- Deep dive: claude/design/Runtime/04-threading-and-modes.md (§Execution Modes — covers the designed-but-unbuilt Event-Driven/Hybrid modes), claude/overview/13-runtime.md -->

--- a/doc/feature-set/Runtime/tick-execution-engine/parallel-tick-fence.md
+++ b/doc/feature-set/Runtime/tick-execution-engine/parallel-tick-fence.md
@@ -1,0 +1,75 @@
+# Parallel Tick Fence
+> Spreads the post-tick `WriteTickFence` step — cluster migrations, AABB refresh, WAL publish — across the worker pool instead of running it on one thread.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Tick-Based Execution Engine](./README.md)
+
+## 🎯 What it solves
+
+`WriteTickFence` applies [cluster migrations](../../Spatial/spatial-coherent-clustering.md) (moving an entity to
+a cluster for its new grid cell when it crosses a cell boundary), recomputes spatial AABBs, and publishes WAL
+records for the tick's dirty cluster content. Run serially on the single TickDriver thread, it can dominate tick
+time on a large simulation with heavy migration/AABB churn — one thread working while the rest of the
+worker pool the runtime just spun up for the tick DAG sits idle, capping how far a tick can scale
+with core count. The Parallel Tick Fence spreads that work across all workers so it scales the same
+way the rest of the tick does.
+
+## ⚙️ How it works (in brief)
+
+The fence is split into four chained phases — Prep, Migrate, AabbRefresh, Finalize — each dispatched
+as a chunk-parallel system on the worker pool right after the user's tick DAG completes. A per-tick
+work planner sizes chunks from measured per-unit cost (continuously recalibrated from a sliding
+window of recent ticks) and bin-packs work evenly across workers rather than splitting by a fixed
+count, so one slow chunk doesn't stall the tick while idle workers wait. This is entirely internal —
+application code does not call into the fence; it is tuned, not invoked, through `RuntimeOptions`.
+
+## 💻 Usage
+
+```csharp
+var options = new RuntimeOptions
+{
+    EnableParallelFence = true,       // default — parallelize WriteTickFence across workers
+    FenceChunkOversubscription = 2,   // chunk-count cap = oversubscription x WorkerCount
+    AdaptiveFenceCost = true,         // recalibrate migration/AABB cost from measured wall-time
+};
+
+using var runtime = TyphonRuntime.Create(engine, schedule => { /* ... */ }, options);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `EnableParallelFence` | `true` | Parallel fence sub-DAG vs. the legacy single-threaded `WriteTickFence` |
+| `FenceChunkOversubscription` | 2 | Chunk-count cap = oversubscription × `WorkerCount`; smooths per-worker preemption jitter |
+| `FenceCostModel` | AntHill-calibrated defaults | Seeds per-unit cost (migration ≈ 33µs/entity, AABB ≈ 2.4µs/cluster) |
+| `AdaptiveFenceCost` | `true` | Continuously recalibrates `FenceCostModel` from a 64-tick sliding window; disable to pin the static seed for repeatable benchmarks |
+
+## ⚠️ Guarantees & limits
+
+- Application code never interacts with the fence DAG directly — there is no API surface beyond the
+  `RuntimeOptions` knobs above.
+- `EnableParallelFence = false` falls back to the legacy serial `WriteTickFence` on the TickDriver
+  thread — useful for diagnostics or as a regression safety valve; observable behavior is otherwise
+  equivalent.
+- Both the parallel and serial paths feed the engine's mandatory WAL + checkpoint pipeline to drain
+  the dirty pages they touch — this is not an opt-in durability mode, it's how dirty cluster state
+  always gets to disk.
+- Chunk sizing targets ~200µs of CPU per chunk; below that floor, per-dispatch overhead (worker wake,
+  page cache attach) would dominate the chunk's own cost.
+- Per-chunk dirty-page tracking uses a local pooled `ChangeSet`, capped at chunk end — this does not
+  change the engine's WAL/checkpoint contract for the rest of the tick.
+- Runs after the user's tick DAG completes and before `UoW.Flush()` — its WAL publishes land in the
+  same fsync as the tick's other commits, not a tick later.
+
+## 🧪 Tests
+
+- [ParallelFenceTests](../../../../test/Typhon.Engine.Tests/Runtime/ParallelFenceTests.cs) — opt-in/opt-out fence correctness, migration storms, spawn+mutation ticks, no-corruption/no-duplicate-chunk-execution
+- [AdaptiveFenceCostTests](../../../../test/Typhon.Engine.Tests/Runtime/AdaptiveFenceCostTests.cs) — `AdaptiveFenceCost` on/off, cost-model recalibration from measured wall-time
+- [FenceWorkPlanPackTests](../../../../test/Typhon.Engine.Tests/Runtime/FenceWorkPlanPackTests.cs) — chunk bin-packing against oversubscription cap and per-unit cost
+
+## 🔗 Related
+
+- Parent feature: [Tick-Based Execution Engine](./README.md)
+- Sibling: [Worker Pool & Threading Model](./worker-pool-threading.md), [Execution Modes](./execution-modes.md)
+- Sibling: [Spatially-Coherent Entity Clustering](../../Spatial/spatial-coherent-clustering.md) — defines what a cluster migration is and why it's deferred to the tick fence instead of applied inline
+- Also catalogued from the tick-durability angle: [Tick Lifecycle → Parallel Tick Fence](../tick-lifecycle/parallel-tick-fence.md)
+
+<!-- Deep dive: claude/overview/13-runtime.md §Parallel Tick Fence -->

--- a/doc/feature-set/Runtime/tick-execution-engine/worker-pool-threading.md
+++ b/doc/feature-set/Runtime/tick-execution-engine/worker-pool-threading.md
@@ -1,0 +1,77 @@
+# Worker Pool & Threading Model
+> Core allocation between a dedicated tick-metronome thread and a pool of worker threads that execute the system DAG in parallel.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Tick-Based Execution Engine](./README.md)
+
+## 🎯 What it solves
+
+A tick loop needs two things that fight each other on a single thread: jitter-free, sub-millisecond
+timing for the metronome, and as much parallel throughput as possible for system execution. Putting
+both on one thread means a slow tick delays the next tick's wakeup; dedicating every core to workers
+leaves nothing driving the clock. The Runtime separates the two concerns onto different threads, each
+using a wait strategy suited to its own latency budget, so timing precision and worker throughput
+don't trade off against each other.
+
+## ⚙️ How it works (in brief)
+
+A dedicated `Typhon.TickDriver` thread (`AboveNormal` priority) owns the metronome: a three-phase
+wait — `Thread.Sleep(1)` while far from the scheduled tick, `Thread.Yield()` as it nears, raw
+`Thread.SpinWait` for the final ~50µs — gets sub-microsecond timing precision without burning a full
+core when ticks are milliseconds apart. The next tick's target is always computed from the
+*previous target* (metronome-style), so timing error never compounds. `RuntimeOptions.WorkerCount`
+worker threads (also `AboveNormal` priority) execute the system DAG via any-worker dispatch — workers
+race to claim ready systems via CAS, with no fixed thread-to-system affinity. Between ticks, workers
+block on a kernel wait (`ManualResetEventSlim`, ~1-5µs wake latency) rather than spinning: that
+latency is negligible against a tick gap that's milliseconds long, and the wait costs zero CPU while
+idle. The TickDriver wakes every worker at once for the next tick (a generation-counter bump plus a
+single `Set()`) — there is no per-worker staggered wake in the current implementation.
+
+## 💻 Usage
+
+```csharp
+var options = new RuntimeOptions
+{
+    BaseTickRate = 60,
+    WorkerCount = 12,   // explicit; -1 (default) = Max(1, Environment.ProcessorCount - 4)
+};
+
+using var runtime = TyphonRuntime.Create(engine, schedule => { /* ... */ }, options);
+runtime.Start();        // launches WorkerCount worker threads + the Typhon.TickDriver thread
+
+Console.WriteLine($"{runtime.Scheduler.WorkerCount} workers, tick {runtime.CurrentTickNumber}");
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `RuntimeOptions.WorkerCount` | -1 (`Max(1, ProcessorCount - 4)`) | Number of worker threads executing the system DAG |
+| `RuntimeOptions.BaseTickRate` | 60 | Metronome rate (Hz) driving the TickDriver thread |
+
+## ⚠️ Guarantees & limits
+
+- The auto-detect formula reserves headroom for I/O and OS/background work — `Max(1,
+  ProcessorCount - 4)`, never all cores by default.
+- Worker wake-up is a single kernel-event signal shared by every worker for a given tick; there is no
+  dynamic/partial worker wake. This is a deliberate v1 choice — under-waking risked doubling tick
+  time at 60-128Hz in POC measurements — not a missing feature; idle workers cost almost nothing
+  while blocked on the kernel wait.
+- The TickDriver's three-phase wait self-calibrates once at startup against this machine's actual
+  `Thread.Sleep(1)` resolution, so the Sleep→Yield split point adapts across OS/hardware without
+  configuration.
+- An unhandled exception inside a system body cannot kill a worker thread: it is caught, the failing
+  system and its successors are marked failed for that tick, and the worker keeps claiming other
+  ready systems.
+- Scaling falls off once a workload exceeds a single CCD's worth of cores on multi-CCD hardware
+  (cross-CCD memory access cost dominates) — see Performance Characteristics in
+  `claude/overview/13-runtime.md`.
+
+## 🧪 Tests
+
+- [DagSchedulerTests](../../../../test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs) — `MultiWorker_DependencyRespected` (any-worker CAS dispatch), `Shutdown_Clean` (worker join on teardown)
+- [TyphonRuntimeTests](../../../../test/Typhon.Engine.Tests/Runtime/TyphonRuntimeTests.cs) — `Start_Shutdown_Clean` — TickDriver + worker pool full lifecycle
+
+## 🔗 Related
+
+- Parent feature: [Tick-Based Execution Engine](./README.md)
+- Sibling: [Execution Modes](./execution-modes.md), [Parallel Tick Fence](./parallel-tick-fence.md)
+
+<!-- Deep dive: claude/design/Runtime/04-threading-and-modes.md, claude/overview/13-runtime.md (§Cadence, §Worker Thread Model) -->

--- a/doc/feature-set/Runtime/tick-lifecycle/README.md
+++ b/doc/feature-set/Runtime/tick-lifecycle/README.md
@@ -1,0 +1,77 @@
+# Tick Lifecycle & Transaction Management
+> Runtime-owned UoW per tick and auto-created per-system Transactions — the developer never commits or disposes a Transaction manually.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+Every tick, every system needs entity access that is correct, isolated, and durable — without the developer
+hand-rolling a UoW/Transaction lifecycle. Manual management invites three failure modes: forgetting to commit
+or dispose a Transaction (silent data loss, resource leak), creating a Transaction on the wrong thread
+(violates Transaction's single-thread affinity), or not handling a commit failure (crash instead of graceful
+recovery). The Runtime eliminates all three by owning the lifecycle entirely.
+
+## ⚙️ How it works (in brief)
+
+At tick start the Runtime opens one Deferred-durability `UnitOfWork`. For each `CallbackSystem`/`QuerySystem`
+in the DAG, it creates a `Transaction` on the worker thread that executes that system, hands it to the system
+via `TickContext.Transaction`, and commits it the instant the system returns — application code must never
+call `Commit`/`Dispose` on it. Entities spawned or destroyed through that Transaction become visible to
+systems that run later in the tick (their Transactions get a higher TSN) but not to systems already running or
+running in parallel. After the last system completes, the Runtime flushes the UoW once — a single WAL fsync
+covering every system's commits for the whole tick — then disposes it. `PipelineSystem`s do not receive a
+Transaction at all; their entity access goes through Gather/Scatter pipelines instead.
+
+## 💻 Usage
+
+```csharp
+EntityId spawnedId = default;
+
+using var runtime = TyphonRuntime.Create(dbe, schedule =>
+{
+    schedule.PublicTrack.DeclareDag("Game")
+        .CallbackSystem("Spawner", ctx =>
+        {
+            var pos = new Position(1, 2, 3);
+            spawnedId = ctx.Transaction.Spawn<Unit>(Unit.Pos.Set(in pos));
+            // No Commit()/Dispose() here — the Runtime commits ctx.Transaction when this system returns.
+        })
+        .CallbackSystem("Reader", ctx =>
+        {
+            // Reader gets its own Transaction (higher TSN) — sees Spawner's commit within the same tick.
+            if (ctx.Transaction.TryOpen(spawnedId, out var unit)) { /* ... */ }
+        }, after: "Spawner");
+}, new RuntimeOptions { BaseTickRate = 60 });
+
+runtime.Start();
+// ... runtime ticks on its own dedicated thread ...
+runtime.Shutdown();
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `RuntimeOptions.BaseTickRate` | 60 | Tick metronome rate (Hz) — also the cadence of the per-tick WAL flush |
+| `RuntimeOptions.WorkerCount` | -1 (`ProcessorCount - 4`) | Worker threads executing per-system Transactions in parallel |
+
+## ⚠️ Guarantees & limits
+
+- Exactly one `Transaction` per `CallbackSystem`/`QuerySystem` invocation; parallel `QuerySystem`s get one
+  Transaction per chunk. Never call `Commit`/`Dispose` on `ctx.Transaction` — the Runtime owns its lifecycle.
+- The tick's main UoW uses Deferred durability: one WAL flush at tick end (~0.1ms) regardless of write count.
+  A crash mid-tick loses at most that one tick's uncommitted work (acceptable for SV/Transient data) — see
+  [Side-Transactions](./side-transactions.md) for writes that cannot tolerate that loss.
+- Spawn/Destroy via a system's Transaction is visible to systems that run later in the DAG (new Transaction,
+  higher TSN) and to the spawning system itself (pending-spawns map) — NOT to systems already executing or
+  running in parallel with it.
+- Destroyed entities remain readable (tombstoned, `DiedTSN` set) until deferred GC reclaims them; they cannot
+  be written.
+- UoW flush failure is not retried — input queues and side effects from the tick may have already changed, so
+  the tick is skipped rather than replayed; the previous tick's committed state remains safe via the WAL.
+- `OnFirstTick`/`OnShutdown` handlers receive their own `TickContext` with a dedicated Transaction (Immediate
+  durability for `OnShutdown`) for one-time initialization/cleanup work.
+
+## 🔗 Related
+
+- Sub-features: [Side-Transactions (Immediate Durability)](./side-transactions.md), [Parallel Tick Fence (WriteTickFence)](./parallel-tick-fence.md)
+
+<!-- Deep dive: claude/design/Runtime/01-tick-lifecycle.md, claude/overview/13-runtime.md -->

--- a/doc/feature-set/Runtime/tick-lifecycle/parallel-tick-fence.md
+++ b/doc/feature-set/Runtime/tick-lifecycle/parallel-tick-fence.md
@@ -1,0 +1,64 @@
+# Parallel Tick Fence (WriteTickFence)
+> Spreads the post-tick WriteTickFence step — cluster migrations, AABB refresh, WAL publish — across the worker pool instead of running it serially on one thread.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+
+## 🎯 What it solves
+
+`WriteTickFence` applies [cluster migrations](../../Spatial/spatial-coherent-clustering.md) (moving an entity to a
+cluster for its new grid cell when it crosses a cell boundary), recomputes spatial AABBs, and publishes WAL records
+for the tick's dirty cluster content. Run serially on the single TickDriver thread, it can dominate tick time on a
+large simulation with heavy migration/AABB churn — one thread working while the rest of the worker pool sits
+idle, capping how far a tick can scale with core count. The Parallel Tick Fence spreads that work across all
+workers so it scales the same way the rest of the tick DAG does.
+
+## ⚙️ How it works (in brief)
+
+The fence is split into four chained phases — Prep, Migrate, AabbRefresh, Finalize — each dispatched as a
+chunk-parallel system after the user's tick DAG completes. A per-tick work planner sizes chunks from measured
+per-unit cost, continuously recalibrated from a sliding window of recent ticks, so work is bin-packed evenly
+across workers rather than split by a fixed count. This is entirely internal — application code does not call
+into it; it is configured via `RuntimeOptions`, not invoked.
+
+## 💻 Usage
+
+```csharp
+var options = new RuntimeOptions
+{
+    EnableParallelFence = true,       // default — parallelize WriteTickFence across workers
+    FenceChunkOversubscription = 2,   // chunk-count cap = oversubscription × WorkerCount
+    AdaptiveFenceCost = true,         // recalibrate migration/AABB cost from measured wall-time
+};
+
+using var runtime = TyphonRuntime.Create(dbe, schedule => { /* ... */ }, options);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `EnableParallelFence` | `true` | Parallel fence sub-DAG vs. the legacy single-threaded `WriteTickFence` |
+| `FenceChunkOversubscription` | 2 | Chunk-count cap = oversubscription × `WorkerCount`; smooths per-worker preemption jitter |
+| `FenceCostModel` | AntHill-calibrated defaults | Seeds per-unit cost (migration ≈ 33µs/entity, AABB ≈ 2.4µs/cluster) |
+| `AdaptiveFenceCost` | `true` | Continuously recalibrates `FenceCostModel` from a 64-tick sliding window; disable to pin the static seed (repeatable benchmarks) |
+
+## ⚠️ Guarantees & limits
+
+- Application code never interacts with the fence DAG directly — there is no API surface beyond the
+  `RuntimeOptions` knobs above.
+- `EnableParallelFence = false` falls back to the legacy serial `WriteTickFence` — useful for diagnostics or
+  as a regression safety valve; behavior is otherwise equivalent.
+- Requires the engine's WAL durability mode (mandatory engine-wide) — both the parallel and serial fence paths
+  rely on it to drain dirty pages.
+- Chunk sizing targets ~200µs of CPU per chunk; below that floor, per-dispatch overhead (worker wake, page
+  cache attach) dominates the chunk's own cost.
+- Per-chunk dirty-page tracking uses a local pooled `ChangeSet`, capped at chunk end — does not change the
+  engine's WAL/checkpoint contract for the rest of the tick.
+- Runs after the user's tick DAG completes and before `UoW.Flush()` — its WAL publishes become durable in the
+  same fsync as the tick's other commits, not a tick later.
+
+## 🔗 Related
+
+- Parent feature: [Tick Lifecycle & Transaction Management](./README.md)
+- Sibling: [Spatially-Coherent Entity Clustering](../../Spatial/spatial-coherent-clustering.md) — defines what a cluster migration is and why it's deferred to the tick fence instead of applied inline
+- Also catalogued from the execution-engine angle: [Tick-Based Execution Engine → Parallel Tick Fence](../tick-execution-engine/parallel-tick-fence.md)
+
+<!-- Deep dive: claude/overview/13-runtime.md §Parallel Tick Fence -->

--- a/doc/feature-set/Runtime/tick-lifecycle/side-transactions.md
+++ b/doc/feature-set/Runtime/tick-lifecycle/side-transactions.md
@@ -1,0 +1,73 @@
+# Side-Transactions (Immediate Durability)
+> A transaction you open and commit from inside a tick system that becomes durable on its own, independent of whether the tick's main UoW ever flushes.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](../README.md)
+**Assumes:** [Durability Modes (Deferred / GroupCommit / Immediate)](../../Transactions/durability-modes/README.md)
+
+## 🎯 What it solves
+
+The tick's main UoW is Deferred — if the server crashes mid-tick, the whole tick's writes are lost (acceptable
+for position/health, recalculated next tick). Economy-critical operations — trades, purchases, loot drops,
+player progression — cannot tolerate that: a crash must never silently erase a completed trade. Side-
+transactions give a system an escape hatch to commit specific writes with immediate, crash-safe durability
+without forcing every other write in the tick to pay that cost.
+
+## ⚙️ How it works (in brief)
+
+`TickContext.CreateSideTransaction(DurabilityMode, DurabilityDiscipline)` opens a brand-new `Transaction` (with
+its own `UnitOfWork`) on the current thread. It is short-lived by design: open it, do the writes, `Commit()`,
+`Dispose()` — all within the same system callback. Because it commits independently with its own TSN, the
+calling system's main `ctx.Transaction` (whose TSN was fixed when it was created) does NOT see the side-
+transaction's writes — only systems that run later in the tick (new Transaction, higher TSN) can. Side-
+transactions see each other's commits, in commit order.
+
+## 💻 Usage
+
+```csharp
+void ProcessTrade(TickContext ctx, TradeRequest trade)
+{
+    // Validate using the system's main Transaction (read-only here).
+    var buyer = ctx.Transaction.Open(trade.BuyerId);
+    var seller = ctx.Transaction.Open(trade.SellerId);
+    if (!ValidateTrade(buyer, seller, trade)) return;
+
+    // Execute the trade in an Immediate side-transaction — durable the instant Commit() returns.
+    using var tradeTx = ctx.CreateSideTransaction(DurabilityMode.Immediate);
+    var buyerMut = tradeTx.OpenMut(trade.BuyerId);
+    var sellerMut = tradeTx.OpenMut(trade.SellerId);
+    ref Wallet bw = ref buyerMut.Write(Player.Wallet);
+    ref Wallet sw = ref sellerMut.Write(Player.Wallet);
+    bw.Gold -= trade.Price;
+    sw.Gold += trade.Price;
+
+    tradeTx.Commit();   // FUA WAL flush — durable now, independent of the tick's main UoW.
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `DurabilityMode` | `Immediate` | FUA on `Commit()` — blocks until the WAL record is on stable media (~15-85µs) |
+| `DurabilityDiscipline` | `TickFence` | `SingleVersion` writes batch durability at the tick fence; pass `Commit` for atomic, zero-loss, commit-scoped writes (no revision chain) on `SingleVersion` components |
+
+## ⚠️ Guarantees & limits
+
+- Caller owns the returned `Transaction` — must `Commit()` + `Dispose()` it; unlike `ctx.Transaction`, the
+  Runtime does not manage its lifecycle.
+- Commits independently of the tick's main UoW — survives a crash even if the rest of the tick never flushes.
+- NOT visible to the calling system's `ctx.Transaction` (snapshot isolation, its TSN is fixed at creation).
+  Visible to systems that run later in the same tick. Use typed event queues for explicit same-tick
+  coordination — don't rely on TSN ordering.
+- Side-transactions see each other's commits, sequentially, in ascending-TSN order.
+- Writes Versioned storage mode (full MVCC, WAL records) by default; pass `DurabilityDiscipline.Commit` for
+  `SingleVersion`-layout components to get atomic, zero-loss commits without paying for a revision chain.
+- No conflict with Patate scatter writes in the same tick — side-transactions write Versioned components,
+  Patate scatter writes SingleVersion/Transient components in place; different storage paths, no overlap.
+- Intended for short-lived, single-purpose commits, not as a substitute for the main tick Transaction's bulk
+  entity operations.
+
+## 🔗 Related
+
+- Parent feature: [Tick Lifecycle & Transaction Management](./README.md)
+- Sibling: [Side-Transactions for Immediate Durability](../side-transactions.md) — same feature, separately catalogued under the top-level Runtime list; not a duplicate to merge, kept for now.
+
+<!-- Deep dive: claude/design/Runtime/01-tick-lifecycle.md §Durability Mode Coordination -->

--- a/doc/feature-set/Runtime/typed-event-queues.md
+++ b/doc/feature-set/Runtime/typed-event-queues.md
@@ -1,0 +1,115 @@
+# Typed Event Queues
+> Lock-free single-producer→single-consumer ring buffers for signalling between systems within a tick.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Runtime](./README.md)
+
+## 🎯 What it solves
+
+Game systems need to react to what another system did this tick — drop loot after a kill, resolve
+damage after combat — without polling shared state or scanning every entity every tick. Typhon's
+DAG is static (no dynamic system insertion), so conditional cascades need a channel that lets a
+downstream system stay statically wired into the schedule yet do nothing on a quiet tick. Typed
+event queues give producer and consumer systems a structured data channel whose emptiness doubles
+as the consumer's skip signal.
+
+## ⚙️ How it works (in brief)
+
+A queue is created once at schedule-build time (`Dag.CreateEventQueue<T>`) and wired to its
+producer/consumer systems either declaratively (`SystemBuilder.WritesEvents` / `.ReadsEvents`,
+which also derives the DAG ordering edge) or via the lambda-shorthand `Dag.Produces` /
+`Dag.Consumes`. Producers `Push` events during `Execute`; DAG ordering guarantees the producer
+fully completes before the consumer starts, so the producer→consumer handoff needs no
+synchronization. `EventQueue<T>` is single-producer, not multi-producer — a parallel system with
+several chunk workers must route events through one designated producer (or a queue per worker,
+merged afterward), not call `Push` directly from every chunk. A reactive system
+(QuerySystem/PipelineSystem) that declares `ReadsEvents` auto-skips when every consumed queue is
+empty and it has no other dirty-entity trigger — its `Execute` never runs, no Transaction is
+created. Every queue is cleared automatically at the start of each tick.
+
+## 💻 Usage
+
+```csharp
+public struct LootEvent
+{
+    public EntityId Source;
+    public int ItemId;
+}
+
+var dag = schedule.PublicTrack.DeclareDag("Game");
+var lootQueue = dag.CreateEventQueue<LootEvent>("LootEvents", capacity: 256);
+
+public class CombatSystem : QuerySystem
+{
+    private readonly EventQueue<LootEvent> _lootQueue;
+    public CombatSystem(EventQueue<LootEvent> lootQueue) => _lootQueue = lootQueue;
+
+    protected override void Configure(SystemBuilder b) => b
+        .Name("Combat").Input(() => combatView)
+        .WritesEvents(_lootQueue);
+
+    protected override void Execute(TickContext ctx)
+    {
+        foreach (var id in ctx.Entities)
+        {
+            if (BossKilled(ctx.Transaction, id))
+            {
+                _lootQueue.Push(new LootEvent { Source = id, ItemId = 42 });
+            }
+        }
+    }
+}
+
+public class LootDropSystem : QuerySystem
+{
+    protected override void Configure(SystemBuilder b) => b
+        .Name("LootDrop").Input(() => combatView)
+        .ReadsEvents(_lootQueue)
+        .After("Combat");
+
+    // Skipped entirely on ticks where Combat produced no LootEvent.
+    protected override void Execute(TickContext ctx)
+    {
+        var queue = (EventQueue<LootEvent>)ctx.ConsumedQueues[0];
+        Span<LootEvent> events = stackalloc LootEvent[queue.Count];
+        var n = queue.Drain(events);
+        for (var i = 0; i < n; i++)
+        {
+            SpawnLoot(ctx.Transaction, events[i]);
+        }
+    }
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `capacity` (`CreateEventQueue<T>`) | 1024 | Must be a power of 2; sizes the per-tick ring buffer for `T` |
+
+## ⚠️ Guarantees & limits
+
+- Push is allocation-free but **not thread-safe** — calling `Push` concurrently from multiple
+  workers races and corrupts the queue. Only one thread may produce into a given queue per tick.
+- Drain is single-consumer and relies on DAG ordering: only the declared consumer should read a
+  queue, after the producer's edge has run — there are no per-slot sequence numbers to make
+  unordered access safe.
+- Queues are reset at the start of every tick; events never carry over, and `Push` past capacity
+  throws `InvalidOperationException` (also counted in the queue's overflow telemetry) — size each
+  queue for the tick's worst-case event volume.
+- `T` has no `unmanaged` constraint — both structs and reference types work; reference-type slots
+  are cleared after each `Drain`/`Reset` so they don't pin garbage.
+- A reactive system whose only trigger is `ReadsEvents` skips completely when its queue(s) are
+  empty — no `Execute`, no Transaction created.
+- Intra-tick signalling only — queues are not persisted, not part of the WAL, and invisible across
+  ticks, snapshots, or processes.
+
+## 🧪 Tests
+
+- [EventQueueTests](../../../test/Typhon.Engine.Tests/Runtime/EventQueueTests.cs) — push/drain round-trip, push-past-capacity throws, power-of-2 capacity, reference-type slot clearing on drain/reset
+- [EventQueueIntegrationTests](../../../test/Typhon.Engine.Tests/Runtime/EventQueueIntegrationTests.cs) — producer→consumer handoff across a DAG edge, `ctx.ConsumedQueues` wiring, reactive skip when empty
+
+## 🔗 Related
+
+- Related feature: [Declarative System Scheduling](./declarative-system-scheduling.md)
+- Sibling: [CallbackSystem](./system-types/callback-system.md) — a common proactive producer/consumer for these queues.
+
+<!-- Deep dive: claude/design/Runtime/02-system-scheduling.md §Typed Event Queues -->
+<!-- Deep dive: claude/design/Runtime/07-system-access-declarations.md (WritesEvents/ReadsEvents access-edge derivation) -->

--- a/doc/feature-set/Schema/README.md
+++ b/doc/feature-set/Schema/README.md
@@ -1,0 +1,27 @@
+# Schema
+> The typed metadata layer over every component: attribute-driven struct declarations reflect into persisted field/index definitions whose FieldIds survive reordering, renames, and reopens. On every database open, the persisted layout is diffed against the running code and classified by compatibility — additions, removals, reorders, and lossless widenings migrate automatically, while genuinely breaking changes require a registered migration function rather than silently losing data. Operational tooling (offline inspection, dry-run validation, progress events, an audit log, tsh shell commands, and Workbench ALC reload) makes every one of those changes observable and verifiable before and during a real deployment.
+
+> 🔬 **Recommended:** read [in-depth-overview/04-schema.md](../../in-depth-overview/04-schema.md) (Chapter 04: Schema) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Component & Field Declaration](component-field-declaration.md) | Attribute-driven declaration of blittable component structs (`[Component]`, `[Field]`, `[Index]`) reflected into `DBComponentDefinition` at registration time | ✅ Implemented | 🟢 Start Here |
+| [FieldId Stability](fieldid-stability.md) | Persistent, name-based FieldId assignment (auto-assign once, match by name on reopen) so adding/removing/reordering fields never breaks index identity; `PreviousName` handles renames | ✅ Implemented | 🔵 Core |
+| [Schema Validation (SchemaDiff)](schema-validation.md) | On every reopen, diffs persisted vs. runtime schema, classifies every change by compatibility level, and fails loudly before any user transaction runs on unresolvable mismatches | ✅ Implemented | 🔵 Core |
+| [Compatible Schema Evolution (Auto-Migration)](compatible-evolution/README.md) | Automatically migrates entities at startup for field add/remove/reorder and lossless type widenings by allocating a new stride segment while preserving ChunkIds so indexes need no rebuild | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Migration Execution Strategy](compatible-evolution/migration-execution-strategy.md) | Migration runs eagerly and synchronously at database open — before any user transaction — with progress events and an offline dry-run check | ✅ Implemented | 🟣 Advanced |
+| [User-Defined Migration Functions](migration-functions.md) | Register pure transform functions for breaking schema changes, with automatic multi-step chain resolution across revisions | ✅ Implemented | 🟣 Advanced |
+| [Offline Schema Inspection & Dry-Run Validation](schema-inspection-dryrun.md) | Read a database's persisted schema, or simulate a code upgrade against it, without opening it for real | ✅ Implemented | 🟣 Advanced |
+| [Migration Progress Tracking](migration-progress-tracking.md) | `OnMigrationProgress` event stream (`Analyzing` → `AllocatingSegments` → `MigratingEntities` → … → `Complete`) for observing long-running eager migrations in production | ✅ Implemented | 🟣 Advanced |
+| [Schema History Audit Log](schema-history-audit.md) | Append-only audit trail recording every applied schema change for production auditing, queried via `dbe.GetSchemaHistory()` | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+| Feature | Summary | Status |
+|---|---|---|
+| [tsh Schema Shell Commands](tsh-schema-commands.md) | Typhon Shell commands (`schema-fields`, `schema-diff`, `schema-validate`, `schema-history`, `schema-export`) exposing persisted-vs-runtime schema comparison and inspection as an interactive CLI on top of the engine schema APIs | ✅ Implemented |
+| [System Schema Persistence](system-schema-persistence.md) | Self-referential storage of component/field metadata as engine-internal ECS entities (`ComponentR1`/`FieldR1`) inside the database itself, loaded/saved via a minimal single-threaded CRUD layer (no MVCC/WAL) at engine open/create | ✅ Implemented |
+| [Workbench Per-Session Schema Loading & ALC Reload](workbench-schema-loading.md) | Loads schema DLLs into a per-session collectible ALC so Workbench sessions can rebuild/swap binaries without restarting the host, classifying engine schema exceptions into Ready/MigrationRequired/Incompatible and rebinding component IDs by schema name across reloads | ✅ Implemented |
+| [Component Family Classification](component-family-classification.md) | Classifies a component into a semantic family (Spatial/Combat/AI/Inventory/Rendering/Networking/Input/Misc) via explicit attribute or name heuristic, for stable Workbench Data Flow grouping | ✅ Implemented |

--- a/doc/feature-set/Schema/compatible-evolution/README.md
+++ b/doc/feature-set/Schema/compatible-evolution/README.md
@@ -1,0 +1,95 @@
+# Compatible Schema Evolution (Auto-Migration)
+> Reopen with an added, removed, reordered, or safely-widened field and Typhon migrates every entity automatically — no migration code, no index rebuild.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Schema](../README.md)
+**Assumes:** [FieldId Stability & Rename Tracking](../fieldid-stability.md)
+
+## 🎯 What it solves
+
+Struct layouts drift across application versions: a field gets added, an obsolete one removed, fields get
+reordered, or a type is widened to a larger compatible one (`int`→`long`, `Float`→`Double`). Without engine
+support, every one of these routine changes would need hand-written byte-copy migration code, and a mistake
+there risks silently misreading old data through the new layout. Compatible Schema Evolution handles the ~80%
+of real-world changes that are structurally safe — pure copy, zero-fill, and well-defined widening — fully
+automatically, so you only write a migration function (see Schema Migration Functions) for the changes that
+truly need one.
+
+## ⚙️ How it works (in brief)
+
+On reopen, `RegisterComponentFromAccessor<T>()` diffs the persisted field layout against your current struct
+(see Schema Validation). If every change is `Compatible` or `CompatibleWidening`, the engine allocates a new
+component segment at the new stride, then copies each entity's bytes into it field-by-field — zero-filling new
+fields and applying sign-extend/zero-extend/IEEE754-promotion for widened ones. Each entity keeps its original
+**ChunkId**, so the primary-key index, surviving secondary indexes, and revision-chain pointers stay valid
+without a rebuild; only a newly-`[Index]`-attributed field triggers an O(N) index build. The MVCC revision chain
+is collapsed to a single HEAD revision — there are no active transactions at startup, so history isn't needed.
+Migration runs eagerly before any user transaction (see Migration Execution Strategy for timing and progress
+details).
+
+## 💻 Usage
+
+```csharp
+// V1 — first deployment
+[Component("Game.Player", 1)]
+struct PlayerV1
+{
+    public int Health;
+    public float Speed;
+}
+
+using (var dbe = host.Services.GetRequiredService<DatabaseEngine>())
+{
+    dbe.RegisterComponentFromAccessor<PlayerV1>();
+    dbe.InitializeArchetypes();
+
+    using var t = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+    t.Spawn<PlayerArch>(PlayerArch.Comp.Set(new PlayerV1 { Health = 100, Speed = 5.5f }));
+    t.Commit();
+}
+
+// V2 — next release: Shield added, Health widened to long. Same [Component] name, same Revision.
+[Component("Game.Player", 1)]
+struct PlayerV2
+{
+    public long Health;     // int -> long: auto sign-extended
+    public int Shield;      // new field: zero-filled
+    public float Speed;
+}
+
+using (var dbe = host.Services.GetRequiredService<DatabaseEngine>())
+{
+    dbe.RegisterComponentFromAccessor<PlayerV2>();   // migrates every entity before returning
+    dbe.InitializeArchetypes();
+    // all entities now readable as PlayerV2; Shield == 0, Health correctly widened
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- ChunkId is preserved across migration — the primary-key index, surviving secondary indexes, and revision-chain
+  pointers need no rebuild. Only a newly-indexed field pays an O(N) B+Tree build.
+- Supported widenings are exact and lossless: integer sign/zero-extension, `Float`→`Double`, `PointNF`→`PointND`
+  / `QuaternionF`→`QuaternionD` (per-component), `String64`→`String1024`. Anything not lossless (narrowing,
+  signed↔unsigned, cross-type, semantic change) is classified `Breaking` and is **not** handled here — it
+  throws `SchemaValidationException` unless a migration function is registered.
+- Field add/remove/reorder/widen can combine freely in a single reopen — they're computed from one diff and
+  applied in one pass.
+- MVCC revision history is discarded — only the HEAD revision survives migration. There is no way to query
+  pre-migration revisions afterward.
+- Migration is crash-safe to retry: it flushes its own segments before WAL replay begins, and only repoints the
+  database's root metadata to the new segments on success. A crash mid-migration leaves the old segments
+  authoritative; the next open re-runs migration from scratch.
+- The component's `[Component(..., Revision)]` number does **not** need to change for a compatible evolution —
+  revision bumps are reserved for breaking changes that require a registered migration function.
+
+## 🧪 Tests
+
+- [SchemaEvolutionTests](../../../../test/Typhon.Engine.Tests/Data/Schema/SchemaEvolutionTests.cs) — add/remove/reorder/widen (int→long, float→double, sign extension) individually and combined, surviving indexes, multi-entity and bulk (10K) migration
+
+## 🔗 Related
+
+- Related feature: [Schema Validation on Reopen](../schema-validation.md) (classifies changes before evolution runs), [FieldId Stability & Rename Tracking](../fieldid-stability.md)
+- Related feature: [User-Defined Migration Functions](../migration-functions.md) (user-supplied conversion for `Breaking` changes)
+- Sub-features: [Migration Execution Strategy](./migration-execution-strategy.md)
+
+<!-- Deep dive: claude/design/Schema/03-compatible-evolution.md, claude/overview/04-data.md §4.10 Schema Evolution -->

--- a/doc/feature-set/Schema/compatible-evolution/migration-execution-strategy.md
+++ b/doc/feature-set/Schema/compatible-evolution/migration-execution-strategy.md
@@ -1,0 +1,88 @@
+# Migration Execution Strategy
+> Migration runs eagerly and synchronously at database open — before any user transaction — with progress events and an offline dry-run check.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Schema](../README.md)
+
+## 🎯 What it solves
+
+A schema migration has to happen *somewhere* in the lifecycle, and the choice has real consequences: migrate
+lazily on first read and every read path forever carries a "which layout is this?" branch; migrate eagerly and
+startup pays a one-time, predictable cost instead. Typhon commits to eager migration, but that only helps if
+callers can reason about it — know it blocks startup, know it's safe to retry after a crash, and (for large
+databases) get visibility into how far along it is instead of an opaque hang.
+
+## ⚙️ How it works (in brief)
+
+`RegisterComponentFromAccessor<T>()` performs migration **inline and synchronously** — it does not return until
+every affected entity has been migrated (or an exception is thrown). The engine flushes the migration's own
+`ChangeSet` to disk and repoints the database's root metadata to the new segments *before* WAL replay begins;
+if the process crashes mid-migration, the old segments are still authoritative and the next open re-runs
+migration from scratch (rule: migration completion is all-or-nothing per reopen). While running, the engine
+raises `DatabaseEngine.OnMigrationProgress` synchronously on the calling thread, once per `MigrationPhase`
+transition, so you can log or display progress without polling. Separately, `DatabaseSchema.ValidateEvolution()`
+runs the same diff/classification logic offline against the database file — no engine instance, no data
+mutated — to answer "would this reopen succeed, and what would it cost?" before you deploy.
+
+## 💻 Usage
+
+```csharp
+// Subscribe before registering — events fire synchronously inside RegisterComponentFromAccessor<T>().
+using var dbe = scope.ServiceProvider.GetRequiredService<DatabaseEngine>();
+dbe.OnMigrationProgress += (_, args) =>
+{
+    log.LogInformation("{Component} migration: {Phase} ({Done}/{Total}, {Pct:F0}%)",
+        args.ComponentName, args.Phase, args.EntitiesMigrated, args.TotalEntities, args.PercentComplete);
+};
+
+dbe.RegisterComponentFromAccessor<PlayerV2>();   // blocks until migration completes, or throws
+```
+
+Check feasibility offline, before shipping the new binary against production data:
+
+```csharp
+var result = DatabaseSchema.ValidateEvolution("game.tdb", registrar =>
+{
+    registrar.RegisterComponent<PlayerV2>();
+});
+
+if (!result.IsValid)
+{
+    foreach (var err in result.Errors)
+    {
+        log.LogError("Schema evolution blocked: {Error}", err);
+    }
+}
+```
+
+`MigrationPhase` values, in the order they're raised:
+
+| Phase | Meaning |
+|---|---|
+| `Analyzing` | SchemaDiff computed, change classified `Compatible`/`CompatibleWidening`/`Breaking` |
+| `AllocatingSegments` | New stride segment(s) allocated |
+| `MigratingEntities` | Per-entity field copy / zero-fill / widening in progress |
+| `RecreatingRevisionChain` | New HEAD-only revision chain written |
+| `Flushing` | Migration's `ChangeSet` flushed to disk before WAL replay |
+| `Complete` | Migration done; new segments are now authoritative |
+
+(`BuildingNewIndexes` and `UpdatingMetadata` are reserved `MigrationPhase` values not currently emitted by the engine — index builds and metadata persistence happen inline within the phases above.)
+
+## ⚠️ Guarantees & limits
+
+- Fully synchronous and blocking — there is no background or async migration mode; `RegisterComponentFromAccessor<T>()` owns the calling thread until done.
+- Runs once per affected component per reopen, before WAL replay and before any user transaction can start — no caller can ever observe a partially-migrated entity.
+- `OnMigrationProgress` fires on the calling thread in monotonically non-decreasing `MigrationPhase` order, always starting at `Analyzing` and ending at `Complete` — safe to drive a log/progress bar, not a substitute for cross-thread coordination.
+- Crash mid-migration is safe to retry: the database's root metadata only repoints to the new segments after migration's own flush succeeds, so a crash before that leaves the prior (pre-migration) segments authoritative and the next open re-runs migration in full.
+- `DatabaseSchema.ValidateEvolution()` mutates nothing — it's read-only analysis against the file, suitable for a pre-deploy CI check.
+- Cost is proportional to entity count and paid once at startup (sub-millisecond to tens of milliseconds for typical sizes; an added index is the only path with O(N) B+Tree cost) — there is no incremental or amortized migration for very large databases today.
+
+## 🧪 Tests
+
+- [OperationalToolingTests](../../../../test/Typhon.Engine.Tests/Data/Schema/OperationalToolingTests.cs) — `MigrationProgress_EventsFiredInOrder` (monotonic phase sequence, `Analyzing`→`Complete`), `ValidateEvolution_CompatibleChange_IsValid` (offline dry-run, no mutation)
+- [SchemaEvolutionTests](../../../../test/Typhon.Engine.Tests/Data/Schema/SchemaEvolutionTests.cs) — `BulkMigration_Performance` times a 10K-entity eager migration, illustrating the synchronous startup cost
+
+## 🔗 Related
+
+- Parent feature: [Compatible Schema Evolution (Auto-Migration)](./README.md)
+
+<!-- Deep dive: claude/design/Schema/03-compatible-evolution.md §10 Why Eager Migration, claude/design/Schema/04-migration-functions.md §4 Execution Strategy -->

--- a/doc/feature-set/Schema/component-family-classification.md
+++ b/doc/feature-set/Schema/component-family-classification.md
@@ -1,0 +1,72 @@
+# Component Family Classification
+> Groups components into semantic families for stable, readable Workbench visualizations.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+The Workbench Data Flow Timeline and Access Matrix show every component a system touches, but a flat list of dozens of component names doesn't read as a picture — there's no visual grouping to tell "movement data" apart from "combat data" apart from "network sync data" at a glance. Component Family Classification assigns each component to one of a small set of well-known families so the Workbench can group and order rows consistently, without requiring the schema author to maintain a separate taxonomy file.
+
+## ⚙️ How it works (in brief)
+
+Each component resolves to a family name through two steps, in order: an explicit `[ComponentFamily("Name")]` attribute on the struct wins if present; otherwise a server-side heuristic substring-matches the component's name against fixed token lists (e.g. `Position`/`Velocity`/`Transform` → `Spatial`, `Health`/`Damage`/`Shield` → `Combat`). Unmatched names fall back to `Misc`. The heuristic is the safety net for components you didn't explicitly tag, and the only path available when classifying components from a recorded trace (no live `Type` to read attributes from). The Workbench renders families in a fixed canonical order so the layout is stable across sessions, independent of declaration order or alphabetical sort.
+
+## 💻 Usage
+
+```csharp
+using System.Runtime.InteropServices;
+using Typhon.Schema.Definition;
+
+// Explicit — wins over the name heuristic regardless of the component's name.
+[Component("Game.Squad", revision: 1)]
+[ComponentFamily("AI")]
+[StructLayout(LayoutKind.Sequential)]
+public struct SquadCommandComponent
+{
+    public int TargetEntityId;
+}
+
+// No attribute — classified by the name heuristic from "Position" -> Spatial.
+[Component("Game.Position", revision: 1)]
+[StructLayout(LayoutKind.Sequential)]
+public struct PositionComponent
+{
+    public float X;
+    public float Y;
+    public float Z;
+}
+```
+
+There is no API call to make as the application developer — registering the component (`RegisterComponentFromAccessor<T>()`) is enough. Classification happens server-side when a Workbench session attaches.
+
+| Family | Heuristic tokens (substring match) |
+|---|---|
+| Spatial | Position, Velocity, Bounds, Rotation, Transform, Scale, Pose |
+| Combat | Health, Damage, Armor, Shield, Hp, Hit |
+| AI | Behaviour, Behavior, Target, Pathfind, NavMesh, Decision |
+| Inventory | Inventory, Equipment, Equipped, Ammo, Item |
+| Rendering | Sprite, Animation, Mesh, Material, Tint, Render |
+| Networking | Network, Replication, Sync, Snapshot |
+| Input | Input, Command, Action |
+| Misc | (default fallback — no match) |
+
+## ⚠️ Guarantees & limits
+
+- `[ComponentFamily]` always overrides the heuristic, regardless of how the component is named.
+- The heuristic always returns a family — there's no "unclassified" state; unmatched names land in `Misc`.
+- Row order in the Workbench is fixed: Spatial → Combat → AI → Inventory → Rendering → Networking → Input → Misc, identical across sessions.
+- Token matching is ordinal substring matching against fixed, non-configurable lists — there is no way to add custom families or tokens without an attribute on the component itself.
+- Trace (recorded) sessions can only use the name heuristic — `[ComponentFamily]` requires reflecting the live CLR `Type`, which a trace replay doesn't have.
+- This is a presentation/grouping aid only — family has no effect on storage, indexing, validation, or schema evolution.
+- This is a Workbench-only concern.
+
+## 🧪 Tests
+
+- [ComponentFamilyResolverTests](../../../test/Typhon.Engine.Tests/Data/Schema/ComponentFamilyResolverTests.cs) — attribute-wins-over-heuristic, per-token heuristic classification (`TestCase` per family), `Misc` fallback, canonical family order
+
+## 🔗 Related
+
+- Sibling: [Workbench Per-Session Schema Loading & ALC Reload](workbench-schema-loading.md) — classification runs server-side each time a Workbench session attaches or reloads
+- Source: `src/Typhon.Engine/Schema/internals/ComponentFamilyResolver.cs`, `src/Typhon.Schema.Definition/Attributes.cs`
+
+<!-- Deep dive: claude/design/Schema/06-workbench-schema-loading.md §5 (resolution order, canonical family order, visibility note) -->

--- a/doc/feature-set/Schema/component-field-declaration.md
+++ b/doc/feature-set/Schema/component-field-declaration.md
@@ -1,0 +1,85 @@
+# Component & Field Schema Declaration
+> Declare a struct, decorate its fields, and Typhon turns it into a fully-indexed, persisted component type.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Every piece of data Typhon stores — components, their fields, indexes, foreign keys — needs metadata describing its shape, identity, and constraints: a stable name and revision, field types and offsets, which fields are indexed and how, which storage discipline applies. Hand-maintaining that metadata separately from the struct definition invites drift between what the code declares and what the engine persists. Attribute-driven declaration keeps the single source of truth in the C# struct itself: the engine reflects it once, at registration time, into the metadata it needs for storage, indexing, and validation.
+
+## ⚙️ How it works (in brief)
+
+A component is a `struct` (blittable, fixed layout) decorated with `[Component(name, revision)]`. Each storable field is plain public field, optionally decorated with `[Field]` (explicit id/name/rename), `[Index]` (secondary B+Tree index), `[ForeignKey]` (referential link to another component), or `[SpatialIndex]` (R-Tree). At registration (`RegisterComponentFromAccessor<T>()` / `RegisterComponentByType()`), Typhon reflects the struct's fields, computes per-field storage offsets and sizes, and builds a `DBComponentDefinition` — the runtime schema object that drives storage layout, index creation, and (on reopen) validation against what's already persisted. Field identity is name-based, not declaration-order-based: an unannotated field gets an auto-assigned `FieldId` on first creation, then that id is matched back by name (or `PreviousName`) on every subsequent reopen, so reordering or inserting fields never reshuffles index associations.
+
+## 💻 Usage
+
+```csharp
+using System.Runtime.InteropServices;
+using Typhon.Engine;
+using Typhon.Schema.Definition;
+
+[Component("Game.Guild", revision: 1, StorageMode = StorageMode.Versioned)]
+[StructLayout(LayoutKind.Sequential)]
+public struct GuildComponent
+{
+    [Index(AllowMultiple = true)]
+    public int Level;
+
+    [Index]
+    public int MemberCap;
+}
+
+[Component("Game.Player", revision: 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+public struct PlayerComponent
+{
+    [Field(Name = "Health", PreviousName = "Hitpoints")]
+    public float Health;
+
+    [Index(AllowMultiple = true), ForeignKey(typeof(GuildComponent))]
+    public long GuildId;
+
+    [Index]
+    public int AccountId;
+}
+
+// At startup, before any UnitOfWork is created:
+dbe.RegisterComponentFromAccessor<GuildComponent>();
+dbe.RegisterComponentFromAccessor<PlayerComponent>();
+
+// Inspecting the reflected schema:
+DBComponentDefinition def = dbe.DBD.GetComponent("Game.Player", revision: 1);
+int healthOffset = def.FieldsByName["Health"].OffsetInComponentStorage;
+```
+
+| Attribute / Option | Default | Effect |
+|---|---|---|
+| `[Component(name, revision)]` | — (required) | Persistent component identity; `revision` is a manual version bump, independent of automatic field evolution |
+| `ComponentAttribute.StorageMode` | `StorageMode.Versioned` | `Versioned` (full MVCC) / `SingleVersion` (in-place, tick-fence durable) / `Transient` (heap-only, no persistence) |
+| `ComponentAttribute.DefaultDiscipline` | `DurabilityDiscipline.TickFence` | `SingleVersion`-only; `Commit` makes writes to this component commit-durable |
+| `[Field(FieldId, Name, PreviousName)]` | name = C# member name, id = auto-assigned | Overrides field name/id; `PreviousName` preserves identity across a rename |
+| `[Index(AllowMultiple)]` | `AllowMultiple = false` | Adds a secondary B+Tree index on the field; `AllowMultiple` allows non-unique values |
+| `[ForeignKey(targetType)]` | — | Declares a referential link (field must be `long`); enables cascade-delete via `IndexAttribute.OnParentDelete` |
+| `[SpatialIndex(margin, cellSize)]` | — | At most one per component; registers the field with the spatial R-Tree |
+| `schemaValidation` (`RegisterComponentFromAccessor<T>`) | `SchemaValidationMode.Enforce` | Throws on breaking changes detected at reopen; `Skip` bypasses validation (unsafe) |
+
+## ⚠️ Guarantees & limits
+
+- `FieldId` is stable across reopens via name matching (or `PreviousName` for renames) — not C# declaration order — so secondary index identity survives field reordering or insertion.
+- Field lookup by id is a dense-array O(1) dereference (`definition[fieldId]`), not a dictionary — chosen for hot-path performance over flexibility.
+- Components must be blittable `unmanaged` structs; only public instance fields are reflected (static fields are ignored).
+- At most one `[SpatialIndex]` field per component; unsupported on `StorageMode.Transient`.
+- `[ForeignKey]` requires the field type to be `long`.
+- Field names must be a single alphabetic word, UTF-8-encoded, ≤ 63 bytes.
+- Registration is startup-only — `RegisterComponentFromAccessor<T>()` / `RegisterComponentByType()` must run before any `UnitOfWork` is created.
+- This is the declaration layer only: schema validation on reopen, compatible evolution (add/remove fields), and migration functions for breaking changes are separate features (see Related).
+
+## 🔗 Related
+
+- Sibling: [FieldId Stability & Rename Tracking](fieldid-stability.md) — assigns and preserves the stable ids for the fields declared here
+- Sibling: [Schema Validation (SchemaDiff)](schema-validation.md) — diffs this declared struct against the persisted layout on every reopen
+- Source: `src/Typhon.Schema.Definition/Attributes.cs`, `src/Typhon.Engine/Schema/public/DBComponentDefinition.cs`, `src/Typhon.Engine/Schema/public/DatabaseDefinitions.cs`, `src/Typhon.Engine/Schema/public/DBObjectDefinition.cs`
+
+<!-- Deep dive: claude/design/Schema/README.md (layered schema versioning architecture, decision log D1–D8) -->
+<!-- Deep dive: claude/design/Schema/01-field-id-stability.md (FieldId resolution algorithm, `PreviousName`) -->
+<!-- Overview: claude/overview/04-data.md §4.8 (Schema System), §4.1 (component registration flow) -->

--- a/doc/feature-set/Schema/fieldid-stability.md
+++ b/doc/feature-set/Schema/fieldid-stability.md
@@ -1,0 +1,67 @@
+# FieldId Stability & Rename Tracking
+> Field identity survives reordering, insertion, removal, and renames — your indexes never silently point at the wrong field.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Typhon identifies a component field internally by a small integer (`FieldId`), and secondary indexes are keyed on that integer, not on the field's name. If FieldIds were assigned purely by declaration order, inserting a field in the middle of a struct — or removing one — would silently shift every later field's id. An index built for `Mana` could end up reading `Shield` after a routine schema edit, with no error raised. FieldId stability removes this trap: a field's id, once assigned, never changes for the life of the database, regardless of how the struct is reshaped across versions.
+
+## ⚙️ How it works (in brief)
+
+The first time a component is created, FieldIds are assigned sequentially and persisted alongside each field's name. On every later reopen, Typhon matches runtime struct fields against the persisted set **by name**: a name match reuses the old id, a brand-new field gets the next free id above the current maximum, and a field no longer present is dropped (its id is never reused). Renames are detected via `PreviousName` rather than name matching. The struct's declaration order only matters for the very first creation — after that, reordering fields freely is safe.
+
+## 💻 Usage
+
+```csharp
+// V1
+[Component("Game.Player", 1)]
+struct Player
+{
+    public int Health;     // FieldId 0
+    public float Speed;    // FieldId 1
+}
+
+// V2 — Health renamed, a field inserted, declaration order changed
+[Component("Game.Player", 1)]
+struct Player
+{
+    [Field(PreviousName = "Health")]
+    public int Hitpoints;  // matched by PreviousName -> keeps FieldId 0
+    public int Shield;     // new field -> gets FieldId 2 (next free, not 1)
+    public float Speed;    // matched by name -> keeps FieldId 1
+}
+
+dbe.RegisterComponentFromAccessor<Player>();
+```
+
+`PreviousName` is also available on `[Component(...)]` for renaming the component itself; it resolves the same way against the persisted component name.
+
+| Mechanism | When to use it |
+|-----------|-----------------|
+| Plain field rename (no attribute) | Never — treated as remove-old + add-new, breaks the old index |
+| `[Field(PreviousName = "Old")]` | Renaming a field while preserving its id, data, and index |
+| `[Field(FieldId = N)]` | Explicit override (cross-assembly schemas, manual control) — wins over name matching |
+| `[Component(PreviousName = "Old.Name")]` | Renaming a component while preserving all of its field ids |
+
+## ⚠️ Guarantees & limits
+
+- Adding, removing, or reordering fields never changes the FieldId of an unaffected field.
+- A rename only preserves identity if `PreviousName` is declared; an undeclared rename is indistinguishable from drop+add and loses the old field's index/data linkage.
+- `PreviousName` need only reference the immediately preceding name — once reopened with the new name, the persisted record updates and subsequent opens match on it directly. Multiple renames are PreviousName chains across versions, not a list of all historical names.
+- Explicit `[Field(FieldId = N)]` always wins, but conflicts with an already-assigned id belonging to a different field fail loudly at registration rather than silently colliding.
+- Two fields claiming the same `PreviousName` in one version is rejected at registration.
+- FieldIds are never recycled — removed fields permanently retire their id. Accumulated additions over a component's lifetime are bounded by `short.MaxValue` (32,767); exceeding it fails registration with an explicit overflow error.
+- Pre-existing databases need no migration: since original auto-assignment was deterministic, name-based matching reconstructs the same ids on first reopen under this scheme.
+
+## 🧪 Tests
+
+- [FieldIdResolverTests](../../../test/Typhon.Engine.Tests/Data/Schema/FieldIdResolverTests.cs) — pure resolver algorithm: name matching, `PreviousName` renames (incl. circular swaps), explicit `FieldId` conflicts, overflow, gap-skipping for new ids
+- [FieldIdStabilityTests](../../../test/Typhon.Engine.Tests/Data/Schema/FieldIdStabilityTests.cs) — end-to-end reopen cycles proving ids/index survive add/remove/rename
+
+## 🔗 Related
+
+- Sibling: [Component & Field Schema Declaration](component-field-declaration.md) — declares the fields whose ids this feature keeps stable across reopens
+- Sibling: [Schema Versioning & Migration](../Ecs/schema-versioning-migration.md) — the Ecs-side view of the same FieldId-based diff/migration flow
+
+<!-- Deep dive: claude/design/Schema/01-field-id-stability.md -->

--- a/doc/feature-set/Schema/migration-functions.md
+++ b/doc/feature-set/Schema/migration-functions.md
@@ -1,0 +1,80 @@
+# User-Defined Migration Functions
+> Register a pure transform to carry data through a breaking schema change — type narrowing, semantic conversions, field split/merge.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Schema Validation auto-resolves additions, removals, and lossless type widenings, but some struct evolutions genuinely change the meaning or shape of the data: `int CategoryId` becoming `String64 Category`, `int HealthPercent` (0-100) becoming `float HealthRatio` (0.0-1.0), or one field splitting into two. None of these can be inferred safely — only the application knows the intended conversion. Without an escape hatch, every such change would force a one-off export/import outside the engine. Migration Functions let you register that conversion once, in code, and have it applied to every existing entity the next time the new struct revision is registered.
+
+## ⚙️ How it works (in brief)
+
+You register a `MigrationFunc<TOld, TNew>` (or a byte-level `ByteMigrationFunc` when `TOld` no longer exists in code) before calling `RegisterComponentFromAccessor<TNew>()`. When that call detects a `Breaking` schema change, it looks up a migration path from the persisted revision to the runtime revision — a direct mapping if one was registered, otherwise a multi-step chain resolved automatically across intermediate revisions (e.g. V1→V2→V3 from two registered single-step functions). The chain runs once, eagerly, over every entity at startup; functions are pure value transforms with no database or transaction access. If any entity's transform throws, that entity is logged and skipped, migration continues, and registration fails afterward with the full list — old data is never modified until every entity succeeds.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", 1)]
+struct PlayerV1 { public int Health; public int Mana; }
+
+[Component("Game.Player", 2)]
+struct PlayerV2 { public float Health; public int Mana; public int Shield; }
+
+// 1. Register the migration before the new revision is registered.
+dbe.RegisterMigration<PlayerV1, PlayerV2>((ref PlayerV1 old, out PlayerV2 new_) =>
+{
+    new_ = new PlayerV2
+    {
+        Health = old.Health / 100f,  // semantic conversion: percent -> ratio
+        Mana = old.Mana,
+        Shield = 0,                  // new field, default value
+    };
+});
+
+// 2. Register the current revision — triggers validation + migration.
+dbe.RegisterComponentFromAccessor<PlayerV2>();
+```
+
+Byte-level form, for when `PlayerV1` is no longer compiled into the application:
+
+```csharp
+dbe.RegisterByteMigration("Game.Player", fromRevision: 1, toRevision: 2,
+    oldSize: 8, newSize: 12,
+    (ReadOnlySpan<byte> oldBytes, Span<byte> newBytes) =>
+    {
+        var health = BitConverter.ToInt32(oldBytes.Slice(0, 4));
+        BitConverter.TryWriteBytes(newBytes.Slice(0, 4), health / 100f);
+        oldBytes.Slice(4, 4).CopyTo(newBytes.Slice(4, 4));
+    });
+```
+
+Track progress on large migrations via `dbe.OnMigrationProgress`.
+
+| API | Use when |
+|---|---|
+| `RegisterMigration<TOld,TNew>(MigrationFunc<TOld,TNew>)` | `TOld` struct is available in code — typed, zero-copy `ref`/`out` |
+| `RegisterByteMigration(name, fromRev, toRev, oldSize, newSize, ByteMigrationFunc)` | `TOld` struct no longer exists — manual byte layout |
+
+## ⚠️ Guarantees & limits
+
+- Both registration APIs must run **before** `RegisterComponentFromAccessor<TNew>()` for the target component — migrations are looked up only when a breaking change is detected at registration time.
+- Multi-step chains resolve automatically (BFS over registered `(name, fromRev, toRev)` edges) — you only need to register adjacent-revision steps, not every combination.
+- A revision with no registered path (direct or chained) throws `SchemaValidationException` at registration, before any data is touched.
+- Migration runs once, eagerly, over all entities at startup — there is no lazy/background path. The function should be a fast, allocation-free value transform; if it isn't, that's a signal to optimize the function, not the engine.
+- Functions are pure: `ref` access to old data, `out` for new data (or `ReadOnlySpan<byte>`/`Span<byte>` for the byte-level form). No database, transaction, or other-entity access — keeps them fast and testable in isolation.
+- A function is sanity-checked once at registration time against zero-initialized input; if it throws there, registration fails immediately with the cause.
+- If a function throws for specific entities during the real run, those entities are logged (chunk ID, hex dump of old bytes, exception) and migration continues; afterward the whole call throws `SchemaMigrationException` with every failure. **Old segments are left untouched** in this case — fix the function and re-run; no data is lost.
+- Duplicate registration of the same `(componentName, fromRevision, toRevision)` throws `InvalidOperationException`.
+- Migration carries only the HEAD revision forward; MVCC history is not replayed through the chain (no active transactions exist at startup, so this doesn't affect snapshot isolation).
+
+## 🧪 Tests
+
+- [MigrationFunctionTests](../../../test/Typhon.Engine.Tests/Data/Schema/MigrationFunctionTests.cs) — typed single-step and chained (V1→V2→V3) migrations, byte-level migration, per-entity failure logging + `SchemaMigrationException`, missing-path throws, duplicate registration
+- [MigrationRegistryTests](../../../test/Typhon.Engine.Tests/Data/Schema/MigrationRegistryTests.cs) — pure registry: name/revision-ordering validation, BFS chain resolution (direct/multi-step/no-path), zero-init sanity check on registration
+
+## 🔗 Related
+
+- Related feature: [Schema Validation on Reopen](./schema-validation.md) (classifies changes as `Compatible`/`CompatibleWidening`/`Breaking`; only `Breaking` requires a migration function)
+
+<!-- Design: claude/design/Schema/04-migration-functions.md (full API, chain resolution, error handling, MVCC interaction) -->
+<!-- Overview: claude/overview/04-data.md §4.10 Schema Evolution -->

--- a/doc/feature-set/Schema/migration-progress-tracking.md
+++ b/doc/feature-set/Schema/migration-progress-tracking.md
@@ -1,0 +1,50 @@
+# Migration Progress Tracking
+> A phase-by-phase event stream for observing long-running schema migrations as they happen.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+When a component's persisted layout differs from the running application's struct definition, Typhon migrates existing entities to the new layout automatically when the component is registered — synchronously, on the calling thread. For a large table this can take measurable time, and a caller with no visibility into it just sees registration "hang." `OnMigrationProgress` gives operators and tooling a live feed of what the migration is doing, how far it has gotten, and how long it has taken, so this can be surfaced in logs, a CLI progress bar, or a deployment dashboard instead of being a black box.
+
+## ⚙️ How it works (in brief)
+
+`DatabaseEngine` exposes a standard .NET event, `OnMigrationProgress`, of type `EventHandler<MigrationProgressEventArgs>`. Subscribe to it before calling `RegisterComponent`/`RegisterComponentFromAccessor`/`RegisterComponentByType`; if that registration triggers a migration (compatible stride change, or a breaking change with a registered migration function), the engine raises one event per phase as it executes, on the same thread, before the registration call returns. Each event reports the component name, the current `MigrationPhase`, entity counts, percent complete, and elapsed time. If registration doesn't trigger a migration, no events fire.
+
+## 💻 Usage
+
+```csharp
+var phases = new List<MigrationPhase>();
+
+dbe.OnMigrationProgress += (sender, args) =>
+{
+    Console.WriteLine($"[{args.ComponentName}] {args.Phase} " +
+                       $"{args.EntitiesMigrated}/{args.TotalEntities} " +
+                       $"({args.PercentComplete:F1}%) elapsed={args.Elapsed.TotalMilliseconds:F1}ms");
+    phases.Add(args.Phase);
+};
+
+// Migration (if needed) runs synchronously inside this call.
+dbe.RegisterComponentFromAccessor<PlayerV2>();
+```
+
+`MigrationPhase` values, in emission order: `Analyzing`, `AllocatingSegments`, `MigratingEntities`, `RecreatingRevisionChain`, `Flushing`, `Complete`. (`BuildingNewIndexes` and `UpdatingMetadata` are reserved phase values not currently emitted by the engine.)
+
+## ⚠️ Guarantees & limits
+
+- Events are raised synchronously on the thread that called the `RegisterComponent*` method — there is no background thread or async dispatch.
+- Phases are emitted in monotonically non-decreasing order; the first event is always `Analyzing` and the last is always `Complete`.
+- `EstimatedRemaining` and `PercentComplete` are coarse, phase-based estimates, not a fine-grained per-entity progress meter — don't rely on them for precise ETAs.
+- Only fires for migrations triggered during component registration at database open. `DatabaseSchema.ValidateEvolution` (dry-run) does not raise progress events since it never migrates anything.
+- No subscribers means no overhead beyond the null-check on the event invocation.
+
+## 🧪 Tests
+
+- [OperationalToolingTests](../../../test/Typhon.Engine.Tests/Data/Schema/OperationalToolingTests.cs) — `MigrationProgress_EventsFiredInOrder` asserts the phase list starts at `Analyzing`, ends at `Complete`, and is monotonically non-decreasing
+
+## 🔗 Related
+
+- Related feature: [Offline Schema Inspection & Dry-Run Validation](./schema-inspection-dryrun.md) (predicts whether a migration will run, without running it)
+- Related feature: [Schema Validation on Reopen](./schema-validation.md) (the broader auto-migration flow this progress stream observes)
+
+<!-- Design: claude/design/Schema/05-operational-tooling.md §4 Migration Progress Tracking -->

--- a/doc/feature-set/Schema/schema-history-audit.md
+++ b/doc/feature-set/Schema/schema-history-audit.md
@@ -1,0 +1,64 @@
+# Schema History Audit Log
+> Every schema change ever applied to the database, permanently recorded and queryable.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Schema changes in production are easy to apply and hard to reconstruct after the fact. When a field was added, when a type was widened, how many entities a migration touched, how long it took — none of that is visible from the current schema alone, yet it's exactly what you need when auditing a deployment, debugging a regression that correlates with a schema change, or proving compliance with a change-management process. The audit log answers "what changed, and when" without requiring you to instrument your own deployment pipeline.
+
+## ⚙️ How it works (in brief)
+
+Every time a component's schema changes on reopen — a compatible evolution (fields added/removed/widened) or a breaking migration — Typhon appends one entry to a built-in `SchemaHistoryR1` audit trail before the new schema becomes active. Each entry captures what changed (field counts by kind), how many entities were touched, and how long it took. Entries are never updated or deleted, and a component that reopens identical to its persisted schema produces no entry. The trail is itself an ordinary system component, so it survives reopen and is queried like any other audit data.
+
+## 💻 Usage
+
+```csharp
+// After opening the database and registering components (some of which may have evolved)
+var history = dbe.GetSchemaHistory();
+
+foreach (var entry in history)
+{
+    Console.WriteLine(
+        $"{new DateTime(entry.Timestamp, DateTimeKind.Utc):u} " +
+        $"{entry.ComponentName} R{entry.FromRevision}->R{entry.ToRevision} " +
+        $"{entry.Kind} (+{entry.FieldsAdded}/-{entry.FieldsRemoved}/~{entry.FieldsTypeChanged} fields, " +
+        $"{entry.EntitiesMigrated} entities, {entry.ElapsedMilliseconds}ms)");
+}
+```
+
+Equivalent from the shell:
+
+```
+tsh> schema-history
+
+  Timestamp            Component        Change             Entities   Time
+  ──────────────────── ──────────────── ────────────────── ────────── ──────
+  2026-02-20 14:30:05  Game.Player      R1→R2 compatible     15,000  0.3ms
+  2026-02-22 09:15:32  Game.Inventory   R1→R2 migration        8,500  12ms
+```
+
+| `Kind` value | Recorded when |
+|--------------|----------------|
+| `Compatible` | Auto-resolved evolution — fields added/removed, lossless type widenings |
+| `Migration` | A registered migration function ran for a breaking type change |
+| `SystemUpgrade` | Reserved for future internal system-schema revisions — not currently emitted |
+
+## ⚠️ Guarantees & limits
+
+- Append-only: entries are never modified or deleted by Typhon; `GetSchemaHistory()` returns the full trail in chronological (insertion) order.
+- One entry per component per reopen where a real schema difference is detected — identical reopens (no field/type/index changes) write nothing.
+- `EntitiesMigrated`/`ElapsedMilliseconds` are populated only for `Migration` entries; `Compatible` entries report zero/the field-count deltas.
+- The history append happens immediately after the schema change is persisted, in the same registration call — but as a separate write, not one atomic unit with it.
+- The trail itself has no built-in retention/pruning — it grows for the life of the database. Plan for this if a database undergoes very frequent schema churn.
+
+## 🧪 Tests
+
+- [OperationalToolingTests](../../../test/Typhon.Engine.Tests/Data/Schema/OperationalToolingTests.cs) — `SchemaHistory_RecordedOnFieldAdd` (entry recorded with correct `Kind`/field-count deltas), `SchemaHistory_SparseKeys_ReturnsAll` (history readable at a high PK offset)
+
+## 🔗 Related
+
+- Sibling: [tsh Schema Shell Commands](tsh-schema-commands.md) — `schema-history` reads the same audit trail this feature writes
+- Sibling: [Migration Progress Tracking](migration-progress-tracking.md) — the live counterpart; this feature records the permanent trail after the fact
+
+<!-- Deep dive: claude/design/Schema/05-operational-tooling.md §5 Schema History Log, claude/overview/04-data.md §4.10 Schema Evolution -->

--- a/doc/feature-set/Schema/schema-inspection-dryrun.md
+++ b/doc/feature-set/Schema/schema-inspection-dryrun.md
@@ -1,0 +1,61 @@
+# Offline Schema Inspection & Dry-Run Validation
+> Read a database's persisted schema, or simulate a code upgrade against it, without opening it for real.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Two questions come up before you ever touch a production database file: "what schema does this database actually have?" and "will my new build's component structs and migrations succeed against it, or fail?". Answering either by opening the database with your application normally means accepting whatever side effects registration and auto-migration trigger — including a hard failure that leaves you debugging a broken deployment. `DatabaseSchema.Inspect` and `DatabaseSchema.ValidateEvolution` answer both questions from outside the application, without registering any components for real and without writing a single byte to the file.
+
+## ⚙️ How it works (in brief)
+
+Both calls spin up a throwaway, isolated engine instance against the target file path, read what they need from the persisted system tables, and dispose it — no shared state with any live `DatabaseEngine` your app may have open elsewhere. `Inspect` reads persisted component/field/index metadata and per-component entity counts directly, with no component registration at all. `ValidateEvolution` takes a configuration callback (the same shape as your real startup registration code) but captures the registrations into a recorder instead of applying them: it computes a `SchemaDiff` per component against the persisted layout, checks whether breaking changes have a registered migration chain, and reports the outcome — all without allocating storage or migrating any entity.
+
+## 💻 Usage
+
+```csharp
+// What's actually in this file?
+var report = DatabaseSchema.Inspect("prod/game.typhon");
+
+Console.WriteLine($"{report.DatabaseName} (format R{report.DatabaseFormatRevision})");
+foreach (var component in report.Components)
+{
+    Console.WriteLine($"  {component.Name} R{component.Revision} — {component.EntityCount} entities");
+    foreach (var field in component.Fields)
+        Console.WriteLine($"    {field.Name} ({field.Type}) FieldId={field.FieldId} Offset={field.Offset}");
+}
+
+// Will my next release's schema open cleanly against it?
+var result = DatabaseSchema.ValidateEvolution("prod/game.typhon", registrar =>
+{
+    registrar.RegisterComponent<PlayerV2>();
+    registrar.RegisterMigration<PlayerV1, PlayerV2>(MigratePlayer);
+});
+
+if (!result.IsValid)
+{
+    foreach (var error in result.Errors)
+        Console.WriteLine($"BLOCKED: {error}");
+    // fail the deploy / CI step here
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Neither call mutates the database file — `Inspect` never registers a component, `ValidateEvolution` never allocates segments, migrates entities, or writes a schema history entry.
+- Safe to run against a database another process has open; each call uses its own short-lived engine and service provider, fully disposed before returning.
+- `ValidateEvolution` only evaluates the components you register in the callback — it does not flag persisted components your configuration omits.
+- `EvolutionValidationResult.IsValid` is `false` only when a component has breaking changes with no registered migration path; non-breaking (`Compatible`/`CompatibleWidening`) changes are reported as `NeedsMigration` but don't fail validation, matching what auto-migration would actually do on real registration.
+- A dry run is a prediction, not a guarantee — it doesn't account for runtime conditions at real-registration time (disk space exhaustion mid-migration, a concurrently-open writer, etc.).
+
+## 🧪 Tests
+
+- [OperationalToolingTests](../../../test/Typhon.Engine.Tests/Data/Schema/OperationalToolingTests.cs) — `Inspect_ReturnsComponentsAndFields` (offline read of persisted components/fields), `ValidateEvolution_CompatibleChange_IsValid` (dry-run reports `NeedsMigration`/`HasMigrationPath` without mutating)
+
+## 🔗 Related
+
+- Related feature: [Schema Validation on Reopen](./schema-validation.md) (the live-path equivalent these calls simulate)
+
+<!-- Design: claude/design/Schema/05-operational-tooling.md §2 Schema Inspection API -->
+<!-- Design: claude/design/Schema/05-operational-tooling.md §3 Dry-Run Validation -->
+<!-- Overview: claude/overview/04-data.md — DatabaseSchema.Inspect / ValidateEvolution API summary -->

--- a/doc/feature-set/Schema/schema-validation.md
+++ b/doc/feature-set/Schema/schema-validation.md
@@ -1,0 +1,71 @@
+# Schema Validation on Reopen
+> Compares persisted schema against your current struct on every reopen and refuses to touch data it can't reconcile safely.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+A component's data on disk was written under whatever struct layout existed when it was last persisted. If you rename a field's C# type, narrow it, reorder fields, or change an array length and just reopen the database, the runtime struct and the on-disk bytes silently disagree — reads return garbage instead of failing. Schema Validation closes that gap: on every reopen it compares what's persisted against what your current struct declares, classifies every difference, and only lets registration proceed once every difference is provably safe or explicitly resolved.
+
+## ⚙️ How it works (in brief)
+
+Each registered component's field metadata (name, FieldId, type, offset, size) is persisted alongside the data. On reopen, `RegisterComponentFromAccessor<T>()` loads that metadata and diffs it against the runtime struct, producing a `SchemaDiff` with one `FieldChange` per difference. Each change is classified into a `CompatibilityLevel` — `Identical`, `InformationOnly` (renames), `Compatible` (add/remove/reorder a field), `CompatibleWidening` (lossless type promotion, e.g. `int`→`long`), or `Breaking` (anything that could lose or misinterpret data). The diff's overall level is the worst level among its changes. `Compatible`/`CompatibleWidening` changes are auto-migrated transparently (see Schema Evolution). A `Breaking` level with no migration function registered throws `SchemaValidationException` before any data is touched — registration fails, the database stays closed for that component. Separately, if the persisted revision is *newer* than the runtime struct's revision, registration throws `SchemaDowngradeException` — running an older binary against newer data is never allowed, validation or not.
+
+## 💻 Usage
+
+```csharp
+// Struct evolved from V1 (int Score) to V2 (string Score) between releases — incompatible.
+[Component("Game.Player", 2)]
+struct Player
+{
+    public String64 Score;
+    public int Level;
+}
+
+try
+{
+    dbe.RegisterComponentFromAccessor<Player>();
+}
+catch (SchemaValidationException ex)
+{
+    // ex.Diff carries the full breakdown for diagnostics/logging
+    foreach (var change in ex.Diff.FieldChanges)
+    {
+        log.LogError("{Field}: {Kind} ({Old} -> {New})", change.FieldName, change.Kind, change.OldType, change.NewType);
+    }
+    throw;
+}
+```
+
+To force registration through a breaking change anyway (e.g. a throwaway dev database you're willing to risk):
+
+```csharp
+dbe.RegisterComponentFromAccessor<Player>(schemaValidation: SchemaValidationMode.Skip);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `schemaValidation: SchemaValidationMode.Enforce` | Default | Throw `SchemaValidationException` on any unresolved breaking change |
+| `schemaValidation: SchemaValidationMode.Skip` | — | Bypass the breaking-change throw; data is read/written under the runtime layout regardless of mismatch — **unsafe** |
+
+## ⚠️ Guarantees & limits
+
+- Validation runs before any user transaction touches the database — a failing component blocks startup, it never lets the application proceed with a half-trusted schema.
+- Identical schemas hit a fast path: no diff overhead beyond the metadata comparison itself.
+- Classification is conservative by construction: only changes proven lossless (the widening table) are ever auto-resolved; everything else is `Breaking` until you supply a migration function or pass `Skip`.
+- A persisted revision newer than the runtime struct always throws `SchemaDowngradeException`, independent of `SchemaValidationMode` — there is no way to force-open data written by a newer binary.
+- `SchemaValidationMode.Skip` does not fix anything — it only suppresses the throw. Field offsets/types are still whatever the runtime struct says; reading old bytes through a changed layout can produce wrong values. Use it only when you accept that risk (e.g. disposable dev/test databases).
+- Validation is per-component: one component failing does not by itself evaluate the others, since registration calls are made one at a time by application startup code.
+
+## 🧪 Tests
+
+- [SchemaValidatorTests](../../../test/Typhon.Engine.Tests/Data/Schema/SchemaValidatorTests.cs) — pure diff/classification algorithm: identical/added/removed/widened/narrowed/breaking, all valid and invalid widening pairs, rename-as-informational
+- [SchemaValidationIntegrationTests](../../../test/Typhon.Engine.Tests/Data/Schema/SchemaValidationIntegrationTests.cs) — reopen cycles: identical no-op, widening allowed, breaking throws `SchemaValidationException`, `SchemaValidationMode.Skip` bypass, `SchemaDowngradeException`
+
+## 🔗 Related
+
+- Related feature: [Compatible Schema Evolution](./compatible-evolution/README.md) (auto-migration of `Compatible`/`CompatibleWidening` changes)
+- Related feature: [User-Defined Migration Functions](./migration-functions.md) (user-supplied conversion for `Breaking` changes)
+
+<!-- Overview: claude/overview/04-data.md §4.10 Schema Evolution — Schema Validation (CompatibilityLevel table, diff mechanics) -->
+<!-- Design: claude/design/Schema/02-schema-validation.md (full SchemaDiff design, change taxonomy, error format) -->

--- a/doc/feature-set/Schema/system-schema-persistence.md
+++ b/doc/feature-set/Schema/system-schema-persistence.md
@@ -1,0 +1,54 @@
+# System Schema Persistence
+> A Typhon database file describes its own component/field metadata — no external schema file needed.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Interpreting a database file requires knowing every component's name, fields, types, offsets, and indexes. Keeping that metadata in a separate sidecar file invites drift — the file gets lost, copied out of sync, or simply doesn't travel with the `.bin` when it's moved. Typhon avoids the problem by storing its own schema *inside* the database: component and field definitions are persisted as ordinary entities, in the same storage engine that holds user data. Any process that opens the file — the real application, or a throwaway inspector — recovers the full schema from the file alone.
+
+## ⚙️ How it works (in brief)
+
+Two system component types, `ComponentR1` and `FieldR1`, carry the metadata: one `ComponentR1` row per registered component (name, revision, storage mode, segment SPIs), with its fields nested as a `FieldR1` collection (name, FieldId, type, offset, size, index flags). On first database creation, `ComponentR1` itself is registered as a component and a `ComponentR1` row is written describing `ComponentR1` — the system table is self-referential. Segment SPIs for the system tables are stored in the root file header's bootstrap dictionary. On reopen, the engine reconnects to those segments from the bootstrap SPIs, then scans the `ComponentR1` table's allocated chunks to rebuild the in-memory map every subsequent `RegisterComponentFromAccessor<T>()` call consults to reattach to existing storage instead of allocating fresh segments. Reads and writes of these system rows go through a dedicated minimal CRUD helper — single-threaded, no MVCC revision chain, no WAL record, no conflict detection — appropriate because schema mutation only ever happens at startup, before any transaction exists.
+
+## 💻 Usage
+
+```csharp
+using Typhon.Engine;
+
+// First run — creates the database; registering GuildComponent persists its
+// ComponentR1 + FieldR1 rows inside the file as a side effect.
+var engine = services.GetRequiredService<DatabaseEngine>();
+engine.RegisterComponentFromAccessor<GuildComponent>();
+// ... application runs ...
+engine.Dispose();
+
+// Later run, same path, no schema file shipped alongside the data file —
+// the same registration call now reattaches to the persisted segments.
+var engine2 = services2.GetRequiredService<DatabaseEngine>();
+engine2.RegisterComponentFromAccessor<GuildComponent>();   // reconnect, no reallocation, no data loss
+```
+
+There is no direct API for this layer — it activates automatically on `RegisterComponentFromAccessor<T>()` / `RegisterComponentByType()`, for every component, on every create or reopen.
+
+## ⚠️ Guarantees & limits
+
+- A `.bin` file is self-describing: full component/field/index metadata travels with the data, recoverable without application code (this is what `DatabaseSchema.Inspect` reads — see Related).
+- System schema rows have no revision history and are not part of WAL crash recovery — they're written via direct page writes inside an explicit `ChangeSet`, flushed to disk synchronously at the point of registration, independent of the WAL pipeline used for user transactions.
+- Reopen cost scales with the number of distinct registered component types (one chunk scanned per component), not with entity count — cheap even on large databases.
+- This is internal infrastructure, not a user-facing API: there's no supported way to read or write `ComponentR1`/`FieldR1` rows directly; the only entry points are component registration (write path) and `DatabaseSchema.Inspect` (read path).
+- The system schema's own layout is not subject to the user-facing schema evolution machinery (validation, compatible evolution, migrations) — it is fixed by the engine version, not by application code.
+
+## 🧪 Tests
+
+- [FieldIdStabilityTests](../../../test/Typhon.Engine.Tests/Data/Schema/FieldIdStabilityTests.cs) — `FieldR1_RoundTrip_SameSession` walks `ComponentR1` chunks and reads nested `FieldR1` entries directly via `SystemCrud.Read`
+- [SchemaManifestTests](../../../test/Typhon.Engine.Tests/Data/Schema/SchemaManifestTests.cs) — persisted assembly manifest (`AssemblyR1`) dedup and `ComponentR1`/`ArchetypeR1.AssemblyId` linkage, core-vs-user-assembly exclusion
+
+## 🔗 Related
+
+- Related feature: [Component & Field Declaration](./component-field-declaration.md) (the attribute-driven layer that produces what gets persisted here)
+- Related feature: [Offline Schema Inspection & Dry-Run Validation](./schema-inspection-dryrun.md) (`DatabaseSchema.Inspect` reads the data this feature persists)
+- Source: `src/Typhon.Engine/Schema/internals/SystemCrud.cs`, `src/Typhon.Engine/Ecs/public/DatabaseEngine.cs` (`CreateSystemSchemaR1`, `LoadSystemSchemaR1`, `SaveInSystemSchema`)
+
+<!-- Deep dive: claude/design/Schema/README.md — Current State -->
+<!-- Overview: claude/overview/04-data.md §4.1 DatabaseEngine (schema persistence flow), §4.8 Schema System -->

--- a/doc/feature-set/Schema/tsh-schema-commands.md
+++ b/doc/feature-set/Schema/tsh-schema-commands.md
@@ -1,0 +1,69 @@
+# tsh Schema Shell Commands
+> Inspect, diff, validate, and export a database's persisted schema interactively, without writing code.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Checking schema state today means writing a throwaway program against `DatabaseSchema.Inspect`/`ValidateEvolution`, or stepping through code in a debugger. During day-to-day development and ops triage — "what FieldId did Score actually get?", "will my new build open this file?", "what changed last Tuesday?" — that overhead is disproportionate to the question. The Typhon Shell (`tsh`) exposes the same persisted-schema-vs-runtime-schema comparison as five interactive commands, so these questions get answered in seconds at a prompt.
+
+## ⚙️ How it works (in brief)
+
+The commands read two things `tsh` already has once a database is open: the **persisted** schema (component/field metadata stored in the file, surfaced via `DatabaseEngine.PersistedComponents` / `PersistedFieldsByComponent`) and the **runtime** schema (component structs loaded into the shell via `load-schema`). `schema-diff` and `schema-validate` compute a `SchemaDiff` between the two and report the compatibility level Typhon would use on next open. `schema-fields` and `schema-export` read persisted metadata only — no runtime type needed. `schema-history` reads the `Typhon.Schema.History` system component, an append-only audit trail of every schema change ever applied. Output is color-coded markup in the console, or structured JSON/CSV via `set format` for piping into other tools.
+
+## 💻 Usage
+
+```
+tsh> open game.typhon
+tsh> load-schema bin/Game.Components.dll
+
+tsh> schema-fields Player
+  FieldId  Name      Type    Offset  Size  Index
+        0  Health    Int32        0     4
+        1  Mana      Int32        4     4  Unique
+        2  Armor     Int32        8     4
+        4  Shield    Int32       12     4   ← FieldId 3 (Legacy) was removed
+
+tsh> schema-diff Player
+  Level: Compatible  Summary: +1 field, -1 field
+  + Shield (Added, FieldId=4)
+  - Legacy (Removed, FieldId=3)
+  Stride change: 24 → 28 bytes
+  Entity count: 15000
+
+tsh> schema-validate
+  OK       Game.Inventory   — identical
+  MIGRATE  Game.Equipment   — Durability Int32→Float (migration registered)
+  All 2 component(s) valid.
+
+tsh> schema-history
+  2026-02-20 14:30:05  Game.Player  rev 1→2 (Compatible)  15000  0ms
+
+tsh> set format json
+tsh> schema-export Player
+```
+
+| Command | Purpose |
+|---------|---------|
+| `schema-fields <component>` | Persisted FieldId → name/type/offset/index mapping |
+| `schema-diff <component>` | Persisted vs. runtime diff, with compatibility level |
+| `schema-validate` | Dry-run diff for every loaded component against the open database |
+| `schema-history` | Append-only audit trail of past schema changes |
+| `schema-export [component]` | Persisted schema as table/JSON/CSV (`set format`) |
+
+## ⚠️ Guarantees & limits
+
+- Read-only: none of these commands register a component, allocate storage, or migrate a single entity — `schema-diff`/`schema-validate` reuse the same dry-run diff machinery the engine uses on real open, but never apply it.
+- Component name resolution accepts a short name (suffix match, case-insensitive) or the full registered `[Component]` name — no need to type the fully-qualified name.
+- `schema-diff`/`schema-validate` need a runtime type loaded via `load-schema` to compare against; `schema-fields`/`schema-export`/`schema-history` work from persisted metadata alone.
+- `schema-validate` reports `MIGRATE` (not `FAIL`) only when a breaking change has a registered migration chain reachable from the persisted revision to the runtime revision; otherwise it reports `FAIL` with no path to open the database as-is.
+- `schema-history` is empty until at least one schema change (compatible evolution or migration) has actually been applied to the database.
+- All five commands require an open database (`open <path>`); there is no offline/file-only mode in the shell — for that, use `DatabaseSchema.Inspect`/`ValidateEvolution` directly (see Related).
+
+## 🔗 Related
+
+- Related feature: [Offline Schema Inspection & Dry-Run Validation](./schema-inspection-dryrun.md) (`schema-fields`/`schema-diff`/`schema-validate` are interactive wrappers over `DatabaseSchema.Inspect`/`ValidateEvolution`'s underlying diff engine)
+- Sibling: [Schema History Audit Log](schema-history-audit.md) — `schema-history` reads the same append-only audit trail this feature persists
+- Source: `src/Typhon.Shell/Commands/SchemaCommandExecutor.cs`
+
+<!-- Design: claude/design/Schema/05-operational-tooling.md §6 tsh Shell Integration -->

--- a/doc/feature-set/Schema/workbench-schema-loading.md
+++ b/doc/feature-set/Schema/workbench-schema-loading.md
@@ -1,0 +1,60 @@
+# Workbench Per-Session Schema Loading & ALC Reload
+> Lets you rebuild and re-attach your schema DLL in the Workbench without restarting the host.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Schema](./README.md)
+
+## 🎯 What it solves
+
+Iterating on a schema while the Workbench is open normally hits a hard wall: .NET can't unload an assembly that's loaded into the default `AssemblyLoadContext`, so a rebuilt DLL can't replace the one already in memory without restarting the whole tool. It also doesn't help that a raw load failure, a breaking schema change, or a failed migration would otherwise just throw and tear down the session. This feature lets each Workbench session load your schema DLL in isolation, swap it for a freshly rebuilt one on the next attach, and turns engine-side schema exceptions into a banner state you can act on instead of a crash.
+
+## ⚙️ How it works (in brief)
+
+Each Open/Attach session loads your schema DLL(s) into a fresh, unloadable assembly context scoped to that session; closing the session releases it so the next attach can load the rebuilt binary cleanly. Every `[Component]`-tagged struct and every concrete type deriving from `Archetype<>`/`Archetype<,>` found in the DLL(s) is registered against the engine one at a time — a failure on one component doesn't stop the others from loading. The aggregate outcome becomes one of three session states: `Ready` (everything registered cleanly), `MigrationRequired` (at least one component registered, but something needs attention), or `Incompatible` (the session isn't navigable — a schema downgrade, a failed migration function, or total registration failure). Because each rebuild produces new CLR `Type` instances even for byte-identical source, the engine re-binds them to the same component IDs by matching the `[Component(Name, ...)]` string across reloads, so re-attaching never inflates component IDs or loses prior registrations.
+
+## 💻 Usage
+
+```csharp
+using System.Runtime.InteropServices;
+using Typhon.Schema.Definition;
+
+// The Name string ("Game.Player") is the stable key the Workbench uses to re-bind this
+// component across rebuilds. Keep it constant even as you change fields or bump Revision.
+[Component("Game.Player", revision: 1)]
+[StructLayout(LayoutKind.Sequential)]
+public struct PlayerComponent
+{
+    public float Health;
+    public int Level;
+}
+```
+
+There's no API to call from application code — this is the Workbench's own loading behavior. As the application developer you just rebuild your schema project and re-attach (Open/Attach) the session; the Workbench handles the rest. What you control is the schema itself: keep `[Component]` names stable across edits, and be aware that a breaking field change or a removed migration function will surface as a `MigrationRequired` or `Incompatible` banner on the next attach rather than failing silently.
+
+| Session outcome | When it happens | What you can still do |
+|---|---|---|
+| `Ready` | Every component registered with no diagnostics | Full session — browse, query, profile |
+| `MigrationRequired` | At least one component registered; one or more had a breaking change, schema error, or other failure | Browse/inspect the components that loaded; fix and rebuild the rest |
+| `Incompatible` | A schema downgrade, a failed migration function, or zero components registered | Session isn't usable until you fix the binary and re-attach |
+
+## ⚠️ Guarantees & limits
+
+- A bad or unbuildable DLL never crashes the Kestrel host or other open sessions — failures are scoped to the session being opened/attached.
+- One component failing to register (breaking change, schema error) does not block its siblings from registering — you keep visibility into everything that's still readable.
+- Re-attaching the same schema project after a rebuild reuses the same component IDs and archetype slot bindings — no ID growth across repeated edit/rebuild/re-attach cycles.
+- `Incompatible` is reserved for unrecoverable cases (schema downgrade, failed migration, or total failure) — a handful of breaking-change components alongside healthy ones is `MigrationRequired`, not `Incompatible`.
+- A schema DLL placed next to a stale copy of an engine assembly still resolves the engine's own copy (`Typhon.*`/`System.*`/`Microsoft.*` and anything already loaded are deferred to the host's context) — you won't silently get zero components from an attribute-identity mismatch.
+- The session must fully close (and its components released) before the underlying DLL file is unlocked for a fresh build — keep the Workbench session closed while rebuilding if your build fails with a file-in-use error.
+- Multi-file schemas (a main DLL plus sibling helper assemblies) resolve correctly only when the dependency sits in the same directory as the DLL you opened.
+
+## 🧪 Tests
+
+- [SchemaLoaderTests](../../../test/Typhon.Workbench.Tests/Schema/SchemaLoaderTests.cs) — missing path (`schema_missing`), invalid assembly (`schema_load_failed`), empty DLL list, real-assembly load through a fresh `WorkbenchAssemblyLoadContext`
+
+## 🔗 Related
+
+- Related feature: [Component Family Classification](component-family-classification.md) (a separate per-session classification step that runs after loading)
+- Related feature: [Schema Validation on Reopen](schema-validation.md) (the underlying breaking/compatible classification this feature surfaces as a banner)
+- Source: `tools/Typhon.Workbench/Schema/SchemaLoader.cs`, `tools/Typhon.Workbench/Schema/WorkbenchAssemblyLoadContext.cs`, `tools/Typhon.Workbench/Schema/SchemaCompatibility.cs`, `src/Typhon.Engine/Ecs/internals/ArchetypeRegistry.cs`
+
+<!-- Deep dive: claude/design/Schema/06-workbench-schema-loading.md (§1-4: loader, compatibility classifier, ALC reload/rebind mechanics) -->
+<!-- Related ADR: claude/adr/055-single-source-schema-resolution.md (where the DLL is resolved from — registered/bundled/legacy-adjacent search order) -->

--- a/doc/feature-set/Spatial/README.md
+++ b/doc/feature-set/Spatial/README.md
@@ -1,0 +1,32 @@
+# Spatial
+> Typhon's spatial layer gives any component field a declarative `[SpatialIndex]` — backing it with a page-backed, crash-safe R-Tree for ad-hoc AABB/Radius/Ray/Frustum/kNN queries, or with the cluster-aware spatial grid for archetypes already using batched SoA storage. On top of that grid, a tiered-simulation system lets game code assign per-cell simulation frequency, sleep idle clusters, and parallelize neighbor-touching systems safely — so a large world spends its CPU budget where the player actually is.
+
+> 🔬 **Recommended:** read [in-depth-overview/07-spatial.md](../../in-depth-overview/07-spatial.md) (Chapter 07: Spatial) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Spatial Architecture Overview](spatial-architecture-overview.md) | Explains how the per-component R-Tree and the engine-wide spatial grid are two independent mechanisms, and which feature to read next | ✅ Implemented | 🟢 Start Here |
+| [Field Attribute & Schema Integration](spatial-field-attribute/README.md) | Declare a component field as spatially indexed via `[SpatialIndex]`, validated against schema rules at registration time | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Storage-Mode Compatibility (SingleVersion / Versioned)](spatial-field-attribute/spatial-storage-mode-compat.md) | The same `[SpatialIndex]` field works on both storage modes — only *when* the tree catches up differs | ✅ Implemented | 🔵 Core |
+| [Spatial Query API (AABB / Radius / Ray)](spatial-query-api.md) | Public fluent `EcsQuery` predicates `WhereNearby`/`WhereInAABB`/`WhereRay` over the per-component spatial index | ✅ Implemented | 🔵 Core |
+| [Spatial Grid Configuration & Tier Control](spatial-grid-config.md) | Engine-wide grid sizing plus the per-cell `SimTier` control surface for multi-resolution simulation | ✅ Implemented | 🔵 Core |
+| [Static / Dynamic Tree Separation](spatial-rtree-index/spatial-rtree-static-dynamic.md) *(part of [Spatial R-Tree Index](spatial-rtree-index/README.md))* | A spatial field lands in one of two independent trees — tick-fence-exempt static, or fat-AABB-maintained dynamic — chosen once at schema time | ✅ Implemented | 🟣 Advanced |
+| [Fat-AABB Incremental Update](fat-aabb-update.md) | Margin-enlarged bounds absorb small moves for ~25ns, with no tree mutation | ✅ Implemented | 🟣 Advanced |
+| [Category Filtering](spatial-category-filtering.md) | Bitmask pruning skips whole clusters before geometry tests via `[SpatialIndex(Category = ...)]` + `ClusterSpatialQuery<TArch>` | ✅ Implemented | 🟣 Advanced |
+| [Spatially-Coherent Entity Clustering](spatial-coherent-clustering.md) | Every entity in a cluster shares one grid cell, so spatial bookkeeping is per-cluster, not per-entity | ✅ Implemented | 🟣 Advanced |
+| [Tiered Simulation Dispatch](tiered-simulation-dispatch.md) | One simulation tier per spatial cell, four dispatch frequencies, zero per-entity distance checks | ✅ Implemented | 🟣 Advanced |
+| [Checkerboard Dispatch](checkerboard-dispatch.md) | Opt-in two-phase Red/Black cluster partitioning for systems that write across cell boundaries, dispatched as one DAG node with two internal phases | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+> Engine machinery below this line backs the public features above but is never directly instantiated or called by application code — kept here for engine contributors.
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Spatial R-Tree Index](spatial-rtree-index/README.md) | Page-backed R-Tree attached to a component field, giving sub-microsecond AABB/radius/ray queries shared across every archetype that uses it | ✅ Implemented |
+| [Trigger Volumes (Enter / Leave / Stay)](spatial-trigger-volumes.md) | Region entities diffed against the spatial tree(s) each cycle to emit Enter/Leave/Stay events at a configurable per-region frequency; no public entry point yet | ✅ Implemented |
+| [Interest Management (Delta Spatial Queries)](spatial-interest-management.md) | Per-observer "what changed near me" delta queries via an archived dirty-bitmap ring buffer, with full-sync fallback for stale observers; no public entry point yet | 🚧 Partial |
+| [Cluster Spatial Queries](cluster-spatial-queries.md) | Per-cell broadphase + per-entity narrowphase AABB/Radius queries for cluster-eligible archetypes; raw enumerator needs an engine-internal `EpochGuard` scope, app code reaches the same path via the public `EcsQuery` predicates above | 🚧 Partial |
+| [Cluster Dormancy (Sleep / Wake)](cluster-dormancy.md) | Clusters with no component writes for N ticks sleep and skip dispatch entirely, waking within one tick of being touched; no public configuration API yet | ✅ Implemented |

--- a/doc/feature-set/Spatial/checkerboard-dispatch.md
+++ b/doc/feature-set/Spatial/checkerboard-dispatch.md
@@ -1,0 +1,77 @@
+# Checkerboard Dispatch
+> Red/Black two-phase parallel dispatch so neighbor-touching systems never race across a cell boundary.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Some systems read or write data in cells adjacent to the one they're processing — pheromone diffusion
+blending values with its neighbors is the canonical example. Dispatching all clusters to worker threads
+in one pass, as [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) normally does, lets two
+adjacent cells run on different workers at the same instant and race on the shared boundary data. Without
+a way to serialize neighbor access, game code is forced to make such systems single-threaded, losing
+parallelism for exactly the systems most likely to be expensive (full-grid diffusion/propagation passes).
+
+## ⚙️ How it works (in brief)
+
+Each cell is colored Red or Black from the parity of its grid coordinates: `(cellX + cellY) % 2`. No two
+orthogonally-adjacent (face-sharing) cells share a color, so all Red clusters can run in parallel safely,
+then all Black clusters can run in parallel safely, and a system that only touches face-adjacent neighbors
+never sees a half-written neighbor. `checkerboard: true` turns this into two sequential dispatch phases
+inside the same DAG node — your callback runs twice per tick (once per phase), with `ctx.Entities` scoped
+to that phase's clusters only. Downstream systems see one node and wait for both phases; nothing else in
+the DAG needs to know dispatch happened twice.
+
+## 💻 Usage
+
+```csharp
+schedule.QuerySystem("Pheromone_Diffuse", ctx =>
+{
+    // Safe to read/write neighboring cells' data — no other worker is touching an adjacent cell
+    // during this phase.
+    foreach (var id in ctx.Entities)
+    {
+        ref var pher = ref ctx.Accessor.OpenMut(id).Write(Pheromone.Data);
+        pher.Value = Diffuse(pher.Value, NeighborSamples(ctx, id));
+    }
+},  input: () => pheromoneView,
+    tier: SimTier.Near,
+    parallel: true,
+    checkerboard: true);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `checkerboard:` (`QuerySystem`) / `b.Checkerboard()` (class-based) | `false` | Split the tier-filtered cluster list into Red/Black and dispatch as two sequential parallel phases |
+
+## ⚠️ Guarantees & limits
+
+- Requires `parallel: true` — registering `checkerboard: true` without it throws
+  `InvalidOperationException` at schedule build time, not at first tick.
+- Incompatible with `ChunkedParallel` — both throw if combined.
+- Composes with `tier:`/`CellAmortize` — coloring is computed over whichever cluster set the tier filter
+  (and dormancy) already produced; sleeping clusters are excluded before the split, same as any other
+  tier-filtered system.
+- Red ∪ Black is always the full filtered cluster set with no overlap — every cluster runs exactly once
+  per tick, never zero or twice.
+- Protects **face adjacency only** (2-color scheme). Diagonal neighbors share the same color — a system
+  that reads/writes diagonal cells, not just orthogonal ones, is not protected by this 2-phase split.
+- Non-spatial archetypes (no spatial grid, or the archetype has no cell mapping) degenerate to all
+  clusters in the Red phase and an empty Black phase — the callback still runs twice, but the second
+  call sees no entities.
+- Overhead is one extra dispatch-prepare + one extra worker barrier per tick (~10-15μs) — negligible
+  unless the per-phase entity processing itself is already very cheap.
+
+## 🧪 Tests
+
+- [CheckerboardTests](../../../test/Typhon.Engine.Tests/Runtime/CheckerboardTests.cs) — `Checkerboard_TwoPhases_BothExecute`, `Checkerboard_RedBlack_NoOverlap`, `Checkerboard_ZeroRedClusters_BlackStillRuns`, `Checkerboard_RequiresParallel_Throws`, `Checkerboard_WithDormancy_SleepingSkipped`, `Checkerboard_NoTierFilter_StillSplits`
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Runtime/public/Dag.cs](../../../src/Typhon.Engine/Runtime/public/Dag.cs) (`QuerySystem` `checkerboard:` parameter), [SystemBuilder.cs](../../../src/Typhon.Engine/Runtime/public/SystemBuilder.cs) (`Checkerboard()`), [TyphonRuntime.cs](../../../src/Typhon.Engine/Runtime/public/TyphonRuntime.cs) (`SplitCheckerboardClusters`, two-phase prepare/re-dispatch)
+- Related catalog entry: [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) (the tier filter checkerboard composes with)
+- Sibling: [Checkerboard (Red/Black) Dispatch](../Runtime/spatial-tiers-adaptive-dispatch/checkerboard-dispatch.md) — same feature cataloged from the Runtime/dispatch angle rather than the spatial-grid angle
+
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/04-tick-integration.md § Checkerboard Parallel Dispatch -->
+<!-- ADR: claude/adr/046-spatial-tiers-architecture.md (Decision 6 — one DAG node, two internal phases) -->
+<!-- Rules: claude/rules/spatial.md (module Checkerboard Partition, CB-01, CB-02) -->

--- a/doc/feature-set/Spatial/cluster-dormancy.md
+++ b/doc/feature-set/Spatial/cluster-dormancy.md
@@ -1,0 +1,93 @@
+# Cluster Dormancy (Sleep / Wake)
+> Clusters with no component writes for N ticks sleep and skip dispatch entirely, waking within one tick of being touched.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Even inside a coarse simulation tier, a large share of clusters do nothing tick after tick — ants in empty
+space, idle props, units with no orders. [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) and
+its cell amortization already shrink the per-tick cluster set; Cluster Dormancy shrinks it further by
+letting the engine notice clusters that have gone quiet and stop dispatching them entirely, until something
+inside them actually changes again.
+
+## ⚙️ How it works (in brief)
+
+Each cluster carries a sleep counter that increments every tick its dirty-bitmap region is clean (no
+component write landed in it) and resets to zero the moment a write does land. Once the counter reaches a
+configurable per-archetype threshold, the cluster flips `Active` → `Sleeping` and is dropped from every
+system's dispatch list for that archetype — tier-filtered or not — at zero per-entity cost. A write to a
+sleeping cluster during parallel system execution doesn't touch shared sleep state inline (that would race);
+it instead records a deferred wake request on a thread-local list, drained single-threaded at the tick fence
+(`Sleeping` → `WakePending`) and promoted to `Active` at the very start of the next tick, before any system
+dispatches — one tick of latency end to end. An optional heartbeat interval wakes sleeping clusters anyway
+on a staggered schedule, for a periodic idle re-check independent of writes.
+
+## 💻 Usage
+
+```csharp
+// Dormancy is per-archetype and opt-in. SleepThresholdTicks / HeartbeatIntervalTicks live on the
+// archetype's cluster runtime state (ArchetypeClusterState, internal) — there is no public configuration
+// wrapper yet, so setting them requires the same engine-internal access AntHill.Core already builds under.
+var clusterState = dbe._archetypeStates[Archetype<Ant>.Metadata.ArchetypeId].ClusterState;
+clusterState.SleepThresholdTicks = 120;     // 60 Hz tick rate: 2s with no writes -> Sleeping
+clusterState.HeartbeatIntervalTicks = 300;  // wake briefly every 5s regardless, for an idle re-check
+
+// From here on dormancy is fully automatic — no per-system opt-in needed. Normal component writes
+// (OpenMut().Write(...)) reset the sleep counter and wake a sleeping cluster; every QuerySystem against
+// this archetype, tier-filtered or not, silently skips clusters that are Sleeping.
+schedule.QuerySystem("IdleDrift", ctx =>
+{
+    foreach (var id in ctx.Entities) { /* never dispatched against a sleeping cluster */ }
+}, input: () => antsView, parallel: true, tier: SimTier.Tier2, cellAmortize: 60);
+```
+
+| Field (`ArchetypeClusterState`) | Default | Effect |
+|---|---|---|
+| `SleepThresholdTicks` | `0` (disabled) | Consecutive clean ticks before `Active` → `Sleeping`; clamped to `[0, 65535]` |
+| `HeartbeatIntervalTicks` | `0` (off) | When `> 0`, sleeping clusters wake on a staggered schedule for a periodic re-check |
+
+## ⚠️ Guarantees & limits
+
+- **Wake is bounded to one tick of latency** — a write to a sleeping cluster at tick T is guaranteed
+  `WakePending` by T's tick fence and `Active` before any system dispatches at tick T+1; never permanently
+  missed.
+- **Zero overhead when nothing sleeps** — the dormancy filter in dispatch prep is skipped entirely
+  (`SleepingClusterCount == 0`), for every system, every tick, until at least one cluster actually sleeps.
+- **Activity is the dirty bitmap, not all writes** — `ClusterRef.WriteSpatial` (the typical high-frequency
+  path for a `[SpatialIndex]`-marked field, e.g. movement) deliberately does **not** mark the slot dirty, so
+  it neither resets the sleep counter nor wakes a sleeping cluster. A cluster whose entities only move via
+  `WriteSpatial` can go to sleep, and stay asleep, while still moving — resetting the counter requires a
+  normal `Transaction.OpenMut().Write(...)` on some other field, or an explicit `SetDirty` call after
+  `WriteSpatial`.
+- **Only two wake triggers exist today**: a dirty write and the heartbeat timer. Proximity-based wake
+  ("another entity approached") and tier-promotion wake ("camera moved closer") are not implemented — a
+  sleeping cluster promoted to `Tier0` stays `Sleeping`, and excluded from dispatch, until a write or
+  heartbeat wakes it.
+- **Filters both tier-filtered and unfiltered systems** — a `SimTier.All` `QuerySystem` against the
+  archetype still skips sleeping clusters; dormancy is not a tier-only mechanism.
+- **Sleep counters are `ushort`, clamped thresholds** — `SleepThresholdTicks` is clamped to `[0, 65535]`
+  (~18 minutes at 60 Hz) so the counter can never wrap and falsely re-arm a sleep transition.
+- **Cluster removal keeps the count honest** — destroying the last entity in a `Sleeping` or `WakePending`
+  cluster decrements `SleepingClusterCount` when the cluster is removed from the active list.
+- **No public configuration API yet** — `ArchetypeClusterState` is engine-internal; only the
+  `ClusterSleepState` enum is part of the public surface. Configuring dormancy currently requires the host
+  project to have `InternalsVisibleTo` access to `Typhon.Engine` (the same boundary `AntHill.Core` and
+  `tsh` build under).
+
+## 🧪 Tests
+
+- [DormancyTests](../../../test/Typhon.Engine.Tests/Runtime/DormancyTests.cs) — `SleepAfterThreshold`/`SleepingClusterSkippedInDispatch`, deferred `WakeRequest_Transition`/`DuplicateWakeDeduplication`, `HeartbeatWake`, `SetDirty_WakesSleepingCluster` vs `WriteSpatial` not waking, cluster-removal count bookkeeping
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs](../../../src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs) (`DormancySweep`, `ProcessWakeRequest`, `TransitionWakePendingToActive`, `SetDirty`)
+- Source: [src/Typhon.Engine/Runtime/internals/DormancyReporter.cs](../../../src/Typhon.Engine/Runtime/internals/DormancyReporter.cs) (thread-local deferred wake requests)
+- Source: [src/Typhon.Engine/Runtime/public/TyphonRuntime.cs](../../../src/Typhon.Engine/Runtime/public/TyphonRuntime.cs) (`OnParallelQueryPrepare` dormancy filter, `BuildTierIndexesAtTickStart` wake transition)
+- Source: [src/Typhon.Engine/Ecs/public/ClusterSleepState.cs](../../../src/Typhon.Engine/Ecs/public/ClusterSleepState.cs)
+- Related catalog entry: [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) (the tier filter dormancy composes with)
+- Related catalog entry: [Spatially-Coherent Entity Clustering](./spatial-coherent-clustering.md) (`WriteSpatial`, cluster/dirty-bitmap fundamentals)
+- Sibling: [Cluster Dormancy (Sleep/Wake)](../Runtime/spatial-tiers-adaptive-dispatch/cluster-dormancy.md) — same feature cataloged from the Runtime/dispatch angle rather than the spatial-grid angle
+
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/03-tier-dispatch.md § Cluster-Level Dormancy -->
+<!-- Rules: claude/rules/spatial.md (module Dormancy, DM-01..DM-03) -->

--- a/doc/feature-set/Spatial/cluster-spatial-queries.md
+++ b/doc/feature-set/Spatial/cluster-spatial-queries.md
@@ -1,0 +1,79 @@
+# Cluster Spatial Queries
+> Per-cell broadphase + per-entity narrowphase AABB/Radius queries for cluster-eligible archetypes.
+
+**Status:** 🚧 Partial · **Visibility:** Internal · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Entity clusters (see [Entity Clusters](../Ecs/entity-clusters.md)) pack many entities of one archetype into a single contiguous chunk for cache-friendly storage. A per-entity spatial index defeats that locality — every entity move triggers an index update, and queries scatter-read leaf nodes across the tree. Cluster Spatial Queries indexes cluster *bounding boxes* instead of individual entities, so spatial lookups (find nearby units, find food in radius, AI sensing) stay cheap even as entity counts scale into the hundreds of thousands, without re-introducing per-entity index maintenance cost.
+
+## ⚙️ How it works (in brief)
+
+Each grid cell (see [Spatial Grid & Cells](./spatial-grid-config.md)) holds a small linear array of cluster AABBs for each cluster-eligible archetype occupying it — typically 15-80 entries. A query first expands its region into the overlapping cells, scans each cell's cluster AABBs (broadphase), and for every cluster whose AABB overlaps, scans that cluster's live entities individually (narrowphase). Cluster AABBs are recomputed once per tick for clusters that changed, not on every entity write. Static and dynamic clusters are indexed separately and both are checked by every query. This path entirely replaces the legacy per-entity R-Tree for cluster-eligible archetypes — there is no fallback.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1)]
+public struct Position
+{
+    [SpatialIndex(margin: 5.0f)]
+    public AABB2F Bounds;
+}
+
+using var guard = EpochGuard.Enter(dbe.EpochManager);
+
+// AABB — direct per-cell query, zero allocation
+var box = new AABB2F { MinX = 0, MinY = 0, MaxX = 50, MaxY = 50 };
+foreach (var hit in dbe.ClusterSpatialQuery<Ant>().AABB<AABB2F>(in box, categoryMask: 0x3))
+{
+    // hit.EntityId, hit.ClusterChunkId, hit.SlotIndex, hit.MinX/Y/Z, hit.MaxX/Y/Z
+}
+
+// Radius — same per-cell path, sphere distance filter
+var sphere = new BSphere2F { CenterX = 10, CenterY = 10, Radius = 15 };
+foreach (var hit in dbe.ClusterSpatialQuery<Ant>().Radius(in sphere))
+{
+    // hit.DistanceSq is populated (closest point on entity AABB to sphere center)
+}
+
+// Equivalent Radius/Nearest access via the fluent ECS query (routes through the same cluster path)
+using var t = dbe.CreateQuickTransaction();
+var nearby = t.Query<AntArch>()
+    .WhereNearby<Position>(centerX: 10, centerY: 10, centerZ: 0, radius: 15)
+    .Execute();
+```
+
+`TBox` must be `AABB2F` or `AABB3F` and must match the archetype's declared spatial field dimensionality/precision exactly — a mismatch throws `InvalidOperationException` at the call site, not silently truncating coordinates.
+
+## ⚠️ Guarantees & limits
+
+- **Raw enumerator requires an `EpochGuard` scope** — `ClusterSpatialQuery<TArch>` reads cluster pages directly, so the caller must hold `EpochGuard.Enter(dbe.EpochManager)` for the call's duration. `EpochGuard` is `internal`; reaching it directly (as above) requires the same `InternalsVisibleTo` boundary as Cluster Dormancy. Application code without that access goes through `EcsQuery.WhereNearby`/`WhereInAABB`, which manages the epoch scope internally.
+- **Requires `ConfigureSpatialGrid`** before `InitializeArchetypes` — a cluster-eligible archetype with a `[SpatialIndex]` field and no configured grid throws at archetype initialization, not at first query.
+- **AABB and Radius only** — Ray and Frustum queries against cluster archetypes throw `NotSupportedException`; use the per-entity [Spatial Query API](./spatial-query-api.md) for non-cluster archetypes that need those shapes.
+- **f32 only** — `AABB2D`/`AABB3D` (f64) throw `NotSupportedException`; only `AABB2F`/`AABB3F` are implemented.
+- **No false negatives** — cluster AABBs always contain every live entity in the cluster (recomputed at the tick fence for dirty clusters), so a query never misses a geometrically-matching entity (rule CA-01).
+- **Category mask is "any bit overlaps"** — a non-zero mask skips a cluster only if none of its entities' OR'd category bits intersect the query mask; pass `uint.MaxValue` (default) for no filtering.
+- **Zero-allocation enumerator** — `AABB<TBox>` and `Radius` both return a `ref struct` enumerator; no heap allocation for the scan itself. `EcsQuery.WhereNearby`/`WhereInAABB` materialize results into a `HashSet<EntityId>` because the fluent API composes with archetype/Where filters.
+- **~2x slower per query than the old per-entity tree, but eliminates all per-entity index maintenance** — broadphase+narrowphase costs roughly 300-400ns for a typical 4-cell query vs ~150-200ns for the legacy tree traversal; the legacy tree's ~25ns-per-entity-per-tick update cost is gone entirely.
+- **No public `Nearest`/kNN on `ClusterSpatialQuery<TArch>` yet** — k-nearest is only reachable internally (consumed by `EcsQuery.WhereNearby`'s radius-expansion path); a dedicated public `.Nearest()` wrapper is deferred.
+- **No overflow tree / SIMD narrowphase** — broadphase is always a linear scan regardless of cluster count; both are profiling-gated future optimizations, not current bottlenecks at typical cell populations (≤80 clusters).
+
+## 🧪 Tests
+
+- [ClusterSpatialTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterSpatialTests.cs) — `SpatialQuery_AABB_ReturnsClusterEntities`/`SpatialQuery_Radius_ReturnsClusterEntities` (2D broadphase+narrowphase correctness)
+- [ClusterSpatial3DTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterSpatial3DTests.cs) — 3D Z-axis AABB/Radius filtering, Z-boundary overlap edge cases
+- [CellSpatialIndexTests](../../../test/Typhon.Engine.Tests/Data/SpatialGrid/CellSpatialIndexTests.cs) — per-cell cluster-AABB array growth/swap-removal, category-union computation backing the broadphase
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/public/ClusterSpatialQuery.cs](../../../src/Typhon.Engine/Spatial/public/ClusterSpatialQuery.cs)
+- Source: [src/Typhon.Engine/Spatial/public/AabbClusterEnumerator.cs](../../../src/Typhon.Engine/Spatial/public/AabbClusterEnumerator.cs)
+- Source: [src/Typhon.Engine/Spatial/public/ClusterSpatialAabb.cs](../../../src/Typhon.Engine/Spatial/public/ClusterSpatialAabb.cs)
+- Source: [src/Typhon.Engine/Spatial/internals/CellSpatialIndex.cs](../../../src/Typhon.Engine/Spatial/internals/CellSpatialIndex.cs)
+- Related catalog entry: [Spatial Query API](./spatial-query-api.md) (the per-entity R-Tree path for non-cluster archetypes)
+- Related catalog entry: [Entity Clusters](../Ecs/entity-clusters.md)
+
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/02-cluster-rtree.md (full design + phase history) -->
+<!-- Deep dive: claude/design/Spatial/spatial-grid-api.md (public API surface inventory) -->
+<!-- Rules: claude/rules/spatial.md (Module: Cluster Spatial AABBs — CA-01) -->

--- a/doc/feature-set/Spatial/fat-aabb-update.md
+++ b/doc/feature-set/Spatial/fat-aabb-update.md
@@ -1,0 +1,70 @@
+# Fat-AABB Incremental Update
+> Margin-enlarged bounds absorb small moves for ~25ns, with no tree mutation.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+A naive spatial index removes and reinserts an entity into the R-Tree every time it moves, even a single unit. At game-tick frequency with thousands of moving entities, that means a full tree mutation (MBR refit, possible split/merge) per entity per tick — the dominant cost of keeping a spatial index live. Fat-AABB Incremental Update absorbs the overwhelming majority of small, continuous motion (walking, patrolling, physics jitter) without touching the tree at all, so the per-tick spatial maintenance budget stays flat regardless of how many entities are merely drifting inside their own neighborhood.
+
+## ⚙️ How it works (in brief)
+
+Each indexed entity's true (tight) bounds are enlarged by a fixed margin into a "fat" AABB, which is what's actually stored in the R-Tree leaf. On each tick/commit, the engine checks whether the entity's new tight bounds are still contained inside its fat AABB — a handful of comparisons, no tree access. If contained, nothing else happens. If the entity has moved far enough to escape its fat AABB, the engine falls back to a full remove-then-reinsert with a freshly enlarged fat AABB around the new position. The margin is fixed per component field for the life of the schema; it does not adapt at runtime.
+
+## 💻 Usage
+
+```csharp
+public struct Position
+{
+    [SpatialIndex(margin: 0.5f)]
+    public float X, Y, Z;
+}
+
+[Archetype(42)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+}
+
+// No extra API to call — fast/slow path selection happens automatically
+// whenever the indexed field changes, at tick fence (SV) or commit (Versioned).
+using var wtx = dbe.CreateQuickTransaction();
+EntityRef m = wtx.OpenMut(entityId);
+ref Position p = ref m.Write(Unit.Pos);
+p.X += dx; p.Y += dy; p.Z += dz;
+wtx.Commit();
+```
+
+| `[SpatialIndex]` arg | Default | Effect |
+|---|---|---|
+| `margin` | required | Half-width added to each side of the tight AABB; larger margin = fewer escapes, wider (less precise) candidate sets |
+
+| Entity profile | Recommended margin |
+|---|---|
+| Slow movers (NPCs, buildings) | 0–5 units |
+| Normal movers (players, vehicles) | 5–20 units |
+| Fast movers (projectiles) | 0.5–2 units |
+
+## ⚠️ Guarantees & limits
+
+- **Fast path ~25ns** (containment check, no tree access) when the move stays inside the margin; this is the common case — **90%+ of per-tick moves** with a reasonably chosen margin.
+- **Slow path ~500–700ns** (remove + reinsert with re-enlarged fat AABB) on escape; typically **5–10% of moves**.
+- **Margin is fixed at schema definition time** — set once via `[SpatialIndex(margin: ...)]`, no runtime auto-tuning. Too small inflates escape rate (more tree mutations); too large inflates false positives in range queries (every query candidate must still pass an exact-bounds post-filter).
+- **Engine logs a warning** when an indexed table's escape rate exceeds 10%, naming the table — signal to raise that field's margin.
+- **Transparent to query results** — queries always test against the entity's exact stored bounds, not the fat AABB; the fat AABB only affects index maintenance cost, never correctness.
+- **No action needed on teleports/large jumps** — these simply always take the slow path; correctness is unaffected, only cost.
+
+## 🧪 Tests
+
+- [ClusterSpatialTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterSpatialTests.cs) — `TickFence_SmallMove_NoEscape_FastPath` (containment, no tree mutation) and `TickFence_MovedEntity_FatAABBEscape_RTreeUpdated` (remove+reinsert on escape)
+- [SpatialPerfTests](../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialPerfTests.cs) — `Bench_ContainmentCheck_2Df32` measures the fast-path containment check cost
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialMaintainer.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialMaintainer.cs)
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialBackPointer.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialBackPointer.cs)
+- Sibling: [Spatial R-Tree Index](./spatial-rtree-index/README.md) — the tree structure fat-AABB entries are stored and refit in
+- Sibling: [Static / Dynamic Tree Separation](./spatial-rtree-index/spatial-rtree-static-dynamic.md) — only `Dynamic`-mode fields receive fat-AABB maintenance; `Static` fields never do
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/03-tree-operations.md § Fat AABB Update Protocol, Back-Pointer Storage -->
+<!-- Deep dive: claude/adr/044-spatial-rtree-architecture.md (update-strategy rationale) -->

--- a/doc/feature-set/Spatial/spatial-architecture-overview.md
+++ b/doc/feature-set/Spatial/spatial-architecture-overview.md
@@ -1,0 +1,46 @@
+# Spatial Architecture Overview
+> Two independent spatial mechanisms — a per-component R-Tree for precise geometric queries, and an engine-wide grid for coarse tiering and clustering — that share vocabulary but not implementation.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Landing on the Spatial category for the first time is disorienting: every feature page already assumes you know how the pieces relate, but nothing tells you there *are* separate pieces. The word "grid" and the parameter `cellSize` both appear in two unrelated places — the R-Tree's internal query accelerator and the engine-wide simulation-tiering grid — and conflating them is the single most common way to misread this category. This page is the map: what exists, what each piece is for, and which feature to read next depending on what you're actually trying to do.
+
+## ⚙️ How it works (in brief)
+
+Two independent, optionally-combined mechanisms sit under Spatial:
+
+1. **The R-Tree** — a page-backed spatial index attached to any component field carrying an AABB/BSphere, declared once via `[SpatialIndex]` ([Field Attribute & Schema Integration](./spatial-field-attribute/README.md)). It answers precise geometric questions — "what overlaps this box/radius/ray" — in O(log n) via the [Spatial Query API](./spatial-query-api.md). Internally it has its own optional acceleration layer: a coarse occupancy hashmap that rejects entirely-empty query regions before the tree is touched at all, sized by the attribute's own `cellSize` parameter. This is the "Layer 1" mentioned in the R-Tree's internal docs, and it is **not** the grid described next, despite the shared name and the shared parameter name.
+2. **The spatial grid** — one engine-wide coordinate grid, configured once via [Spatial Grid Configuration & Tier Control](./spatial-grid-config.md) (`ConfigureSpatialGrid`, its own separate `cellSize`). It answers coarse questions — "how often should this region simulate," "which entities are near enough to batch together" — cheaply, per cell instead of per entity. It drives two downstream features: [Spatially-Coherent Entity Clustering](./spatial-coherent-clustering.md) (every entity in a cluster shares one grid cell) and [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) (per-cell simulation frequency), with [Checkerboard Dispatch](./checkerboard-dispatch.md) as a safe-parallelism refinement on top of tiering.
+
+The two mechanisms can be used independently or together. A component only needs `[SpatialIndex]` to get R-Tree queries — that alone never touches the grid. It additionally benefits from the grid only if `ConfigureSpatialGrid` has been called *and* its archetype is cluster-eligible (see [Entity Clusters](../Ecs/entity-clusters.md)). Nothing in the API forces you to use both, and using one says nothing about whether the other is configured.
+
+## Decision table
+
+| You want to... | Read |
+|---|---|
+| Query "what's near this point / in this box / along this ray" | [Field Attribute & Schema Integration](./spatial-field-attribute/README.md) → [Spatial Query API](./spatial-query-api.md) |
+| Simulate a large world at multiple frequencies (near the player vs. far away) | [Spatial Grid Configuration & Tier Control](./spatial-grid-config.md) → [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) |
+| Keep spatially-nearby entities in the same cluster for cheap per-cell operations | [Spatially-Coherent Entity Clustering](./spatial-coherent-clustering.md) (requires the grid, above) |
+| Tune R-Tree maintenance cost for rarely-moving vs. every-tick data | [Static / Dynamic Tree Separation](./spatial-rtree-index/spatial-rtree-static-dynamic.md) |
+| Skip whole subtrees/clusters by a bitmask before geometry tests | [Category Filtering](./spatial-category-filtering.md) |
+
+## ⚠️ Guarantees & limits
+
+- The R-Tree's Layer-1 occupancy filter and the engine-wide `SpatialGridConfig` are separate structures with independently-set `cellSize` values — changing one never affects the other, and neither is derived from the other.
+- `[SpatialIndex]` alone is sufficient for R-Tree queries; it does not require `ConfigureSpatialGrid` to have been called, and registering it never implicitly configures the grid.
+- The grid (`ConfigureSpatialGrid`) is engine-wide and singular — every participating spatial archetype shares the same cell size and bounds. The R-Tree has no such restriction — each field's Layer-1 filter, if enabled, is sized independently per `[SpatialIndex(cellSize: ...)]` declaration.
+- This page describes architecture, not an API surface of its own — there is nothing here to call; every code example lives on the linked feature pages.
+
+## 🔗 Related
+
+- Sibling: [Field Attribute & Schema Integration](./spatial-field-attribute/README.md) — the R-Tree side's entry point
+- Sibling: [Spatial Query API](./spatial-query-api.md) — the R-Tree side's read path
+- Sibling: [Spatial Grid Configuration & Tier Control](./spatial-grid-config.md) — the grid side's entry point
+- Sibling: [Spatially-Coherent Entity Clustering](./spatial-coherent-clustering.md) — the grid side's clustering consumer
+- Sibling: [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) — the grid side's dispatch consumer
+- Deep dive on the R-Tree's own two-layer design: [Spatial R-Tree Index](./spatial-rtree-index/README.md) (Internal)
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/01-architecture.md (two-layer R-Tree design, Layer 1/Layer 2) -->
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/01-spatial-clusters.md (grid/cluster architecture) -->

--- a/doc/feature-set/Spatial/spatial-category-filtering.md
+++ b/doc/feature-set/Spatial/spatial-category-filtering.md
@@ -1,0 +1,70 @@
+# Category Filtering
+> Bitmask pruning skips whole subtrees and clusters before geometry tests — AND-conjunctive at the R-Tree, any-bit-overlap at the cluster broadphase.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Most spatial queries only want a subset of what's geometrically nearby — an AI perception check wants enemies, not props; a capture-zone trigger wants players, not projectiles. Without a category filter, every query visits all geometrically matching entities and discards the irrelevant ones afterward, wasting the bulk of the traversal on data the caller never wanted. Category Filtering pushes a 32-bit bitmask test into the index itself so non-matching subtrees and clusters are skipped before any per-entity work happens.
+
+## ⚙️ How it works (in brief)
+
+Two independent mechanisms exist, with different semantics — know which one you're using. **R-Tree (per-component index):** each leaf entry carries a 32-bit `CategoryMask`, and each internal node carries a `UnionCategoryMask` (the OR of its subtree's entry masks). Traversal prunes a subtree when `node.UnionCategoryMask & queryMask == 0`; surviving leaf entries are tested exactly with `(entry.CategoryMask & queryMask) == queryMask` — **AND-conjunctive**, every requested bit must be present. **Per-cluster broadphase:** category is an *archetype-level* constant set on the `[SpatialIndex]` field, not per-entity — every entity in the archetype contributes the same value, so a cluster's mask is just that constant once occupied. A cluster is admitted when `(clusterMask & queryMask) != 0` — **any-bit-overlap**, not AND. Both layers never produce false negatives; a removed entity's bit can linger in an ancestor's union mask until the next refit, causing extra (never missing) traversal.
+
+## 💻 Usage
+
+```csharp
+[Flags]
+public enum Faction : uint
+{
+    Player = 1 << 0,
+    Enemy  = 1 << 1,
+    Alive  = 1 << 2,
+}
+
+public struct Position
+{
+    [SpatialIndex(margin: 0f, Category = (uint)(Faction.Enemy | Faction.Alive))]
+    public AABB2F Bounds;
+}
+
+// dbe.ConfigureSpatialGrid(...) must run before InitializeArchetypes — see the cluster broadphase setup.
+
+var box = new AABB2F { MinX = 0, MinY = 0, MaxX = 50, MaxY = 50 };
+
+foreach (var hit in dbe.ClusterSpatialQuery<UnitArch>().AABB(box, categoryMask: (uint)Faction.Enemy))
+{
+    // hit.EntityId — cluster's mask shared at least one bit with Faction.Enemy
+}
+```
+
+| `[SpatialIndex]` arg | Default | Effect |
+|---|---|---|
+| `Category` | `uint.MaxValue` | Archetype-constant bitmask; cluster admitted when `(Category & queryCategoryMask) != 0` |
+| `categoryMask` (query param) | `uint.MaxValue` | `0` disables the filter entirely (accept all clusters) |
+
+## ⚠️ Guarantees & limits
+
+- **R-Tree per-entry filtering is engine-internal today** — `SpatialNodeHelper`'s `CategoryMask`/`UnionCategoryMask` storage, pruning, and the AND-conjunctive leaf test are fully implemented and exercised by every R-Tree query enumerator (AABB/Radius/Ray/Frustum/kNN/Count), but reachable only via the internal `SpatialQuery<T>` handle — the public `EcsQuery.WhereInAABB`/`WhereNearby`/`WhereRay` predicates do not yet expose a `categoryMask` parameter, and there is no public API to assign a per-entity category. Use the two-pass pattern (spatial query → component post-filter) until that lands.
+- **Cluster broadphase is the publicly usable path today** — `[SpatialIndex(Category = ...)]` plus `ClusterSpatialQuery<TArch>.AABB`/`.Radius`, both fully public.
+- **Cluster category is archetype-level, not per-entity** — it cannot vary entity-to-entity within an archetype, and there is no runtime mutator; reclassifying requires a schema-level `Category` change.
+- **Semantics differ by layer** — R-Tree is AND-conjunctive (`entry.CategoryMask & queryMask == queryMask`); cluster broadphase is OR/any-bit-overlap (`clusterMask & queryMask != 0`). Mixing up the two produces wrong filtering, not a crash.
+- **No false negatives** — union-mask staleness after a remove only causes extra (unnecessary) traversal, never a missed match, at either layer.
+- **Zero-cost when unused** — default `Category`/`categoryMask` of `uint.MaxValue` and the `0` "no filter" sentinel mean queries that never opt in pay no extra branch cost beyond the mask compare.
+
+## 🧪 Tests
+
+- [SpatialRTreeTests](../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialRTreeTests.cs) — R-Tree AND-conjunctive leaf test and union-mask pruning (`Query_WithCategoryMask_FiltersCorrectly`, `CategoryMask_WithBruteForce_RandomData`, `SetEntryCategoryMask_UpdatesLeafAndAncestors`)
+- [CellSpatialIndexTests](../../../test/Typhon.Engine.Tests/Data/SpatialGrid/CellSpatialIndexTests.cs) — per-cluster `CategoryMask` storage and any-bit-overlap union computation for the cluster broadphase
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialNodeHelper.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialNodeHelper.cs) (leaf/union mask storage and refit)
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialRTree.Query.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialRTree.Query.cs) (per-enumerator pruning and leaf test)
+- Source: [src/Typhon.Engine/Spatial/public/ClusterSpatialAabb.cs](../../../src/Typhon.Engine/Spatial/public/ClusterSpatialAabb.cs) (per-cluster category union)
+- Source: [src/Typhon.Engine/Spatial/public/ClusterSpatialQuery.cs](../../../src/Typhon.Engine/Spatial/public/ClusterSpatialQuery.cs) (public query entry point)
+- Source: [src/Typhon.Schema.Definition/Attributes.cs](../../../src/Typhon.Schema.Definition/Attributes.cs) (`SpatialIndexAttribute.Category`, OR-disjunctive semantics documented inline)
+- Related catalog entry: [Spatial Query API](./spatial-query-api.md), [Spatial Query Predicates](../Querying/spatial-predicates.md)
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/08-game-features.md (Feature F1 — Category Filtering: design rationale, bit-width choice, node-layout impact) -->
+<!-- Rules: claude/rules/spatial.md (ST-02 union mask correctness, SQ-01/SQ-02 query completeness and AND-conjunctive semantics) -->

--- a/doc/feature-set/Spatial/spatial-coherent-clustering.md
+++ b/doc/feature-set/Spatial/spatial-coherent-clustering.md
@@ -1,0 +1,94 @@
+# Spatially-Coherent Entity Clustering
+> Every entity in a cluster shares one grid cell, so spatial bookkeeping is per-cluster, not per-entity.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+[Entity Clusters](../Ecs/entity-clusters.md) pack many same-archetype entities into one contiguous chunk for
+cache-friendly bulk iteration — but a cluster built with no spatial awareness can end up containing entities
+scattered anywhere in the world. Any cell-based operation (tier assignment, dormancy, per-cell broadphase
+queries) would then need a position check on every entity in every cluster to know which cell it belongs to.
+Spatially-Coherent Entity Clustering constrains cluster membership so all entities in a cluster share one coarse
+grid cell, collapsing that check from per-entity to per-cluster — typically 50-100x fewer checks — and keeps it
+that way as entities move, without the caller doing anything extra.
+
+## ⚙️ How it works (in brief)
+
+Spawning an entity with a `[SpatialIndex]` field places it in a cluster already assigned to its cell, or
+allocates a fresh one for that cell if none has room. As entities move, the engine detects when a new position
+exits the current cell by more than a small hysteresis margin (so walking along a boundary doesn't thrash) and
+queues a migration instead of moving it inline. All queued migrations for a tick are drained together at the
+tick fence, after every system has run: entity data (including any Transient components), index entries, and
+the spatial back-pointer are moved atomically into a cluster of the destination cell, and the per-cluster AABB
+is recomputed. None of this cell/cluster bookkeeping is persisted — it's derived from entity positions and
+rebuilt on every startup.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.AntPos", 1, StorageMode = StorageMode.SingleVersion)]
+public struct AntPos
+{
+    [SpatialIndex(1.0f)]
+    public AABB2F Bounds;
+}
+
+[Archetype(50)]
+public partial class Ant : Archetype<Ant>
+{
+    public static readonly Comp<AntPos> Pos = Register<AntPos>();
+}
+
+// Opt in once, before InitializeArchetypes (see Spatial Grid Configuration).
+dbe.ConfigureSpatialGrid(new SpatialGridConfig(
+    worldMin: new Vector2(0, 0), worldMax: new Vector2(1000, 1000), cellSize: 100f));
+dbe.InitializeArchetypes();
+
+// Spawn — lands in a cluster that already occupies the entity's cell, or a fresh one.
+using var t = dbe.CreateQuickTransaction();
+var id = t.Spawn<Ant>(Ant.Pos.Set(new AntPos { Bounds = new AABB2F { MinX = 5, MinY = 5, MaxX = 5, MaxY = 5 } }));
+t.Commit();
+
+// Move it across a cell boundary — migration is detected and executed automatically
+// at the next tick fence; no explicit migration call.
+using var wt = dbe.CreateQuickTransaction();
+var ant = wt.OpenMut(id);
+ref var pos = ref ant.Write(Ant.Pos);
+pos.Bounds = new AABB2F { MinX = 105, MinY = 5, MaxX = 105, MaxY = 5 };
+wt.Commit();
+```
+
+| Config field (`SpatialGridConfig`) | Default | Effect |
+|---|---|---|
+| `MigrationHysteresisRatio` | `0.05` (5% of cell size) | Dead-zone margin past the cell boundary an entity must cross before a migration is queued; absorbs boundary-walking oscillation |
+
+## ⚠️ Guarantees & limits
+
+- **Cluster-cell invariant always holds** — every entity in a cluster belongs to that cluster's assigned cell; enforced at spawn (cell-aware slot claim) and re-enforced by migration, never violated mid-cluster.
+- **Migration is deferred and batched, not inline** — movement systems only write positions; the engine detects crossings and executes all of a tick's migrations together at the tick fence, after all systems complete and before the WAL flush, so migration writes are durable in the same fsync as normal commits.
+- **One tick of spatial staleness is accepted** — between a position write and the fence, entity data is always correct via direct lookup (EntityMap), but a per-cell spatial query may miss an entity that just crossed a boundary for that one tick.
+- **Migration moves everything atomically** — component data (Persistent and Transient), secondary index entries, and the spatial back-pointer move together inside one durability unit; a crash mid-tick can't leave an entity split across clusters.
+- **Hysteresis suppresses boundary thrash** — an entity oscillating within the margin around a cell edge never triggers a migration; only a true cross-and-stay does.
+- **No compaction policy** — an emptied cluster is deallocated immediately, but a cluster with internal gaps (e.g. 10/64 occupied) is never compacted or merged; occupancy-bit scanning makes gaps cheap to skip.
+- **Opt-in, all-or-nothing per engine** — clustering only engages for archetypes with a `[SpatialIndex]` field once `ConfigureSpatialGrid` has been called before `InitializeArchetypes`; non-spatial archetypes are entirely unaffected.
+- **Fully transient, rebuilt every startup** — the cluster→cell map, per-cell cluster lists, and cluster AABBs are never written to disk; they're reconstructed from live cluster data after crash recovery or reopen (~1.5ms for 150K clusters), so there's no persisted state to corrupt.
+
+## 🧪 Tests
+
+- [ClusterSpatialCoherenceTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterSpatialCoherenceTests.cs) — cluster-cell invariant at spawn/overflow (`Spawn_ManyEntitiesInSameCell_LandInSameCluster`, `Spawn_BeyondClusterCapacity_AllocatesSecondClusterInSameCell`), grid-config opt-in guards, reopen rebuild
+- [ClusterMigrationTests](../../../test/Typhon.Engine.Tests/Data/ECS/ClusterMigrationTests.cs) — hysteresis (`PositionChangeWithinHysteresis_NoMigration`/`_BeyondHysteresis_Migrates`), atomic cross-cluster migration incl. Transient data, empty-cluster deallocation, reopen remapping
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/CellClusterPool.cs](../../../src/Typhon.Engine/Spatial/internals/CellClusterPool.cs)
+- Source: [src/Typhon.Engine/Spatial/internals/MigrationRequest.cs](../../../src/Typhon.Engine/Spatial/internals/MigrationRequest.cs)
+- Source: [src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs](../../../src/Typhon.Engine/Ecs/internals/ArchetypeClusterState.cs) (`ClaimSlotInCell`, `RebuildCellState`, `RebuildClusterAabbs`)
+- Source: [src/Typhon.Engine/Ecs/public/DatabaseEngine.cs](../../../src/Typhon.Engine/Ecs/public/DatabaseEngine.cs) (`DetectClusterMigrations`, `ExecuteMigrations`, `ConfigureSpatialGrid`)
+- Related catalog entry: [Entity Clusters](../Ecs/entity-clusters.md) (the base SoA storage this constrains)
+- Related catalog entry: [Spatial Grid Configuration & Tier Control](./spatial-grid-config.md) (the grid this clustering shares)
+- Related catalog entry: [Cluster Spatial Queries](./cluster-spatial-queries.md) (the query layer this coherence makes cheap)
+
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/01-spatial-clusters.md (cell-cluster mapping, migration, hysteresis, AABB maintenance, bulk loading) -->
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/04-tick-integration.md (tick-fence ordering, migration-fence flow) -->
+<!-- Rules: claude/rules/spatial.md (modules CC-01, CA-01, MD-01, MD-02, MD-03) -->

--- a/doc/feature-set/Spatial/spatial-field-attribute/README.md
+++ b/doc/feature-set/Spatial/spatial-field-attribute/README.md
@@ -1,0 +1,83 @@
+# Field Attribute & Schema Integration
+> Declare a component field as spatially indexed, validated against schema rules the moment the component is registered.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Spatial](../README.md)
+
+## 🎯 What it solves
+
+A spatial index needs to know, before a single entity exists, which field holds an entity's bounds, how much
+slack to give that field before a tree mutation is needed, whether it belongs in the static or dynamic tree, and
+whether a coarse occupancy filter is worth maintaining. Wiring this up imperatively — manual tree construction,
+manual field-offset bookkeeping, ad-hoc checks scattered through game code — is exactly the kind of boilerplate
+Typhon's schema reflection already removes for secondary indexes and foreign keys. `[SpatialIndex]` extends that
+same declarative path to spatial fields, and pushes every configuration mistake to startup instead of runtime.
+
+## ⚙️ How it works (in brief)
+
+Decorate one field of a supported geometry type (`AABB2F`/`AABB3F`/`BSphere2F`/`BSphere3F`, plus their `f64`
+equivalents) with `[SpatialIndex(margin, cellSize)]`, optionally setting `Mode` and `Category`. At component
+registration the engine checks the field's type, the component's storage mode, and that no second
+`[SpatialIndex]` field exists on the struct — any violation throws immediately, before the schema is built. On
+success, the attribute's values flow into the component's `DBComponentDefinition.SpatialField` and into the
+runtime state that backs the R-Tree, the back-pointer segment, and — when `cellSize > 0` — the Layer-1
+occupancy hashmap.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Ship", revision: 1, StorageMode = StorageMode.SingleVersion)]
+public struct ShipComponent
+{
+    [Field] public String64 Name;
+
+    // margin/cellSize are constructor args; Mode/Category are named properties.
+    [Field] [SpatialIndex(margin: 5.0f, Mode = SpatialMode.Dynamic, Category = 1u << 2)]
+    public AABB3F Bounds;
+}
+
+dbe.RegisterComponentFromAccessor<ShipComponent>();   // throws here on any violation, not later
+
+// Inspecting the reflected metadata:
+DBComponentDefinition def = dbe.DBD.GetComponent("Game.Ship", revision: 1);
+DBComponentDefinition.Field spatial = def.SpatialField;
+float margin = spatial.SpatialMargin;
+SpatialFieldType type = spatial.SpatialFieldType;     // AABB3F
+```
+
+| `[SpatialIndex]` arg | Default | Effect |
+|---|---|---|
+| `margin` (ctor) | required | Fat-AABB enlargement in world units — see [Spatial R-Tree Index](../spatial-rtree-index/README.md) |
+| `cellSize` (ctor) | `0` | `0` = no Layer-1 hashmap; `>0` enables a coarse occupancy filter at that cell size |
+| `Mode` | `SpatialMode.Dynamic` | `Static` bulk-loads once and is skipped by per-tick/commit maintenance; `Dynamic` gets fat-AABB updates |
+| `Category` | `uint.MaxValue` | Archetype-level bitmask consumed by the cluster broadphase to skip whole clusters |
+
+## ⚠️ Guarantees & limits
+
+- Exactly 8 supported field types: `AABB2F`/`AABB3F`/`BSphere2F`/`BSphere3F` and their `f64` (`...D`) equivalents
+  — any other field type throws `InvalidOperationException` at registration.
+- At most one `[SpatialIndex]` field per component — a second one throws at registration, not at first use.
+- `margin` must be ≥ 0 — a negative value throws at registration.
+- Not supported on `StorageMode.Transient` — registering a `[SpatialIndex]` field on a Transient component throws
+  `InvalidOperationException`.
+- Validation runs once, at `RegisterComponentFromAccessor`/`RegisterComponentByType` time, before any
+  `UnitOfWork` exists — by the time the schema is usable, the spatial configuration is already known-good.
+- `BSphere*` fields are accepted directly — the engine converts to an enclosing AABB internally for indexing; the
+  component's stored field stays a sphere, unchanged.
+- The attribute only declares configuration; it does not itself maintain the tree — see the sub-feature below
+  for *when* the tree picks up a write, and [Spatial R-Tree Index](../spatial-rtree-index/README.md) for
+  the index structure it configures.
+
+## 🧪 Tests
+
+- [SpatialFieldTypeTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialFieldTypeTests.cs) — `[SpatialIndex]` reflection (margin/cellSize), `FieldType.FromType` mapping for all 8 supported types, `SpatialFieldInfo.ToVariant`/`IsSphere`
+- [SpatialEcsIntegrationTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialEcsIntegrationTests.cs) — schema validation at registration (`Schema_TransientWithSpatialIndex_Throws`, `Schema_ValidSpatialField_CreatesSpatialIndex`, `Schema_NoSpatialField_NullSpatialIndex`, `Schema_CellSizeZero_NoHashmap`)
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialIndexState.cs](../../../../src/Typhon.Engine/Spatial/internals/SpatialIndexState.cs), [src/Typhon.Engine/Spatial/public/SpatialFieldInfo.cs](../../../../src/Typhon.Engine/Spatial/public/SpatialFieldInfo.cs), [src/Typhon.Schema.Definition/Attributes.cs](../../../../src/Typhon.Schema.Definition/Attributes.cs)
+- Sub-features: [Storage-Mode Compatibility (SingleVersion / Versioned)](./spatial-storage-mode-compat.md)
+- Sibling: [Spatial R-Tree Index](../spatial-rtree-index/README.md) — the index structure this attribute configures
+- Overview: [Spatial Architecture Overview](../spatial-architecture-overview.md) — how this fits with the separate spatial grid
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/05-ecs-integration.md (attribute API, schema registration flow) -->
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/01-architecture.md (storage-mode compatibility table) -->

--- a/doc/feature-set/Spatial/spatial-field-attribute/spatial-storage-mode-compat.md
+++ b/doc/feature-set/Spatial/spatial-field-attribute/spatial-storage-mode-compat.md
@@ -1,0 +1,97 @@
+# Storage-Mode Compatibility (SingleVersion / Versioned)
+> The same `[SpatialIndex]` field works on SingleVersion and Versioned components — only *when* the tree catches up differs.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Spatial](../README.md)
+
+## 🎯 What it solves
+
+A spatial field can live on a fast, loss-tolerant `SingleVersion` component (a ship's position) or on a full-MVCC
+`Versioned` component (a building's footprint) — but those two storage modes commit data on very different
+schedules. Game code needs a clear answer to "when does my write to a spatially-indexed field become visible to
+a spatial query", or it will assume the tree is always current and get surprised by a query that doesn't yet see
+a just-written move. This sub-feature defines that timing per storage mode, and confirms what's explicitly out
+of scope: `Transient` components.
+
+## ⚙️ How it works (in brief)
+
+The R-Tree maintenance logic (insert/update/remove) is identical regardless of storage mode — only the trigger
+point differs. For `SingleVersion`, the engine batches per-table dirty entities and applies them once per
+`DatabaseEngine.WriteTickFence(tickNumber)` call, so several writes to the same entity within a tick collapse
+into a single tree update of its final position. For `Versioned`, the tree update happens inline during
+`Transaction.Commit()`, right after MVCC conflict detection and revision stamping. In both cases the R-Tree
+itself carries no MVCC — it is always a "current state" structure reflecting the latest write/commit, never an
+AS-OF snapshot. `Transient` is not a third compatibility tier: `[SpatialIndex]` on a Transient component fails
+schema validation outright (see the parent feature).
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Ship", revision: 1, StorageMode = StorageMode.SingleVersion)]
+public struct ShipComponent
+{
+    [Field] [SpatialIndex(margin: 5.0f)]
+    public AABB3F Bounds;
+}
+
+[Component("Game.Building", revision: 1, StorageMode = StorageMode.Versioned)]
+public struct BuildingComponent
+{
+    [Field] [SpatialIndex(margin: 0.0f)]
+    public AABB3F Footprint;
+}
+
+// ShipArchetype.Hull / BuildingArchetype.Footprint: Comp<T> handles registered on their archetypes as usual.
+
+// SingleVersion — committed immediately, but the R-Tree only catches up at the next tick fence.
+using (var tx = dbe.CreateQuickTransaction())
+{
+    ref ShipComponent hull = ref tx.OpenMut(shipId).Write(ShipArchetype.Hull);
+    hull.Bounds = newBounds;
+    tx.Commit();
+}
+dbe.WriteTickFence(tickNumber);   // ← R-Tree update for SingleVersion happens here
+
+// Versioned — the R-Tree update happens inline, as part of the commit itself.
+using (var tx = dbe.CreateQuickTransaction())
+{
+    ref BuildingComponent b = ref tx.OpenMut(buildingId).Write(BuildingArchetype.Footprint);
+    b.Footprint = newFootprint;
+    tx.Commit();                  // ← R-Tree update for Versioned happens here
+}
+```
+
+| Storage Mode | Update Trigger | Typical Use |
+|---|---|---|
+| `SingleVersion` | `WriteTickFence()` — once per tick, batched | High-frequency movement (ships, units, projectiles) |
+| `Versioned` | `Transaction.Commit()` — inline, per entity | Low-frequency ACID spatial data (buildings, zones, triggers) |
+| `Transient` | N/A — rejected at registration | Not applicable; spatial data must be persisted |
+
+## ⚠️ Guarantees & limits
+
+- Multiple writes to the same `SingleVersion` entity within one tick produce exactly one tree update (the final
+  position) — intermediate positions within the tick never appear in query results.
+- The R-Tree has no MVCC in either mode — it always reflects current/latest-committed state; `Versioned`'s
+  revision chain does not extend to spatial queries (no AS-OF spatial reads).
+- `Destroy` removes the entity from the tree at the same trigger point as updates: tick fence for
+  `SingleVersion`, commit for `Versioned`.
+- Enable/Disable never mutates the tree in either mode — disabled entities stay indexed. A standalone spatial
+  query returns them (the caller's `Open()`/visibility check filters); `Query<T>().WhereNearby()` filters them
+  out automatically.
+- Contention profile differs by mode: `SingleVersion` tick-fence processing is single-threaded per
+  `ComponentTable` (no contention to manage); `Versioned` commits can run concurrently, but spatially-indexed
+  `Versioned` data is expected to be low-update-rate (buildings/zones, not every-tick movers).
+- `Transient` rejection is a schema-registration error, not a degraded mode — there is no heap-only spatial
+  index.
+
+## 🧪 Tests
+
+- [SpatialEcsIntegrationTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialEcsIntegrationTests.cs) — `SingleVersion` tick-fence-batched update timing (`SpatialQuery_CountAndAny_RespectSpatialPredicate` via `WriteTickFence`), schema registration on both `SingleVersion` and `Versioned` spatial components
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialMaintainer.cs](../../../../src/Typhon.Engine/Spatial/internals/SpatialMaintainer.cs)
+- Parent feature: [Field Attribute & Schema Integration](./README.md)
+- Sibling: [Storage Modes](../../Ecs/storage-modes/README.md) — the `SingleVersion`/`Versioned`/`Transient` disciplines this compatibility table is defined against
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/01-architecture.md §Storage Mode Compatibility -->
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/05-ecs-integration.md §SpatialMaintainer -->

--- a/doc/feature-set/Spatial/spatial-grid-config.md
+++ b/doc/feature-set/Spatial/spatial-grid-config.md
@@ -1,0 +1,75 @@
+# Spatial Grid Configuration & Tier Control
+> One global grid, one cell size, and a per-cell simulation-tier control surface for multi-resolution worlds.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Large worlds can't afford to simulate every entity at full frequency every tick — a 10M-entity world needs the few thousand entities near a player to run physics at 60 Hz while everything else runs coarser or not at all. Doing this with per-entity distance checks costs O(N) every frame and collapses well before six figures. Spatial Grid Configuration sets up the engine-wide coordinate grid every spatial archetype shares, and the tier control surface lets game code assign a simulation tier (full / reduced / coarse / dormant) per cell — cheaply, once per tick — instead of per entity.
+
+## ⚙️ How it works (in brief)
+
+`SpatialGridConfig` is computed once: world bounds and a single cell size derive the grid dimensions, and the config is handed to `DatabaseEngine.ConfigureSpatialGrid` before `InitializeArchetypes` — it cannot change afterward. All spatial archetypes share this one grid; there's no per-archetype sizing. At runtime, a `TierAssignment`-style callback system (run with `SystemPriority.High` so it executes before other systems) reads `TickContext.SpatialGrid` — an `SpatialGridAccessor` — and assigns each cell a `SimTier` flag (`Tier0`..`Tier3`). The engine consumes these per-cell tiers downstream to filter which clusters a system or query touches (see tier-filtered system dispatch in the Runtime category) — assignment itself is entirely game-owned policy; Typhon only provides storage and the helper methods below.
+
+## 💻 Usage
+
+```csharp
+// Once, before InitializeArchetypes:
+dbe.ConfigureSpatialGrid(new SpatialGridConfig(
+    worldMin: new Vector2(-1000f, -1000f),
+    worldMax: new Vector2( 1000f,  1000f),
+    cellSize: 32f));
+
+// Every tick, a high-priority callback system assigns tiers:
+schedule.CallbackSystem("TierAssignment", ctx =>
+{
+    var grid = ctx.SpatialGrid;
+    if (!grid.IsValid) return;
+
+    grid.ResetAllTiers(SimTier.Tier3);               // start everyone at lowest priority
+
+    foreach (var observer in connectedPlayers)
+    {
+        grid.SetTierInAABB(observer.Tier0MinX, observer.Tier0MinY,
+                            observer.Tier0MaxX, observer.Tier0MaxY, SimTier.Tier0);
+        grid.SetTierInAABB(observer.Tier1MinX, observer.Tier1MinY,
+                            observer.Tier1MaxX, observer.Tier1MaxY, SimTier.Tier1);
+    }
+}, priority: SystemPriority.High);
+```
+
+| Config field | Meaning | Notes |
+|---|---|---|
+| `WorldMin` / `WorldMax` | World-space extent | `WorldMax` is exclusive on both axes |
+| `CellSize` | Side length of one cell, world units | Must be `> 0`; one size for the whole grid |
+| `MigrationHysteresisRatio` | Dead-zone fraction for migration | Default `0.05`; reserved, currently passive |
+
+## ⚠️ Guarantees & limits
+
+- **Set once, immutable after** — `ConfigureSpatialGrid` throws `InvalidOperationException` if called twice or after `InitializeArchetypes`.
+- **One grid, one cell size, for every spatial archetype** — no per-archetype grid sizing; entity scale should be roughly uniform across archetypes sharing the grid.
+- **`KeySpaceDim` capped at 32,768 per axis** — a consequence of 32-bit Morton cell-key encoding; oversized world/cell-size combinations throw `ArgumentOutOfRangeException` at config time.
+- **`SetCellTier` requires a single-bit `SimTier` flag** — passing a combined flag (e.g. `Tier0 | Tier1`) is rejected; use the `Min` variants or per-call assignment for unions.
+- **`SetCellTierMin` / `SetTierInAABB` are promote-only** — they never demote a cell already holding a higher-priority (lower-valued) tier, which is what makes the multi-observer "union of zones" pattern correct without per-observer bookkeeping.
+- **All accessor methods throw `InvalidOperationException` when no grid is configured** — check `SpatialGridAccessor.IsValid` first, especially in non-spatial engines or during shutdown.
+- **One tick of staleness** — tier assignment runs once per tick (before other systems); cells crossing a tier boundary mid-tick are dispatched at their prior tier until the next tick.
+- **Tier filtering itself lives downstream** — this feature only assigns and exposes tiers; consuming them to filter system/query dispatch is a separate mechanism (rules `TI-01`..`TI-03`).
+
+## 🧪 Tests
+
+- [SpatialGridTests](../../../test/Typhon.Engine.Tests/Data/SpatialGrid/SpatialGridTests.cs) — grid dimension derivation, `WorldToCellKey`/`CellKeyToCoords` round-trips, `SetCellTier` single-bit validation, `KeySpaceDim` overflow throws
+- [CheckerboardTests](../../../test/Typhon.Engine.Tests/Runtime/CheckerboardTests.cs) — `SetCellTierMin_OnlyPromotes`, `ResetAllTiers_BulkSetsAllCells`, `SetTierInAABB_MinSemantics`, `SpatialGridAccessor_AccessibleFromTickContext`/`_MultiObserver_Union` (promote-only tiering, multi-observer union)
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/public/SpatialGridConfig.cs](../../../src/Typhon.Engine/Spatial/public/SpatialGridConfig.cs)
+- Source: [src/Typhon.Engine/Spatial/public/SpatialGridAccessor.cs](../../../src/Typhon.Engine/Spatial/public/SpatialGridAccessor.cs)
+- Source: [src/Typhon.Engine/Ecs/public/DatabaseEngine.cs](../../../src/Typhon.Engine/Ecs/public/DatabaseEngine.cs) (`ConfigureSpatialGrid`)
+- Related catalog entry: [Spatial Query API](./spatial-query-api.md) (the per-component query layer this grid complements)
+- Sibling: [Tiered Simulation Dispatch](./tiered-simulation-dispatch.md) — the primary consumer of the per-cell `SimTier` this feature exposes
+- Overview: [Spatial Architecture Overview](./spatial-architecture-overview.md) — this grid vs. the R-Tree's own, unrelated Layer-1 occupancy filter
+
+<!-- Deep dive: claude/design/Spatial/spatial-grid-api.md (full public API inventory) -->
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/03-tier-dispatch.md (tier assignment, dispatch, amortization, dormancy) -->
+<!-- ADR: claude/adr/046-spatial-tiers-architecture.md -->
+<!-- Rules: claude/rules/spatial.md (modules SC-01, TI-01..TI-03) -->

--- a/doc/feature-set/Spatial/spatial-interest-management.md
+++ b/doc/feature-set/Spatial/spatial-interest-management.md
@@ -1,0 +1,73 @@
+# Interest Management (Delta Spatial Queries)
+> Per-observer "what changed near me since tick T" queries in O(dirty × observers), not O(everything in view × observers).
+
+**Status:** 🚧 Partial · **Visibility:** Internal · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Multiplayer servers face the N-squared broadcast problem: naively re-sending every entity's state to every connected player each tick costs O(entities × players) bandwidth and CPU. What each observer actually needs is much smaller — only the entities near them that changed since the observer last looked. Interest Management answers exactly that question per observer, without the caller re-running a full spatial query and diffing it by hand every tick.
+
+## ⚙️ How it works (in brief)
+
+Instead of the traditional "per observer: spatial query, then filter by freshness" (O(entities in view × observers)), Typhon inverts the order: the engine archives each tick's `DirtyBitmap` into a 64-tick ring buffer, then for a delta request it ORs together the bitmaps for the ticks the observer missed and walks only the resulting (small) dirty set, testing each dirty entity's current position against the observer's interest AABB and category mask. Cost scales with how much changed, not with how much exists. An observer whose `LastConsumedTick` has fallen more than 64 ticks behind the ring (or who consumes before any tick has been archived) cannot be served a delta and instead gets a full-sync result — every currently-matching entity, treated as "changed."
+
+## 💻 Usage
+
+```csharp
+// Engine-internal entry point today — see Guarantees & limits.
+var table = dbe.GetComponentTable<Position>();
+var interest = table.SpatialIndex.GetOrCreateInterestSystem(table);
+
+// Register once per connected client, e.g. centered on their camera/view frustum AABB.
+double[] bounds = { 0, 0, 0, 200, 200, 200 };   // [minX,minY,minZ, maxX,maxY,maxZ]
+SpatialObserverHandle observer = interest.RegisterObserver(bounds, categoryMask: (uint)Faction.Enemy, initialTick: dbe.CurrentTick);
+
+// Each tick, after dbe.WriteTickFence(tick) has archived that tick's dirty set:
+SpatialChangeResult delta = interest.GetSpatialChanges(observer, currentTick: tick);
+if (delta.IsFullSync)
+{
+    // Observer fell off the 64-tick ring (or first call) — resync its whole interest region.
+}
+foreach (long entityId in delta.ChangedEntities)
+{
+    // Serialize this entity's current state into the observer's outgoing packet.
+}
+
+// On camera/view move:
+interest.UpdateObserverBounds(observer, newBounds);
+
+// On disconnect:
+interest.UnregisterObserver(observer);
+```
+
+| `RegisterObserver` arg | Default | Effect |
+|---|---|---|
+| `bounds` | required | Interest AABB, `[minX,minY,(minZ,) maxX,maxY,(maxZ)]` |
+| `categoryMask` | `0` | `0` = no filtering; non-zero = AND-conjunctive, same semantics as R-Tree category filtering |
+| `initialTick` | `0` | Starting point for delta accumulation on the first `GetSpatialChanges` call |
+
+## ⚠️ Guarantees & limits
+
+- **Engine-internal only today** — `SpatialInterestSystem`, `ComponentTable.SpatialIndex`, and `SpatialIndexState.GetOrCreateInterestSystem` are all `internal`. There is no public `DatabaseEngine` method to reach an observer system; only `SpatialObserverHandle` and `SpatialChangeResult` are public types. Application code cannot call this without engine-internal access today (this is the "Partial" status).
+- **SV-only (rule IM-03)** — dirty-bitmap ring archival only exists for SingleVersion/Transient `ComponentTable`s and SV-backed cluster archetypes; Versioned tables don't participate and have no ring to query.
+- **No missed changes (rule IM-01)** — any entity mutated at tick T, still matching an observer's region and category mask at query time, appears in that observer's `ChangedEntities` provided `LastConsumedTick < T ≤ currentTick` and T is still within the ring.
+- **Ring depth is 64 ticks** (~2.1s at 30Hz) — an observer that doesn't call `GetSpatialChanges` for longer than that is flagged `IsFullSync` rather than served a (silently incomplete) delta (rule IM-02).
+- **Only Tier 1 (`GetSpatialChanges`) is implemented** — spatial/bounds changes only. The design's Tier 2 (`GetEntityChanges`, any component on the entity changed, via cross-table dirty projection) is documented but not built.
+- **Zero-allocation in steady state** — `ChangedEntities` is a span over a per-observer buffer reused across calls; valid only until the next `GetSpatialChanges` call for that same observer.
+- **Handles are generation-checked** — calling any method with an unregistered or stale (reused-slot) handle throws `ArgumentException`.
+- **Covers both spatial-index layers** — a single delta call fans out across the legacy per-component R-Tree path and the per-cluster archetype path, so observers don't need to know which storage backs a given archetype.
+
+## 🧪 Tests
+
+- [SpatialInterestTests](../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialInterestTests.cs) — observer lifecycle + generation-checked handle reuse, `UpdateObserverBounds`, dirty-entity delta reporting in/out of region
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialInterestSystem.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialInterestSystem.cs) (observer registry, inverted dirty-set delta query, full-sync fallback)
+- Source: [src/Typhon.Engine/Spatial/public/SpatialObserverHandle.cs](../../../src/Typhon.Engine/Spatial/public/SpatialObserverHandle.cs) (public handle type)
+- Source: [src/Typhon.Engine/Spatial/public/SpatialChangeResult.cs](../../../src/Typhon.Engine/Spatial/public/SpatialChangeResult.cs) (public result type)
+- Source: [src/Typhon.Engine/Ecs/internals/DirtyBitmapRing.cs](../../../src/Typhon.Engine/Ecs/internals/DirtyBitmapRing.cs) (64-tick archival ring, multi-tick OR accumulation)
+- Related catalog entry: [Category Filtering](./spatial-category-filtering.md) (the AND-conjunctive mask semantics this feature reuses)
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/08-game-features.md (Feature F4 — Interest Management: inverted dirty-set rationale, ring buffer design, Tier 1/Tier 2 split) -->
+<!-- Rules: claude/rules/spatial.md (Module: Interest Management — IM-01 no missed changes, IM-02 ring buffer safety, IM-03 SV-only scope) -->

--- a/doc/feature-set/Spatial/spatial-query-api.md
+++ b/doc/feature-set/Spatial/spatial-query-api.md
@@ -1,0 +1,82 @@
+# Spatial Query API (AABB / Radius / Ray / Frustum / kNN / Count)
+> Six query algorithms over the per-component R-Tree, from zero-allocation engine hot loops to composable fluent ECS filters.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+A spatial index is only as useful as the questions it can answer. "What's in this box", "what's within range", "what does this ray hit", "what's visible in this frustum", "what are the k nearest", and "how many without listing them" are all distinct access patterns with different traversal strategies — answering all of them with one generic algorithm wastes cycles on every call site. The Spatial Query API gives each pattern its own traversal over the same R-Tree (see [Spatial R-Tree Index](./spatial-rtree-index/README.md)), so AI/physics/replication code picks the cheapest primitive for the job instead of over-fetching and post-filtering by hand.
+
+## ⚙️ How it works (in brief)
+
+Two entry-point tiers sit over the same tree. Engine-internal hot loops (trigger evaluation, interest management, the spatial query planner's fallback path) use `SpatialQuery<T>`, a zero-allocation handle exposing all six algorithms. Application code reaches a subset of the same traversals through the public fluent `EcsQuery<TArchetype>` — `WhereNearby`, `WhereInAABB`, and `WhereRay` attach one spatial predicate that composes with `.With`/`.Without`/`.Where`/`.WhereField` (see [Spatial Query Predicates](../Querying/spatial-predicates.md) for composition rules). Every algorithm returns a `ref struct` enumerator — a stack-based DFS over R-Tree nodes with per-node optimistic-lock-coupling (OLC) version checks; a concurrent writer mid-traversal triggers a restart from the root rather than returning torn data, so results are always complete even under contention. AABB is the base traversal; Radius converts to an AABB pre-filter the caller post-filters by squared distance; Ray walks front-to-back via a min-heap on entry distance; Frustum prunes whole subtrees that classify fully INSIDE or OUTSIDE the half-space planes; kNN iteratively doubles a radius query until enough candidates are found; Count replaces the result buffer with a counter and skips descent into subtrees fully contained by the query region.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1)]
+public struct Position
+{
+    [SpatialIndex(margin: 5.0f)]
+    public AABB3F Bounds;
+}
+
+using var t = dbe.CreateQuickTransaction();
+
+// AABB — public fluent surface (composes with archetype/Where filters)
+var inRoom = t.Query<UnitArch>()
+    .WhereInAABB<Position>(minX: 0, minY: 0, minZ: 0, maxX: 50, maxY: 0, maxZ: 50)
+    .Execute();                                                    // → HashSet<EntityId>
+
+// Radius — same surface, distance-bounded
+var nearby = t.Query<UnitArch>()
+    .WhereNearby<Position>(centerX: 10, centerY: 0, centerZ: 10, radius: 15)
+    .Where<Faction>(f => f.Id == 3)
+    .Execute();
+
+// Ray — front-to-back ordered candidates along a direction
+var rayHits = t.Query<UnitArch>()
+    .WhereRay<Position>(originX: 0, originY: 1, originZ: 0, dirX: 1, dirY: 0, dirZ: 0, maxDist: 100)
+    .Execute();
+```
+
+| Algorithm | Public entry point | Engine-internal entry point |
+|---|---|---|
+| AABB overlap | `EcsQuery.WhereInAABB<T>` | `SpatialQuery<T>.AABB` |
+| Radius (sphere) | `EcsQuery.WhereNearby<T>` | `SpatialQuery<T>.Radius` |
+| Ray (front-to-back) | `EcsQuery.WhereRay<T>` | `SpatialQuery<T>.Ray` |
+| Frustum | — not yet exposed | `SpatialQuery<T>.Frustum` |
+| kNN | — not yet exposed | `SpatialQuery<T>.Nearest` |
+| Count (AABB/Radius) | — not yet exposed | `SpatialQuery<T>.CountInAABB` / `.CountInRadius` |
+
+## ⚠️ Guarantees & limits
+
+- **Query completeness, no false negatives** — every entity geometrically matching a query is returned; fat-AABB and union-category-mask staleness can produce extra candidates (filtered by the caller) but never drop a true match (rule SQ-01).
+- **Zero heap allocation per query** — every enumerator is a `ref struct`; no boxing, no list materialization until the caller chooses to collect results.
+- **Concurrent-safe via restart, not blocking** — OLC version mismatch mid-traversal restarts the DFS from the root; readers never block writers and vice versa.
+- **Radius/kNN are AABB-box pre-filters** — false positive rate against the true sphere is ~21% in 2D, ~48% in 3D; callers post-filter by squared distance when exactness matters.
+- **Ray query terminates early** — nodes are visited in increasing entry-distance order via a min-heap; traversal stops once the next candidate's entry distance exceeds `maxDist`, typically visiting only 5–15 nodes regardless of tree size.
+- **Frustum pruning is subtree-level** — an MBR classified fully INSIDE yields its entire subtree without per-entry plane tests; only boundary-straddling subtrees pay the full classification cost.
+- **kNN distances are not returned** — the tree stores fat AABBs, not tight bounds, so `Nearest` returns candidate `EntityId`s with `distSq = 0`; callers recompute exact distance from component data if exact ordering is needed.
+- **Count avoids materialization** — `CountInAABB`/`CountInRadius` use the same subtree-containment shortcut as Frustum, up to ~30x faster than enumerating + counting when most of the query region is fully covered (rules SQ-03, SQ-04).
+- **Frustum, kNN, and Count are engine-internal today** — only reachable from engine code via `SpatialQuery<T>`, not from the public `EcsQuery` fluent surface.
+- **Public fluent surface allows one spatial predicate per query** — a second `WhereNearby`/`WhereInAABB`/`WhereRay` call throws; see [Spatial Query Predicates](../Querying/spatial-predicates.md) for full composition rules.
+
+## 🧪 Tests
+
+- [SpatialQueryTests](../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialQueryTests.cs) — `SpatialQuery<T>` Radius/Ray/Frustum/kNN traversal correctness vs a brute-force reference, ray/AABB intersection edge cases
+- [SpatialEcsIntegrationTests](../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialEcsIntegrationTests.cs) — public fluent `WhereInAABB`/`WhereNearby`/`WhereRay`, composition with `WhereField`/`Where`, and the "one spatial predicate per query"/foreach guard exceptions
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialQuery.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialQuery.cs) (engine-internal handle, all six algorithms)
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialRTree.Query.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialRTree.Query.cs) (enumerator implementations)
+- Source: [src/Typhon.Engine/Ecs/public/EcsQuery.cs](../../../src/Typhon.Engine/Ecs/public/EcsQuery.cs) (public fluent surface)
+- Related catalog entry: [Querying / Spatial Query Predicates](../Querying/spatial-predicates.md) (fluent composition rules)
+- Related catalog entry: [Spatial R-Tree Index](./spatial-rtree-index/README.md) (the index structure these queries run against)
+- Overview: [Spatial Architecture Overview](./spatial-architecture-overview.md) — how this fits with the separate spatial grid
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/04-query-api.md (API surface, traversal algorithms per query type) -->
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/08-game-features.md (category filtering, Count Queries feature rationale) -->
+<!-- Rules: claude/rules/spatial.md (Module: Queries — SQ-01 through SQ-05) -->
+<!-- ADR: claude/adr/044-spatial-rtree-architecture.md -->

--- a/doc/feature-set/Spatial/spatial-rtree-index/README.md
+++ b/doc/feature-set/Spatial/spatial-rtree-index/README.md
@@ -1,0 +1,50 @@
+# Spatial R-Tree Index
+> Page-backed R-Tree attached to a component field, giving sub-microsecond AABB/radius/ray queries shared across every archetype that uses it.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Spatial](../README.md)
+
+## 🎯 What it solves
+
+Any component holding a position or bounds needs spatial answers — "what's near this point", "what's inside this box" — and a linear scan over every entity falls apart well before 10K entities at 60 Hz. A B+Tree field index doesn't help either: it orders on a scalar key, not on 2D/3D overlap. The R-Tree gives a component field a real spatial index: O(log n) descent instead of O(n) scan, durable across crashes and restarts like any other Typhon structure, and shared by every archetype that happens to use the component — no per-archetype index duplication.
+
+## ⚙️ How it works (in brief)
+
+Annotate a component field holding an `AABB2F`/`AABB3F`/`BSphere2F`/`BSphere3F` (or the `f64` equivalents) with `[SpatialIndex]`. The engine infers the field's spatial type, picks the matching tree variant (2D/3D × f32/f64), and builds one R-Tree per `ComponentTable` — not per archetype, so entities of different archetypes sharing the component land in the same tree. Each tree node is a single page-backed chunk (512 B for 2D/3D-f32, 768 B for 3D-f64) holding 12–24 entries depending on variant, so a handful of page reads resolve any query. Entries store a *fat* AABB — the tight bounds enlarged by `margin` — so small moves are absorbed without touching the tree; only a margin-escaping move costs a real remove+reinsert (see [Fat-AABB Incremental Update](../fat-aabb-update.md)). A back-pointer per entity gives O(1) leaf lookup on update/remove, and all node access goes through Optimistic Lock Coupling — readers never block writers, a concurrent mutation mid-traversal just restarts the descent. An optional Layer-1 coarse occupancy hashmap (`cellSize > 0`) rejects entirely-empty query regions before the tree is touched at all.
+
+## Sub-features
+
+| Sub-feature | Use it when... |
+|---|---|
+| [Static / Dynamic Tree Separation](./spatial-rtree-static-dynamic.md) | A component's spatial data is either rarely-moving (terrain, buildings, fixed triggers) or moves every tick (units, projectiles), and you want each to pay only its own maintenance cost |
+
+## ⚠️ Guarantees & limits
+
+- **Crash-safe** — tree mutations ride the same WAL/tick-fence durability path as the component's storage mode (tick fence for SingleVersion, transaction commit for Versioned); no separate persistence story to manage.
+- **Zero boot cost** — the tree lives in the database file; reopening a database does not rebuild it.
+- **No MVCC** — the tree always reflects current/latest-committed state, regardless of the component's storage discipline. Not available on `Transient` components (registration fails at schema time).
+- **One tree per ComponentTable, not per archetype** — every archetype that shares the spatially-indexed component is queried by a single tree traversal; archetype filtering on results is a cheap bitmask check, not a separate index probe.
+- **Query completeness is guaranteed** — every entity whose geometry matches a query is in the result set; node MBRs are refit on every mutation to keep this true (false positives at the leaf/fat-AABB level are expected and filtered by the caller; false negatives are not).
+- **Fixed fanout per variant** — 20 (2D f32) / 14 (3D f32) / 12 (2D f64) / 13 (3D f64) leaf entries per node; not configurable per component.
+- **Lazy underflow** — nodes below minimum fill are tolerated, not merged; only fully empty leaves are reclaimed. Slightly higher storage overhead under heavy churn, no correctness impact.
+- **~600 µs total spatial budget** at 100K entities / 60 Hz (update + 100 queries/tick) — roughly 3.6% of a 16 ms frame.
+- At most one `[SpatialIndex]` field per component, and exactly one R-Tree variant is selected for it at registration time — switching field type later means re-registering the schema, not a runtime reconfiguration.
+
+## 🧪 Tests
+
+- [SpatialRTreeTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialRTreeTests.cs) — insert/split/remove correctness across all 4 variants, AABB query vs brute force, category-mask pruning
+- [SpatialNodeDescriptorTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialNodeDescriptorTests.cs) — node capacities/header sizes/SOA layout match the design doc, per variant
+- [SpatialRTreeBulkTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialRTreeBulkTests.cs) — many sequential inserts, `TreeValidator` structural invariant checks
+
+## 🔗 Related
+
+- Related catalog entry: [Field Attribute & Schema Integration](../spatial-field-attribute/README.md) (the `[SpatialIndex]` attribute that configures this index)
+- Related catalog entry: [Spatial Query API](../spatial-query-api.md) and [Querying / Spatial Query Predicates](../../Querying/spatial-predicates.md) (the algorithms that run against this index)
+- Related catalog entry: [Fat-AABB Incremental Update](../fat-aabb-update.md) (per-tick maintenance mechanics)
+- Sub-features: [Static / Dynamic Tree Separation](./spatial-rtree-static-dynamic.md)
+- Overview: [Spatial Architecture Overview](../spatial-architecture-overview.md) — clarifies that the Layer-1 occupancy hashmap below is not the engine-wide spatial grid
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/01-architecture.md (two-layer design, storage-mode compatibility, archetype convergence) -->
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/02-node-layout.md (SOA node layout, variant capacities) -->
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/03-tree-operations.md (insert/split/remove, fat-AABB protocol, correctness invariants) -->
+<!-- Rules: claude/rules/spatial.md (R-Tree structure, query, fat-AABB invariants) -->
+<!-- ADR: claude/adr/044-spatial-rtree-architecture.md -->

--- a/doc/feature-set/Spatial/spatial-rtree-index/spatial-rtree-static-dynamic.md
+++ b/doc/feature-set/Spatial/spatial-rtree-index/spatial-rtree-static-dynamic.md
@@ -1,0 +1,72 @@
+# Static / Dynamic Tree Separation
+> A component's spatial field lands in one of two independent R-Trees — tick-fence-exempt static, or fat-AABB-maintained dynamic — chosen once at schema time.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Spatial](../README.md)
+
+## 🎯 What it solves
+
+A typical game or simulation world is mostly static geometry — terrain, buildings, walls, fixed trigger volumes — with a small fraction of entities actually moving every tick. Indexing both in the same R-Tree means every per-tick maintenance pass walks static entities that will never move, and the insert/split/remove churn from dynamic entities keeps widening MBRs around static ones that should stay tight forever. Static/Dynamic separation gives each spatial component its own tree so movers pay tick-fence maintenance cost and never-movers pay none.
+
+## ⚙️ How it works (in brief)
+
+`SpatialMode` on `[SpatialIndex]` selects which of the two trees a component's spatial field uses — `Dynamic` (default) or `Static`. The choice is per spatial field, not per entity: every entity carrying that component lands in the same tree, decided at schema registration, never at spawn time. Entities reach either tree the same way — a normal insert when the entity is spawned — but only the dynamic tree is visited by the per-tick (SingleVersion) or per-commit (Versioned) fat-AABB maintenance pass; the static tree is never scanned for movement once an entity is in it. Destruction still removes an entity from whichever tree it's in via the same O(1) back-pointer lookup. Internally the engine also has a Sort-Tile-Recursive bulk-build primitive that packs a whole batch of entries into a near-optimal tree in one pass — useful for constructing a large static tree from a pre-known dataset rather than one incremental insert at a time — but it is an engine-internal construction path today, not something application code calls directly; spawning entities one at a time still produces a fully correct, query-ready static tree.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Terrain", revision: 1, StorageMode = StorageMode.SingleVersion)]
+public struct TerrainPiece
+{
+    [Field] [SpatialIndex(margin: 0.0f, Mode = SpatialMode.Static)]
+    public AABB3F Footprint;
+}
+
+[Archetype(50)]
+partial class TerrainArchetype : Archetype<TerrainArchetype>
+{
+    public static readonly Comp<TerrainPiece> Footprint = Register<TerrainPiece>();
+}
+
+// Spawning is identical to a dynamic component — Mode only changes what happens to the entity afterward.
+using (var tx = dbe.CreateQuickTransaction())
+{
+    tx.Spawn<TerrainArchetype>(TerrainArchetype.Footprint.Set(new TerrainPiece { Footprint = footprint }));
+    tx.Commit();
+}
+
+// Querying is identical to a dynamic component too.
+using var qtx = dbe.CreateQuickTransaction();
+var hits = qtx.Query<TerrainArchetype>().WhereInAABB<TerrainPiece>(-5, -5, -5, 55, 15, 10).Execute();
+
+dbe.WriteTickFence(tickNumber);   // never visits TerrainPiece's static tree — only Dynamic-mode components are scanned for movement
+```
+
+| `[SpatialIndex]` arg | Default | Effect |
+|---|---|---|
+| `Mode` | `SpatialMode.Dynamic` | `Static` — inserted once, never visited by tick-fence/commit maintenance. `Dynamic` — full fat-AABB update cycle every tick/commit. |
+
+## ⚠️ Guarantees & limits
+
+- **Exclusive membership** — a given component's spatial field lives in exactly one tree (static *or* dynamic); the engine never holds the same `ComponentTable`'s entities split across both.
+- **Mode is schema-fixed** — set once via `[SpatialIndex(Mode = ...)]` at component registration; there is no runtime API to move an entity between trees. Reclassifying means changing the schema and re-registering, not a per-entity operation.
+- **Static skip is unconditional** — the tick-fence (SingleVersion) and commit (Versioned) maintenance passes never visit static-tree entities; if a static-mode component's field value does change, that change is written to component storage but the tree is not updated to match — `Mode = Static` is a correctness contract with the caller, not just a performance hint.
+- **Insert and remove still work normally on the static tree** — spawning adds an entity, destroying removes it, both via the same back-pointer path as the dynamic tree. Only the per-tick *movement* maintenance is skipped.
+- **No merge/dedup needed at query time** — `WhereInAABB`/`WhereNearby`/`WhereRay` against a component resolve to that component's single active tree; there's no second tree to fan out to or reconcile results against.
+- **Bulk construction is an internal primitive, not a public API** — the engine has a Sort-Tile-Recursive bulk-loader that builds a near-optimal tree from a full dataset in one pass, but it isn't currently exposed through `DatabaseEngine`/ECS spawn; populating a static tree today means spawning entities individually like any other component.
+
+## 🧪 Tests
+
+- [SpatialEcsIntegrationTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialEcsIntegrationTests.cs) — `Schema_StaticMode_SetsFieldInfoMode`/`Schema_DefaultMode_IsDynamic` (mode selection at registration), `StaticComponent_InsertAndQuery`/`StaticComponent_Remove_Works`, `StaticComponent_TickFenceSkipped` (unconditional maintenance skip)
+- [SpatialBulkLoadTests](../../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialBulkLoadTests.cs) — the internal STR `SpatialRTree.BulkLoad` primitive: valid-tree construction, query correctness vs brute force, category-mask filtering
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialIndexState.cs](../../../../src/Typhon.Engine/Spatial/internals/SpatialIndexState.cs)
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialRTree.BulkLoad.cs](../../../../src/Typhon.Engine/Spatial/internals/SpatialRTree.BulkLoad.cs) (internal STR construction primitive)
+- Parent feature: [Spatial R-Tree Index](./README.md)
+- Sibling: [Fat-AABB Incremental Update](../fat-aabb-update.md) — only `Dynamic`-mode fields (this feature's default) receive fat-AABB maintenance; `Static` fields never do
+- Sibling: [Spatial Query API](../spatial-query-api.md) — querying is identical regardless of which tree a field's mode lands it in
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/08-game-features.md §Feature F2 — Static/Dynamic Separation -->
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/05-ecs-integration.md §SpatialIndexState -->
+<!-- Rules: claude/rules/spatial.md §Module: Fat AABB Updates (SF-02) -->

--- a/doc/feature-set/Spatial/spatial-trigger-volumes.md
+++ b/doc/feature-set/Spatial/spatial-trigger-volumes.md
@@ -1,0 +1,69 @@
+# Trigger Volumes (Enter / Leave / Stay)
+> Per-region occupant diffing against the R-Tree(s) emits Enter/Leave/Stay events at a configurable per-region frequency.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Games need transition events — the moment an entity enters or leaves a region — not just a point-in-time occupancy snapshot: capture zones, stealth detection, environmental hazards, loading boundaries all key off the edge, not the level. Polling every region against every nearby entity each tick to derive that edge by hand is wasteful and easy to get wrong (duplicate or missed events at the boundary). Trigger Volumes turn a region into a maintained query that does the diffing for the caller and only at the cadence the caller asks for.
+
+## ⚙️ How it works (in brief)
+
+A trigger region is a lightweight config slot (bounds, category mask, evaluation frequency, target-tree mode) — not an ECS entity or component. Each evaluation queries the spatial tree(s) for the region's AABB and category mask, builds a bitmap of current occupants, and XORs it against the bitmap captured at the region's previous evaluation: set-but-not-previously-set bits are Enter, previously-set-but-not-set bits are Leave, the rest are Stay (count only, not materialized). Evaluation is frequency-gated per region — a region is skipped unless `currentTick - lastEvaluatedTick >= EvaluationFrequency` — so cheap ambient zones and expensive per-tick damage fields can share the same system at different cadences. `TargetTreeMode` controls which tree(s) are queried: `DynamicOnly` (default) never touches the static tree; `Both`/`StaticOnly` query the static tree once and cache the result, only re-querying it when the static tree mutates or the region's bounds/category change. Spatial-grid cluster archetypes registered on the same index are diffed too, tracked by EntityId rather than by R-Tree chunk id.
+
+## 💻 Usage
+
+Trigger regions are reached through the per-table spatial index state, which is engine-internal today (see Guarantees below) — this is the actual API, shown as the test suite exercises it:
+
+```csharp
+var table = dbe.GetComponentTable<Position>();
+var triggers = table.SpatialIndex.GetOrCreateTriggerSystem(table);
+
+double[] zoneBounds = { -10, -10, -10, 50, 50, 50 };   // minX,minY,minZ,maxX,maxY,maxZ
+var zone = triggers.CreateRegion(zoneBounds, categoryMask: (uint)Faction.Player,
+    evaluationFrequency: 5, targetTree: TargetTreeMode.DynamicOnly);
+
+// once per tick, per region:
+SpatialTriggerResult r = triggers.EvaluateRegion(zone, currentTick);
+if (r.WasEvaluated)
+{
+    foreach (long entityId in r.Entered) { /* fire OnEnter */ }
+    foreach (long entityId in r.Left)    { /* fire OnLeave */ }
+    // r.StayCount — occupants unchanged since the previous evaluation
+}
+
+triggers.UpdateRegionBounds(zone, newBounds);       // invalidates static-tree cache
+triggers.UpdateRegionCategoryMask(zone, newMask);   // invalidates static-tree cache
+triggers.DestroyRegion(zone);
+```
+
+| `TargetTreeMode` | Default | Effect |
+|---|---|---|
+| `DynamicOnly` | yes | Queries the dynamic tree only; static tree never touched |
+| `Both` | — | Dynamic tree every evaluation + cached static-tree result, merged |
+| `StaticOnly` | — | Static tree only, fully cached after the first evaluation |
+
+## ⚠️ Guarantees & limits
+
+- **Engine-internal only today** — `SpatialTriggerSystem`, `ComponentTable.SpatialIndex`, and `GetOrCreateTriggerSystem` are all `internal`; there is no public `DatabaseEngine`/ECS entry point yet, so application code outside the engine assembly cannot create or evaluate trigger regions. `SpatialRegionHandle`, `SpatialTriggerResult`, and `TargetTreeMode` are public types, ready for a future public wrapper.
+- **Event completeness (rule TV-01)** — every outside→inside transition between two evaluations produces exactly one Enter, every inside→outside produces exactly one Leave; an entity inside at both evaluations produces neither (it's counted in `StayCount` only).
+- **Frequency contract (rule TV-02)** — `EvaluationFrequency = N` guarantees at most one evaluation every N ticks. A skipped evaluation returns `SpatialTriggerResult.Skipped` (`WasEvaluated == false`; `Entered`/`Left`/`StayCount` are not meaningful). A freshly created region always evaluates on its first call regardless of N.
+- **Result spans are transient** — `Entered`/`Left` are `ReadOnlySpan<long>` over pooled buffers, valid only until the next `EvaluateRegion` call on that system; copy entity ids out before yielding control if they need to outlive the call.
+- **Static-tree caching, not re-querying** — `Both`/`StaticOnly` regions re-run the static query only when the static tree's mutation version changes or the region's bounds/category mask are updated; steady-state evaluations reuse the cached bitmap.
+- **Cluster archetypes are included automatically** — if the table's spatial index has spatial-grid cluster archetypes registered, their entities are queried and diffed in the same `EvaluateRegion` call, tracked by EntityId in a separate set from the R-Tree bitmap.
+- **Destroyed handles are rejected** — `DestroyRegion` bumps the slot's generation; any further use of the old handle (including a double-destroy) throws `ArgumentException`.
+- **Designed for ~800ns per region** at ~50 occupants (AABB query + bitmap diff); cost tracks occupant count and tree depth, and per-tick total cost is bounded by staggering `EvaluationFrequency` across regions rather than evaluating all regions every tick.
+
+## 🧪 Tests
+
+- [SpatialTriggerTests](../../../test/Typhon.Engine.Tests/Data/SpatialIndex/SpatialTriggerTests.cs) — region lifecycle + generation-checked handle reuse, `Enter`/`Leave`/`StayInside` event completeness, `EvalFrequency_SkipsTicks`
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Spatial/internals/SpatialTriggerSystem.cs](../../../src/Typhon.Engine/Spatial/internals/SpatialTriggerSystem.cs)
+- Source: [src/Typhon.Engine/Spatial/public/SpatialRegionHandle.cs](../../../src/Typhon.Engine/Spatial/public/SpatialRegionHandle.cs) (`TargetTreeMode`)
+- Source: [src/Typhon.Engine/Spatial/public/SpatialTriggerResult.cs](../../../src/Typhon.Engine/Spatial/public/SpatialTriggerResult.cs)
+- Related catalog entry: [Spatial Category Filtering](./spatial-category-filtering.md), [Spatial R-Tree Index](./spatial-rtree-index/README.md)
+
+<!-- Deep dive: claude/design/Spatial/SpatialIndex/08-game-features.md (Feature F3 — Trigger Volumes: algorithm, static-cache strategy, frequency budget) -->
+<!-- Rules: claude/rules/spatial.md (Module: Trigger Volumes — TV-01 event completeness, TV-02 frequency contract) -->

--- a/doc/feature-set/Spatial/tiered-simulation-dispatch.md
+++ b/doc/feature-set/Spatial/tiered-simulation-dispatch.md
@@ -1,0 +1,107 @@
+# Tiered Simulation Dispatch
+> One simulation tier per spatial cell, four dispatch frequencies, zero per-entity distance checks.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Spatial](./README.md)
+
+## 🎯 What it solves
+
+Large worlds can't run every entity at full simulation frequency — entities near the player need 60 Hz
+physics, the next ring only needs movement updates, and the bulk of a 10M-entity world should barely be
+touched. Deciding "should I simulate this" with a per-entity distance check costs O(N) every tick and
+becomes the bottleneck before any tiering even pays off. Tiered Simulation Dispatch lets game code
+classify the world coarsely — per spatial cell, once per tick — and have every system and view
+downstream automatically restrict its work to the matching cells, at cluster granularity, for near-zero
+extra cost.
+
+## ⚙️ How it works (in brief)
+
+Game code assigns a `SimTier` flag (`Tier0`..`Tier3`) to each cell via `TickContext.SpatialGrid` (see
+[Spatial Grid Configuration](./spatial-grid-config.md)). At tick start the engine rebuilds, per
+archetype, a compact list of active clusters grouped by tier; the rebuild is skipped whenever neither
+the grid's tier assignment nor the archetype's cluster set changed since the last tick. A `QuerySystem`
+declares a `Tier(...)` filter to dispatch only against clusters in matching cells, and can add
+`CellAmortize(N)` to additionally process just `1/N` of those clusters per tick — rotating cluster
+buckets, not skipping entities one by one — for the coarsest tiers. `View.WithTier` applies the same
+scoping to a View's materialized entity set, useful for published/subscription views or change-filter
+scans. `TickContext.TierBudgetMetrics` reports per-tier wall-clock cost from the previous tick so a
+`TierAssignment` system can adapt tier boundaries to a frame budget instead of fixed radii.
+
+## 💻 Usage
+
+```csharp
+// Game-owned policy: assign cell tiers once per tick, before any tier-filtered system runs.
+var game = schedule.PublicTrack.DeclareDag("Game");
+game.CallbackSystem("TierAssignment", ctx =>
+{
+    var grid = ctx.SpatialGrid;
+    if (!grid.IsValid) return;
+
+    grid.ResetAllTiers(SimTier.Tier3);
+    grid.SetTierInAABB(camera.Tier0MinX, camera.Tier0MinY, camera.Tier0MaxX, camera.Tier0MaxY, SimTier.Tier0);
+    grid.SetTierInAABB(camera.Tier1MinX, camera.Tier1MinY, camera.Tier1MaxX, camera.Tier1MaxY, SimTier.Tier1);
+
+    // Adapt next tick's radius to this tick's measured cost.
+    if (ctx.TierBudgetMetrics.UtilizationRatio > 0.85f)
+    {
+        camera.Tier0Radius *= 0.95f;
+    }
+}, priority: SystemPriority.High);
+
+// Full-fidelity AI: every tick, Tier 0 cells only.
+game.QuerySystem("CombatAi", ctx =>
+{
+    foreach (var id in ctx.Entities) { /* full-fidelity AI */ }
+}, input: () => antsView, parallel: true, tier: SimTier.Tier0);
+
+// Coarse tier: process 1/60th of Tier 2's clusters per tick, integrate over the elapsed bucket time.
+game.QuerySystem("IdleDrift", ctx =>
+{
+    foreach (var id in ctx.Entities)
+    {
+        ref var pos = ref ctx.Accessor.OpenMut(id).Write(Ant.Position);
+        pos.X += DriftSpeed * ctx.AmortizedDeltaTime;   // ~1s of drift, once every 60th tick
+    }
+}, input: () => antsView, parallel: true, tier: SimTier.Tier2, cellAmortize: 60);
+
+// A published view scoped to Tier 0 — the output phase only computes deltas for nearby entities.
+var viewportView = tx.Query<Ant>().ToView().WithTier(SimTier.Tier0);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `tier:` (`QuerySystem`) / `b.Tier(...)` (class-based) | `SimTier.All` | Restrict dispatch to clusters in matching cells; flags combine (e.g. `SimTier.Near` = `Tier0 \| Tier1`) |
+| `cellAmortize:` / `b.CellAmortize(N)` | `0` (off) | Process `1/N` of the tier's clusters per tick, rotating buckets by tick number; requires a non-`All` tier |
+| `View.WithTier(SimTier)` | `SimTier.All` | Scope a View's materialized entity set / change-filter scan to matching cells |
+
+## ⚠️ Guarantees & limits
+
+- Filtering operates on cluster lists, not per-entity checks — a tier-filtered system touches only the
+  clusters in its tier, never scans the rest of the archetype.
+- Tier-list rebuild is dual-invalidated (grid tier version + per-archetype cluster-set version) —
+  camera-stationary, no-migration ticks pay two integer compares, not a re-scan.
+- `CellAmortize` skips whole untouched clusters; it is not entity-id modulo — the 59/60 you skip in a
+  tick are never iterated.
+- A system's `Tier(...)` and its input View's `WithTier` combine by bit-AND; if the two have no overlap
+  (e.g. system `Tier0` against a view `WithTier(Tier1)`), the engine throws at dispatch-prepare time
+  instead of silently materializing zero entities.
+- One tick of staleness — a cell's tier change takes effect at the next tick's dispatch, same as the
+  underlying grid (see [Spatial Grid Configuration](./spatial-grid-config.md)).
+- `TickContext.TierBudgetMetrics` is all-zero on the first tick — guard `BudgetMs == 0` before computing
+  utilization ratios.
+- Stored cell tiers must be single-bit (`SetCellTier` rejects combined flags like `Tier0 | Tier1`);
+  multi-tier flags (`Near`, `Active`, `All`) are valid only as system/view filters, never as a cell's
+  stored value.
+
+## 🧪 Tests
+
+- [TierDispatchTests](../../../test/Typhon.Engine.Tests/Runtime/TierDispatchTests.cs) — tier-list rebuild/invalidation, `Tier(...)`/`CellAmortize` dispatch scoping, `View.WithTier`, tier×view AND-combination throw, `TierBudgetMetrics`
+
+## 🔗 Related
+
+- Source: [src/Typhon.Engine/Runtime/public/SimTier.cs](../../../src/Typhon.Engine/Runtime/public/SimTier.cs), [Dag.cs](../../../src/Typhon.Engine/Runtime/public/Dag.cs), [SystemBuilder.cs](../../../src/Typhon.Engine/Runtime/public/SystemBuilder.cs)
+- Source: [src/Typhon.Engine/Ecs/internals/TierClusterIndex.cs](../../../src/Typhon.Engine/Ecs/internals/TierClusterIndex.cs), [TyphonRuntime.cs](../../../src/Typhon.Engine/Runtime/public/TyphonRuntime.cs) (tier-scoped dispatch, budget metrics)
+- Related catalog entry: [Spatial Grid Configuration & Tier Control](./spatial-grid-config.md) (per-cell tier assignment, `SpatialGridAccessor`)
+- Sibling: [Tier-Filtered & Amortized Dispatch](../Runtime/spatial-tiers-adaptive-dispatch/tier-filtered-amortized-dispatch.md) — same feature cataloged from the Runtime/dispatch angle rather than the spatial-grid angle
+
+<!-- Deep dive: claude/design/Spatial/SpatialTiers/03-tier-dispatch.md, 04-tick-integration.md -->
+<!-- Rules: claude/rules/spatial.md (modules TierClusterIndex/TI-01..TI-03, SetCellTier Validation/SC-01) -->

--- a/doc/feature-set/Storage/README.md
+++ b/doc/feature-set/Storage/README.md
@@ -1,0 +1,29 @@
+# Storage
+> The persistence layer underlying every Typhon data structure: a memory-mapped, 8 KiB-page cache with clock-sweep eviction and epoch-based concurrency safety, layered on allocation abstractions that go file-page occupancy → multi-page segments → fixed-size chunks. Pluggable persistent and transient backends share that one substrate, and integrity (CRC32C + A/B pairing), file locking, and read-only introspection round out what makes the on-disk file safe and inspectable.
+
+> 🔬 **Recommended:** read [in-depth-overview/02-storage.md](../../in-depth-overview/02-storage.md) (Chapter 02: Storage) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Transient Store (heap-backed)](pluggable-storage-backend/transient-store.md) *(part of [Pluggable Storage Backend](pluggable-storage-backend/README.md))* | Pinned heap blocks standing in for the page cache, so Transient components get raw-memory speed through the same segment code — tune via `TransientOptions` | ✅ Implemented | 🔵 Core |
+| [Database File Locking & Lifecycle](file-locking-lifecycle.md) | Two-layer protection against concurrent multi-process opens — OS `FileShare.Read` plus an advisory `.lock` sidecar with stale/live/cross-machine PID detection — plus create/open/delete lifecycle handling | ✅ Implemented | 🔵 Core |
+| [Memory-Mapped Page Cache & Clock-Sweep Eviction](page-cache.md) | 8 KiB pages, 4-state lifecycle, clock-sweep eviction with sequential-allocation optimization, async I/O, and backpressure handling | ✅ Implemented | 🟣 Advanced |
+| [Page Integrity — CRC32C, Seqlock Snapshots & A/B Page Pairing](page-integrity.md) | Hardware CRC32C page checksums, seqlock-protected checkpoint snapshots, and A/B slot pairing for structural pages that can't be rebuilt | ✅ Implemented | 🟣 Advanced |
+| [Variable-Sized Buffer Storage (VSBS)](vsbs.md) | Linked-chunk-chain storage for variable-length, reference-counted buffers — backs multi-value B+Tree index entries and per-element-type `ComponentCollection<T>` pools | ✅ Implemented | 🟣 Advanced |
+| [Storage Introspection & Integrity Diagnostics](storage-introspection.md) | Read-only APIs exposing segment/page topology and auditing occupancy-vs-segment consistency, powering the Workbench Database File Map | ✅ Implemented | 🟣 Advanced |
+| [Page Compression (Future)](page-compression-future.md) | Planned LZ4-style compression adapter for cold/historical data, string-heavy tables, and backups — deliberately not implemented in v1 so hot real-time paths stay within microsecond latency targets | 📋 Planned | 🟣 Advanced |
+
+## Internal Features
+
+> Engine machinery that makes the features above work. Application code never calls these directly — documented here for engine contributors.
+
+| Feature | Summary | Status |
+|---|---|---|
+| [Epoch-Based Page Protection & Dirty-Page Tracking](epoch-dirty-tracking.md) | Epoch-tagged eviction safety plus the ChangeSet/DirtyCounter/ActiveChunkWriters/SlotRefCount protocol that pins modified or pointer-referenced pages until checkpoint write-back | ✅ Implemented |
+| [Page Allocation & Occupancy Tracking](page-allocation-occupancy.md) | A 3-level bitmap that allocates and tracks every 8 KiB page in the database file, growing the file automatically as needed | ✅ Implemented |
+| [Segment & Chunk-Based Allocation Engine](segment-chunk-allocation.md) | Multi-page directories and fixed-size slot allocation — the substrate every component, index, and revision chain is built from | ✅ Implemented |
+| [Pluggable Storage Backend (Persistent vs Transient)](pluggable-storage-backend/README.md) | One set of segment/index code, JIT-specialized per backend, so Transient components get heap speed for free | ✅ Implemented |
+| &nbsp;&nbsp;↳ [Persistent Store (MMF-backed)](pluggable-storage-backend/persistent-store.md) | The default backend — every durable component's segments run through the memory-mapped page cache at zero abstraction cost | ✅ Implemented |
+| [String Table Storage](string-table.md) | UTF-8 string storage spread across linked fixed-size chunks, for strings too long to hold inline | ✅ Implemented |

--- a/doc/feature-set/Storage/epoch-dirty-tracking.md
+++ b/doc/feature-set/Storage/epoch-dirty-tracking.md
@@ -1,0 +1,75 @@
+# Epoch-Based Page Protection & Dirty-Page Tracking
+> Per-page eviction safety built from an epoch tag plus three counters, replacing per-page reference counting entirely.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+The page cache must never reclaim a memory page that a live reader still has a raw pointer into, that has modifications not yet durable on disk, or that a B+Tree write is mid-flight on — but the *general* "don't evict what's in use" problem is already solved by [Epoch-Based Resource Protection](../Foundation/epoch-based-resource-protection.md). What's specific to the page cache is everything epoch scoping alone can't express: a page can still be "in use" after the transaction that wrote it has exited its scope (it's dirty and not yet checkpointed), or while a B+Tree's lock-free write is in flight on it (no exclusive latch is held), or while a `ChunkAccessor` slot holds a cached raw pointer into it across an eviction. Each of these needs its own protection signal layered on top of the epoch tag.
+
+## ⚙️ How it works (in brief)
+
+Every cached memory page carries an `AccessEpoch` tag (stamped to the current epoch on each access, via compare-and-swap so it only ever increases) plus three independent counters: `DirtyCounter` (modifications pending checkpoint write-back), `ActiveChunkWriters` (in-flight lock-free B+Tree writes, which checkpoint's snapshot must not race), and `SlotRefCount` (live `ChunkAccessor` slot references to the page's raw address). A page is only eligible for clock-sweep eviction when all four say it's safe: epoch stale, no dirty marks, no active writers, no slot references. Dirty marks are produced by a `ChangeSet` attached to a unit of work — every mutated page is registered exactly once, the mark count is conservation-tracked (so concurrent unit-of-work scopes touching the same page never under- or over-release it), and disposal drains the UoW's marks back to the one outstanding mark the next checkpoint cycle needs to find and clear by writing the page.
+
+## 💻 Usage
+
+This is transparent engine plumbing — every component write, index update, and B+Tree mutation registers its dirty pages and exits its epoch scope automatically. There is no API to mark a page dirty or to pin it directly:
+
+```csharp
+using var uow = db.CreateUnitOfWork();            // owns the ChangeSet for this scope
+using var tx = uow.CreateTransaction();           // epoch scope entered here
+
+EntityRef e = tx.OpenMut(entityId);
+ref Position p = ref e.Write<Position>();         // touched pages: epoch-tagged + DirtyCounter++
+p.X += 1f;
+tx.Commit();                                      // epoch scope exited; dirty marks released to 1
+                                                   // (checkpoint writes the page later, DirtyCounter -> 0)
+```
+
+The one place application code interacts with this layer is sizing the cache and handling the failure mode when it's undersized — a single transaction's working set must fit within `DatabaseCacheSize`, since every page it touches is epoch-protected for the scope's whole lifetime:
+
+```csharp
+services.AddScopedManagedPagedMemoryMappedFile(options =>
+{
+    options.DatabaseCacheSize = 64UL * 1024 * 1024;   // 8192 pages @ 8KB; size above the largest expected UoW working set
+});
+
+try
+{
+    BulkInsertThousandsOfEntities(db);
+}
+catch (PageCacheBackpressureTimeoutException ex)
+{
+    // No evictable page after waiting TimeoutOptions.Current.PageCacheBackpressureTimeout (default 5s).
+    // ex.DirtyPageCount / ex.EpochProtectedCount say which protection is holding pages back.
+    // Fix: enlarge DatabaseCacheSize, or split the transaction into smaller batches.
+}
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `PagedMMFOptions.DatabaseCacheSize` | 256 pages (2 MiB) | Total memory page budget; must exceed the largest single transaction's unique-page working set |
+| `TimeoutOptions.Current.PageCacheBackpressureTimeout` | 5s | How long allocation waits for a page to become evictable before throwing |
+
+## ⚠️ Guarantees & limits
+
+- **A clean, epoch-stale, unreferenced page is always reclaimable** — eviction never blocks on anything but these four signals; there's no separate "this page is special" escape hatch to reason about.
+- **Dirty data is never evicted before it's durable** — `DirtyCounter` only reaches zero after the checkpoint has actually written the page; rollback and crash-recovery paths cannot make the count go negative.
+- **In-flight lock-free B+Tree writes are checkpoint-safe** — `ActiveChunkWriters` blocks the checkpoint's page snapshot, not eviction; it exists because optimistic B+Tree writes don't take the page's exclusive latch the way ordinary writes do.
+- **Raw pointers stay valid across deferred slot eviction** — `SlotRefCount` protects a page for as long as any `ChunkAccessor` slot — even one logically evicted from its warm cache — might still be dereferenced through a cached `byte*`/`ref T`.
+- **Known limitation — working set must fit the cache**: because protection is granted for the whole epoch scope, a transaction touching more unique pages than the cache holds cannot proceed — every page it touches becomes unevictable by its own epoch tag, a circular dependency with no automatic resolution. Size `DatabaseCacheSize` above the largest expected transaction's page footprint.
+- No per-page synchronized increment/decrement on the read path — only writes register dirty marks; the epoch tag (shared with the underlying scope mechanism) is already paid for once per transaction.
+
+## 🧪 Tests
+
+- [EpochPageCacheTests](../../../test/Typhon.Engine.Tests/Storage/EpochPageCacheTests.cs) — epoch-tagged page stays protected while a scope is active, becomes evictable only after scope exit
+- [ChangeSetConservationTests](../../../test/Typhon.Engine.Tests/Storage/ChangeSetConservationTests.cs) — `DirtyCounter` conservation across add/release/reset/checkpoint-ack, never over- or under-releases
+- [CheckpointManagerTests](../../../test/Typhon.Engine.Tests/Durability/CheckpointManagerTests.cs) — `ActiveChunkWriters` coverage gate blocks checkpoint capture on a pinned page and unblocks once released
+
+## 🔗 Related
+
+- Related feature: [Epoch-Based Resource Protection](../Foundation/epoch-based-resource-protection.md) (the underlying scope mechanism), [Page Allocation & Occupancy Tracking](./page-allocation-occupancy.md) (the layer below, file-page bookkeeping)
+
+<!-- Deep dive: claude/design/Storage/PageCache/02-page-states.md, claude/design/Storage/PageCache/06-changesets.md, claude/design/Storage/PageCache/07-concurrency.md -->
+<!-- ADR: claude/adr/033-epoch-based-page-eviction.md -->
+<!-- Rules: claude/rules/durability.md — module Page Safety (PS-01..PS-09) -->

--- a/doc/feature-set/Storage/file-locking-lifecycle.md
+++ b/doc/feature-set/Storage/file-locking-lifecycle.md
@@ -1,0 +1,74 @@
+# Database File Locking & Lifecycle
+> Two-layer protection against two processes opening the same database file, plus safe create/open/delete handling.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+Two processes (or two `DatabaseEngine` instances in the same process) writing to the same `.bin` file would corrupt it — there's no merge, no second writer protocol. Typhon needs to refuse a second writer outright, and refuse it with enough information that an operator can act: which process holds it, on which machine, since when. It also needs file create/open/delete to behave correctly on Windows, where a deleted file's directory entry can briefly linger after `File.Delete` returns, which would otherwise break an immediate re-create of the same database name.
+
+## ⚙️ How it works (in brief)
+
+Opening a database acquires two independent locks. The OS-level one is the real guarantee: the data file handle is opened with `FileShare.Read`, so a second process requesting read-write access is rejected by the OS kernel (mandatory on Windows; advisory-only on POSIX). The advisory one is a JSON sidecar, `<DatabaseName>.lock`, written next to the data file with the owning process's PID, machine name, and start time — its only job is to turn an opaque OS sharing-violation into a `DatabaseLockedException` that names the culprit. The lock file is acquired before the data file is opened and removed on `Dispose()`; a dead owner's lock is detected (PID no longer running) and cleared automatically rather than blocking the new open. Deleting a database file polls for NTFS's deferred directory-entry removal so a delete-then-recreate of the same name doesn't race the filesystem.
+
+## 💻 Usage
+
+```csharp
+var services = new ServiceCollection();
+services.AddResourceRegistry();
+services.AddMemoryAllocator();
+services.AddEpochManager();
+
+services
+    .AddScopedManagedPagedMemoryMappedFile(options =>
+    {
+        options.DatabaseName = "GameWorld";
+        options.DatabaseDirectory = @"C:\Data\Saves";
+    })
+    .AddScopedDatabaseEngine();
+
+var sp = services.BuildServiceProvider();
+
+try
+{
+    var dbe = sp.GetRequiredService<DatabaseEngine>();
+    // ... normal ECS/transaction work
+}
+catch (DatabaseLockedException ex)
+{
+    log.LogError("database held by PID {Pid} on '{Machine}' since {StartedAt:u}",
+        ex.OwnerPid, ex.OwnerMachine, ex.StartedAt);
+}
+
+// Wipe a database (data + lock file), waiting out NTFS deferred-delete:
+sp.EnsureFileDeleted<ManagedPagedMMFOptions>();
+```
+
+| Scenario | Behavior |
+|---|---|
+| Lock file owner PID alive, **same machine** | `DatabaseLockedException` (`OwnerPid`, `OwnerMachine`, `StartedAt`) |
+| Lock file owner PID dead, same machine | Stale — logged, removed, open proceeds |
+| Lock file from a **different machine name** | Can't verify a remote PID — always treated as live, throws |
+| Lock file corrupt / unreadable JSON | Logged, removed, open proceeds |
+| Lock file write itself fails (e.g. read-only dir) | Logged, open proceeds — the OS `FileShare.Read` layer is still active |
+
+## ⚠️ Guarantees & limits
+
+- The OS `FileShare.Read` handle is the actual enforcement layer and cannot be bypassed by deleting `.lock` — on Windows a second writer's `File.OpenHandle` throws `IOException` regardless of the sidecar's state.
+- On POSIX, OS file sharing is advisory only (the kernel doesn't block a second writer), so the `.lock` file is the *only* cross-process guard there — don't rely on this feature for safety on a network filesystem shared between hosts that don't see each other's processes.
+- A stale lock from a crashed process on the **same machine** is detected and cleared automatically (`Process.GetProcessById` liveness check) — no manual cleanup needed after an ungraceful shutdown.
+- A lock file from a **different machine name** is always treated as live and blocks the open, even if that machine is long gone — there's no way to verify a remote PID. Clearing it (delete the `.lock` file) is a manual, deliberate operation after confirming the other machine truly isn't using the file.
+- PID reuse is a narrow theoretical gap: if a crashed owner's PID is later reassigned by the OS to an unrelated live process before the next open, that lock would be (incorrectly) treated as live. In practice this requires PID exhaustion/wraparound in the window between crash and reopen.
+- `Dispose()` always releases the lock file, even on an initialization failure that occurs after it was acquired — a failed open doesn't leave a phantom lock behind.
+- `PagedMMFOptions.EnsureFileDeleted()` (and the `IServiceProvider.EnsureFileDeleted<TO>()` DI helper) remove both the `.bin` and `.lock` files and poll for NTFS's deferred-delete to actually complete; `DeleteDatabaseFile()` only removes the data file and does not wait — prefer `EnsureFileDeleted` before recreating a database under the same name.
+
+## 🧪 Tests
+
+- [DatabaseFileLockingTests](../../../test/Typhon.Engine.Tests/Storage/DatabaseFileLockingTests.cs) — full scenario matrix: stale/live/cross-machine/corrupt lock files, `FileShare` enforcement, `EnsureFileDeleted`
+
+## 🔗 Related
+
+- Source: `src/Typhon.Engine/Storage/internals/PagedMMF.cs` (`AcquireLockFile`/`ReleaseLockFile`/`DeleteFileAndWait`), `src/Typhon.Engine/Storage/public/PagedMMFOptions.cs` (`EnsureFileDeleted`)
+
+<!-- Overview: claude/overview/03-storage.md — File Locking -->
+<!-- Overview: claude/overview/10-errors.md (exception hierarchy, DatabaseLockedException) -->

--- a/doc/feature-set/Storage/page-allocation-occupancy.md
+++ b/doc/feature-set/Storage/page-allocation-occupancy.md
@@ -1,0 +1,59 @@
+# Page Allocation & Occupancy Tracking
+> A 3-level bitmap that allocates and tracks every 8KB page in the database file, growing the file automatically as needed.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+Every persistent structure in Typhon — components, indexes, revision chains, clusters, spatial trees — is built from fixed-size 8KB file pages. Something has to answer "which pages are free?", hand out new ones without scanning the whole file, and grow the file transparently as data accumulates, all without ever risking two structures claiming the same page. Page Allocation & Occupancy Tracking is that foundation layer: every other storage feature (segments, chunk allocators) sits on top of it and never has to reason about raw file-page bookkeeping itself.
+
+## ⚙️ How it works (in brief)
+
+A bitmap with one bit per file page tracks allocation, organized in three levels. The bottom level (L0) is the durable ground truth — it lives on disk, in the occupancy segment's own pages. Two in-memory summary levels (L1/L2) let the allocator skip straight to a free run instead of scanning bit-by-bit, giving O(1) amortized allocate/free via `BitOperations.TrailingZeroCount`. When the bitmap itself runs out of room to track more pages, the occupancy segment grows by one page — using pages set aside in advance specifically to avoid a "need a free page to record more free pages" deadlock. A compact key/value bootstrap dictionary on the file's root page persists the occupancy segment's location and its growth-reserve page indices, so adding a new piece of root-level metadata is a new dictionary key, never a file-format revision.
+
+## 💻 Usage
+
+Allocation itself is an internal primitive — application code never calls `AllocatePage`/`FreePages` directly; every component table, index, and segment acquires pages through it transparently as you spawn entities and write components. The surface application code actually touches is read-only introspection over what the allocator has done:
+
+```csharp
+// Audit storage-level invariants — safe to call at any time, no data-page I/O.
+var report = db.RunStorageIntegrityCheck();
+if (!report.IsHealthy)
+{
+    foreach (var issue in report.Issues)
+    {
+        Console.WriteLine($"{issue.Kind} @ segment {issue.SegmentRootPageIndex}: {issue.Detail}");
+    }
+}
+
+// Per-segment footprint: which pages each structure owns, and (for chunk-based
+// segments) live allocated/free chunk counts.
+foreach (var seg in db.EnumerateStorageSegments())
+{
+    Console.WriteLine($"{seg.Kind} root={seg.RootPageIndex} pages={seg.Pages.Length} " +
+                       $"allocChunks={seg.AllocatedChunkCount} freeChunks={seg.FreeChunkCount}");
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- One bit per page; O(1) amortized allocate/free via the L1/L2 in-memory skip levels — no full-bitmap scans on the happy path.
+- The occupancy bitmap is treated as a *derived* structure on crash recovery: it is never trusted as-is, but rebuilt wholesale from actual segment ownership (rule CK-09) — a torn or stale bitmap page can't cause a double-allocation after restart.
+- Growth is self-financing: the pages needed to extend the bitmap are reserved ahead of time, so growing the map never itself requires an allocation (no chicken-and-egg deadlock).
+- Each additional occupancy page extends tracking capacity by 64,000 file pages (~500 MiB of file growth) — very large databases pay periodic, not continuous, growth pauses.
+- Adding new root-level metadata (an SPI, a counter) is a new `BootstrapDictionary` key, not a file-format bump.
+- Not directly callable by application code — `AllocatePage`/`FreePages` are internal allocator primitives consumed by segments; the only supported app-facing surface is read-only introspection (`RunStorageIntegrityCheck`, `EnumerateStorageSegments`).
+
+## 🧪 Tests
+
+- [BitmapL3FreeRangeTests](../../../test/Typhon.Engine.Tests/Storage/BitmapL3FreeRangeTests.cs) — `ManagedPagedMMF.FreePages` contiguous-range bit-flip and subsequent reallocation
+- [ManagedPagedMMFTests](../../../test/Typhon.Engine.Tests/Storage/ManagedPagedMMFTests.cs) — L0/L1 bitmap find/set primitives, occupancy map save/reload, map growth
+- [BootstrapDictionaryTests](../../../test/Typhon.Engine.Tests/Storage/BootstrapDictionaryTests.cs) — root-page key/value round-trip backing the occupancy segment's persisted bootstrap entries
+
+## 🔗 Related
+
+- Sibling: [Segment & Chunk-Based Allocation Engine](segment-chunk-allocation.md) — the multi-page/chunk allocator layered directly on top of this page-level bookkeeping
+
+<!-- Deep dive: claude/design/Storage/database-file-format.md §3–4 (root header, bootstrap dictionary, occupancy map structure) -->
+<!-- Overview: claude/overview/03-storage.md §3.2 (ManagedPagedMMF) -->
+<!-- Rules: claude/rules/durability.md — CK-09 (occupancy bitmap is derived, re-derived on crash) -->

--- a/doc/feature-set/Storage/page-cache.md
+++ b/doc/feature-set/Storage/page-cache.md
@@ -1,0 +1,76 @@
+# Memory-Mapped Page Cache & Clock-Sweep Eviction
+> The 8 KiB page cache underneath every Typhon structure — clock-sweep eviction and async I/O instead of trusting the OS, with backpressure instead of crashing when full.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+Every persistent structure in Typhon — components, indexes, revision chains, segments — is built from fixed-size 8 KiB pages backed by a memory-mapped file. Keeping every page resident would blow past available RAM on any real database; relying on the OS to page things in and out naively gives no control over what gets evicted under pressure, no way to guarantee a page a thread is mid-read on stays put, and no async I/O path. The page cache is the layer every other storage feature is built on: it decides which pages are resident, picks what to evict when full, and never lets a page disappear out from under a thread still using it.
+
+## ⚙️ How it works (in brief)
+
+The cache holds a fixed number of 8192-byte slots in natively-addressed, memory-mapped memory. Each slot moves through a 4-state lifecycle — `Free` → `Allocating` (loading from disk) → `Idle` (resident, readable) → `Exclusive` (single-writer latch) → back to `Idle`. When a slot is needed and none is free, clock-sweep eviction scans slots in circular order: each slot carries a 0–5 "second-chance" counter, bumped on access and decremented as the sweep passes over it, so a slot is only taken once its counter has decayed to 0 *and* it's otherwise unprotected (not dirty, not actively read). Allocating the next file page adjacent to the previous one is tried first, so sequential access lands in contiguous cache memory and several small I/Os batch into one. Reads and writes use async `RandomAccess` I/O instead of blocking the calling thread. If every slot is pinned when a new one is needed, the allocator blocks and waits (triggering a flush) rather than failing outright — up to a configurable timeout.
+
+## 💻 Usage
+
+The cache itself is internal plumbing — application code never calls into it directly. What you control is its size and the timeouts around it, at engine startup:
+
+```csharp
+services.AddResourceRegistry();
+services.AddMemoryAllocator();
+services.AddEpochManager();
+
+services
+    .AddManagedPagedMMF(options =>
+    {
+        options.DatabaseName = "GameWorld";
+        options.DatabaseCacheSize = 64 * 1024 * 1024; // 64 MiB = 8192 pages
+    })
+    .AddDatabaseEngine(options =>
+    {
+        options.Timeouts.PageCacheBackpressureTimeout = TimeSpan.FromSeconds(10);
+    });
+
+var dbe = services.BuildServiceProvider().GetRequiredService<DatabaseEngine>();
+
+try
+{
+    // normal ECS/transaction work — the cache is transparent below this layer
+}
+catch (PageCacheBackpressureTimeoutException ex)
+{
+    // every page was dirty or actively in use; the working set didn't fit the cache
+    log.LogWarning(ex, "page cache backpressure: {Dirty} dirty, {Pinned} pinned",
+        ex.DirtyPageCount, ex.EpochProtectedCount);
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `PagedMMFOptions.DatabaseCacheSize` (via `AddManagedPagedMMF`) | 2 MiB (256 × 8 KiB) | Total cache capacity; must be a multiple of 8 KiB, between 2 MiB and 4 GiB |
+| `ResourceOptions.PageCachePages` / `MaxPageCachePages` | 256 / 16384 | Budget bookkeeping consumed by `ResourceOptions.Validate()` — not auto-synced with `DatabaseCacheSize`; keep both consistent yourself |
+| `TimeoutOptions.PageCacheBackpressureTimeout` | 5 s | Max wait for a page to free up before `PageCacheBackpressureTimeoutException` |
+| `TimeoutOptions.PageCacheLockTimeout` | 5 s | Max wait on a page state-transition lock |
+
+## ⚠️ Guarantees & limits
+
+- A page actively being read or written can never be evicted out from under the caller — eviction only ever takes unprotected, clean slots.
+- Eviction is O(1) amortized: clock-sweep finds a candidate within a couple of sweeps at most, no per-access list maintenance.
+- The second-chance counter (cap 5) gives hot pages (e.g. B+Tree roots) natural protection without manual pinning or priority tuning — a page can survive up to 5 sweeps before becoming evictable.
+- Sequential file-page access tends to land in contiguous cache memory, batching what would otherwise be many small I/Os into one.
+- Hard constraint: a single transaction's *working set* (distinct pages touched) must fit within the configured cache. If it doesn't, every resident page ends up pinned by that one transaction and allocation deadlocks until `PageCacheBackpressureTimeout` fires. Size the cache to the largest expected transaction, not the average.
+- Cache size is fixed for the life of the open database (2 MiB–4 GiB, multiple of 8 KiB) — no dynamic resizing while running.
+
+## 🧪 Tests
+
+- [PagedMMFTests](../../../test/Typhon.Engine.Tests/Storage/PagedMMFTests.cs) — `SequentialWrites` (contiguous mem-pages batch into a single disk write), `ReliabilityTest` (concurrent read/write under deliberate cache pressure, forcing repeated clock-sweep eviction)
+
+## 🔗 Related
+
+- Sibling: [Epoch-Based Page Protection & Dirty-Page Tracking](epoch-dirty-tracking.md) — the four eviction-safety signals layered on top of this cache
+- Sibling: [Page Integrity — CRC32C, Seqlock Snapshots & A/B Page Pairing](page-integrity.md) — CRC verification runs on every cold page load into this cache
+
+<!-- Overview: claude/overview/03-storage.md §3.1 (PagedMMF cache architecture) -->
+<!-- Design: claude/design/Storage/PageCache/02-page-states.md (state machine, eviction predicate) -->
+<!-- Design: claude/design/Storage/PageCache/03-clock-sweep.md (clock-sweep algorithm in detail) -->
+<!-- ADRs: claude/adr/006-8kb-page-size.md, claude/adr/007-clock-sweep-eviction.md, claude/adr/009-pinned-memory-unsafe-code.md -->

--- a/doc/feature-set/Storage/page-compression-future.md
+++ b/doc/feature-set/Storage/page-compression-future.md
@@ -1,0 +1,46 @@
+# Page Compression (Future)
+> Planned LZ4-style adapter for cold/historical data and backups — deliberately absent from v1 to protect microsecond-latency paths.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+Uncompressed pages cost disk space and I/O bandwidth proportional to raw data size. For cold/historical data, string-heavy tables, and backup snapshots, that cost is real money and real restore time — and none of it sits on the real-time hot path. Today Typhon stores every page as-is; there is no way to trade CPU for size on the data that would actually benefit (rarely-touched archives, large string tables, offline backups) without also paying that cost on the live game-state pages that must stay within microsecond latency budgets.
+
+## ⚙️ How it works (in brief)
+
+The planned design slots a `CompressionAdapter` between `ChunkBasedSegment`/`PagedMMF` and the OS file layer: pages are compressed (LZ4-class) just before the write to disk and decompressed just after the read, with the adapter maintaining the logical-page → compressed-block mapping. The page cache, segments, and chunk accessors above the adapter are unaware it exists — they keep working with full, uncompressed 8 KiB pages in memory; compression only ever touches the on-disk representation. The intent is opt-in, scoped to specific segments or storage tiers (cold data, backups) rather than a database-wide switch, so hot real-time tables are never forced through a compress/decompress cycle.
+
+## 💻 Usage
+
+Not implemented in the current release — there is no API to enable or configure compression today. Pages are always stored uncompressed, on every segment, with no opt-in switch. The sketch below shows the *intended* shape of the feature once built, for planning purposes only; none of this compiles against today's API:
+
+```csharp
+// Illustrative only — not a real/current Typhon API.
+// services
+//     .AddManagedPagedMMF(options =>
+//     {
+//         options.DatabaseName = "GameWorld";
+//     })
+//     .AddDatabaseEngine(options =>
+//     {
+//         // Planned: per-segment or per-tier opt-in, not a global flag —
+//         // so hot real-time tables stay uncompressed by default.
+//         // options.Storage.Compression = CompressionPolicy.ColdTierOnly;
+//     });
+```
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** Nothing in `src/Typhon.Engine/Storage` performs compression today; every page is written and read as raw bytes.
+- When built, it is expected to be opt-in per segment/tier — real-time game-state paths (small, high-entropy components like position/velocity/health) are expected to stay uncompressed by default, since LZ4-class ratios on that kind of data are poor (roughly 1.1–1.3x) for measurable added latency.
+- Expected costs once implemented, order of magnitude: +1–5 µs/page on read (decompression), +2–10 µs/page on write (compression) — acceptable for batch/cold/backup paths, not for the live hot path.
+- Best-fit candidates: cold/historical data, string-heavy tables (3–5x expected ratio), backup/snapshot storage. Not intended for live component pages.
+- No file-format or API commitment exists yet — names, option shapes, and the exact adapter boundary in this document are a design sketch, not a spec; treat them as subject to change when this is actually designed.
+
+## 🔗 Related
+
+- Related feature: [Memory-Mapped Page Cache & Clock-Sweep Eviction](./page-cache.md) (the layer the adapter would slot beneath)
+- Related feature: [String Table Storage](./string-table.md) (a candidate use case — high expected compression ratio)
+
+<!-- Overview: claude/overview/03-storage.md §3.10 Compression (Future) -->

--- a/doc/feature-set/Storage/page-integrity.md
+++ b/doc/feature-set/Storage/page-integrity.md
@@ -1,0 +1,75 @@
+# Page Integrity — CRC32C, Seqlock Snapshots & A/B Page Pairing
+> Every 8 KiB page is checksummed, torn writes are detected, and structural pages survive a power cut without ever repairing a byte.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+An 8 KiB page spans two 4 KB device blocks; on commodity NVMe an 8 KiB write is not atomic, so a power cut mid-write can leave a page half-old, half-new. Left undetected, that torn page silently feeds wrong bytes into the engine. Detecting it requires a checksum verified on every load; *repairing* it without a doubled write cost requires either a before-image (the old Full-Page-Image design) or — Typhon's choice — rebuilding the page from elsewhere. Two page classes need different answers: derived pages (indexes, occupancy) can always be thrown away and recomputed, but a handful of structural pages (the file's root meta, segment directories) have no "elsewhere" to rebuild from and must instead never lose their last good copy.
+
+## ⚙️ How it works (in brief)
+
+Every page header carries a CRC32C checksum (`PageChecksum`) computed over the whole page except the checksum field itself, verified lazily the first time a page is touched after load. The checkpoint also needs to copy a page that a transaction might be mid-write on without blocking either side: a seqlock counter (`ModificationCounter`) is bumped odd→even around every exclusive-latched write, and the checkpoint's snapshot copy retries if the counter changed or was odd during the copy — so the copy it CRCs and persists is always self-consistent. For the structural pages that can't be derived-and-rebuilt (the root meta page, segment directory pages), a third mechanism — A/B slot pairing — keeps two physical copies and always writes to the *other* one, bumping a generation counter; the currently-valid slot is never touched, so a torn write can never destroy the only good copy.
+
+## 💻 Usage
+
+CRC verification and torn-page response are configured at engine startup; the slot-pairing and seqlock machinery are fully internal (no API surface):
+
+```csharp
+services
+    .AddManagedPagedMMF(options =>
+    {
+        options.DatabaseName = "GameWorld";
+    })
+    .AddDatabaseEngine(options =>
+    {
+        // OnLoad (default): verify every page's CRC the first time it's touched after load.
+        // RecoveryOnly: skip on normal operation, verify only during crash recovery (lower steady-state overhead).
+        options.Resources.PageChecksumVerification = PageChecksumVerification.OnLoad;
+    });
+
+var dbe = services.BuildServiceProvider().GetRequiredService<DatabaseEngine>();
+
+try
+{
+    // normal ECS/transaction work — CRC verification runs transparently on page load
+}
+catch (PageCorruptionException ex)
+{
+    // a primary page failed CRC outside of crash recovery — torn/corrupted, no on-load repair
+    log.LogCritical(ex, "page {Page} CRC mismatch: stored=0x{Expected:X8} computed=0x{Computed:X8}",
+        ex.PageIndex, ex.ExpectedCrc, ex.ComputedCrc);
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `ResourceOptions.PageChecksumVerification` | `OnLoad` | `OnLoad` verifies CRC on every cold page load (~0.4 µs/page, hardware CRC32C); `RecoveryOnly` skips it in normal operation and verifies only during crash recovery |
+
+A third mode, `RecoverySuspect`, exists only on the crash-recovery path — the engine switches into it automatically while replaying and restores the configured mode once recovery completes; it is not a setting application code chooses.
+
+## ⚠️ Guarantees & limits
+
+- Every page's CRC32C is checked the first time it's accessed after a cold load (`OnLoad` mode, the default); a mismatch outside of recovery throws `PageCorruptionException` rather than silently serving torn bytes.
+- CRC32C is hardware-accelerated (SSE4.2/ARMv8 CRC32 instruction) — roughly 0.4 µs per 8 KiB page; `RecoveryOnly` mode trades that cold-load cost away when an application is willing to defer all detection to crash recovery.
+- The checkpoint never persists a torn snapshot of a page being concurrently written: the seqlock retry loop guarantees the copy it checksums and writes is from a single consistent write, not a half-old/half-new blend.
+- Derived structures (secondary indexes, occupancy bitmap) are never repaired in place on a CRC failure — they're discarded and rebuilt from primary data during recovery; this is intentionally simpler and cheaper than per-page repair.
+- The structural pages that *can't* be rebuilt (root meta, segment directories) are protected by A/B pairing instead: a torn write can corrupt only the non-current slot, so the currently-valid copy always survives. If — and only if — *both* slots of a pair are CRC-invalid, the open fails loudly rather than silently picking a corrupt one.
+- A primary data page (component/revision content, EntityMap, etc.) that fails CRC during recovery and still backs live data is **not** silently healed — the open fails loudly naming the page, rather than serving possibly-wrong bytes. This is a deliberate trade: an uncovered torn primary page is genuinely lost data, and refusing to open is the honest outcome.
+- There is no full-page-image (FPI) repair path — it was retired in favor of this rebuild-or-loud-fail model; checkpoint cost no longer includes a before-image write per dirtied page.
+
+## 🧪 Tests
+
+- [PageCrcVerificationTests](../../../test/Typhon.Engine.Tests/Durability/PageCrcVerificationTests.cs) — `OnLoad` vs `RecoveryOnly` verification modes, `PageCorruptionException` on a genuine mismatch
+- [SeqlockProtocolTests](../../../test/Typhon.Engine.Tests/Durability/SeqlockProtocolTests.cs) — `ModificationCounter` odd/even latch protocol, checkpoint snapshot consistency under concurrent writers
+- [DirectoryPairTests](../../../test/Typhon.Engine.Tests/Storage/DirectoryPairTests.cs) — A/B slot pairing for segment-directory pages: torn-slot reopen selects the sibling, both-slots-corrupt fails loudly
+- [MetaPairTests](../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/MetaPairTests.cs) — the same A/B pairing guarantees applied to the root meta page
+
+## 🔗 Related
+
+- Related feature: [Page Allocation & Occupancy Tracking](./page-allocation-occupancy.md) (an example derived structure healed by rebuild, not repair)
+
+<!-- Overview: claude/overview/03-storage.md — Page Checksums, Seqlock & CRC Integration -->
+<!-- Overview: claude/overview/06-durability.md §6.6 Torn-Page Safety, §6.7 Page Checksums & Seqlock Snapshots -->
+<!-- ADR: claude/adr/015-crc32c-page-checksums.md -->
+<!-- Rules: claude/rules/durability.md — modules CK-05 (A/B pairing), RB-01/RB-04 (rebuild-or-loud-fail), SQ-01..06 (seqlock) -->

--- a/doc/feature-set/Storage/pluggable-storage-backend/README.md
+++ b/doc/feature-set/Storage/pluggable-storage-backend/README.md
@@ -1,0 +1,54 @@
+# Pluggable Storage Backend (Persistent vs Transient)
+> One set of segment/index code, JIT-specialized per backend, so `Transient` components get heap speed for free.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Storage](../README.md)
+
+## 🎯 What it solves
+
+Every Typhon data structure — segments, B+Trees, hash maps, chunk accessors — needs to read and write 8 KiB
+pages. For durable components those pages live in the memory-mapped file and carry dirty tracking, eviction,
+and CRC protection; for `StorageMode.Transient` components (see [Storage Modes](../../Ecs/storage-modes/README.md))
+none of that applies — the data is heap-only and gone on restart by design. Forking the segment/B+Tree/hash-map
+implementations to get a fast heap-only path would double the maintenance surface and risk the two copies
+drifting. The pluggable storage backend lets one implementation serve both cases at full speed for each.
+
+## ⚙️ How it works (in brief)
+
+`IPageStore` is the abstraction every generic storage type is built against (`where TStore : struct, IPageStore`)
+— never as a runtime-polymorphic field. Because the constraint is a struct, not a class, the JIT compiles a
+fully specialized copy of `LogicalSegment<TStore>`, `ChunkBasedSegment<TStore>`, `ChunkAccessor<TStore>`,
+`BTree<TKey, TStore>`, etc. per concrete backend, with zero virtual dispatch. Two backends ship in-tree:
+`PersistentStore`, a one-line forwarding wrapper around the memory-mapped page cache, and `TransientStore`,
+a heap-only store backed by pinned memory blocks. `typeof(TStore)` checks in hot paths (e.g. dirty tracking)
+are constant-folded per specialization, so a `TransientStore` build of `ChunkAccessor` literally has no dirty-
+tracking instructions left in it — not a cheap no-op call, an absent one.
+
+## Sub-features
+
+| Sub-feature | Backs | Use it for |
+|-------------|-------|-----------|
+| [Persistent Store (MMF-backed)](./persistent-store.md) | `StorageMode.Versioned` / `SingleVersion` | Any durable component — the default path, selected automatically |
+| [Transient Store (heap-backed)](./transient-store.md) | `StorageMode.Transient` | Scratch data with `StorageMode.Transient` — tune via `TransientOptions` |
+
+## ⚠️ Guarantees & limits
+
+- `IPageStore` is `[PublicAPI]` for type-visibility reasons only — it is not meant for external implementation;
+  the two stores ship in-tree and selection is automatic from `StorageMode`, not something application code
+  chooses directly.
+- Backend selection is per-component, decided at `[Component(StorageMode = ...)]` registration — never mixed
+  within a single segment.
+- `PersistentStore` is `readonly struct` (8 bytes, one pointer) with every method `AggressiveInlining`-forwarded
+  to the page cache — the abstraction costs nothing over calling the page cache directly.
+- `TransientStore` trades the persistence guarantees away entirely in exchange for the no-op dirty-tracking path
+  — see the [Transient Store](./transient-store.md) page for what that costs you.
+
+## 🧪 Tests
+
+- [StorageModeInfrastructureTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeInfrastructureTests.cs) — per-component backend selection via `[Component(StorageMode = ...)]`; confirms Versioned/SV/Transient never share a segment
+
+## 🔗 Related
+
+- Related feature: [Storage Modes](../../Ecs/storage-modes/README.md) — the component-level decision this backend split exists to serve
+- Sub-features: [Persistent Store (MMF-backed)](./persistent-store.md), [Transient Store (heap-backed)](./transient-store.md)
+
+<!-- Deep dive: claude/design/Storage/PageCache/08-page-stores.md, claude/design/Storage/StorageModeGuide.md -->

--- a/doc/feature-set/Storage/pluggable-storage-backend/persistent-store.md
+++ b/doc/feature-set/Storage/pluggable-storage-backend/persistent-store.md
@@ -1,0 +1,64 @@
+# Persistent Store (MMF-backed)
+> The default backend — every durable component's segments run through the memory-mapped page cache at zero abstraction cost.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Storage](../README.md)
+
+## 🎯 What it solves
+
+`StorageMode.Versioned` and `StorageMode.SingleVersion` components need their pages backed by the durable,
+crash-recoverable memory-mapped file — dirty tracking, eviction protection, CRC verification, WAL/checkpoint
+integration, all of it. The persistent store is the backend that wires segments, B+Trees, and chunk accessors
+to that machinery, and it has to do so without adding a cent of overhead over calling the page cache directly,
+since this is the path nearly every component in a Typhon database takes.
+
+## ⚙️ How it works (in brief)
+
+`PersistentStore` is a `readonly struct` wrapping a single `ManagedPagedMMF` reference (8 bytes total — one
+pointer). Every `IPageStore` member is a one-line, `AggressiveInlining` forward to the underlying page cache
+(`RequestPageEpoch`, `IncrementDirty`, `TryLatchPageExclusive`, `AllocatePages`, …). Because the struct is
+`readonly` and every method inlines, the JIT produces the same assembly as if the segment code called the page
+cache directly — the generic `where TStore : struct, IPageStore` constraint costs nothing here. This is the
+backend selected for every component that isn't `StorageMode.Transient`.
+
+## 💻 Usage
+
+You never construct a `PersistentStore` yourself — it's selected automatically the moment a component uses the
+default storage mode (or explicitly `Versioned`/`SingleVersion`):
+
+```csharp
+[Component("Game.Inventory", 1, StorageMode = StorageMode.Versioned)]
+struct Inventory { public int Gold; }
+
+[Component("Game.Position", 1, StorageMode = StorageMode.SingleVersion)]
+struct Position { public float X, Y, Z; }
+
+// No StorageMode = Versioned by default — also routes through PersistentStore.
+[Component("Game.Tag", 1)]
+struct Tag { public int Value; }
+```
+
+What you actually configure is the page cache the store wraps — see
+[Memory-Mapped Page Cache & Clock-Sweep Eviction](../page-cache.md) for sizing and timeout options.
+
+## ⚠️ Guarantees & limits
+
+- Zero-cost abstraction: every method is an inlined forward, `readonly struct` avoids defensive copies — the
+  generated code for `LogicalSegment<PersistentStore>` matches hand-written non-generic page-cache calls.
+- Full durability surface: dirty tracking (`DirtyCounter`/`ActiveChunkWriters`), slot ref-counting, CRC
+  verification, and checkpoint coordination are all live — this is the only backend that participates in
+  WAL/checkpoint.
+- `MemPagesBaseAddress` is non-null and contiguous, letting `ChunkAccessor` reverse-map a raw pointer to a
+  memory-page index via pointer arithmetic — a path `TransientStore` cannot offer.
+- An escape hatch (`PersistentStore.Mmf`) exposes the wrapped `ManagedPagedMMF` for code that needs MMF-specific
+  APIs (`AllocateSegment`, `CreateChangeSet`, …) — internal engine plumbing, not an application-facing surface.
+
+## 🧪 Tests
+
+- [ManagedPagedMMFTests](../../../../test/Typhon.Engine.Tests/Storage/ManagedPagedMMFTests.cs) — segment/chunk allocation exercised directly through `PersistentStore` (every `AllocateSegment`/`AllocateChunkBasedSegment` call wraps one)
+
+## 🔗 Related
+
+- Related feature: [Memory-Mapped Page Cache & Clock-Sweep Eviction](../page-cache.md), [Epoch-Based Page Protection & Dirty-Page Tracking](../epoch-dirty-tracking.md)
+- Parent feature: [Pluggable Storage Backend](./README.md)
+
+<!-- Deep dive: claude/design/Storage/PageCache/08-page-stores.md — PersistentStore -->

--- a/doc/feature-set/Storage/pluggable-storage-backend/transient-store.md
+++ b/doc/feature-set/Storage/pluggable-storage-backend/transient-store.md
@@ -1,0 +1,81 @@
+# Transient Store (heap-backed)
+> Pinned heap blocks standing in for the page cache, so `Transient` components get raw-memory speed through the same segment code.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Storage](../README.md)
+**Assumes:** [Transient (Storage Mode)](../../Ecs/storage-modes/storage-mode-transient.md)
+
+## 🎯 What it solves
+
+`StorageMode.Transient` components (see [Transient](../../Ecs/storage-modes/storage-mode-transient.md))
+promise no durability cost at all — no WAL, no checkpoint, no dirty tracking. Routing them through the
+memory-mapped page cache would mean paying for (and then discarding) eviction bookkeeping and dirty-counter
+updates the data will never need. The transient store gives those components their own backend — plain pinned
+heap memory — so the cost genuinely disappears instead of just being hidden.
+
+## ⚙️ How it works (in brief)
+
+`TransientStore` allocates 8 KiB pages from pinned heap blocks (`TransientOptions.PagesPerBlock` pages per
+block, one `IMemoryAllocator.AllocatePinned` call per block) and maps file-page index directly to memory-page
+index — there is no cache layer to translate, and pages are never evicted once allocated. All dirty-tracking
+and slot-ref-counting members of `IPageStore` are empty method bodies; combined with `AggressiveInlining` and
+the generic specialization, the JIT removes those call sites entirely from `ChunkAccessor<TransientStore>` and
+friends rather than executing a cheap no-op. Page latching still uses a real per-page spinlock (concurrent
+B+Tree growth can race even on transient pages), just a lighter one than the persistent path — no seqlock, no
+torn-page repair, no state machine. Growth is capped: `AllocatePages` throws `InsufficientMemoryException` once
+the store would exceed its configured memory budget.
+
+## 💻 Usage
+
+You select the transient backend indirectly, by declaring a component `Transient`:
+
+```csharp
+[Component("Game.AnimState", 1, StorageMode = StorageMode.Transient)]
+struct AnimState
+{
+    public int ClipId;
+    public float Time;
+}
+```
+
+The one thing you do configure directly is the memory budget and block granularity, at engine startup:
+
+```csharp
+services.AddDatabaseEngine(options =>
+{
+    options.Transient.MaxMemoryBytes = 512 * 1024 * 1024; // default: 256 MB
+    options.Transient.PagesPerBlock  = 64;                // default: 32 (8 KiB pages -> 512 KiB/block)
+});
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `TransientOptions.MaxMemoryBytes` | 256 MB | Hard cap; `AllocatePages` throws `InsufficientMemoryException` once exceeded |
+| `TransientOptions.PagesPerBlock` | 32 (256 KiB/block) | Pages per pinned allocation call — larger reduces allocator overhead, wastes more for small stores |
+
+## ⚠️ Guarantees & limits
+
+- No durability whatsoever, by design: data lives only in pinned heap memory and is gone on process exit or
+  crash — there is no recovery path, not even a degraded one.
+- Dirty tracking, slot-ref counting, and CRC verification are compiled away, not skipped at runtime — the
+  `ChunkAccessor<TransientStore>` specialization has no instructions for them at all.
+- Pages are never evicted once allocated — the whole store must fit in `MaxMemoryBytes`; there is no spill-to-disk
+  fallback. Hitting the cap throws `InsufficientMemoryException` rather than degrading.
+- `MemPagesBaseAddress` is `null` — transient pages live in separate, non-contiguous heap blocks, so the
+  pointer-arithmetic reverse-mapping `PersistentStore` supports isn't available here (a `typeof(TStore)` branch
+  routes around it).
+- `GetOrAllocateDirectoryTwin` always returns "no twin" — transient segments are never persisted, so the
+  torn-write protection that exists for persistent segment-directory pages doesn't apply.
+- `TransientStore` itself is an internal type — application code configures it through `TransientOptions` and
+  `StorageMode.Transient`, never by constructing or implementing it directly.
+
+## 🧪 Tests
+
+- [TransientSegmentGrowthRegressionTests](../../../../test/Typhon.Engine.Tests/Storage/TransientSegmentGrowthRegressionTests.cs) — page-address stability across `TransientStore`'s internal array growth (a bug `PersistentStore`'s stable base pointer doesn't share)
+- [StorageModeInfrastructureTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeInfrastructureTests.cs) — `Transient`-declared components allocate transient segments/chunks and carry no WAL type id
+
+## 🔗 Related
+
+- Related feature: [Transient (Storage Mode)](../../Ecs/storage-modes/storage-mode-transient.md) — the component-level feature this backend powers
+- Parent feature: [Pluggable Storage Backend](./README.md)
+
+<!-- Deep dive: claude/design/Storage/PageCache/08-page-stores.md — TransientStore, TransientOptions -->

--- a/doc/feature-set/Storage/segment-chunk-allocation.md
+++ b/doc/feature-set/Storage/segment-chunk-allocation.md
@@ -1,0 +1,53 @@
+# Segment & Chunk-Based Allocation Engine
+> Multi-page directories and fixed-size slot allocation — the substrate every component, index, and revision chain is built from.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+A single 8 KiB file page is too small to hold a component table, a B+Tree index, or a revision chain — these structures span thousands of pages and grow as data accumulates. Something has to stitch many pages into one addressable, growable structure, and — for structures that store many same-size records (components, index entries, revision slots) — hand out and reclaim fixed-size slots within that structure without a linear scan or false sharing under concurrent access. The segment/chunk allocation engine is that substrate: every higher-level storage feature (component tables, B+Tree indexes, VSBS, archetype clusters) is built on it rather than reinventing multi-page addressing and slot bookkeeping itself.
+
+## ⚙️ How it works (in brief)
+
+A **logical segment** is a directory of file pages: the root page holds up to 2,000 page-index entries (the database's directory-only v4 root format — the root carries no data of its own, only the directory), and a chain of extension pages picks up beyond that. Two independent linked lists run through the page headers — one through directory pages, one through data pages — so the structure can grow incrementally without ever moving existing pages. A **chunk-based segment** layers fixed-stride slot allocation on top: each page keeps a persisted occupancy bitmap (1 bit per slot, the durable ground truth), while an in-memory forward linked list tracks which pages still have free slots, so an allocator can skip straight to a page with room instead of scanning every page. A magic-multiplier division replaces the page-locating arithmetic's integer divide with a multiply+shift. Both segment types grow automatically (capped-doubling) when capacity runs out. A **chunk accessor** is the per-call helper that turns a chunk ID into a live pointer — it keeps a small SIMD-searchable cache of recently touched pages so repeated access to the same handful of pages (typical of B+Tree descents) avoids re-resolving the page on every call.
+
+## 💻 Usage
+
+This is internal allocator infrastructure — application code never constructs a segment or calls `AllocateChunk` directly. Every `ComponentTable`, B+Tree index, VSBS, and archetype cluster acquires its pages and chunks transparently as you spawn entities and write components. The supported application-facing surface is read-only introspection over what the allocator has built:
+
+```csharp
+// Per-segment footprint and live chunk-allocator stats for every chunk-based segment.
+foreach (var seg in db.EnumerateStorageSegments().Where(s => s.IsChunkBased))
+{
+    Console.WriteLine(
+        $"{seg.Kind} root={seg.RootPageIndex} stride={seg.Stride}B pages={seg.Pages.Length} " +
+        $"capacity={seg.ChunkCapacity} used={seg.AllocatedChunkCount} free={seg.FreeChunkCount}");
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Chunk addressing is O(1): a magic-multiplier multiply+shift replaces the ~20–80 cycle integer divide that would otherwise be needed to locate a chunk's page.
+- Allocation is lock-free and near-constant time: ~2–3 `Interlocked` operations per successful `AllocateChunk`, walking only pages known to have free slots.
+- The per-page occupancy bitmap is the durable, persisted ground truth; the in-memory free-page list is rebuilt from it in O(pages) on database open — a crash can never leave allocator state that disagrees with what's on disk.
+- Growth is capped-doubling (geometric while small, additive beyond 1,024 pages) so a single grow request never demands an unreasonably large page-allocation burst.
+- Every segment spans at least 2 pages: the directory-only root carries no chunk data, so chunk 0 always lives on the first data page, not the root.
+- Minimum chunk stride is 8 bytes; chunk 0 of every chunk-based segment is reserved as a sentinel and is never handed out by `AllocateChunk`.
+- The chunk accessor's per-call page cache holds a bounded number of recently touched pages (SIMD-searched, clock-hand evicted) — it accelerates repeated access to the same pages within one call chain but is not a substitute for the page cache itself.
+- Not directly callable by application code — segment/chunk allocation is an internal primitive consumed by component tables, indexes, VSBS, and clusters; the only supported app-facing surface is read-only introspection (`EnumerateStorageSegments`).
+
+## 🧪 Tests
+
+- [ChunkAccessorTests](../../../test/Typhon.Engine.Tests/Storage/ChunkAccessorTests.cs) — SIMD-searchable MRU page cache, clock-hand eviction, exclusive latch acquire/release
+- [ChunkBasedSegmentBitmapL3Tests](../../../test/Typhon.Engine.Tests/Storage/ChunkBasedSegmentBitmapL3Tests.cs) — chunk allocate/free, L0/L1/L2 bitmap invariants, capacity growth
+- [ManagedPagedMMFTests](../../../test/Typhon.Engine.Tests/Storage/ManagedPagedMMFTests.cs) — `LogicalSegmentGrowTest`: directory-only v4 root growing into a map-extension chain
+
+## 🔗 Related
+
+- Related feature: [Page Allocation & Occupancy Tracking](page-allocation-occupancy.md) (the file-page-level allocator segments are built on top of)
+
+<!-- Deep dive: claude/design/Storage/PageCache/04-segments.md (LogicalSegment directory structure, growth, directory-only v4 root) -->
+<!-- Deep dive: claude/design/Storage/PageCache/05-chunk-allocator.md (forward linked-list allocator, L0 bitmap, AllocateChunk/FreeChunk algorithms) -->
+<!-- Reference: claude/design/Storage/database-file-format.md §5–6 (on-disk page layout for segments and chunks) -->
+<!-- Reference: claude/design/Storage/StackChunkAccessor.md (notes the superseded design; points to the live ChunkAccessor<TStore>) -->
+<!-- ADRs: claude/adr/008-chunk-based-segments.md (superseded), claude/adr/041-treiber-stack-chunk-allocator.md (superseded — documents the move away from the three-level bitmap, itself later replaced by the forward linked list), claude/adr/010-soa-simd-chunk-accessor.md (partially superseded — SOA+SIMD design rationale for the chunk accessor) -->

--- a/doc/feature-set/Storage/storage-introspection.md
+++ b/doc/feature-set/Storage/storage-introspection.md
@@ -1,0 +1,69 @@
+# Storage Introspection & Integrity Diagnostics
+> Read-only APIs that expose the database file's page/segment topology and audit it for corruption.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+Typhon's file is a graph of pages, segments and chunks that's normally opaque to application code — there's no SQL-style `pg_class` to ask "what owns page 1024?" or "is this file internally consistent?". Operators and tooling need that visibility for two distinct reasons: to *inspect* the file's physical layout (capacity planning, fragmentation, debugging a specific page/segment) and to *audit* it (verify occupancy bookkeeping, segment directories and chunk allocators agree with each other after a crash, a migration, or just as a health check). This feature exposes both without requiring any data-page I/O or blocking writers.
+
+## ⚙️ How it works (in brief)
+
+Every page in the file is classified into a `StoragePageType` (Root, Occupancy, Component, Revision, Index, Cluster, Vsbs, StringTable, Spatial, EntityMap, System, Free, Unknown), and every logical segment is described by a `StorageSegmentDescriptor` carrying its kind (`StorageSegmentKind`), the file pages it owns, and — for chunk-based segments — the stride/chunk-count layout constants needed to decode it further. All of this is derived purely from in-memory structures (the segment registry, the occupancy bitmap) — no page bodies are read. A separate integrity pass cross-checks these structures against each other (occupancy popcount vs. segment-claimed pages, forward chain vs. page directory, chunk free-list vs. chunk bitmaps) and reports every disagreement as a named, localized issue rather than a generic "corrupt" flag.
+
+## 💻 Usage
+
+```csharp
+var dbe = services.BuildServiceProvider().GetRequiredService<DatabaseEngine>();
+
+// 1. Segment topology — every live segment's kind, root page, and owned pages.
+IReadOnlyList<StorageSegmentDescriptor> segments = dbe.EnumerateStorageSegments();
+foreach (var seg in segments)
+{
+    Console.WriteLine($"root={seg.RootPageIndex} kind={seg.Kind} pages={seg.Pages.Length} " +
+                       $"chunks alloc={seg.AllocatedChunkCount}/{seg.ChunkCapacity}");
+}
+
+// 2. Per-page classification — one StoragePageType per file page.
+var pageCount = dbe.MMF.StorageFilePageCount;
+Span<StoragePageType> pageTypes = new StoragePageType[pageCount];
+dbe.ClassifyAllPages(pageTypes);
+
+// 3. Raw occupancy bits — one bit per file page, 1 = allocated.
+var words = new long[(dbe.MMF.OccupancyCapacityPages + 63) / 64];
+dbe.MMF.ReadOccupancyBits(words);
+
+// 4. Whole-engine integrity audit.
+StorageIntegrityReport report = dbe.RunStorageIntegrityCheck();
+if (!report.IsHealthy)
+{
+    foreach (var issue in report.Issues)
+    {
+        log.LogCritical("storage integrity: {Kind} segment={Segment} pages=[{First}..+{Count}] {Detail}",
+            issue.Kind, issue.SegmentRootPageIndex, issue.FirstPageIndex, issue.PageCount, issue.Detail);
+    }
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- All four entry points (`EnumerateStorageSegments`, `ClassifyAllPages`, `MMF.ReadOccupancyBits`, `RunStorageIntegrityCheck`) are read-only and touch only resident in-memory structures — no data-page I/O, safe to call on a live engine at any time, no write blocking.
+- `EnumerateStorageSegments` is authoritative: it walks the engine's segment registry directly, so every persistent segment kind (component, revision, index, cluster, VSBS, string-table, spatial, entity-map, occupancy, system) is attributed — no page should ever classify as `Unknown` on a healthy engine.
+- `ClassifyAllPages` requires a destination span of at least `MMF.StorageFilePageCount` entries; it throws `ArgumentException` otherwise.
+- `RunStorageIntegrityCheck` is the canary for two independent invariant classes: a **popcount canary** (occupancy bitmap set-bit count vs. every page claimed by a segment, its directory-extension pages, reserved roots, occupancy reserves, and directory twins) and **chunk-segment capacity** (`AllocatedChunkCount + FreeChunkCount == ChunkCapacity` per chunk-based segment). A non-empty `Issues` list is a hard structural/durability bug, not a soft warning — `IsHealthy` is the single assertion callers need.
+- The audit is best-effort under concurrency for chain/directory cross-checks (it runs under an epoch guard) but the popcount and chunk-capacity checks are point-in-time snapshots; running it against a database under heavy concurrent allocation can occasionally observe a transient mismatch that resolves on a re-run — a persistent mismatch is the signal to act on.
+- This is diagnostic surface, not a repair API: it reports issues, it does not fix them. Recovery / rebuild (occupancy re-derive, EntityMap rebuild, etc.) is a separate, crash-path mechanism.
+
+## 🧪 Tests
+
+- [StorageIntrospectionTests](../../../test/Typhon.Engine.Tests/Storage/StorageIntrospectionTests.cs) — segment enumeration, page classification (no page ever `Unknown`), occupancy-bit reads, and the zero-disk-read guarantee
+
+## 🔗 Related
+
+- Source: `src/Typhon.Engine/Storage/public/StorageMapTypes.cs` (`StoragePageType`, `StorageSegmentKind`, `StorageSegmentDescriptor`, `StorageIntegrityIssueKind`, `StorageIntegrityIssue`, `StorageIntegrityReport`)
+- Source: `src/Typhon.Engine/Ecs/public/DatabaseEngine.StorageIntrospection.cs` (`EnumerateStorageSegments`, `ClassifyAllPages`, `RunStorageIntegrityCheck`)
+- Source: `src/Typhon.Engine/Storage/internals/ManagedPagedMMF.StorageMap.cs` (`StorageFilePageCount`, `StoragePageSize`, `ReadOccupancyBits`)
+- Related feature: [Page Allocation & Occupancy Tracking](./page-allocation-occupancy.md) — the occupancy bitmap this feature reads and audits
+
+<!-- Deep dive: claude/design/Apps/Workbench/views/file-map.md — the Workbench Database File Map view this API powers -->
+<!-- Deep dive: claude/design/Storage/database-file-format.md — on-disk page/segment/chunk layout these types describe -->

--- a/doc/feature-set/Storage/string-table.md
+++ b/doc/feature-set/Storage/string-table.md
@@ -1,0 +1,59 @@
+# String Table Storage
+> UTF-8 string storage spread across linked fixed-size chunks, for strings too long to hold inline.
+
+**Status:** ✅ Implemented · **Visibility:** Internal · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+Inline fixed-width string fields (`String64`, 64 bytes) cover short identifiers and key-like strings, but plenty of string data — names, descriptions, paths, log messages — has no fixed upper bound and would either truncate or waste space if forced into a fixed-width slot. `StringTableSegment<TStore>` is the building block for storing strings of arbitrary length in the same chunk-based storage every other structure uses: a string is split across as many fixed-size chunks as it needs and reassembled on load, so storage cost scales with actual content size rather than a worst-case bound.
+
+## ⚙️ How it works (in brief)
+
+A string is UTF-8 encoded, then sliced into chunk-sized blocks; each chunk holds a small header (bytes remaining, next chunk id) plus its slice of the payload, with chunks linked forward into a chain. `StoreString` allocates the whole chain up front, writes the slices, and returns the id of the root chunk — that id is the string's handle. `LoadString` walks the chain from the root chunk, copying each slice into a buffer and decoding back to UTF-8 once the chain is exhausted. `DeleteString` walks the same chain, freeing each chunk back to the owning `ChunkBasedSegment`. The type is generic over `TStore : IPageStore`, so it works unmodified over both the persistent (MMF-backed) and transient (heap-backed) storage backends — see [Pluggable Storage Backend](pluggable-storage-backend/README.md).
+
+## 💻 Usage
+
+`StringTableSegment<TStore>` is `internal` engine plumbing — it sits directly on a `ChunkBasedSegment<TStore>` and is driven within an epoch scope, the same pattern used by every chunk-based structure:
+
+```csharp
+var segment = pagedMmf.AllocateChunkBasedSegment(PageBlockType.None, length: 10, stride: 64);
+
+var depth = epochManager.EnterScope();
+try
+{
+    var stringTable = new StringTableSegment<PersistentStore>(segment, epochManager);
+
+    int id = stringTable.StoreString("a string longer than one 64-byte chunk...");
+
+    string roundTripped = stringTable.LoadString(id);
+
+    stringTable.DeleteString(id);
+}
+finally
+{
+    epochManager.ExitScope(depth);
+}
+```
+
+The returned `int` (root chunk id) is the only handle needed to reload or delete a stored string later — callers persist that id wherever they'd otherwise store the string itself.
+
+## ⚠️ Guarantees & limits
+
+- Storage cost is proportional to actual UTF-8 byte length (rounded up to the chunk stride), not a fixed worst-case width — unlike `String64`.
+- No length cap other than the owning segment's available chunk capacity (which auto-grows).
+- Each `StoreString`/`LoadString`/`DeleteString` call must run inside an `EpochManager` scope, like any other chunk-accessor-driven operation.
+- Not indexable: there is no B+Tree variant over string-table content — use `String64` (see [B+Tree Key-Size Variants](../Indexing/btree-key-variants.md)) when a string needs to be a lookup key.
+- `internal` type — not exposed on the public API surface and not yet wired into the component schema's field type system (no variable-length string `FieldType` exists today); currently engine-internal infrastructure, exercised directly rather than through a component field.
+- Storing a string allocates its full chunk chain up front (no partial/streaming writes); deleting frees the whole chain in one call.
+
+## 🧪 Tests
+
+- [ManagedPagedMMFTests](../../../test/Typhon.Engine.Tests/Storage/ManagedPagedMMFTests.cs) — `StringTableTest`: store/load/delete round-trip of a string spanning multiple chained chunks
+
+## 🔗 Related
+
+- Related feature: [Segment & Chunk-Based Allocation Engine](segment-chunk-allocation.md) — the `ChunkBasedSegment<TStore>` this type is built on
+- Related feature: [Pluggable Storage Backend](pluggable-storage-backend/README.md) — the `TStore` generic backend it specializes over
+- Compare: [B+Tree Key-Size Variants](../Indexing/btree-key-variants.md) — `String64`, the fixed-width indexable alternative
+
+<!-- Deep dive: claude/overview/03-storage.md §3.8 -->

--- a/doc/feature-set/Storage/vsbs.md
+++ b/doc/feature-set/Storage/vsbs.md
@@ -1,0 +1,68 @@
+# Variable-Sized Buffer Storage (VSBS)
+> Linked-chunk buffer storage for variable-length, ref-counted data — the substrate behind per-entity collections and multi-value indexes.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Storage](./README.md)
+
+## 🎯 What it solves
+
+Components are fixed-size blittable structs stored SoA for cache-friendly iteration — there's no room in that layout for a naturally variable-length, per-entity list (an inventory, a tag set, a pending-event buffer). VSBS is the storage primitive that holds that kind of data outside the fixed-size record: the component embeds only a 4-byte buffer id, and the actual elements live in a pool sized to grow and shrink independently. The same mechanism also backs multi-value secondary index entries (`[Index(AllowMultiple = true)]`), where one key maps to many entity references.
+
+## ⚙️ How it works (in brief)
+
+A buffer is a forward-linked chain of fixed-size chunks holding elements of one uniform type; appending grows the chain by linking in another chunk — there's no copy of existing elements on grow, and no random-access API (only sequential enumeration). Every buffer carries a reference count. For `Versioned` components, overwriting a revision shares its `ComponentCollection<T>` buffer with the previous revision (`RefCounter > 1`) instead of deep-copying it; the first mutation through a shared buffer transparently clones it (copy-on-write), so older snapshots keep seeing the contents they originally referenced. `SingleVersion` components have exactly one owner, so their buffers are always mutated in place. Elements of a given CLR type all share one pool (segment kind `ComponentCollection`) — every `ComponentCollection<T>` field, across every component table, resolves to the same pool by `T` alone.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Player", revision: 1)]
+public struct PlayerComponent
+{
+    public int Health;
+    public ComponentCollection<int> Inventory;   // 4-byte buffer id — no inline storage
+}
+
+using var t = dbe.CreateQuickTransaction();
+var player = new PlayerComponent { Health = 100 };
+
+using (var inv = t.CreateComponentCollectionAccessor(ref player.Inventory))
+{
+    inv.Add(1001);   // item ids
+    inv.Add(1002);
+}
+
+var entityId = t.Spawn<PlayerArchetype>(PlayerArchetype.Player.Set(in player));
+t.Commit();
+
+// Later: read it back (read-only enumerator, no write lock taken)
+using var rt = dbe.CreateQuickTransaction();
+var loaded = rt.Open(entityId).Read(PlayerArchetype.Player);
+
+foreach (var itemId in rt.GetReadOnlyCollectionEnumerator(ref loaded.Inventory))
+{
+    Console.WriteLine(itemId);
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- Element type must be `unmanaged`, same blittability constraint as components.
+- Appending is amortized O(1) — bounded by occasional chunk allocation, never a full-buffer copy.
+- No random-element access by index; reading means sequentially enumerating the buffer (`GetAllElements` / the enumerator).
+- `Versioned` components get copy-on-write sharing automatically — the application never manages the ref-count directly; divergence cost is paid only on the first write to a shared buffer, not on every revision.
+- `SingleVersion` components mutate the buffer in place — cheapest path, no MVCC sharing applies.
+- **Crash safety caveat:** buffer *content* reaches disk only at the next checkpoint — collection writes are not WAL-redo-logged. A crash between a collection write and the following checkpoint can lose that write (the component's buffer id itself is recovered; the new elements are not). Collection durability is checkpoint-bounded, not commit-bounded — treat collections as you would deferred-durability data, not as commit-durable state.
+- `ComponentCollectionAccessor<T>` and the read-only enumerator are transaction-affine, like all other component access — use them only from the owning transaction's thread, and dispose them (`using`) to release the underlying chunk accessor.
+- Persists across reopen — pools reload as ordinary segments and component tables reconnect to existing buffer ids automatically.
+
+## 🧪 Tests
+
+- [ComponentCollectionTests](../../../test/Typhon.Engine.Tests/Data/ComponentCollectionTests.cs) — create/read/update, `RefCounter` sharing, copy-on-write clone-on-first-write, destroy frees the buffer
+- [ManagedPagedMMFTests](../../../test/Typhon.Engine.Tests/Storage/ManagedPagedMMFTests.cs) — low-level `VariableSizedBufferSegment` chain allocation, buffer cloning, and delete mechanics
+
+## 🔗 Related
+
+- Related feature: [Segment & Chunk-Based Allocation Engine](segment-chunk-allocation.md) (the chunk substrate VSBS chains are built from)
+
+<!-- Deep dive: claude/overview/03-storage.md §3.7 VariableSizedBufferSegment -->
+<!-- Deep dive: claude/overview/04-data.md §4.16 ComponentCollection Storage -->
+<!-- ADR: claude/adr/056-cluster-componentcollection-storage.md -->

--- a/doc/feature-set/Subscriptions/README.md
+++ b/doc/feature-set/Subscriptions/README.md
@@ -1,0 +1,31 @@
+# Subscriptions
+> Server-driven, View-based client state replication: the runtime publishes query Views, diffs them against connected clients' subscription sets each tick, and pushes a single MemoryPack-encoded `TickDelta` over TCP per client per tick — turning "subscribe to a query" into automatic incremental sync without the developer writing networking, change-detection, or serialization code.
+
+> 🔬 **Recommended:** Subscriptions doesn't have its own in-depth-overview chapter yet — read the Subscriptions section inside [in-depth-overview/09-querying.md](../../in-depth-overview/09-querying.md) (Chapter 09: Querying) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Published Views](published-views/README.md) | Register a query View as a subscribable target via `TyphonRuntime.PublishView`, as either one shared instance for all clients or a per-client factory | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Shared Views](published-views/shared-views.md) | One View instance, refreshed and diffed once per tick, fanned out to every subscriber | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Per-Client Views](published-views/per-client-views.md) | A `Func<ClientContext, ViewBase>` that builds a fresh, parameterized View for each subscriber | ✅ Implemented | 🔵 Core |
+| [Subscription Management (SetSubscriptions)](subscription-management/README.md) | Atomic, idempotent, diff-based API to set a client's full subscription list each tick — the runtime computes subscribed/unsubscribed/kept Views and applies the transition within one TickDelta | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Server-Driven Subscriptions (v1)](subscription-management/subscription-server-driven.md) | Game code calls `SetSubscriptions` whenever game state changes; the runtime applies the diff-based transition on the next tick | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Client-Initiated Subscriptions (v2)](subscription-management/subscription-client-initiated.md) | Clients request their own subscription changes via an `OnClientSubscriptionRequest` callback, validated server-side before being applied | 📋 Planned | 🟣 Advanced |
+| [Client Connections & Lifecycle](client-connections.md) | TCP listener thread accepts sockets and assigns each a `ConnectionId`; the public `ClientContext` is the only handle game code touches — connections, subscriber lists, and per-client Views are cleaned up automatically on disconnect | ✅ Implemented | 🔵 Core |
+| [Per-Tick Delta Computation & Encoding](delta-computation/README.md) | After `WriteTickFence`, the Output phase diffs published Views (ring buffer ∪ dirty-bitmap supplement) into Added/Removed/Modified and encodes only the changed component bytes | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Component-Level Dirty Encoding (v1)](delta-computation/delta-encoding-component-dirty.md) | Modified entities send full bytes for each component whose chunk was dirty this tick; unchanged components are omitted | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Per-Field Dirty Encoding (v1.1)](delta-computation/delta-encoding-per-field-dirty.md) | Planned output-phase field diffing to shrink Modified payloads to only the bytes of fields that actually changed; not implemented yet | 📋 Planned | 🟣 Advanced |
+| [Subscription Server Configuration](server-configuration.md) | Tunable knobs for the TCP subscription listener: port, max clients, per-client send buffer capacity, backpressure warning threshold, incremental sync batch size, and published-View ring buffer capacity | ✅ Implemented | 🔵 Core |
+| [Reference C# Client SDK](reference-client-sdk.md) | `Typhon.Client` connects over TCP, decodes `TickDeltaMessage`s, and maintains a per-View local entity cache that application code reads directly | ✅ Implemented | 🔵 Core |
+| [Published/System-Input View Separation Guard](published-view-isolation.md) | Runtime throws if a published View doubles as a system input (or vice versa), since the View's MPSC delta ring buffer can only have one consumer | ✅ Implemented | 🟣 Advanced |
+| [TCP Transport & Wire Format](wire-transport.md) | One length-prefixed, MemoryPack-serialized `TickDeltaMessage` per client per tick over TCP_NODELAY; steady-state shared-only clients get a single serialize-once frame memcpy'd to every matching send buffer instead of N serializations | ✅ Implemented | 🟣 Advanced |
+| [Incremental Sync](incremental-sync.md) | New subscriptions to large Views sync in tick-sized batches instead of one giant first delta | ✅ Implemented | 🟣 Advanced |
+| [Backpressure & Resync Recovery](backpressure-resync.md) | A full client send buffer drops one tick's delta and triggers an automatic full-state resync — never an unbounded queue | ✅ Implemented | 🟣 Advanced |
+| [Subscription Priority & Overload Throttling](priority-overload-throttling.md) | Critical/Normal/Low priority per published View; under overload Normal/Low Views are throttled while Critical Views always go out | ✅ Implemented | 🟣 Advanced |
+| [Subscription Telemetry & Tracing](subscription-telemetry.md) | Per-tick `OutputPhaseMs`/`DeltasPushed`/`OverflowCount` counters plus a live per-tick Output-phase trace span; the deeper per-subscriber dispatch span subtree (kinds 235-240) ships its wire format but has no producer wired yet | 🚧 Partial | 🟣 Advanced |
+
+## Internal Features
+
+*No internal-only engine machinery in this category — every feature here is directly reachable and usable by application code (server-side publish/subscribe API or the client-side wire protocol/SDK).*

--- a/doc/feature-set/Subscriptions/backpressure-resync.md
+++ b/doc/feature-set/Subscriptions/backpressure-resync.md
@@ -1,0 +1,71 @@
+# Backpressure & Resync Recovery
+> A full client send buffer drops one tick's delta and triggers an automatic full-state resync — never an unbounded queue.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+A client's network link can momentarily drain slower than the server produces deltas (a lag spike, a busy client thread, a saturated link). Without a bound, the server would have to choose between growing per-client memory without limit or blocking the tick on a slow socket — either one threatens the engine's real-time budget. Typhon instead caps per-client outbound memory, sacrifices one tick's delta for a stuck client, and recovers the client's state automatically — the application never has to detect or handle desync itself.
+
+## ⚙️ How it works (in brief)
+
+Each client has a fixed-capacity send buffer. As it fills, the server logs a warning past a configurable threshold but keeps enqueuing normally. If a tick's serialized `TickDeltaMessage` doesn't fit at all, that tick's delta is dropped for the client and the client is flagged for resync — no partial or torn writes. On the next tick, instead of an incremental delta, the affected View(s) send a `Resync` event followed by a full entity snapshot (batched across ticks via the same incremental-sync machinery as a fresh subscription, if the View is large). The client is expected to discard its local cache for that View and rebuild it from the snapshot.
+
+## 💻 Usage
+
+There's no resync-specific API — it's automatic backend behavior driven by `SubscriptionServerOptions` and observed via telemetry and the `Resync` event your client already handles:
+
+```csharp
+var options = new SubscriptionServerOptions
+{
+    SendBufferCapacity = 262_144,          // per-client send buffer, bytes
+    BackpressureWarningThreshold = 0.75f,  // fill ratio that triggers a log warning
+};
+
+// Client-side: Resync is just another EventType — handle it like a (re)subscribe.
+conn.OnTickDelta += tickDelta =>
+{
+    foreach (var evt in tickDelta.Events)
+    {
+        if (evt.Type == EventType.Resync) DiscardLocalCache(evt.ViewId);
+    }
+
+    foreach (var viewDelta in tickDelta.Views)
+    {
+        foreach (var added in viewDelta.Added) SpawnClientEntity(added); // resync snapshot arrives here too
+    }
+};
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `SendBufferCapacity` | 262144 (256 KB) | Per-client send buffer; overflow drops the tick and triggers resync |
+| `BackpressureWarningThreshold` | 0.75 | Fill ratio (0.0–1.0) at which a warning is logged; enqueueing continues |
+| `SyncBatchSize` | 200 | Entities per batch when a resync snapshot is large enough to need incremental delivery |
+
+## ⚠️ Guarantees & limits
+
+- **No unbounded growth** — a client that can't keep up never grows server memory past `SendBufferCapacity`; the cost of falling behind is a dropped tick, not a memory leak.
+- **Self-healing** — resync is fully automatic: the affected View's data is sent again (as a snapshot, batched if large) with no application code needed to detect or request it.
+- **Per-View granularity** — only the View(s) implicated by the overflow are resynced; other subscriptions on the same client continue with normal incremental deltas.
+- **Warning threshold is observational only** — crossing `BackpressureWarningThreshold` logs but never drops data or alters behavior; only a full buffer triggers resync.
+- **Telemetry-visible** — per-tick overflow counts are tracked so persistent backpressure on a client population is observable rather than silent.
+- **One dropped tick per overflow, not a stall** — the server never blocks the tick loop waiting for a slow client to drain; the I/O thread sends asynchronously regardless.
+
+## 🧪 Tests
+
+- [SubscriptionStressTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs) —
+  `Backpressure_SlowClient_TriggersResync`: a slow client with a small `SendBufferCapacity` overflows and gets
+  flagged for resync
+- [SendBufferTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SendBufferTests.cs) —
+  `TryWrite_ExceedsCapacity_Fails`/`FillPercentage_CorrectAtVariousLevels`: the overflow/threshold mechanics
+  underneath backpressure
+- [DeltaProcessingTests](../../../test/Typhon.Client.Tests/DeltaProcessingTests.cs) —
+  `Resync_ClearsCacheAndFiresCallback`: client-side handling of the `Resync` event
+
+## 🔗 Related
+
+- Related feature: [TCP Transport & Wire Format](./wire-transport.md), [Server-driven subscriptions](./subscription-management/subscription-server-driven.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Backpressure & Recovery -->
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Incremental Sync -->

--- a/doc/feature-set/Subscriptions/client-connections.md
+++ b/doc/feature-set/Subscriptions/client-connections.md
@@ -1,0 +1,80 @@
+# Client Connections & Lifecycle
+> Every accepted socket becomes a stable `ClientContext` handle, with disconnect cleanup handled automatically.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+Subscription delivery needs a server-side identity for "this specific client" that survives across ticks —
+something to hand to per-client View factories, to pass to `SetSubscriptions`, and to use for
+application-level player identity. Without it, every feature would have to invent its own socket-to-player
+mapping. Connections also need teardown: when a client disconnects, its View subscriptions and any per-client
+View instances must be released or they leak. Typhon owns both the identity and the teardown — game code only
+ever touches a `ClientContext`, never a socket.
+
+## ⚙️ How it works (in brief)
+
+A dedicated listener thread runs a `Socket.Accept()` loop on a dual-stack TCP/IPv6 socket. Each accepted
+connection gets `TCP_NODELAY` enabled and is assigned a process-lifetime-unique `ConnectionId` (monotonically
+increasing). The connection's public face is a `ClientContext` carrying that `ConnectionId` plus a free-form
+`UserData` slot the application can use for its own identity (player ID, auth token, anything). All
+subscription APIs (`SetSubscriptions`, per-client View factories) take `ClientContext`, never the underlying
+connection. When a client disconnects — detected either by a failed send on the I/O thread or as a dead-socket
+check during the Output phase — the runtime removes it from every `PublishedView`'s subscriber list, disposes
+its per-client Views, and evicts it from the connection registry, all without game code intervention.
+
+## 💻 Usage
+
+```csharp
+// The runtime hands a ClientContext to per-client View factories — this is the main
+// touchpoint where game code reads identity stashed on UserData.
+runtime.PublishView("my_inventory", (ClientContext client) =>
+{
+    using var tx = runtime.CreateSideTransaction();
+    int playerId = (int)client.UserData;   // populated by application/auth code
+    return tx.Query<InventoryArch>()
+        .WhereField<InventoryItem>(i => i.OwnerId == playerId)
+        .ToView();
+});
+
+// The same ClientContext is the key for subscription management — resolved internally
+// by ConnectionId, so passing a stale (disconnected) context is a safe no-op.
+runtime.SetSubscriptions(client, worldStatePub, inventoryPub);
+```
+
+| Option (`SubscriptionServerOptions`) | Default | Effect |
+|---|---|---|
+| `Port` | 9000 | TCP listen port (dual-stack IPv6/IPv4) |
+| `MaxClients` | 0 (unlimited) | Connections beyond this are refused at accept time, before a `ClientContext` is created |
+
+## ⚠️ Guarantees & limits
+
+- `ConnectionId` is a monotonically increasing `int`, unique for the server process's lifetime — not reused,
+  not persisted across restarts.
+- `UserData` is an untyped `object` slot Typhon never reads or interprets; populating, casting, and validating
+  it is entirely the application's responsibility.
+- An accepted connection is implicitly trusted — v1 has no built-in authentication or TLS (see
+  [TCP Transport & Wire Format](./wire-transport.md)).
+- Disconnect cleanup (subscriber-list removal, per-client View disposal, registry eviction) runs exactly once
+  per connection — `ClientConnection.Dispose` is idempotent, so a race between the I/O thread and the Output
+  phase detecting the same disconnect cannot double-clean.
+- `SetSubscriptions(client, ...)` silently no-ops if the connection behind `client` was already torn down —
+  callers don't need to guard every call with a liveness check.
+- No public "client connected" notification exists yet in v1 — a `ClientContext` only reaches game code via a
+  per-client View factory call or as the argument to a `SetSubscriptions` call already in flight. There is no
+  hook to run application code exactly once at accept time.
+
+## 🧪 Tests
+
+- [SubscriptionIntegrationTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionIntegrationTests.cs)
+  — `Client_Connects_And_ReceivesTickDelta_WithSpawnedEntity`: accept → `ClientContext` → subscribe → receive,
+  end to end over a real socket
+- [SubscriptionStressTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs) —
+  `RapidConnectDisconnect_NoServerCrash`: concurrent connect/disconnect churn exercises the idempotent cleanup path
+
+## 🔗 Related
+
+- Related feature: [Published Views](./published-views/README.md), [Server-driven subscriptions](./subscription-management/subscription-server-driven.md), [TCP Transport & Wire Format](./wire-transport.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Connection Lifecycle -->
+<!-- Deep dive: claude/overview/13-runtime.md — Subscription Server -->

--- a/doc/feature-set/Subscriptions/delta-computation/README.md
+++ b/doc/feature-set/Subscriptions/delta-computation/README.md
@@ -1,0 +1,61 @@
+# Per-Tick Delta Computation & Encoding
+> Each tick, the engine figures out exactly what changed in a published View and encodes only that.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+A client cache only needs three things per tick: what entered, what left, and what changed on entities that
+stayed. Computing that diff against the previous tick — across every component, including changes that never
+touch an indexed field — is exactly the kind of bookkeeping a game developer should never write by hand.
+`Per-Tick Delta Computation & Encoding` is the step that turns a published View's raw state into that
+Added/Removed/Modified triple and puts only the changed bytes on the wire, with zero query code from the
+developer.
+
+## ⚙️ How it works (in brief)
+
+After `WriteTickFence`, the Output phase refreshes every published View and reads two sources of change: the
+View's own ring buffer (entities whose `[Index]`-marked fields changed) and `PreviousTickDirtyBitmap` (every
+SV/Transient component chunk written this tick, indexed or not). The union becomes the View's Modified set —
+this is what makes "any field changed" detection work, not just indexed ones. For each Modified entity, only
+the components whose chunk was actually dirty are read and encoded; untouched components on the same entity
+are omitted entirely. Added entities get a full component snapshot; Removed entities are just an ID. The
+result is handed to the wire-transport layer for serialization (see [TCP Transport & Wire
+Format](../wire-transport.md)) — this feature stops at "what bytes represent this change," not how they
+travel.
+
+## Sub-features
+
+| Sub-feature | Status | Use it for |
+|-------------|--------|-----------|
+| [Component-Level Dirty Encoding (v1)](./delta-encoding-component-dirty.md) | ✅ Implemented | Default behavior today — every Modified entity sends full bytes for each dirty component |
+| [Per-Field Dirty Encoding (v1.1)](./delta-encoding-per-field-dirty.md) | 📋 Planned | Future bandwidth optimization — send only the fields that actually changed within a dirty component |
+
+## ⚠️ Guarantees & limits
+
+- **Modified detection covers all field changes, not just indexed ones** — the `PreviousTickDirtyBitmap`
+  supplement exists specifically because the View ring buffer only fires for `[Index]`-marked fields.
+- **Per-component filtering, not per-entity** — a Modified entity only carries the components whose chunk was
+  dirty this tick; components that didn't change are never serialized even if the entity itself did change.
+- **Delta computation happens once per View, not once per client** — every subscriber to a shared View reuses
+  the same Added/Removed/Modified result; cost scales with View size and change volume, not subscriber count.
+- **Versioned components are read unconditionally** for Modified entities — they have no `DirtyBitmap`, so the
+  encoder includes them whenever the entity is in the Modified set rather than risk omitting a real change.
+- This feature only determines *what* changed and produces the wire structs — see [TCP Transport & Wire
+  Format](../wire-transport.md) for serialization, framing, and delivery.
+
+## 🧪 Tests
+
+- [ViewDeltaTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs) —
+  `DeltaBuilder_SharedView_ProducesCorrectDelta`/`DeltaBuilder_SecondCall_OnlyNewEntities`: Added/Modified/Removed
+  computed once per View, not once per client
+- [SubscriptionStressTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs)
+  — `HighEntityChurn_SpawnDestroy_DeltasConsistent`: sustained spawn/destroy churn under an active subscription
+
+## 🔗 Related
+
+- Related feature: [Shared Views](../published-views/shared-views.md), [TCP Transport & Wire Format](../wire-transport.md)
+- Sub-features: [Component-Level Dirty Encoding (v1)](./delta-encoding-component-dirty.md), [Per-Field Dirty Encoding (v1.1)](./delta-encoding-per-field-dirty.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Modified Entity Detection, Message Format -->
+<!-- Deep dive: claude/overview/13-runtime.md — Subscription Server -->

--- a/doc/feature-set/Subscriptions/delta-computation/delta-encoding-component-dirty.md
+++ b/doc/feature-set/Subscriptions/delta-computation/delta-encoding-component-dirty.md
@@ -1,0 +1,73 @@
+# Component-Level Dirty Encoding (v1)
+> Today's wire encoding: a Modified entity sends the full bytes of every component that actually changed.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+When an entity in a subscribed View changes, the client needs the new data — but sending every component on
+that entity, every tick, wastes bandwidth on fields that didn't move. Component-level dirty encoding gives a
+middle ground that needs no extra developer effort: skip components that weren't touched, but don't try to
+track which individual fields inside a touched component changed (that's the v1.1 follow-up). It's the
+encoding that ships today and the one every client/server pair on v1 should assume.
+
+## ⚙️ How it works (in brief)
+
+For each Modified entity, the encoder walks its enabled component slots and includes only the ones whose
+storage chunk was marked dirty this tick (via `PreviousTickDirtyBitmap`); Versioned components have no dirty
+bitmap and are always included when the entity is Modified. Each included component is wire-encoded as a
+`ComponentFieldUpdate` with `FieldDirtyBits = ~0UL` (all bits set) and `FieldValues` holding the component's
+complete raw bytes. The all-bits-set convention is what makes this forward-compatible: a client that only
+understands "read the bitmask, then read the bytes it covers" works unmodified once the bitmask ever becomes
+sparse — see [Per-Field Dirty Encoding (v1.1)](./delta-encoding-per-field-dirty.md).
+
+## 💻 Usage
+
+This is the only Modified-encoding path today — there is no opt-in/opt-out switch. It applies automatically
+to every `Modified` entry your client receives:
+
+```csharp
+conn.OnTickDelta += tickDelta =>
+{
+    foreach (var viewDelta in tickDelta.Views)
+    {
+        foreach (var modified in viewDelta.Modified)
+        {
+            foreach (var update in modified.ChangedComponents)
+            {
+                // v1: FieldDirtyBits is always ~0UL — FieldValues is the full component struct.
+                // Forward-compatible clients should still branch on FieldDirtyBits rather than
+                // assuming "full struct" outright, since v1.1 will start sending sparse bitmasks.
+                ApplyComponent(modified.Id, update.ComponentId, update.FieldValues);
+            }
+        }
+    }
+};
+```
+
+## ⚠️ Guarantees & limits
+
+- **Whole-component granularity** — if any field in a component changed, the entire component's bytes are
+  sent; there is no partial-component savings yet.
+- **`FieldDirtyBits` is always `~0UL`** — clients must not hardcode "ignore the bitmask," since it will carry
+  real per-field information once v1.1 ships; reading it now costs nothing and avoids a future client rewrite.
+- **Unchanged components are omitted** — a Modified entity with five components but only one dirty chunk
+  sends one `ComponentFieldUpdate`, not five.
+- **Cost is proportional to dirty components, not entity count** — roughly 10-30µs to serialize ~200 Modified
+  entities with ~2 dirty components each (~64 bytes per component), per the design doc's measured figures.
+
+## 🧪 Tests
+
+- [ProtocolTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ProtocolTests.cs) —
+  `ComponentFieldUpdate_AllFieldsDirty_V1Format`: verifies the v1 wire convention (`FieldDirtyBits = ~0UL`, full
+  component bytes)
+- [ViewDeltaTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs) —
+  `DeltaBuilder_SharedView_ProducesCorrectDelta`: Added entities carry full component snapshot bytes
+
+## 🔗 Related
+
+- Code: `ComponentFieldUpdate` (`src/Typhon.Protocol/ComponentFieldUpdate.cs`), `EntityUpdate` (`src/Typhon.Protocol/EntityUpdate.cs`)
+- Parent feature: [Per-Tick Delta Computation & Encoding](./README.md)
+- Sibling: [Per-Field Dirty Encoding (v1.1)](./delta-encoding-per-field-dirty.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Modified Entity Encoding — Component-Level Dirty (v1) -->

--- a/doc/feature-set/Subscriptions/delta-computation/delta-encoding-per-field-dirty.md
+++ b/doc/feature-set/Subscriptions/delta-computation/delta-encoding-per-field-dirty.md
@@ -1,0 +1,65 @@
+# Per-Field Dirty Encoding (v1.1)
+> Planned: shrink Modified updates further by sending only the fields that changed inside a dirty component.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+[Component-Level Dirty Encoding (v1)](./delta-encoding-component-dirty.md) already skips components that
+didn't change, but a component with ten fields where only one moved still sends all ten. For wide components
+that change one field at a time (a position component where only `Y` ticks, a stats block where only `Mana`
+regenerates), that's bandwidth spent on bytes the client already has. Per-field dirty encoding is the planned
+follow-up: shrink the payload to just the changed fields, with no wire-format migration needed because the
+format was designed for this from the start.
+
+## ⚙️ How it works (in brief)
+
+The plan is an output-phase diff: the runtime would keep the previous tick's component snapshot per published
+View and, for each Modified entity's dirty component, memcmp it field-by-field against that snapshot. Fields
+that differ set their bit in `FieldDirtyBits`; `FieldValues` would carry only the bytes for those fields,
+concatenated in field-index order, instead of the full struct. The cost lands entirely in the Output phase —
+no write-path overhead — and the design doc estimates roughly 60% bandwidth savings on Modified entities. The
+wire format already supports this without a protocol bump: `ComponentFieldUpdate.FieldDirtyBits` exists today
+and v1 already sets it (to `~0UL`); v1.1 only changes which bits get set and how much of `FieldValues` gets
+written.
+
+## 💻 Usage
+
+Not implemented — there is no separate API to enable this; it would replace how `FieldValues` is populated
+for existing Modified deltas. The current reference client (`src/Typhon.Client/ViewSubscription.cs`) is
+written to handle it once it lands:
+
+```csharp
+// Illustrative only — design complete, not implemented yet.
+// A forward-compatible client already keys off FieldDirtyBits, not "always full struct":
+foreach (var update in modified.ChangedComponents)
+{
+    if (update.FieldDirtyBits == ~0UL)
+    {
+        ApplyFullComponent(modified.Id, update.ComponentId, update.FieldValues);   // v1 path
+    }
+    else
+    {
+        ApplySparseFields(modified.Id, update.ComponentId, update.FieldDirtyBits, update.FieldValues); // v1.1 path
+    }
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** No code under `src/Typhon.Engine/Subscriptions` performs per-field diffing today;
+  `DeltaBuilder` always sets `FieldDirtyBits = ~0UL` and sends full component bytes (v1).
+- **No wire-format change required when it ships** — `ComponentFieldUpdate` already carries the bitmask field;
+  v1.1 is expected to be a server-side encoding change plus a client decode change, not a new message type.
+- **Expected scope: Output-phase diffing only** — the plan keeps one previous-tick snapshot per published
+  View; it does not propose any write-path instrumentation or per-field change tracking during simulation.
+- A client written against v1 that ignores `FieldDirtyBits` and always treats `FieldValues` as the full struct
+  will silently mis-decode once v1.1 ships — read the bitmask now to avoid a future client-side bug.
+
+## 🔗 Related
+
+- Code: `ComponentFieldUpdate` (`src/Typhon.Protocol/ComponentFieldUpdate.cs`) — the bitmask field this sub-feature would populate
+- Parent feature: [Per-Tick Delta Computation & Encoding](./README.md)
+- Sibling: [Component-Level Dirty Encoding (v1)](./delta-encoding-component-dirty.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Modified Entity Encoding (v1.1 planned), R-Q18, Scope (v1 / Demo) -->

--- a/doc/feature-set/Subscriptions/incremental-sync.md
+++ b/doc/feature-set/Subscriptions/incremental-sync.md
@@ -1,0 +1,88 @@
+# Incremental Sync
+> New subscriptions to large Views sync in tick-sized batches instead of one giant first delta.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+When a client subscribes to a View that already holds thousands of entities, sending the whole entity set
+in a single `TickDelta` would blow the per-tick output budget and stall every other client behind one large
+serialization. Incremental sync spreads that initial snapshot across as many ticks as it takes, so a new
+subscription never causes a latency spike — for everyone else, or for the subscribing client's own
+steady-state deltas once sync finishes.
+
+## ⚙️ How it works (in brief)
+
+On subscribe, the runtime snapshots the View's current entity set and walks it forward a fixed number of
+entities per tick, sending each chunk as a normal `Added` batch under a `Syncing` state. No `Modified` or
+`Removed` deltas are sent for that View while sync is in progress — entities that change mid-sync simply pick
+up their current values whenever their turn in the snapshot comes. Once the last batch is sent, the runtime
+flips the View to `Active` for that client and emits a `SyncComplete` event; normal `Added`/`Modified`/`Removed`
+deltas resume from the next tick. Small Views that fit in one batch sync and complete in the same tick. The
+same mechanism is reused for `Resync` recovery after a backpressure overflow (see
+[Backpressure & Resync Recovery](./backpressure-resync.md)).
+
+## 💻 Usage
+
+Incremental sync requires no special call — it activates automatically whenever `SetSubscriptions` adds a
+client to a View:
+
+```csharp
+var dungeonNpcs = runtime.PublishView("dungeon_npcs", dungeonNpcsView);
+runtime.SetSubscriptions(client, dungeonNpcs);   // sync begins next Output phase
+
+// Client-side: only act on the View once it reports SyncComplete
+conn.OnTickDelta += tickDelta =>
+{
+    foreach (var evt in tickDelta.Events)
+    {
+        if (evt.Type == EventType.SyncComplete)
+        {
+            MarkViewReady(evt.ViewId);   // safe to assume the local cache mirrors the server now
+        }
+    }
+
+    foreach (var viewDelta in tickDelta.Views)
+    {
+        foreach (var added in viewDelta.Added)
+        {
+            SpawnOrUpdateClientEntity(added);   // applies to both sync batches and steady-state Added
+        }
+    }
+};
+```
+
+| Option (`SubscriptionServerOptions`) | Default | Effect |
+|---|---|---|
+| `SyncBatchSize` | 200 | Max entities sent per `Added` batch per client per View per tick while syncing |
+
+## ⚠️ Guarantees & limits
+
+- **No interleaving** — a client never receives `Modified`/`Removed` deltas for a View while it is `Syncing`;
+  only `Added` batches and the terminal `SyncComplete` event.
+- **Consistent terminal state, not consistent snapshot** — the snapshot is captured once at subscribe time, but
+  individual entities are read (and their current data sent) lazily as their batch comes up, so an entity
+  changed mid-sync arrives with whatever state it has when its turn comes, not the state at subscribe time.
+- **Fixed batch size, not adaptive** — `SyncBatchSize` is a flat per-tick cap; it does not currently scale down
+  automatically under tick overload (see [Subscription Cost & Overload Integration](../../../claude/design/Subscriptions/05-subscriptions.md#subscription-cost--overload-integration)).
+  Tune it down if large syncs are pushing `OutputPhaseMs` over budget.
+- **Per-client, per-View state** — sync progress is tracked independently for each (client, View) pair; one
+  client mid-sync on a View does not block or slow other clients' deltas on the same View.
+- **Entity lifetime during sync is not guarded** — the sync snapshot is a fixed list of entity IDs captured at
+  subscribe time; an entity destroyed before its batch comes up is not specially handled, unlike the
+  steady-state delta path which only ever reports entities still present in the View.
+- **Memory cost is bounded by subscriber count, not View size growth** — the sync snapshot is a flat array of
+  entity IDs (not full component data) held only for the duration of that client's sync, and freed as soon as
+  the last batch ships.
+
+## 🧪 Tests
+
+- [ViewDeltaTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs) —
+  `SubscriptionFlow_EntitiesExistBeforeSubscribe_SyncCapturesThem`/`SubscriptionFlow_RefreshPopulatesView_ThenBeginSync_ThenBuildDelta_NoDoubleAdd`:
+  `BeginSync` snapshot capture and Output-phase ordering (no double-Added)
+
+## 🔗 Related
+
+- Related feature: [Subscription Management](./subscription-management/README.md), [Backpressure & Resync Recovery](./backpressure-resync.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Incremental Sync -->

--- a/doc/feature-set/Subscriptions/priority-overload-throttling.md
+++ b/doc/feature-set/Subscriptions/priority-overload-throttling.md
@@ -1,0 +1,62 @@
+# Subscription Priority & Overload Throttling
+> Tag Views Critical/Normal/Low so the server protects player-state delivery when the tick budget is blown.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+A loaded server can't always compute and push every subscription delta on time. Without a priority signal,
+the runtime would have to throttle everything equally — including the player-state View that the client's
+own UI depends on every tick. Priority lets the developer say up front which Views matter most, so when the
+engine's overload detector trips, throttling falls on world-flavor data (weather, ambient NPCs) first, never
+on gameplay-critical state.
+
+## ⚙️ How it works (in brief)
+
+Priority is set once, at `PublishView` time, and applies to all subscribers of that View — it is not
+per-client. The Output phase reads the runtime's current overload level each tick and decides, per published
+View, whether to skip delta computation/push for that tick. `Critical` Views are never skipped. `Normal` and
+`Low` Views are skipped on a tick-number modulus that gets stricter as overload climbs — the View's ring
+buffer still drains underneath (no missed-update bugs), only the push to clients is withheld, and the next
+non-skipped tick simply reports more accumulated change.
+
+## 💻 Usage
+
+```csharp
+runtime.PublishView("player_state", playerStateView, SubscriptionPriority.Critical);
+runtime.PublishView("world_npcs", npcView, SubscriptionPriority.Normal);   // default if omitted
+runtime.PublishView("weather", weatherView, SubscriptionPriority.Low);
+```
+
+| Overload level | Critical | Normal | Low |
+|---|---|---|---|
+| `Normal` | every tick | every tick | every tick |
+| `SystemThrottling` (1) | every tick | every tick | every 2nd tick |
+| `ScopeReduction` (2) | every tick | every 2nd tick | every 4th tick |
+| `TickRateModulation` (3) | every tick | every 2nd tick | every 4th tick |
+| `PlayerShedding` (4) | every tick | every 2nd tick | every 4th tick |
+
+## ⚠️ Guarantees & limits
+
+- `Priority` is fixed at publish time (`PublishView(..., SubscriptionPriority)`) — there is no per-client
+  override and no API to change a View's priority after publishing.
+- `Critical` Views are pushed every tick at every overload level, including `PlayerShedding` — this is the
+  guarantee the feature exists for.
+- Throttling only withholds the delta push; the View itself is still refreshed every tick (ring buffer
+  drained), so no Added/Removed/Modified entries are lost — a throttled tick's worth of changes is simply
+  folded into the next push.
+- At `PlayerShedding`, Normal/Low Views keep throttling at the same cadence as `ScopeReduction` — they are not
+  automatically paused. Shedding load further (e.g. dropping a client's non-critical subscriptions outright)
+  is left to game code via `TyphonRuntime.OnCriticalOverload`.
+- Overload level is a single, server-wide value driven by the scheduler's tick-budget detector — it is not
+  computed per client or per View beyond the priority comparison above.
+- Priority affects subscription push only; it has no effect on whether the View itself is queryable, indexed,
+  or usable as a system input elsewhere.
+
+## 🔗 Related
+
+- Related feature: [Published Views](./published-views/README.md)
+- Sibling: [Overload Management](../Runtime/overload-management.md) — the scheduler-side overload detector this feature's throttling levels key off
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Subscription Cost & Overload Integration -->
+<!-- Deep dive: claude/overview/13-runtime.md — Overload Management -->

--- a/doc/feature-set/Subscriptions/published-view-isolation.md
+++ b/doc/feature-set/Subscriptions/published-view-isolation.md
@@ -1,0 +1,53 @@
+# Published/System-Input View Separation
+> A View used to drive client subscriptions can never double as a system's query input, or vice versa.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+Subscriptions stream **incremental** deltas: a published View must accumulate every change made during a tick so the next Output-phase flush can compute exactly what changed since the last flush. If the same View instance were also consumed by a game system mid-tick (as a query input), that system would drain the View's pending change entries for its own use — leaving subscriptions with a gap, and the system with entries it didn't ask for. The two roles need two independent change streams, and Typhon enforces that at the API boundary instead of leaving it as a footgun.
+
+## ⚙️ How it works (in brief)
+
+Every `ViewBase` tracks whether it has been published (`PublishView`) or wired as a system's query input (`QuerySystem(..., input: ...)`). Whichever of these happens second checks the View's state and throws `InvalidOperationException` if the other role is already set. There is no way to "downgrade" a View back to neutral — once a View takes on a role, it keeps it for its lifetime. The fix is always the same: create a second View over the same query, one per role.
+
+## 💻 Usage
+
+```csharp
+// Two separate View instances over the same query — one per role.
+var npcViewForAI = tx.Query<NPC>().Where(n => n.Health > 0).ToView();
+var npcViewForSubs = tx.Query<NPC>().Where(n => n.Health > 0).ToView();
+
+dag.QuerySystem("AI", AiTick, input: () => npcViewForAI);
+runtime.PublishView("world_npcs", npcViewForSubs);   // OK — distinct instance
+
+// Reusing the system's input View for publishing throws InvalidOperationException:
+// runtime.PublishView("world_npcs", npcViewForAI);
+//   "Cannot publish View (ViewId=...) — it is already used as a system input.
+//    Published Views must be separate instances. Create a new View with the same query for subscriptions."
+
+// The reverse order throws too, when the DAG resolves:
+// runtime.PublishView("world_npcs", npcView);
+// dag.QuerySystem("AI", AiTick, input: () => npcView);
+//   "Input View (ViewId=...) is already published for subscriptions.
+//    Published Views must be separate instances from system input Views."
+```
+
+## ⚠️ Guarantees & limits
+
+- **Caught at setup, not at runtime corruption** — the violation throws `InvalidOperationException` as soon as the second role is assigned (publish call or DAG build), before any tick runs with the misconfigured View.
+- **One role per View, for its whole lifetime** — a View cannot be reassigned from published to system-input or back; create a new instance per role instead.
+- **No extra cost for the common case** — the check is two boolean reads at registration time; it does not affect per-tick delta computation.
+- Applies to both shared and per-client published Views — the per-client factory path always creates fresh `ViewBase` instances per subscriber, so this conflict only arises with shared Views and explicit system-input wiring.
+
+## 🧪 Tests
+
+- [ViewSeparationTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewSeparationTests.cs) —
+  `UseAsSystemInput_ThenPublish_Throws`/`PublishView_SameInstanceTwice_Throws` cover both violation directions;
+  `SeparateViewInstances_SameQuery_NoConflict` shows the correct fix (two instances)
+
+## 🔗 Related
+
+- Related feature: [Server-Driven Subscriptions (v1)](./subscription-management/subscription-server-driven.md), [Per-client View Factories](./published-views/per-client-views.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Published View Constraints, R-Q19 -->

--- a/doc/feature-set/Subscriptions/published-views/README.md
+++ b/doc/feature-set/Subscriptions/published-views/README.md
@@ -1,0 +1,60 @@
+# Published Views
+> Register a View as a subscribable target — one shared instance or one per client — and get a handle clients can subscribe to.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+Streaming live state to connected clients needs a server-side notion of "what is subscribable" that's
+independent of any one client's connection — a name clients reference, a priority for overload behavior, and a
+subscriber count for diagnostics. Without it, every feature wiring up client sync would invent its own
+ad-hoc registry of "queries clients can ask for." `PublishedView` is that registry entry: it wraps a query
+result (a `ViewBase`) with the metadata the subscription system needs to deliver deltas, and it is the only
+currency `SetSubscriptions` accepts — callers hand it `PublishedView` handles, never raw Views.
+
+## ⚙️ How it works (in brief)
+
+`TyphonRuntime.PublishView(...)` registers a View under a unique name and returns a `PublishedView` handle.
+Two registration modes exist, picked by which overload you call: pass a `ViewBase` instance directly for a
+**shared** View (one instance, all subscribers see the same data), or pass a `Func<ClientContext, ViewBase>`
+factory for a **per-client** View (a fresh instance created for each subscriber). Every `PublishedView` carries
+a `Name`, a `Priority` (for overload throttling), an `IsShared` flag, and a live `SubscriberCount`. The
+`PublishedViewRegistry`, reachable via `runtime.PublishedViews`, holds every published View for lookup and
+diagnostics. Registration itself does not start pushing data — a client only receives deltas for a View once
+it is included in a `SetSubscriptions` call.
+
+## Sub-features
+
+| Sub-feature | Use it for |
+|-------------|-----------|
+| [Shared (world-state) Views](./shared-views.md) | World objects, NPCs, terrain — one delta computed per tick, fanned out to every subscriber |
+| [Per-client View factories](./per-client-views.md) | Inventory, quest state, anything parameterized by which client is asking |
+
+## ⚠️ Guarantees & limits
+
+- **Names are unique and permanent** — `PublishView` throws `ArgumentException` if the name is already
+  registered; there is no unpublish/rename.
+- **A View can only be published once** — `RegisterShared` throws `InvalidOperationException` on a View
+  that's already published, and on one already wired as a system input (see Published/System-Input View
+  Separation). Use a dedicated View instance per published name.
+- **Publishing is setup-time, not per-tick** — registration takes a lock and rebuilds a snapshot array;
+  it is meant to happen during startup/configuration, not on a hot path.
+- `PublishedView.PublishedId` (`ushort`) is assigned in registration order and is stable for the process
+  lifetime; it is not persisted across restarts.
+- `SubscriberCount` reflects only clients currently in `Active`/`Syncing` subscription state — it changes as
+  `SetSubscriptions` transitions are applied during the Output phase, not the instant the call is made.
+
+## 🧪 Tests
+
+- [ViewSeparationTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewSeparationTests.cs) — name
+  uniqueness (`ArgumentException`), single-publish rule (`InvalidOperationException`), the `IsPublished` flag, and
+  that two separate View instances over the same query don't conflict
+
+## 🔗 Related
+
+- Sibling: [Published/System-Input View Separation](../published-view-isolation.md)
+- Sibling: [Persistent Views](../../Querying/persistent-views.md) — the underlying `ViewBase` query mechanism this feature publishes over the wire
+- Sub-features: [Shared (world-state) Views](./shared-views.md), [Per-client View factories](./per-client-views.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Public Surface, View Types for Subscriptions -->
+<!-- Deep dive: claude/overview/13-runtime.md — Subscription Server -->

--- a/doc/feature-set/Subscriptions/published-views/per-client-views.md
+++ b/doc/feature-set/Subscriptions/published-views/per-client-views.md
@@ -1,0 +1,74 @@
+# Per-client View Factories
+> A `Func<ClientContext, ViewBase>` that builds a fresh, parameterized View for each subscriber.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+Some data is private per connection — inventory, quest progress, anything scoped to "whoever is asking." A
+single shared View can't express that: every subscriber would see the same query result. Per-client View
+factories let you register one logical subscription name (`"my_inventory"`) whose actual query is built lazily,
+per subscriber, parameterized by that subscriber's `ClientContext` — without hand-rolling a separate
+registration call (and a separate name) per connected player.
+
+## ⚙️ How it works (in brief)
+
+`PublishView(name, factory)` registers a `Func<ClientContext, ViewBase>` instead of a View instance. No View
+is created at registration time. When a client is added to this subscription (via `SetSubscriptions`), the
+runtime invokes the factory with that client's `ClientContext`, refreshes the returned View to capture its
+initial entity set, and starts incremental sync from it — same as a shared View, just scoped to one
+subscriber. The View is disposed automatically when the client unsubscribes or disconnects. Because each
+subscriber gets its own View instance, delta computation and serialization happen once per subscriber, not
+once for the whole published target — the per-subscriber cost the design doc calls out is the tradeoff for
+per-client data.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.InventoryItem", 1)]
+public struct InventoryItem
+{
+    [Index] public int OwnerId;
+    public int ItemId;
+    public int Quantity;
+}
+
+[Archetype(10)]
+public class InventoryArch : Archetype<InventoryArch>
+{
+    public static readonly Comp<InventoryItem> Data = Register<InventoryItem>();
+}
+
+// Factory runs once per subscriber, on subscribe — it has no ambient transaction, so it opens its own.
+var myInventory = runtime.PublishView("my_inventory", (ClientContext client) =>
+{
+    using var tx = runtime.CreateSideTransaction();
+    int ownerId = (int)client.UserData;   // set by your own connection-handling code
+    return tx.Query<InventoryArch>()
+        .WhereField<InventoryItem>(i => i.OwnerId == ownerId)
+        .ToView();
+});
+
+runtime.SetSubscriptions(clientContext, myInventory);
+```
+
+## ⚠️ Guarantees & limits
+
+- **One View instance per subscriber** — `SubscriberCount` on the returned `PublishedView` counts live
+  per-client Views, not a shared one; cost scales linearly with subscriber count (refresh + delta + serialize
+  per client), unlike shared Views.
+- **Created on subscribe, disposed on unsubscribe/disconnect** — the factory is not called at publish time,
+  and nothing leaks: every per-client View is torn down when its owning subscription ends.
+- The factory runs on the Output-phase thread during subscription-transition processing — keep it cheap; it is
+  not parallelized across subscribers.
+- `IsShared` is `false` for a factory-registered `PublishedView`; `SharedView` is `null` — there is no single
+  instance to inspect via the registry.
+- The factory must return a dedicated View instance per call (a fresh `ToView()` result) — it follows the same
+  "must not double as a system input" rule as shared Views.
+
+## 🔗 Related
+
+- Sibling: [Published/System-Input View Separation](../published-view-isolation.md)
+- Parent feature: [Published Views](./README.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — View Types for Subscriptions, Connection Lifecycle -->

--- a/doc/feature-set/Subscriptions/published-views/shared-views.md
+++ b/doc/feature-set/Subscriptions/published-views/shared-views.md
@@ -1,0 +1,78 @@
+# Shared (World-State) Views
+> One View instance, refreshed and diffed once per tick, fanned out to every subscriber.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+World state — NPCs, terrain objects, the player roster — is the same for every client watching it. Computing
+that delta independently per subscriber wastes CPU proportional to subscriber count for data that doesn't
+vary by who's asking. Shared Views let many clients subscribe to the exact same query result: the engine
+refreshes and diffs it once per tick no matter how many clients are subscribed.
+
+## ⚙️ How it works (in brief)
+
+`PublishView(name, view)` registers a single `ViewBase` instance as the published target. During the Output
+phase, the engine refreshes that one View, computes its Added/Removed/Modified delta once, and serializes the
+resulting `TickDeltaMessage` once for steady-state clients — the same byte buffer is then memcpy'd into every
+subscriber's send buffer. Subscriber count only affects the fan-out step, not the delta computation or
+serialization cost. The View instance must be dedicated to subscriptions — it cannot also be wired as a
+system's query input (see Published/System-Input View Separation).
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Npc", 1)]
+public struct Npc
+{
+    [Index] public int Health;
+}
+
+[Archetype(10)]
+public class NpcArch : Archetype<NpcArch>
+{
+    public static readonly Comp<Npc> Data = Register<Npc>();
+}
+
+using var tx = dbe.CreateQuickTransaction();
+
+// Dedicated View instance for subscriptions — do not reuse a system's input View here.
+var worldNpcsView = tx.Query<NpcArch>()
+    .WhereField<Npc>(n => n.Health > 0)
+    .ToView();
+
+var worldNpcs = runtime.PublishView("world_npcs", worldNpcsView, SubscriptionPriority.Normal);
+
+// Subscribe a client to it; the runtime diffs against their previous subscription set.
+runtime.SetSubscriptions(clientContext, worldNpcs);
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `priority` | `SubscriptionPriority.Normal` | `Critical` always pushed; `Normal` throttled at overload Level 1+; `Low` throttled aggressively, paused at Level 4 |
+
+## ⚠️ Guarantees & limits
+
+- **One delta, one serialization, N memcpys** — cost scales with View size and change volume, not with
+  subscriber count, for the steady-state (no pending events, no sync) case.
+- **Must be a dedicated View** — using the same instance as a system's query input throws
+  `InvalidOperationException`; the View's change-tracking ring buffer has a single consumer.
+- New subscribers receive the View's current entity set via incremental sync (batched across ticks for large
+  Views), not a free pass to the live delta stream — see Incremental Sync in the design doc.
+- All subscribers to a shared View see identical data; there is no per-client filtering within a shared View
+  (use a per-client View factory for that).
+
+## 🧪 Tests
+
+- [SubscriptionStressTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs) —
+  `MultiClient_50Clients_SharedView_AllReceiveDeltas`: one shared View fanned out to 50 concurrent subscribers
+- [ViewDeltaTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs) —
+  `DeltaBuilder_SharedView_ProducesCorrectDelta`/`DeltaBuilder_SecondCall_OnlyNewEntities`: delta correctness across
+  ticks for a shared `PublishedView`
+
+## 🔗 Related
+
+- Sibling: [Published/System-Input View Separation](../published-view-isolation.md)
+- Parent feature: [Published Views](./README.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — View Types for Subscriptions, Output Phase Threading -->

--- a/doc/feature-set/Subscriptions/reference-client-sdk.md
+++ b/doc/feature-set/Subscriptions/reference-client-sdk.md
@@ -1,0 +1,89 @@
+# Reference C# Client SDK
+> A drop-in `Typhon.Client` library that turns wire bytes into a ready-to-read local entity cache.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+Every other Subscriptions feature describes what the *server* sends. Something still has to open the
+socket, frame the bytes, deserialize them, and keep a local copy of each View's entities in sync as
+Added/Modified/Removed deltas arrive — tedious, easy-to-get-wrong plumbing that has nothing to do with
+game logic. `Typhon.Client` is the reference implementation of that consumer: connect, register interest
+in a View by name, and read a live entity cache. No socket code, no MemoryPack calls, no manual delta
+application in application code.
+
+## ⚙️ How it works (in brief)
+
+`TyphonClient.Connect` opens a TCP socket and starts a dedicated receive thread on a `TyphonConnection`.
+That thread reads each length-prefixed frame, deserializes it as a `TickDeltaMessage` (MemoryPack), and
+dispatches it: `SubscriptionEvent`s drive per-View state (`Subscribed`/`Unsubscribed`/`SyncComplete`/`Resync`),
+and `ViewDeltaMessage`s are applied to a `ViewSubscription`'s entity cache — `Added` entities are inserted,
+`Modified` entities are patched in place, `Removed` entities are deleted. The cache is a plain
+`Id → CachedEntity` map; application code reads it (or reacts to the subscription's events) on its own
+schedule. All callbacks fire synchronously on the receive thread. `Subscribe(viewName)` only registers
+*local* interest by name — matching is against whatever the server already pushed via its own
+server-driven `SetSubscriptions`; the v1 client cannot request a subscription from the server.
+
+## 💻 Usage
+
+```csharp
+using var conn = TyphonClient.Connect("server-host", 9000);
+
+// Required once per component type before CachedEntity.Get<T>/TryGet<T> can decode it.
+conn.RegisterComponent<Position>(componentId: 1);
+conn.RegisterComponent<Health>(componentId: 2);
+
+var npcs = conn.Subscribe("world_npcs");
+npcs.OnEntityAdded += entity => SpawnClientEntity(entity.Id, entity.Get<Position>(1));
+npcs.OnEntityModified += (entity, changed) => PatchClientEntity(entity.Id, entity.Get<Position>(1));
+npcs.OnEntityRemoved += entityId => DespawnClientEntity(entityId);
+npcs.OnSyncComplete += () => MarkViewReady("world_npcs");
+npcs.OnResync += () => RebuildClientEntitiesFrom(npcs.Entities);
+
+conn.OnDisconnected += (_, ex) => LogDisconnect(ex);
+```
+
+| Option (`TyphonConnectionOptions`) | Default | Effect |
+|---|---|---|
+| `ReceiveBufferSize` | 65536 (64 KB) | Initial frame buffer; grows automatically for larger frames |
+| `AutoReconnect` | `true` | Reconnect with exponential backoff (1s, doubling) on connection loss |
+| `ReconnectMaxDelay` | 30s | Cap on the backoff delay |
+| `Logger` | `null` | Optional `ILogger`; `null` disables logging at zero cost |
+
+## ⚠️ Guarantees & limits
+
+- **All events fire on the receive thread** — `OnConnected`, `OnDisconnected`, `OnReconnected`, `OnTick`,
+  and every `ViewSubscription` event. Application code must not block in a callback; it stalls delta
+  processing for that connection.
+- **`Subscribe` is local-only** — it does not send a request to the server. It registers a name to match
+  against Views the server already pushed (server-driven `SetSubscriptions`); client-initiated subscription
+  requests are not part of v1.
+- **The cache is the source of truth between ticks** — `ViewSubscription.Entities` reflects exactly the
+  last applied tick; read it for rendering/logic rather than re-deriving state from individual callbacks.
+- **`CachedEntity.Get<T>`/`TryGet<T>` require prior `RegisterComponent<T>`** for that component ID, and
+  `T`'s size must match the cached byte length — a mismatch throws (`Get`) or returns `false` (`TryGet`).
+- **v1 component encoding is full-replace** — `Modified` always carries full component bytes
+  (`FieldDirtyBits = ~0UL`); per-field patching is a future wire upgrade the client already tolerates.
+- **Reconnect clears all caches** — on connection loss with `AutoReconnect = true`, every
+  `ViewSubscription`'s cache is cleared and `ViewId` reset; the server re-establishes subscriptions and
+  resyncs after `OnReconnected` fires.
+- **C#-only** — this is the one reference SDK for v1; other languages would need to reimplement framing,
+  MemoryPack decoding, and the cache-apply logic described here.
+
+## 🧪 Tests
+
+- [DeltaProcessingTests](../../../test/Typhon.Client.Tests/DeltaProcessingTests.cs) — Added/Modified/Removed/
+  SyncComplete/Resync/Disconnect dispatch over a fake server, plus lazy-subscription for server-pushed Views the
+  client hasn't named locally yet
+- [ViewSubscriptionTests](../../../test/Typhon.Client.Tests/ViewSubscriptionTests.cs) — the per-View entity cache
+  itself: add/remove/modify, sync/resync state resets
+- [CachedEntityTests](../../../test/Typhon.Client.Tests/CachedEntityTests.cs) — `Get<T>`/`TryGet<T>` decode
+  guarantees: missing component, size mismatch
+- [TyphonConnectionIntegrationTests](../../../test/Typhon.Client.Tests/Integration/TyphonConnectionIntegrationTests.cs)
+  — `Client_Connects_SubscribesAndReceivesAddedEntity`: real socket, real server, end to end
+
+## 🔗 Related
+
+- Related feature: [TCP Transport & Wire Format](./wire-transport.md), [Incremental Sync](./incremental-sync.md), [Backpressure & Resync](./backpressure-resync.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Client Data Model -->

--- a/doc/feature-set/Subscriptions/server-configuration.md
+++ b/doc/feature-set/Subscriptions/server-configuration.md
@@ -1,0 +1,72 @@
+# Subscription Server Configuration
+> One options object tunes the TCP listener's port, capacity, and backpressure behavior.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+Every other subscription feature — client connections, backpressure/resync, incremental sync — has a knob that
+needs a sane default for development and a tunable value for production (different port, more headroom for a
+laptop demo vs. a 500-player server, tighter batch sizes to protect the tick budget). Rather than scattering
+these across constructor parameters or environment variables, Typhon collects them into a single options
+object that's set once, at runtime startup.
+
+## ⚙️ How it works (in brief)
+
+`SubscriptionServerOptions` is a plain settings object assigned to `RuntimeOptions.SubscriptionServer` before
+the runtime starts. There is nothing to call at runtime — the listener, send buffers, and Output-phase batching
+all read these values once at startup and apply them for the life of the process. Leaving it unset
+(`null`) or constructing it with no initializers falls back to development-friendly defaults.
+
+## 💻 Usage
+
+```csharp
+var runtimeOptions = new RuntimeOptions
+{
+    SubscriptionServer = new SubscriptionServerOptions
+    {
+        Port = 9000,
+        MaxClients = 500,
+        SendBufferCapacity = 262_144,
+        BackpressureWarningThreshold = 0.75f,
+        SyncBatchSize = 200,
+        PublishedViewBufferCapacity = 8192,
+    },
+};
+
+// runtimeOptions flows into the runtime/hosting setup that starts the listener
+// and Output-phase subscription pipeline.
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `Port` | 9000 | TCP listen port (dual-stack IPv6/IPv4) |
+| `MaxClients` | 0 (unlimited) | Connections beyond this are refused at accept time |
+| `SendBufferCapacity` | 262144 (256 KB) | Per-client send buffer; full buffer drops a tick and triggers resync |
+| `BackpressureWarningThreshold` | 0.75 | Send-buffer fill ratio (0.0–1.0) that logs a warning |
+| `SyncBatchSize` | 200 | Max entities per incremental-sync batch per client per View per tick |
+| `PublishedViewBufferCapacity` | 8192 | Capacity (must be a power of 2) of a published View's delta ring buffer |
+
+## ⚠️ Guarantees & limits
+
+- **Set once, at startup** — there is no API to change these values on a running server; reconfiguring means
+  restarting the runtime with new options.
+- **`null` is a valid default** — omitting `RuntimeOptions.SubscriptionServer` runs the subscription server with
+  every option at its built-in default rather than failing startup.
+- **`MaxClients = 0` means unlimited** — there is no implicit cap; size it explicitly for production deployments.
+- **`PublishedViewBufferCapacity` must be a power of 2** — this matches the ring-buffer requirement used
+  throughout Typhon's View infrastructure (see [Querying](../Querying/README.md)).
+- This object only configures the server side — client-side connection settings (reconnect, timeouts) belong to
+  the client SDK, not here.
+
+## 🧪 Tests
+
+- [SubscriptionStressTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs) —
+  `Backpressure_SlowClient_TriggersResync` sets a non-default `SendBufferCapacity` and shows it changing overflow
+  behavior — the one place a config knob is verified to take effect end-to-end
+
+## 🔗 Related
+
+- Related feature: [Client Connections & Lifecycle](./client-connections.md), [Backpressure & Resync Recovery](./backpressure-resync.md), [Incremental Sync](./incremental-sync.md), [TCP Transport & Wire Format](./wire-transport.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md -->

--- a/doc/feature-set/Subscriptions/subscription-management/README.md
+++ b/doc/feature-set/Subscriptions/subscription-management/README.md
@@ -1,0 +1,52 @@
+# Subscription Management (SetSubscriptions)
+> Atomic, idempotent, diff-based API to set a client's full subscription list each tick.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+A connected client's subscription needs change constantly — zone transitions, party joins, UI panels opening
+and closing. Hand-rolling this as incremental subscribe/unsubscribe calls forces the caller to track what the
+client is currently subscribed to, and risks leaked subscriptions (a forgotten unsubscribe) or a client briefly
+observing a half-applied state (some Views swapped, others not). `SetSubscriptions` removes both problems: the
+caller always declares the client's *target* subscription state, and the runtime guarantees it gets there as a
+single atomic step, with no networking or change-tracking code to write.
+
+## ⚙️ How it works (in brief)
+
+`SetSubscriptions` takes a client's complete desired list of `PublishedView` handles and replaces the pending
+set for that connection. On the next tick's Output phase, the runtime diffs this list against the client's
+currently active subscriptions: Views present only in the new list are subscribed (incremental sync begins),
+Views present only in the old list are unsubscribed, and Views present in both are left untouched — no resync,
+no interruption. The resulting events and any deltas land in that tick's single `TickDeltaMessage`, so the
+client never observes an intermediate state. Today, the full list is always supplied by server-side game code
+(v1); a client-initiated request path is planned (v2).
+
+## Sub-features
+
+| Sub-feature | Status | Use it for |
+|-------------|--------|-----------|
+| [Server-Driven Subscriptions (v1)](./subscription-server-driven.md) | ✅ Implemented | Game systems call `SetSubscriptions` directly when game state changes (zone transition, party join) |
+| [Client-Initiated Subscriptions (v2)](./subscription-client-initiated.md) | 📋 Planned | Clients request their own subscription changes, validated server-side before being applied |
+
+## ⚠️ Guarantees & limits
+
+- **Idempotent** — calling with an identical list is a no-op; no events are generated.
+- **Atomic** — the full transition (unsubscribe + subscribe + keep) lands in a single tick's `TickDeltaMessage`; the client never sees a partially-applied set.
+- **Full list, not a delta** — always pass the complete desired set. The runtime converges to exactly that state, so there is no way to leak a subscription via a missed unsubscribe call.
+- **Silently ignored for dead connections** — if the client disconnected between the caller obtaining its `ClientContext` and this call, the request is dropped; no exception, no error path to handle.
+- Kept Views never resync, even when other Views in the same call are added or removed.
+- New Views in the set go through normal incremental sync (batched across ticks for large Views) before reaching steady-state delta flow.
+
+## 🧪 Tests
+
+- [SubscriptionTransitionTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionTransitionTests.cs)
+  — `ComputeTransition` diff logic: empty→new, all→empty, partial overlap, identical-set no-op, and the
+  `Subscribed` event's `ViewName`
+
+## 🔗 Related
+
+- Related feature: [Published Views](../published-views/README.md), [Published/System-Input View Separation](../published-view-isolation.md)
+- Sub-features: [Server-Driven Subscriptions (v1)](./subscription-server-driven.md), [Client-Initiated Subscriptions (v2)](./subscription-client-initiated.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Subscription Management, R-Q16 -->

--- a/doc/feature-set/Subscriptions/subscription-management/subscription-client-initiated.md
+++ b/doc/feature-set/Subscriptions/subscription-management/subscription-client-initiated.md
@@ -1,0 +1,46 @@
+# Client-Initiated Subscriptions (v2)
+> Clients request their own subscription changes; the server validates before applying them.
+
+**Status:** 📋 Planned · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+Server-driven subscriptions (v1) require game server code to be the one deciding every subscription change.
+Some interaction patterns are more naturally client-initiated — a player opens a UI panel that needs a View
+it isn't already subscribed to, or browses a list before deciding what to commit to. Forcing every such case
+through a server-side system adds plumbing the game code shouldn't need to write. Client-initiated
+subscriptions let the client ask directly, while keeping the server as the final authority over what it is
+allowed to see.
+
+## ⚙️ How it works (in brief)
+
+The plan is a server-side `OnClientSubscriptionRequest` callback: the client sends a subscription request
+(by View name), the callback validates it against game/permission rules, and only on acceptance does the
+runtime fold the change into that client's subscription set using the same diff-and-apply machinery as
+`SetSubscriptions`. Rejected requests never reach the active set. This is additive to v1 — server-driven
+calls keep working unchanged, and a client request is just another way to populate the same target list.
+
+## 💻 Usage
+
+```csharp
+// Illustrative only — design complete, not implemented yet.
+// runtime.OnClientSubscriptionRequest((client, requestedViewName) =>
+// {
+//     // Server-side validation — e.g. zone/permission check
+//     return PlayerCanSee(client, requestedViewName);
+// });
+```
+
+## ⚠️ Guarantees & limits
+
+- **Not implemented.** No code under `src/Typhon.Engine/Subscriptions` defines `OnClientSubscriptionRequest`
+  today; v1 is server-driven only (see [Server-Driven Subscriptions](./subscription-server-driven.md)).
+- **Server validation is the point.** Unlike v1, the runtime will not blindly trust a `PublishedView` request — the callback decides whether a connection may subscribe to a given name.
+- **Expected to reuse v1's transition machinery.** Once a request is accepted, it is expected to fold into the same atomic diff-based transition `SetSubscriptions` already provides — no second delta-delivery path.
+
+## 🔗 Related
+
+- Parent feature: [Subscription Management (SetSubscriptions)](./README.md)
+- Sibling: [Server-Driven Subscriptions (v1)](./subscription-server-driven.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Client-Initiated (v2), Scope (v1 / Demo) -->

--- a/doc/feature-set/Subscriptions/subscription-management/subscription-server-driven.md
+++ b/doc/feature-set/Subscriptions/subscription-management/subscription-server-driven.md
@@ -1,0 +1,61 @@
+# Server-Driven Subscriptions (v1)
+> Game code calls `SetSubscriptions` whenever game state changes; the runtime applies the transition next tick.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Subscriptions](../README.md)
+
+## 🎯 What it solves
+
+For v1, every subscription change originates on the server — there is no client request to validate or
+trust. Game systems already know when a client's interest set should change (a zone transition, a party
+join, a UI panel opening) so they are the natural place to declare it. This sub-feature is the direct, no
+round-trip path: call `SetSubscriptions` with the new target list from any worker thread, and the runtime
+takes care of diffing, sequencing, and delivering the transition.
+
+## ⚙️ How it works (in brief)
+
+`SetSubscriptions(client, params PublishedView[] views)` resolves the live connection from the `ClientContext`
+and atomically swaps in the new desired list as the connection's pending subscription set. The Output phase
+picks up the pending set on the next tick, computes the diff against the client's active subscriptions, and
+applies it — no further action from the caller. Because the set is replaced via an atomic exchange, this can
+be called safely from any system/worker thread, including the same client multiple times within one tick.
+
+## 💻 Usage
+
+```csharp
+var pubA = runtime.PublishView("nearby_players", nearbyPlayersView);
+var pubB = runtime.PublishView("world_objects", worldObjectsView);
+var pubC = runtime.PublishView("my_inventory", myInventoryView);
+
+// Initial subscription set, e.g. right after the client connects
+runtime.SetSubscriptions(client, pubA, pubB, pubC);
+
+// Later — zone transition: drop nearby_players/world_objects, add dungeon Views, keep inventory
+var pubD = runtime.PublishView("dungeon_npcs", dungeonNpcsView);
+var pubE = runtime.PublishView("loot", lootView);
+runtime.SetSubscriptions(client, pubC, pubD, pubE);
+// -> nearby_players, world_objects unsubscribed (events sent)
+// -> dungeon_npcs, loot subscribed (incremental sync begins)
+// -> my_inventory kept (no interruption, no resync)
+```
+
+## ⚠️ Guarantees & limits
+
+- **Thread-safe, no locking required** — backed by `Interlocked.Exchange` on the connection's pending-set slot; callable from any game system or worker thread.
+- **Last-call-wins per tick** — if `SetSubscriptions` is called more than once for the same client before the next Output phase, only the most recent call is applied; earlier calls in that window are discarded entirely (not merged).
+- **No server-side validation hook** — v1 trusts the caller; any `PublishedView` handle the game code holds can be assigned to any client. There is no concept of a client being disallowed from a View.
+- **One tick of latency** — a call made during tick N's simulation is applied in tick N's (or N+1's, depending on call timing relative to the Output phase) `TickDeltaMessage`, never synchronously.
+
+## 🧪 Tests
+
+- [SubscriptionTransitionTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionTransitionTests.cs)
+  — the diff-based transition `SetSubscriptions` relies on (subscribed/unsubscribed/kept sets)
+- [SubscriptionStressTests](../../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs) —
+  `ConcurrentSetSubscriptions_LastWriterWins_NoCorruption`: last-call-wins under concurrent calls from multiple
+  worker threads
+
+## 🔗 Related
+
+- Parent feature: [Subscription Management (SetSubscriptions)](./README.md)
+- Sibling: [Client-Initiated Subscriptions (v2)](./subscription-client-initiated.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Server-Driven (v1) -->

--- a/doc/feature-set/Subscriptions/subscription-telemetry.md
+++ b/doc/feature-set/Subscriptions/subscription-telemetry.md
@@ -1,0 +1,65 @@
+# Subscription Telemetry & Tracing
+> Per-tick counters for Output-phase cost and delta volume, plus a tracing span around the whole phase.
+
+**Status:** 🚧 Partial · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+Subscription delta push runs inside the tick budget — if it gets slow or a client population starts overflowing send buffers, that needs to show up in telemetry without the application instrumenting it manually. Operators need three things: how long the Output phase took, how many entity deltas were actually pushed, and how often clients fell behind and had to resync. This feature exposes those numbers as part of Typhon's existing tick telemetry, and adds a trace span so the Output phase is visible alongside the rest of the tick in a profiler timeline.
+
+## ⚙️ How it works (in brief)
+Each tick, `TyphonRuntime` reads three counters off the internal `SubscriptionOutputPhase` (wall-clock duration, deltas pushed, overflow count) and writes them into that tick's `TickTelemetry` record in the `TickTelemetryRing`. Separately, the whole Output phase is wrapped in a `RuntimeSubscriptionOutputExecute` trace span (gated by `TelemetryConfig`, zero-cost when disabled) so it appears as a span in the runtime's tick trace. A deeper per-subscriber subtree — six more span kinds for per-subscriber dispatch, delta build, serialization, sync transitions, and cleanup — has its wire format and config-resolver leaves already shipped, but nothing in `SubscriptionOutputPhase` emits them yet, so today they produce no events.
+
+## 💻 Usage
+```csharp
+// Per-tick counters — always populated, no configuration needed
+var ring = runtime.Telemetry;
+ref readonly var tick = ref ring.GetTick(ring.NewestTick);
+
+Console.WriteLine($"output={tick.OutputPhaseMs}ms " +
+                   $"pushed={tick.SubscriptionDeltasPushed} " +
+                   $"overflows={tick.SubscriptionOverflowCount}");
+```
+
+```jsonc
+// typhon.telemetry.json — opt into the Output-phase trace span
+{
+  "Typhon": {
+    "Profiler": {
+      "Enabled": true,
+      "Runtime": {
+        "Enabled": true,
+        "Subscription": { "Output": { "Execute": { "Enabled": true } } }
+      }
+    }
+  }
+}
+```
+
+| Telemetry field | Source | Always available? |
+|---|---|---|
+| `TickTelemetry.OutputPhaseMs` | `TickTelemetryRing` (per tick) | Yes |
+| `TickTelemetry.SubscriptionDeltasPushed` | `TickTelemetryRing` (per tick) | Yes |
+| `TickTelemetry.SubscriptionOverflowCount` | `TickTelemetryRing` (per tick) | Yes |
+| `RuntimeSubscriptionOutputExecute` span | Trace event (kind 164), gated by `Typhon:Profiler:Runtime:Subscription:Output:Execute:Enabled` | Opt-in |
+| Per-subscriber dispatch spans (`Subscriber`, `Delta:Build`/`Serialize`/`DirtyBitmapSupplement`, `Transition:BeginSync`, `Output:Cleanup`) | Wire format + config leaves shipped | No producer wired — never emitted today |
+
+## ⚠️ Guarantees & limits
+- **Per-tick counters are unconditional** — `OutputPhaseMs`, `SubscriptionDeltasPushed`, and `SubscriptionOverflowCount` are recorded every tick regardless of profiler configuration; no opt-in needed to see them.
+- **The Output-phase span exists but is off by default** — `RuntimeSubscriptionOutputExecute` requires explicit opt-in via `TelemetryConfig`/`typhon.telemetry.json`, same zero-cost-when-disabled model as the rest of the tracer.
+- **The Output-phase span's stats fields are placeholders today** — the span's begin parameters (tick number, overload level) are live, but the per-tick stat fields it carries (client count, views refreshed, deltas pushed, overflow count) are not yet populated from `SubscriptionOutputPhase`.
+- **No per-subscriber or per-View trace detail yet** — you cannot currently see which subscriber, View, or client a given delta/serialize cost belongs to; only the aggregate per-tick numbers above are observable. The six deeper span kinds exist in the wire protocol and config tree but have no producer wired into `SubscriptionOutputPhase`/`DeltaBuilder`, so enabling them today changes nothing.
+- **`SubscriptionDeltasPushed` counts entities, not bytes** — it sums `Added + Modified + Removed` across all Views pushed this tick; it is not a measure of wire payload size.
+- **Ring buffer retention is bounded** — `TickTelemetryRing` only retains the most recent `Capacity` ticks (default 1024, ~17s at 60Hz); read promptly if correlating with an external event.
+
+## 🧪 Tests
+
+- [TraceEventEncodeEquivalenceTests](../../../test/Typhon.Engine.Tests/Profiler/TraceEventEncodeEquivalenceTests.cs)
+  — `RuntimeSubscriptionOutputExecuteEvent_StructEncode_MatchesCodec`: binary encode of the Output-phase span,
+  including its still-placeholder stat fields (client count, views refreshed, deltas pushed, overflow count)
+
+## 🔗 Related
+- Related feature: [Backpressure & Resync Recovery](./backpressure-resync.md), [Priority & Overload Throttling](./priority-overload-throttling.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Subscription Cost & Overload Integration -->
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Profiling / Tracing Hooks -->
+<!-- Design: claude/design/Profiler/07-tracing-instrumentation/09-subscription-dispatch.md -->

--- a/doc/feature-set/Subscriptions/wire-transport.md
+++ b/doc/feature-set/Subscriptions/wire-transport.md
@@ -1,0 +1,72 @@
+# TCP Transport & Wire Format
+> One length-prefixed, MemoryPack-serialized message per client per tick over TCP_NODELAY.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Subscriptions](./README.md)
+
+## 🎯 What it solves
+
+Once the server knows what changed for a client, it still needs to get those bytes across the wire — reliably, in order, framed so the client can tell where one tick's message ends and the next begins, and cheaply enough that talking to hundreds of clients doesn't blow the tick budget. Hand-rolling this (socket setup, message framing, serialization, per-client buffering, backpressure) is exactly the kind of plumbing that has nothing to do with game logic. Typhon owns all of it: one call to publish a View and set a client's subscriptions is enough — the bytes arrive on the other end as ready-to-apply delta objects.
+
+## ⚙️ How it works (in brief)
+
+Each connected client gets a dedicated TCP socket with `TCP_NODELAY` enabled — deltas are already batched per tick, so Nagle's algorithm would only add latency for no batching benefit. Every tick, the server builds at most one `TickDeltaMessage` per client, serializes it with MemoryPack (a zero-copy, source-generated serializer — effectively a `memcpy` for the unmanaged component data Typhon stores), prefixes it with a 4-byte little-endian length, and queues it on that client's send buffer. A dedicated I/O thread drains send buffers asynchronously so a slow client never blocks the tick. When many clients share the same View data, the server serializes the common payload once and copies the resulting frame to every matching client's buffer instead of re-serializing per client.
+
+## 💻 Usage
+
+The wire transport has no separate API — it's the delivery mechanism behind `PublishView` / `SetSubscriptions` (see [shared-views](./published-views/shared-views.md) and [subscription-server-driven](./subscription-management/subscription-server-driven.md)). Configure it via `SubscriptionServerOptions` when setting up the runtime:
+
+```csharp
+var options = new SubscriptionServerOptions
+{
+    Port = 9000,
+    SendBufferCapacity = 262_144,       // per-client send buffer, bytes
+    BackpressureWarningThreshold = 0.75f,
+};
+
+// runtime wiring (DI/Hosting extension) takes SubscriptionServerOptions and starts
+// the listener + I/O flush threads; clients connect with the reference C# SDK:
+var conn = TyphonClient.Connect("tcp://server:9000");
+conn.OnTickDelta += tickDelta =>
+{
+    foreach (var viewDelta in tickDelta.Views)
+    {
+        foreach (var added in viewDelta.Added) SpawnClientEntity(added);
+        foreach (var modified in viewDelta.Modified) PatchClientEntity(modified);
+        foreach (var removed in viewDelta.Removed) DespawnClientEntity(removed);
+    }
+};
+```
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `Port` | 9000 | TCP listen port (dual-stack IPv6/IPv4) |
+| `SendBufferCapacity` | 262144 (256 KB) | Per-client send buffer; full buffer triggers a dropped tick + resync |
+| `BackpressureWarningThreshold` | 0.75 | Fill ratio at which a warning is logged |
+| `MaxClients` | 0 (unlimited) | Connections beyond this are refused at accept time |
+
+## ⚠️ Guarantees & limits
+
+- **One TCP send per client per tick** — all View deltas and subscription events for a tick are bundled into a single `TickDeltaMessage`, so the client never observes a half-applied tick.
+- **Reliable, ordered delivery** — TCP guarantees entity lifecycle events (add/remove) arrive in order and are never dropped silently; this is why the transport is TCP, not UDP.
+- **Length-prefixed framing** — `[4-byte LE length][MemoryPack payload]`; the client reads the prefix to know exactly how many bytes to buffer before decoding.
+- **Serialize-once for shared state** — steady-state clients with no pending events, no per-client Views, and an Active subscription set matching exactly the shared Views computed that tick reuse one pre-built frame (one `MemoryPackSerializer.Serialize` call, N buffer writes). Clients with events, in-progress sync, or per-client Views fall back to individual serialization.
+- **I/O is off the tick's critical path** — the timer thread only enqueues bytes into per-client buffers; an `ManualResetEventSlim` signal wakes a separate I/O thread that performs the blocking `Socket.Send` calls.
+- **Backpressure, not unbounded growth** — if a client's send buffer is too full to hold the next frame, that tick's delta is dropped and the client is flagged for resync (full snapshot) instead of growing memory or stalling the server (see [Backpressure & Recovery](../../../claude/design/Subscriptions/05-subscriptions.md#backpressure--recovery)).
+- **No built-in transport security or auth** — v1 treats an established connection as trusted; TLS, auth, and permissions are out of scope for this version.
+- **C#-only wire format today** — MemoryPack is a .NET serializer; cross-language client SDKs would need either a MemoryPack-compatible reader or a future pluggable serializer.
+
+## 🧪 Tests
+
+- [ProtocolTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/ProtocolTests.cs) —
+  `TickDeltaMessage`/`ViewDeltaMessage` MemoryPack round-trips, including the full multi-View Added/Modified/Removed
+  message shape
+- [FrameReaderTests](../../../test/Typhon.Client.Tests/FrameReaderTests.cs) — length-prefixed frame reading:
+  fragmentation, buffer growth, zero/negative/excessive length rejection
+- [SendBufferTests](../../../test/Typhon.Engine.Tests/Runtime/Subscriptions/SendBufferTests.cs) — the per-client
+  ring buffer the I/O thread drains: wraparound, capacity, fill percentage
+
+## 🔗 Related
+
+- Related feature: [Shared Views](./published-views/shared-views.md), [Server-driven subscriptions](./subscription-management/subscription-server-driven.md)
+
+<!-- Deep dive: claude/design/Subscriptions/05-subscriptions.md — Transport, Message Format, Output Phase Threading, Backpressure & Recovery sections -->

--- a/doc/feature-set/Transactions/README.md
+++ b/doc/feature-set/Transactions/README.md
@@ -1,0 +1,37 @@
+# Transactions
+
+> Implements Typhon's three-tier execution model (`DatabaseEngine` → `UnitOfWork` → `Transaction`): the durability
+> boundary, the ACID commit/rollback pipeline, per-UoW durability modes plus the orthogonal per-transaction
+> `SingleVersion` discipline, deadline/cancellation propagation, and the crash-safe UoW identity that together decide
+> how application writes become atomic, isolated, and durable. Three creation patterns (standard, quick, read-only)
+> and an opt-in Bulk Load path cover everything from per-tick batching to multi-million-entity imports.
+
+> 🔬 **Recommended:** read [in-depth-overview/08-transactions.md](../../in-depth-overview/08-transactions.md) (Chapter 08: Transactions) first to understand the overall design and concepts behind this category, before diving into the specific features below.
+
+## Public Features
+
+| Feature | Summary | Status | Level |
+|---|---|---|---|
+| [Unit of Work (durability boundary)](unit-of-work.md) | Middle tier of the three-tier API hierarchy — batches Transactions under a single flush/durability boundary, owning the shared ChangeSet, deadline, and UoW identity | ✅ Implemented | 🟢 Start Here |
+| [Durability Modes (Deferred / GroupCommit / Immediate)](durability-modes/README.md) | Per-UoW control of WAL flush timing — trade commit latency for the data-at-risk window on crash | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Per-Transaction Durability Override](durability-modes/durability-override-escalation.md) | Escalate one critical operation to zero-loss durability without raising the durability mode of the surrounding batch | ✅ Implemented | 🟣 Advanced |
+| [Transaction Creation Patterns](transaction-creation-patterns/README.md) | Three ways to obtain a `Transaction` — explicit UoW + `CreateTransaction`, single-shot quick transaction, or UoW-less read-only snapshot transaction | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [Standard (UnitOfWork + CreateTransaction)](transaction-creation-patterns/transaction-creation-standard.md) | Open a `UnitOfWork` once and draw as many transactions from it as a batch needs, sharing one durability/flush boundary | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [CreateQuickTransaction (single-shot, auto-dispose)](transaction-creation-patterns/transaction-creation-quick.md) | One call fuses a `UnitOfWork` and its one `Transaction` into a single disposable for single-shot writes | ✅ Implemented | 🟢 Start Here |
+| &nbsp;&nbsp;↳ [CreateReadOnlyTransaction (snapshot reads)](transaction-creation-patterns/transaction-creation-readonly.md) | A `Transaction` with no `UnitOfWork`, UoW ID, or `ChangeSet` at all, for pure-read MVCC-snapshot workloads | ✅ Implemented | 🔵 Core |
+| [SingleVersion Durability Discipline (TickFence / Commit)](durability-discipline/README.md) | Per-transaction knob, orthogonal to `DurabilityMode`, that picks how a `SingleVersion` write becomes durable | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [TickFence Discipline (Default)](durability-discipline/durability-discipline-tickfence.md) | The default, lowest-cost `SingleVersion` write — durable at the next tick fence, not at commit | ✅ Implemented | 🔵 Core |
+| &nbsp;&nbsp;↳ [Commit Discipline (Variant-A Staging)](durability-discipline/durability-discipline-commit.md) | Atomic, zero-loss `SingleVersion` writes — durable and visible together at `Commit()`, with no revision chain | ✅ Implemented | 🟣 Advanced |
+| [Commit / Rollback Pipeline (ACID Commit Path)](commit-rollback-pipeline.md) | `Transaction.Commit`/`Rollback` overloads implementing the append-before-publish commit pipeline with atomic conflict resolution and always-completing rollback | ✅ Implemented | 🔵 Core |
+| [Optimistic Concurrency Conflict Resolution](optimistic-conflict-resolution.md) | Pluggable `ConcurrencyConflictHandler` invoked per conflicting entity during commit, exposing four data views via `ConcurrencyConflictSolver`; default with no handler is last-writer-wins | ✅ Implemented | 🔵 Core |
+| [Deadline & Cooperative Cancellation](deadline-cancellation.md) | An absolute deadline rides every transaction commit, propagating through every lock and aborting cleanly only before work starts | ✅ Implemented | 🔵 Core |
+| [UoW Identity & Crash-Safe Recovery Boundary](uow-identity-crash-recovery.md) | Each UoW gets a 15-bit ID from a persistent, back-pressured `UowRegistry`; on crash, still-`Pending` UoW IDs are voided so their revisions become instantly invisible with no replay | ✅ Implemented | 🟣 Advanced |
+| [Transaction Lifecycle, Thread Affinity & Pooling](transaction-lifecycle-pooling.md) | `Transaction` is single-thread-affine with a fail-fast state machine; `TransactionChain` provides lock-free CAS-based creation, exclusive-lock removal, 16-instance pooling, and `MinTSN` tracking for MVCC garbage collection | ✅ Implemented | 🟣 Advanced |
+| [Bulk Load Session](bulk-load-session.md) | Opt-in, exclusive write path that batches writes through a recycled `Transaction` and commits the whole load atomically via a checkpoint barrier | ✅ Implemented | 🟣 Advanced |
+
+## Internal Features
+
+*No internal-only engine machinery broken out in this category — Transactions is Typhon's primary
+application-facing tier (`DatabaseEngine` → `UnitOfWork` → `Transaction`). The engine machinery behind it
+(`TransactionChain`, `UowRegistry`, `CommitContext`) is covered inline within the public features above, as the
+mechanics that back their guarantees, rather than as separately usable capabilities.*

--- a/doc/feature-set/Transactions/bulk-load-session.md
+++ b/doc/feature-set/Transactions/bulk-load-session.md
@@ -1,0 +1,75 @@
+# Bulk Load Session
+> An opt-in, exclusive write path that batches writes through a recycled Transaction and commits the whole load atomically.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Transactions](./README.md)
+
+**Assumes:** [Unit of Work (durability boundary)](./unit-of-work.md)
+
+## 🎯 What it solves
+The standard `UnitOfWork`/`Transaction` path is tuned for OLTP: every commit appends a WAL record and every open
+transaction pins its touched pages until it commits or rolls back. That is exactly the wrong trade-off for seeding
+a multi-million-entity database, importing a dataset, or rebuilding a fixture — at that scale the per-row WAL
+traffic and epoch-pinned pages exhaust the page cache and the load aborts with a backpressure timeout, regardless
+of `DurabilityMode`. Bulk Load Session is a second write path for exactly this one workload, opt-in and isolated
+from every other transaction's durability contract.
+
+## ⚙️ How it works (in brief)
+`DatabaseEngine.BeginBulkLoad` opens a session backed by one `UnitOfWork` and one `Transaction`, configured to skip
+per-row WAL records entirely. Internally the session periodically commits and replaces its underlying `Transaction`
+every few thousand operations so the page cache can keep evicting touched pages — the owning `UnitOfWork` itself
+stays open, and MVCC-invisible to everyone else, for the whole session. `CompleteBulkLoad` is the single barrier
+that makes the session durable and visible: it commits the final transaction, forces a checkpoint, and waits for a
+closing manifest record to reach disk before returning. This axis is orthogonal to `DurabilityMode` — a bulk
+session doesn't run in Deferred/GroupCommit/Immediate, it bypasses per-row WAL altogether and substitutes one
+session-wide durability barrier.
+
+## 💻 Usage
+```csharp
+using var session = engine.BeginBulkLoad(new BulkLoadOptions
+{
+    ProgressReporter = p => Console.WriteLine($"{p.EntitiesSpawned:N0} spawned"),
+    CheckpointTimeout = TimeSpan.FromMinutes(10),
+});
+
+for (var i = 0; i < 4_000_000; i++)
+{
+    var id = session.Spawn<ParticleArchetype>();
+    session.Update(id, new Position { X = i, Y = 0, Z = 0 });
+}
+
+session.CompleteBulkLoad();   // blocks: commit + forced checkpoint + manifest durable
+// every entity spawned above is now visible to other transactions
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `ProgressReporter` | `null` | Callback invoked every `ProgressBatchSize` operations |
+| `ProgressBatchSize` | `10_000` | Operations between progress callbacks |
+| `CheckpointTimeout` | 5 min | Max wait in `CompleteBulkLoad` for the forced checkpoint; throws `BulkLoadCheckpointTimeoutException` and leaves the session open on expiry |
+
+## ⚠️ Guarantees & limits
+- **Exclusive** — one `BulkLoadSession` per engine; a concurrent `BeginBulkLoad` throws `BulkSessionAlreadyActiveException`.
+- **Thread-affine** — only the thread that called `BeginBulkLoad` may call methods on the returned session.
+- **Same call shape as `Transaction`** — `Spawn`/`OpenMut`/`Update`/`Destroy` mirror their `Transaction` counterparts, so application entity/component code mostly ports unchanged.
+- **Update/Destroy scope** — only target entities spawned earlier in the *same* session; mutating pre-existing entities still requires the standard `UnitOfWork` path.
+- **All-or-nothing at session granularity** — entities become durable and visible only when `CompleteBulkLoad` returns; `Dispose` without `CompleteBulkLoad`, or a crash mid-session, discards everything written so far.
+- **Closed once** — after `CompleteBulkLoad` or `Dispose`, further calls throw `BulkSessionClosedException`.
+- **No latency budget** — `CompleteBulkLoad` blocks on a real checkpoint cycle; `CheckpointTimeout` only guards against it never finishing, it doesn't bound how long the call takes.
+- **Concurrent readers unaffected** — regular `UnitOfWork`s keep running during the session and see the pre-bulk MVCC snapshot throughout.
+
+## 🧪 Tests
+- [BulkLoadApiSurfaceTests](../../../test/Typhon.Engine.Tests/Durability/BulkLoadApiSurfaceTests.cs) — session
+  API shape: exclusivity (`BeginBulkLoad_TwiceWithoutClosing_Throws`), closed-session guards, option defaults
+- [BulkLoadWriteTests](../../../test/Typhon.Engine.Tests/Durability/BulkLoadWriteTests.cs) — entities visible only
+  after `CompleteBulkLoad`, exactly-one bulk-begin/bulk-end WAL record pair (no per-row records), transaction-recycle
+  threshold crossing
+- [BulkLoadRecoveryTests](../../../test/Typhon.Engine.Tests/Durability/BulkLoadRecoveryTests.cs) — crash after
+  bulk-begin loses everything, crash after `CompleteBulkLoad` survives reopen in full
+
+## 🔗 Related
+- Deep dive (write-path internals, manifest, recovery): [Durability — BulkLoad Write Path](../Durability/bulk-load.md)
+- Sibling: [Durability Modes](./durability-modes/README.md) — the per-UoW axis this session deliberately bypasses
+
+<!-- Design: claude/design/Durability/BulkLoad/README.md -->
+<!-- ADR: 053-bulk-load-write-path — claude/adr/053-bulk-load-write-path.md -->
+<!-- Rules: claude/rules/durability.md — module BulkLoad (BL-01..04) -->

--- a/doc/feature-set/Transactions/commit-rollback-pipeline.md
+++ b/doc/feature-set/Transactions/commit-rollback-pipeline.md
@@ -1,0 +1,68 @@
+# Commit / Rollback Pipeline (ACID Commit Path)
+> The two methods that end a transaction — `Commit` makes writes durable and visible as one atomic unit, `Rollback` always unwinds them completely.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Transactions](./README.md)
+
+## 🎯 What it solves
+Ending a transaction has to be all-or-nothing from the caller's point of view: either every component you touched becomes visible and crash-durable, or none of it does. A commit that can be interrupted partway — by a timeout, a lock failure, or a crash — and leave some components written and others not is worse than no transaction support at all. Symmetrically, an aborted transaction must always finish unwinding its work; a rollback that itself times out and leaves orphaned revisions behind turns every failure into a slow leak. `Commit`/`Rollback` are the two calls that give those guarantees without the caller having to reason about internal ordering.
+
+## ⚙️ How it works (in brief)
+`Commit` processes each touched component in two halves: PREPARE (conflict detection/resolution, index and spatial-index maintenance — fallible work, nothing made visible yet) and PUBLISH (clear isolation flags, bump revision sequence numbers, copy into cluster slots — plain field writes). Between the two phases sits one WAL append, the commit's point of no return: once it succeeds the transaction *is* `Committed`, even if a later `Immediate`-mode durability wait can't confirm the fsync in time (see [Commit Pipeline](../Durability/commit-pipeline.md) for the full append-before-publish mechanics). `Rollback` has no such split — it runs entirely inside a holdoff (see [Deadline & Cooperative Cancellation](./deadline-cancellation.md)) so cleanup always reaches completion regardless of the caller's deadline.
+
+## 💻 Usage
+```csharp
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.GroupCommit);
+using var tx = uow.CreateTransaction();
+
+tx.OpenMut(accountId).Write(Account.Balance).Amount -= 10m;
+
+var ctx = UnitOfWorkContext.FromTimeout(TimeSpan.FromSeconds(2));
+try
+{
+    bool committed = tx.Commit(ref ctx);   // null handler => last-writer-wins on conflicts
+}
+catch (TyphonTimeoutException)
+{
+    // Deadline expired before any work was touched — state is still InProgress.
+    var rbCtx = UnitOfWorkContext.None;    // rollback should never itself time out
+    tx.Rollback(ref rbCtx);
+}
+catch (CommitDurabilityUncertainException)
+{
+    // Already committed and visible — do not roll back, do not retry.
+}
+
+// Backward-compatible wrappers — no explicit context needed:
+tx.Commit();      // ConcurrencyConflictHandler optional; default 30s timeout
+tx.Rollback();    // infinite deadline (UnitOfWorkContext.None)
+```
+
+| Overload | Default | Effect |
+|---|---|---|
+| `Commit(ref UnitOfWorkContext, handler = null)` | — | Full control over the deadline; pass a `ConcurrencyConflictHandler` to resolve write-write conflicts instead of last-writer-wins |
+| `Commit(handler = null)` | `TimeoutOptions.Current.DefaultCommitTimeout` (30s) | Wrapper for call sites that don't need custom deadlines |
+| `Rollback(ref UnitOfWorkContext)` / `Rollback()` | infinite deadline | Rollback ignores the deadline for its own cleanup work regardless of which overload is used |
+
+## ⚠️ Guarantees & limits
+- **Atomic commit** — the only cancellation check in `Commit` is at entry, before any component is touched; once the holdoff opens, every component's PREPARE/PUBLISH runs to completion, so a deadline can never produce a partially-committed transaction.
+- **Append before publish** — no change (isolation flag, index, entity map, cluster slot) becomes visible before its WAL record is appended; see [Commit Pipeline](../Durability/commit-pipeline.md) for the full ordering and the residual spawn-publish throw case (#396).
+- **Rollback always completes** — runs entirely inside holdoff with no yield point; an expired deadline or cancelled token cannot abort cleanup partway through, by design (`Rollback()`'s wrapper uses `UnitOfWorkContext.None`).
+- **`bool` return, not an exception, for already-finished transactions** — both methods return `false` on an already-`Committed`/`Rollbacked` transaction and `true` on an empty (`Created`-state) one; only CRUD calls on a finished transaction throw `InvalidOperationException` (ADR-038).
+- **Conflict resolution is opt-in** — pass a `ConcurrencyConflictHandler` to `Commit` for anything other than last-writer-wins; see [Optimistic Conflict Resolution](./optimistic-conflict-resolution.md) for the handler API.
+- **A failed durability wait is not a failed commit** — `Immediate`-mode commits that append successfully but can't confirm the fsync raise `CommitDurabilityUncertainException`, never roll back; treat it as "committed, durability unconfirmed."
+- **A lock timeout mid-commit is still possible** — holdoff suppresses the cooperative cancellation check, not lock-acquisition failure; a `LockTimeoutException` can surface before the WAL append, leaving the transaction `InProgress` and requiring an explicit `Rollback()`.
+
+## 🧪 Tests
+- [TransactionTests](../../../test/Typhon.Engine.Tests/Data/TransactionTests.cs) — `DoubleCommit_ReturnsFalse`,
+  `DoubleRollback_ReturnsFalse`, `CrudAfterCommitOrRollback_ThrowsInvalidOperation`, `Rollback_*` series (created/
+  updated/deleted/multi-component), `Commit_AfterRollback_ReturnsFalse`, `Dispose_UncommittedTransaction_AutoRollbacks`
+- [TransactionUnitOfWorkContextTests](../../../test/Typhon.Engine.Tests/Concurrency/TransactionUnitOfWorkContextTests.cs)
+  — `Commit`/`Rollback` overloads taking `ref UnitOfWorkContext`: expired-deadline-at-entry throw,
+  already-committed/rolled-back returning `false`, holdoff correctness mid-commit
+
+## 🔗 Related
+- Related features: [Commit Pipeline](../Durability/commit-pipeline.md) (the append-before-publish mechanics in depth), [Deadline & Cooperative Cancellation](./deadline-cancellation.md), [Optimistic Conflict Resolution](./optimistic-conflict-resolution.md), [Unit of Work](./unit-of-work.md)
+
+<!-- Deep dive: claude/design/Transactions/transaction-overview.md §4-5, claude/design/Transactions/04-transaction-api.md -->
+<!-- Rules: claude/rules/durability.md — Module AP -->
+<!-- ADR: 038 — Transaction CRUD Throws on Invalid State — claude/adr/038-transaction-throw-on-invalid-state.md -->

--- a/doc/feature-set/Transactions/deadline-cancellation.md
+++ b/doc/feature-set/Transactions/deadline-cancellation.md
@@ -1,0 +1,69 @@
+# Deadline & Cooperative Cancellation
+> A single absolute deadline rides every transaction commit, aborting cleanly before work starts and never leaving a partial commit behind.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Transactions](./README.md)
+
+## 🎯 What it solves
+
+A commit can block on contended locks, revision-chain growth, or a durability wait — with no bound, a stuck commit holds resources indefinitely and stalls every transaction behind it. Per-call timeouts don't compose: a commit that re-derives a fresh timeout at each internal step (lock acquire, index update, WAL wait) can run far longer than the caller intended. And a timeout that fires *during* a commit is worse than no timeout at all if it aborts mid-write — half the components persisted, half not. Typhon needs one deadline shared by the whole commit, cancellation that reaches code blocked on a lock or a wait (not just spinning code), and a hard guarantee that once a commit starts mutating data it cannot be cut off partway through.
+
+## ⚙️ How it works (in brief)
+
+`UnitOfWorkContext` is a 24-byte struct carrying an absolute `Deadline`, a `CancellationToken`, the UoW id, and a holdoff counter; it is passed `ref` into `Transaction.Commit`/`Rollback` and propagates unchanged into every lock acquisition along the commit path, so every internal wait shares the same endpoint. `Commit` checks `ctx.ThrowIfCancelled()` exactly once, at entry, before any data is touched — that is the only place a timeout or cancellation can abort the operation. Immediately after, it enters a holdoff region (`ctx.EnterHoldoff()`) that wraps the entire commit loop and nested critical sections (B+Tree splits, revision-chain appends): while in holdoff, cancellation checks are a no-op, so the deadline keeps running underneath but cannot interrupt the commit — it can only fail a lock acquisition, never abandon a half-written commit. A 200Hz `DeadlineWatchdog` fires the `CancellationToken` for any deadline within ~5ms of expiry, so threads parked on a wait (e.g. WAL durability) observe cancellation too, not just threads spinning on a lock.
+
+## 💻 Usage
+
+```csharp
+using var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+using var t = dbe.CreateQuickTransaction();
+t.Spawn<CompAArch>(CompAArch.A.Set(in a));
+
+// One relative timeout, converted to an absolute deadline once.
+var ctx = UnitOfWorkContext.FromTimeout(TimeSpan.FromSeconds(5));
+
+try
+{
+    t.Commit(ref ctx);   // every lock acquired during commit shares ctx's single deadline
+}
+catch (TyphonTimeoutException)
+{
+    // Deadline expired before commit began — transaction state is still InProgress, untouched.
+    t.Rollback();
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `Commit(handler)` / `Rollback()` | `TimeoutOptions.Current.DefaultCommitTimeout` (30s) / infinite | Backward-compatible overloads — no `ref ctx` needed, existing call sites are unaffected |
+| `UnitOfWorkContext.FromTimeout(TimeSpan)` | — | Converts a relative timeout to an absolute deadline, no cancellation token |
+| `UnitOfWorkContext.None` | — | Infinite deadline, no cancellation — used internally for rollback/cleanup |
+
+## ⚠️ Guarantees & limits
+
+- **Commit atomicity** — the only yield point in `Commit()` is before any mutation begins; once the holdoff opens, the commit loop runs to completion regardless of deadline expiry. A timeout can never leave some components committed and others not.
+- **Rollback always completes** — `Rollback()` runs entirely under holdoff with no yield point; cleanup is never abandoned, even with an expired deadline or cancelled token.
+- **Deadline composition** — internal lock sites combine the UoW deadline with a subsystem timeout via `Deadline.Min`, so a long UoW deadline never overrides a tighter internal lock-timeout ceiling.
+- **~5ms cancellation latency** — the `DeadlineWatchdog` checks registered deadlines at 200Hz; threads blocked on a wait (not spinning) observe cancellation within one tick, not instantly.
+- **Zero allocation** — `UnitOfWorkContext` is a stack-passed struct; no heap object, no pooling, no GC pressure on the commit hot path.
+- **A lock timeout during holdoff still throws** — holdoff suppresses the cooperative `ThrowIfCancelled()` check, not lock-acquisition failures; a `LockTimeoutException` can still surface mid-commit, leaving the transaction `InProgress` and requiring an explicit `Rollback()`.
+- **Backward compatible** — `Commit()`/`Rollback()` without a context build one internally (30s default / infinite); all pre-existing call sites behave unchanged.
+
+## 🧪 Tests
+
+- [TransactionUnitOfWorkContextTests](../../../test/Typhon.Engine.Tests/Concurrency/TransactionUnitOfWorkContextTests.cs)
+  — `Commit`/`Rollback(ref UnitOfWorkContext)`: expired-deadline and cancelled-token throw at entry,
+  expired-during-holdoff still commits, holdoff nesting counter, `ComposeWaitContext_*` deadline-composition cases
+- [UnitOfWorkContextTests](../../../test/Typhon.Engine.Tests/Concurrency/UnitOfWorkContextTests.cs) — the
+  `UnitOfWorkContext` struct itself: 24-byte size, `FromTimeout`/`None`, holdoff enter/exit semantics
+  (`ThrowIfCancelled` becomes a no-op inside holdoff, throws again after exit)
+- [DeadlineWatchdogTests](../../../test/Typhon.Engine.Tests/Concurrency/DeadlineWatchdogTests.cs) — the 200Hz
+  watchdog firing `CancellationToken`s for deadlines near expiry, so parked (not spinning) waiters observe
+  cancellation
+
+## 🔗 Related
+
+- Related feature: [Deadline & Timeout Propagation](../Foundation/deadline-timeout-propagation.md) (the underlying `Deadline`/`WaitContext` primitives)
+
+<!-- Deep dive: claude/design/Transactions/01-uow-context.md, claude/design/Transactions/02-deadline-watchdog.md, claude/design/Transactions/03-yield-points-holdoff.md, claude/design/Transactions/04-transaction-api.md -->
+<!-- Overview: claude/overview/02-execution.md §2.4-2.6 -->
+<!-- ADR: 034 — UnitOfWorkContext Struct Design — claude/adr/034-unitofworkcontext-struct-design.md -->

--- a/doc/feature-set/Transactions/durability-discipline/README.md
+++ b/doc/feature-set/Transactions/durability-discipline/README.md
@@ -1,0 +1,67 @@
+# SingleVersion Durability Discipline (TickFence / Commit)
+> Per-transaction knob that picks how a `SingleVersion` write becomes durable, orthogonal to `DurabilityMode`.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Transactions](../README.md)
+
+**Assumes:** [SingleVersion (Tick-Fence Durability)](../../Ecs/storage-modes/storage-mode-singleversion.md)
+
+## 🎯 What it solves
+
+`SingleVersion` components write in ~3ns (an in-place store) but are durable only at the next tick fence — up to
+one tick of writes can be lost on crash. Some writes need atomicity and zero loss — a teleport, an item pickup, a
+currency debit — without the snapshot isolation or AS-OF history a `Versioned` component provides. Routing those
+writes through `Versioned` buys zero-loss durability at ~6x the write cost (a revision-chain allocation plus its
+GC) for an isolation guarantee they never use. `DurabilityDiscipline` is a second, transaction-scoped knob that
+makes a `SingleVersion` write commit-durable without changing the component's layout or paying that tax.
+
+## ⚙️ How it works (in brief)
+
+`DurabilityDiscipline { TickFence (default) | Commit }` is fixed when a transaction is created — via
+`dbe.CreateQuickTransaction(discipline:)`, `uow.CreateTransaction(discipline:)`, or
+`ctx.CreateSideTransaction(mode, discipline)` — and never changes for that transaction's lifetime. It is
+orthogonal to `DurabilityMode`: `DurabilityMode` decides *when* a UoW's WAL records reach stable media,
+`DurabilityDiscipline` decides *how* a `SingleVersion` write reaches the WAL in the first place. The two compose
+freely — `Commit` discipline under a `Deferred` UoW still buffers its WAL record until `Flush()`. Discipline is
+**uniform per transaction** (CM-02): a component declared `[Component(DefaultDiscipline = Commit)]` silently
+escalates the whole transaction to `Commit` on first touch; once escalated, every `SingleVersion` write that
+transaction makes is commit-staged.
+
+## Sub-features
+
+| Sub-feature | Use when | Write cost (Zen 4) | Loss window |
+|-------------|----------|---------------------|--------------|
+| [TickFence discipline (default)](./durability-discipline-tickfence.md) | High-frequency, loss-tolerant data (positions, AI state, anything the next tick re-derives) | ~3 ns | ≤ 1 tick |
+| [Commit discipline (Variant-A staging)](./durability-discipline-commit.md) | Atomic, zero-loss writes that don't need snapshot isolation (teleport, item pickup, currency debit) | ~23 ns stage / ~65 ns publish | zero |
+
+## ⚠️ Guarantees & limits
+
+- Applies only to `StorageMode.SingleVersion` components — `Versioned` writes are already commit-scoped (no
+  benefit from this knob), `Transient` is never durable (the knob is meaningless there).
+- Discipline is fixed at transaction start; there is no API to change it mid-transaction (CM-02).
+- Both disciplines give read-committed isolation, not snapshot isolation — a `SingleVersion` component (under
+  either discipline) used with `ReadsSnapshot` fails loudly at scheduler `Build()` time (rule CM-04); use
+  `Versioned` for snapshot/AS-OF reads.
+- Composes with any `DurabilityMode` — discipline picks the write→WAL mechanism, mode still picks the flush
+  timing.
+- No revision chain is ever allocated for `SingleVersion` writes under either discipline; recovery replays both
+  through the same `RecoveryApplier` slot upsert (LSN-ordered, last-writer-wins) — zero discipline-specific
+  recovery code.
+
+## 🧪 Tests
+
+- [CommittedDisciplineTests](../../../../test/Typhon.Engine.Tests/Data/ECS/CommittedDisciplineTests.cs) —
+  `DefaultDiscipline_Commit_EscalatesTransaction` covers the CM-02 uniform-per-transaction escalation rule that
+  makes the two disciplines mutually exclusive within one transaction
+- [StorageModeTickFenceTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeTickFenceTests.cs) — the
+  default `TickFence` path this knob overrides
+
+## 🔗 Related
+
+- Sub-features: [TickFence discipline (default)](./durability-discipline-tickfence.md), [Commit discipline
+  (Variant-A staging)](./durability-discipline-commit.md)
+- Related feature: [Durability Modes](../durability-modes/README.md) — the orthogonal per-UoW axis that decides
+  *when* WAL records reach stable media
+
+<!-- Deep dive: claude/overview/02-execution.md — Durability Discipline (SingleVersion) (#durability-discipline-singleversion), claude/design/Ecs/committed-storage-mode.md -->
+<!-- ADR: ADR-057 — Committed Durability Discipline — claude/adr/057-committed-durability-discipline.md -->
+<!-- Rules: claude/design/Durability/MinimalWal/07-rules.md — module CM -->

--- a/doc/feature-set/Transactions/durability-discipline/durability-discipline-commit.md
+++ b/doc/feature-set/Transactions/durability-discipline/durability-discipline-commit.md
@@ -1,0 +1,96 @@
+# Commit Discipline (Variant-A Staging)
+> Atomic, zero-loss `SingleVersion` writes — durable and visible together at `Commit()`, with no revision chain.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Transactions](../README.md)
+
+**Assumes:** [SingleVersion (Tick-Fence Durability)](../../Ecs/storage-modes/storage-mode-singleversion.md)
+
+## 🎯 What it solves
+
+A `SingleVersion` write under the default `TickFence` discipline can lose up to one tick on crash — fine for
+regenerable state, unacceptable for a teleport, an item pickup, or a currency debit. The traditional fix is to
+make the component `Versioned`, but that pays a ~6x write-cost tax (copy-on-write content-chunk allocation,
+revision-chain append, eventual GC) for snapshot isolation and AS-OF history these writes never use. `Commit`
+discipline closes that gap: zero-loss, atomic durability at near-`SingleVersion` write cost, with no chain.
+
+## ⚙️ How it works (in brief)
+
+A `Commit`-discipline write stages its value into a per-transaction native arena — the cluster HEAD slot is never
+touched before commit (CM-01). The first write to a given (entity, component) pair seeds the staging slot from
+the current HEAD, so partial-field writes are correct. At `Commit()`, every staged value is appended to the WAL
+as an ordinary slot record (carrying a `Committed` flag, telemetry only) and, after the append, published in
+place: memcpy into HEAD, exact secondary B+Tree index reconciled, slot marked dirty — the same publish step
+`Versioned` uses for its exact-index guarantee. `Rollback()` is O(1): the arena is discarded and HEAD was never
+touched, so there is nothing to undo. Discipline is uniform per transaction (CM-02) — once any write escalates,
+every `SingleVersion` write that transaction makes is staged the same way.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Wallet", 1, StorageMode = StorageMode.SingleVersion,
+           DefaultDiscipline = DurabilityDiscipline.Commit)]   // optional: every tx touching this escalates
+struct Wallet { public long Gold; }
+
+[Archetype(42)]
+partial class Player : Archetype<Player>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+    public static readonly Comp<Wallet> Wallet = Register<Wallet>();
+}
+
+// Explicit escalation for one critical operation:
+using var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit);
+ref var pos = ref tx.OpenMut(playerId).Write(Player.Pos);
+pos.X = teleportTarget.X;
+pos.Y = teleportTarget.Y;
+tx.Commit();                  // staged value WAL-logged then published — zero loss on crash
+
+// From inside a scheduled system, via the TickContext side-transaction idiom:
+using var side = ctx.CreateSideTransaction(DurabilityMode.Immediate, DurabilityDiscipline.Commit);
+side.OpenMut(playerId).Write(Player.Wallet).Gold -= price;
+side.Commit();
+```
+
+| Discipline | Write cost (Zen 4) | Durable when | Loss window | Isolation |
+|------------|---------------------|--------------|-------------|-----------|
+| `TickFence` (default) | ~3 ns | at the next tick fence | ≤ 1 tick | tick-fence |
+| `Commit` | ~23 ns stage / ~65 ns publish | at `Commit()` | zero | read-committed |
+
+## ⚠️ Guarantees & limits
+
+- All of a transaction's `Commit`-discipline writes become visible together at commit, or none do — `Rollback()`
+  discards the staged values and HEAD is unaffected (CM-01).
+- Read-your-own-writes works for point reads (`EntityRef.Read`/`Write`) inside the writing transaction. Bulk span
+  reads (`ClusterRef.GetSpan<T>`) taken *inside* that same transaction do **not** see staged values — they read
+  HEAD. Read after commit, or through a different transaction, instead.
+- Isolation is **read-committed**, not snapshot — a `Commit`-discipline component used with `ReadsSnapshot` fails
+  loudly at scheduler `Build()` (rule CM-04); use `Versioned` for snapshot/AS-OF reads.
+- No revision chain and no deferred-cleanup GC cost — rollback is an arena reset, not a chain unwind (AC-6).
+- An indexed field additionally pays a B+Tree `Move` (~200 ns) at commit, the same cost a `Versioned` write
+  pays — the ≤25 ns / ≤60 ns targets are for non-indexed fields. Spatial indexing stays fence-batched for all
+  modes (no extra commit-time cost).
+- A duplicate WAL record from a concurrent tick fence re-emitting the just-committed value is benign
+  (last-writer-wins by LSN, rule CM-03) — at most one redundant record, never a correctness issue.
+- Recovery needs no discipline-specific code: a `Commit`-discipline write is an ordinary WAL slot record, replayed
+  by the same `RecoveryApplier` slot upsert as every other write (AC-7).
+- Composes with any `DurabilityMode`: discipline picks the write→WAL mechanism, mode still picks the flush
+  timing — pairing `Commit` discipline with `DurabilityMode.Deferred` still buffers the WAL record until
+  `Flush()`.
+
+## 🧪 Tests
+
+- [CommittedDisciplineTests](../../../../test/Typhon.Engine.Tests/Data/ECS/CommittedDisciplineTests.cs) —
+  staging/publish (`CommitDiscipline_Write_PublishesAtCommit`), read-your-own-writes, rollback discards staged
+  values (`CommitDiscipline_Rollback_DiscardsStaged`), multi-write atomicity, indexed-field commit cost
+- [CommittedDisciplineRecoveryTests](../../../../test/Typhon.Engine.Tests/Durability/CrashRecovery/CommittedDisciplineRecoveryTests.cs)
+  — zero-loss crash survival, mixed `Commit`/`TickFence` writes under churn, indexed cluster spawn across a
+  consolidating checkpoint crash
+
+## 🔗 Related
+
+- Parent feature: [SingleVersion Durability Discipline](./README.md)
+- Sibling: [TickFence discipline (default)](./durability-discipline-tickfence.md)
+
+<!-- Deep dive: claude/overview/02-execution.md — Durability Discipline (SingleVersion) (#durability-discipline-singleversion), claude/design/Ecs/committed-storage-mode.md -->
+<!-- ADR: ADR-057 — Committed Durability Discipline — claude/adr/057-committed-durability-discipline.md -->
+<!-- Rules: claude/design/Durability/MinimalWal/07-rules.md — module CM -->

--- a/doc/feature-set/Transactions/durability-discipline/durability-discipline-tickfence.md
+++ b/doc/feature-set/Transactions/durability-discipline/durability-discipline-tickfence.md
@@ -1,0 +1,78 @@
+# TickFence Discipline (Default)
+> The default, lowest-cost `SingleVersion` write — durable at the next tick fence, not at commit.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Transactions](../README.md)
+
+**Assumes:** [SingleVersion (Tick-Fence Durability)](../../Ecs/storage-modes/storage-mode-singleversion.md)
+
+## 🎯 What it solves
+
+The bulk of a real-time simulation's writes — positions, velocities, AI state, anything the next tick
+recomputes anyway — don't need per-write durability. Paying a WAL append, or worse a revision-chain allocation,
+on every one of these writes would dominate the tick budget for no benefit: if the process crashes, the next
+tick would have overwritten the value regardless. `TickFence` discipline gives these writes the cheapest
+possible path while still bounding the data-at-risk window to a single tick.
+
+## ⚙️ How it works (in brief)
+
+A `TickFence`-discipline write is an in-place store directly into the `SingleVersion` cluster slot (HEAD) — no
+staging, no per-write WAL append. The write marks the slot's chunk in the table's `DirtyBitmap`; at the tick
+fence, the engine batches every dirty slot since the last fence into WAL records in one pass. This is the same
+path every `SingleVersion` write has always used — `TickFence` is simply the name for it now that `Commit` exists
+as an alternative. It is the implicit default: any transaction created without an explicit `discipline:` argument
+uses it.
+
+## 💻 Usage
+
+```csharp
+[Archetype(42)]
+partial class Player : Archetype<Player>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();   // StorageMode.SingleVersion
+}
+
+// Game tick — TickFence is the default, no argument needed
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.Deferred);
+using var tx = uow.CreateTransaction();
+ref var pos = ref tx.OpenMut(playerId).Write(Player.Pos);
+pos.X += velocity.X * dt;
+pos.Y += velocity.Y * dt;
+tx.Commit();                  // ~3 ns write; value rides the next tick fence to the WAL
+
+// Equally explicit, if calling out the choice matters at the call site:
+using var tx2 = uow.CreateTransaction(discipline: DurabilityDiscipline.TickFence);
+```
+
+## ⚠️ Guarantees & limits
+
+- Commit latency is unaffected by this write — there is no per-write WAL or commit-time cost; the cost is paid
+  once per tick at the fence, amortized across every dirty `SingleVersion` slot.
+- Data-at-risk window is **up to one tick** (~16ms at 60fps): a crash between the write and the next fence loses
+  it. Acceptable for state the simulation regenerates or where a one-tick rollback is harmless.
+- Tick-fence isolation — distinct from `Commit`'s read-committed: bulk and point reads by other transactions
+  always read HEAD directly (no chain to walk, no staging to consult), so a reader can observe a value the
+  writer hasn't yet flushed to WAL.
+- A `SingleVersion` component used with `ReadsSnapshot` is rejected at scheduler `Build()` (rule CM-04) under
+  either discipline — `TickFence` has no history to freeze to.
+- Mixing disciplines on the same component across different transactions is fine — `TickFence` and `Commit`
+  writes to the same slot compose correctly at recovery (last-writer-wins by LSN).
+- A component declared `[Component(DefaultDiscipline = DurabilityDiscipline.Commit)]` cannot be written
+  `TickFence`-style: the first write to it escalates the whole transaction to `Commit` (CM-02). Once any
+  `TickFence` in-place write has already happened in that transaction, later escalation to `Commit` throws —
+  pick the discipline before the first write.
+
+## 🧪 Tests
+
+- [StorageModeTickFenceTests](../../../../test/Typhon.Engine.Tests/Data/StorageModeTickFenceTests.cs) —
+  `WriteTickFence_ClearsDirtyBitmap` (in-place write, dirty-bitmap batching), `WriteTickFence_VersionedAndTransient_Skipped`
+  (discipline only applies to `SingleVersion`)
+- [TickFenceE2ETests](../../../../test/Typhon.Engine.Tests/Durability/TickFenceE2ETests.cs) — end-to-end
+  write/reopen survival, last-write-wins across multiple updates, multi-entity recovery, only-dirty-entities-written
+
+## 🔗 Related
+
+- Parent feature: [SingleVersion Durability Discipline](./README.md)
+- Sibling: [Commit discipline (Variant-A staging)](./durability-discipline-commit.md)
+
+<!-- Deep dive: claude/overview/02-execution.md — Durability Discipline (SingleVersion) (#durability-discipline-singleversion) -->
+<!-- ADR: ADR-057 — Committed Durability Discipline — claude/adr/057-committed-durability-discipline.md -->

--- a/doc/feature-set/Transactions/durability-modes/README.md
+++ b/doc/feature-set/Transactions/durability-modes/README.md
@@ -1,0 +1,94 @@
+# Durability Modes (Deferred / GroupCommit / Immediate)
+> Per-UoW control of WAL flush timing — trade commit latency for the data-at-risk window on crash.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Transactions](../README.md)
+
+## 🎯 What it solves
+
+The Unit of Work (UoW) is Typhon's durability boundary — the closest equivalent to a session or connection in a
+traditional database. Different workloads sharing one engine instance need different durability guarantees: a
+game tick can tolerate losing the last ~16ms of work on crash, a player trade must never lose anything, and a
+general request handler sits somewhere in between. A single global durability setting would force every workload
+onto the slowest, most conservative choice. `DurabilityMode` lets each UoW pick its own commit-latency vs.
+data-at-risk trade-off once, at creation, independent of every other UoW running concurrently.
+
+## ⚙️ How it works (in brief)
+
+`DurabilityMode` is fixed when a UoW is created and controls only **when** that UoW's WAL records are forced to
+stable media (FUA) — never whether a transaction commits or becomes MVCC-visible. Every `tx.Commit()` inside the
+UoW serializes its WAL record to the commit buffer in ~1-2µs regardless of mode; the mode decides whether that
+record stays buffered until you ask (`Deferred`), gets swept up by the WAL writer's periodic flush
+(`GroupCommit`, default every 5ms), or blocks the calling thread for the FUA round-trip before `Commit()` returns
+(`Immediate`, ~15-85µs). The transaction is always the unit of crash atomicity in every mode — recovery replays a
+clean prefix of committed work, never a half-applied transaction.
+
+## 💻 Usage
+
+```csharp
+// Game tick — batch many transactions, flush once at the tick boundary
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.Deferred);
+foreach (var player in activePlayers)
+{
+    using var tx = uow.CreateTransaction();
+    ref var pos = ref tx.OpenMut(player.Id).Write(Player.Position);
+    ApplyMovement(ref pos);
+    tx.Commit();              // ~1-2µs — WAL record buffered, not yet on disk
+}
+await uow.FlushAsync();       // one FUA for the whole tick's worth of changes
+
+// General request handler — bounded data-at-risk, no per-tx wait
+using var req = dbe.CreateUnitOfWork(DurabilityMode.GroupCommit);
+using var tx2 = req.CreateTransaction();
+ref var hp = ref tx2.OpenMut(targetId).Write(Player.Health);
+hp.Current -= damage;
+tx2.Commit();                 // ~1-2µs — durable within WalWriterOptions.GroupCommitIntervalMs (default 5ms)
+
+// Financial trade — zero data-at-risk
+using var trade = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+ref var wallet = ref trade.OpenMut(buyerId).Write(Player.Wallet);
+wallet.Gold -= price;
+trade.Commit();               // blocks ~15-85µs — WAL FUA complete before returning
+```
+
+| Mode | Commit latency | Data-at-risk window | Best for |
+|------|-----------------|----------------------|----------|
+| `Deferred` | ~1-2µs | until `uow.Flush()` / `FlushAsync()` | game ticks, batch imports |
+| `GroupCommit` | ~1-2µs | ≤ `GroupCommitIntervalMs` (default 5ms) | general request handlers |
+| `Immediate` | ~15-85µs | zero | trades, irreversible state changes |
+
+## ⚠️ Guarantees & limits
+
+- Mode is fixed for the UoW's lifetime — there is no API to change it mid-UoW; open a second UoW for a
+  different trade-off.
+- Atomicity and MVCC isolation are unaffected by mode — only the post-crash data-loss window changes.
+- `GroupCommitIntervalMs` is an engine-wide WAL writer setting (`DatabaseEngineOptions.Wal`), shared by every
+  `GroupCommit` UoW; the WAL writer also flushes early once the ring buffer exceeds 80% capacity, so the
+  interval is a maximum delay, not a guarantee.
+- Disposing a `Deferred` UoW does **not** flush — unflushed work stays volatile until something else flushes
+  the WAL (explicit `Flush()`/`FlushAsync()`, the GroupCommit timer, or back-pressure). `GroupCommit` and
+  `Immediate` UoWs flush on dispose.
+- `Immediate` can throw `CommitDurabilityUncertainException` if the FUA confirmation doesn't arrive in time —
+  the transaction is already committed and MVCC-visible; this means "durability unconfirmed," never a rollback.
+- Two orthogonal knobs extend this axis without changing UoW mode: [Per-Transaction Durability
+  Override](./durability-override-escalation.md) escalates a single operation's flush timing, and
+  [SingleVersion Durability Discipline](../durability-discipline/README.md) controls *how* a `SingleVersion`
+  write becomes durable, independent of flush timing.
+- Max durable tx/s: ~12K-65K for `Immediate` (FUA round-trip bound) vs. millions for `GroupCommit`/`Deferred`
+  (CPU-bound, amortized FUA).
+
+## 🧪 Tests
+
+- [WalIntegrationTests](../../../../test/Typhon.Engine.Tests/Durability/WalIntegrationTests.cs) —
+  `WAL_GameTick_DeferredBatch_FlushAtEnd` (batched `Deferred` commits + single end-of-tick flush),
+  `WAL_CriticalTrade_ImmediateAtomicity` (`Immediate` zero-loss trade), `WAL_MixedDurability_AllModesCoexist`
+  (all three modes running concurrently), `WAL_Commit_DurableLsnAdvances` (parametrized across all three modes)
+
+## 🔗 Related
+
+- Sub-features: [Per-Transaction Durability Override](./durability-override-escalation.md)
+- Related feature: [SingleVersion Durability Discipline](../durability-discipline/README.md) — the orthogonal
+  per-transaction axis (TickFence/Commit) that decides *how* a `SingleVersion` write reaches the WAL
+
+<!-- Deep dive: claude/overview/02-execution.md §2.1 Unit of Work (#21-unit-of-work), §2.3 Durability Modes (#23-durability-modes), claude/overview/README.md -->
+<!-- ADRs: ADR-005 — Durability Mode Per Unit of Work — claude/adr/005-durability-mode-per-uow.md, ADR-036 — WAL Durability Modes Architecture — claude/adr/036-wal-durability-modes.md -->
+<!-- Rules: claude/rules/durability.md — module UoW Registry -->

--- a/doc/feature-set/Transactions/durability-modes/durability-override-escalation.md
+++ b/doc/feature-set/Transactions/durability-modes/durability-override-escalation.md
@@ -1,0 +1,95 @@
+# Per-Transaction Durability Override
+> Escalate one critical operation to zero-loss durability without raising the durability mode of the surrounding batch.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Transactions](../README.md)
+
+## 🎯 What it solves
+
+A `Deferred` or `GroupCommit` UoW is the right choice for the bulk of a workload, but a single operation inside
+that batch — a rare item drop, a purchase — may need zero data-at-risk. Forcing the *entire* UoW to `Immediate`
+would pay the ~15-85µs FUA cost on every commit in the batch, not just the one that matters. Per-transaction
+escalation lets one operation get `Immediate`-grade durability while the rest of the batch keeps its cheaper
+mode.
+
+## ⚙️ How it works (in brief)
+
+Escalation is scoped to a transaction-sized UoW, not a flag on a single `Commit()` call: you open a dedicated,
+short-lived UoW with `DurabilityMode.Immediate` for just the critical operation, commit it, and continue the
+surrounding `Deferred`/`GroupCommit` batch unaffected. From top-level code this is
+`dbe.CreateQuickTransaction(DurabilityMode.Immediate)`; from inside a scheduled system — where you don't own a
+top-level `Transaction` — `TickContext.CreateSideTransaction(DurabilityMode.Immediate)` does the same thing
+without leaving the tick. Escalation only ever raises durability for the operation it wraps; it never changes
+the mode of any other UoW.
+
+## 💻 Usage
+
+```csharp
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.Deferred);
+
+// Fast batch — volatile until uow.Flush()
+foreach (var mob in npcs)
+{
+    using var tx = uow.CreateTransaction();
+    UpdateAI(tx, mob);
+    tx.Commit();                  // ~1-2µs, buffered
+}
+
+// One critical operation mid-batch — escalate via its own UoW
+using (var drop = dbe.CreateQuickTransaction(DurabilityMode.Immediate))
+{
+    ref var inv = ref drop.OpenMut(playerId).Write(Player.Inventory);
+    inv.Add(legendaryItem);
+    drop.Commit();                // ~15-85µs — durable on return, independent of `uow`'s mode
+}
+
+await uow.FlushAsync();           // flush the remaining buffered batch
+```
+
+```csharp
+// From inside a scheduled system — same escalation via the side-transaction idiom
+void GrantRareDrop(ref TickContext ctx, EntityId playerId, ItemId item)
+{
+    using var side = ctx.CreateSideTransaction(DurabilityMode.Immediate);
+    ref var inv = ref side.OpenMut(playerId).Write(Player.Inventory);
+    inv.Add(item);
+    side.Commit();
+}
+```
+
+| Approach | Scope | Cost paid by | Use when |
+|----------|-------|---------------|----------|
+| Whole-UoW `Immediate` | every commit in the UoW | every transaction (~15-85µs each) | the entire batch needs zero loss |
+| Dedicated escalation UoW / side-tx | one operation | just that operation | one rare critical operation inside a cheaper batch |
+
+## ⚠️ Guarantees & limits
+
+- Escalation only raises durability (`Deferred`/`GroupCommit` → `Immediate`); there is no mechanism to lower a
+  UoW's mode for a single commit.
+- The `DurabilityOverride` enum (`Default` / `Immediate`) is declared on the public API surface
+  (`DurabilityMode.cs`) per ADR-005 as a future
+  `Commit(DurabilityOverride)` parameter, but it is **not yet wired into `Transaction.Commit()`** — there is no
+  single-call escalation today. Use a dedicated `Immediate`-mode UoW (`CreateQuickTransaction`) or
+  side-transaction (`ctx.CreateSideTransaction`) for the escalated operation instead; both reuse the same
+  WAL-writer signal/wait path the override was designed around.
+- A `CreateQuickTransaction` UoW auto-disposes with its transaction, so the escalated operation's flush happens
+  on `Dispose()` even if `Commit()` already returned.
+- The escalated operation is its own atomic unit — it does not share a commit/rollback boundary with the
+  surrounding batch's transactions.
+- `Immediate` escalation can throw `CommitDurabilityUncertainException` if the FUA confirmation doesn't arrive
+  before the deadline — the operation is already committed and MVCC-visible; treat this as "durability
+  unconfirmed," not a rollback.
+
+## 🧪 Tests
+
+- [SideTransactionTests](../../../../test/Typhon.Engine.Tests/Runtime/SideTransactionTests.cs) — the
+  `ctx.CreateSideTransaction(DurabilityMode.Immediate)` escalation idiom: independent commit, snapshot-isolation
+  invisibility to the main tick transaction, caller-owned lifecycle
+
+## 🔗 Related
+
+- Parent feature: [Durability Modes](./README.md)
+- Sibling: [CreateQuickTransaction](../transaction-creation-patterns/transaction-creation-quick.md) — the entry
+  point this escalation idiom uses to open its dedicated `Immediate`-mode UoW
+
+<!-- Deep dive: claude/overview/02-execution.md §2.2 Transaction Commit Path (#22-transaction-commit-path), claude/design/Transactions/05-unit-of-work.md §3 (#3-48--durabilitymode-enum--state-machine-types) -->
+<!-- ADR: ADR-005 — Durability Mode Per Unit of Work — claude/adr/005-durability-mode-per-uow.md -->

--- a/doc/feature-set/Transactions/optimistic-conflict-resolution.md
+++ b/doc/feature-set/Transactions/optimistic-conflict-resolution.md
@@ -1,0 +1,76 @@
+# Optimistic Concurrency Conflict Resolution
+> Plug a handler into `Commit` to reconcile write-write conflicts per entity, instead of accepting silent last-writer-wins.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Transactions](./README.md)
+
+## 🎯 What it solves
+
+Typhon transactions take no locks during execution (ADR-003) — two transactions can read the same entity and both
+intend to write it, and by default the second one to commit simply overwrites the first. That's fine for most
+state, but some writes are not safe to clobber blindly: counters, deltas, accumulators, or anything where "last
+writer wins" silently discards real work. Without a way to inspect what changed underneath a transaction before
+its write lands, the only options are accept data loss or build retry/merge logic entirely outside the engine.
+
+## ⚙️ How it works (in brief)
+
+Pass a `ConcurrencyConflictHandler` to `Commit`. While committing, each entity is checked for a conflict (another
+transaction committed a newer value since this transaction's read); detection uses a monotonic per-entity commit
+counter rather than chain position, so background revision-chain compaction can't produce a false negative. When a
+conflict fires, a `ConcurrencyConflictSolver` is populated with the entity's read/committed/committing state and the
+handler is invoked once for that entity, under the entity's revision-chain lock — detection and resolution are one
+atomic step, no other writer can interleave. The handler resolves the conflict by writing the value it wants
+committed; if it writes nothing, the pre-seeded default (the committing transaction's own value) is what commits.
+
+## 💻 Usage
+
+```csharp
+void RebaseDelta(ref ConcurrencyConflictSolver solver)
+{
+    var delta = solver.CommittingData<Gold>().Amount - solver.ReadData<Gold>().Amount;
+    solver.ToCommitData<Gold>().Amount = solver.CommittedData<Gold>().Amount + delta;
+}
+
+using var t = dbe.CreateQuickTransaction();
+t.Open(playerId).Read(GoldArch.Gold);
+ref var w = ref t.OpenMut(playerId).Write(GoldArch.Gold);
+w.Amount -= 10;                 // spend 10 gold
+
+t.Commit(RebaseDelta);          // conflicting writers rebase instead of clobbering each other
+```
+
+| Helper | Effect |
+|---|---|
+| `solver.TakeRead<T>()` | Discard the change, revert to the read snapshot |
+| `solver.TakeCommitted<T>()` | Accept the other transaction's committed value |
+| `solver.TakeCommitting<T>()` | Keep this transaction's value (also the default with no handler) |
+| `solver.ToCommitData<T>() = ...` | Write a custom resolution (rebase, merge, clamp, …) |
+
+## ⚠️ Guarantees & limits
+
+- **No handler = last writer wins** — the default `Commit()` overload never inspects conflicts; the committing
+  value always replaces the prior one.
+- **One call per conflicting entity**, not per field — a multi-component commit can invoke the handler several
+  times in one `Commit()`, once per entity that actually conflicted.
+- **Runs under the revision-chain lock** — detection, handler execution, and publish are atomic; keep handlers
+  fast and allocation-light (no I/O, no calling back into the engine, no blocking waits).
+- **`ConcurrencyConflictSolver` is a reused, thread-local instance** — valid only for the duration of the handler
+  call; don't store a reference to it or its data pointers beyond that call.
+- **No abort path** — the handler can't reject the conflict and fail the commit; it can only choose what value
+  commits. Application-level "give up and roll back" logic has to be expressed by writing back the read value
+  (`TakeRead`) and checking for that outcome afterward, if that distinction matters.
+- **Versioned components only** — applies where a revision chain exists (`StorageMode.Versioned`); `Committed`/
+  `SingleVersion` writes have no prior revision to compare against.
+
+## 🧪 Tests
+
+- [ConcurrencyConflictTests](../../../test/Typhon.Engine.Tests/Data/ConcurrencyConflictTests.cs) — no-handler
+  last-writer-wins, delta-rebase and `TakeCommitted`/`TakeRead` resolutions, per-entity handler invocation on
+  multi-entity commits, concurrent-thread rebase race, `ConcurrencyConflictSolver` thread-local reuse
+
+## 🔗 Related
+
+- Related feature: [Write-Conflict Baseline Tracking](../Revision/optimistic-conflict-baseline.md) (the underlying per-entity baseline/CommitSequence mechanism), [Unit of Work](./unit-of-work.md)
+- Source: [`ConcurrencyConflictSolver`](../../../src/Typhon.Engine/Transactions/public/ConcurrencyConflictSolver.cs), [`Transaction.DetectAndResolveConflict`/`Commit`](../../../src/Typhon.Engine/Transactions/public/Transaction.cs), [`CommitContext`](../../../src/Typhon.Engine/Transactions/internals/CommitContext.cs)
+
+<!-- Deep dive: claude/design/Transactions/transaction-overview.md §4.2 (#42-conflict-detection--two-paths) -->
+<!-- ADR: 003 — MVCC Snapshot Isolation — claude/adr/003-mvcc-snapshot-isolation.md -->

--- a/doc/feature-set/Transactions/transaction-creation-patterns/README.md
+++ b/doc/feature-set/Transactions/transaction-creation-patterns/README.md
@@ -1,0 +1,62 @@
+# Transaction Creation Patterns
+> Three ways to obtain a `Transaction`, depending on how long the work lives and whether it writes at all.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Transactions](../README.md)
+
+## 🎯 What it solves
+
+Every write or read against Typhon starts with a `Transaction`, but not every caller needs the same scaffolding
+around it. A game tick wants one `UnitOfWork` shared by dozens of transactions with an explicit flush at the end; a
+REPL command or a test wants a single transaction with zero ceremony; a query handler that never writes shouldn't
+pay for a durability boundary it will never use. Picking the wrong pattern either adds boilerplate (manual UoW
+management for a one-off write) or wastes a scarce resource (a UoW Registry slot held by a pure read). These three
+entry points cover those cases without forcing every caller through the same full hierarchy.
+
+## ⚙️ How it works (in brief)
+
+All three patterns ultimately produce a `Transaction` pulled from the same pooled `TransactionChain`, so they share
+identical MVCC semantics, TSN assignment, and auto-rollback-on-`Dispose` behavior. They differ only in *who owns the
+`UnitOfWork`* — the durability boundary — and how much of it gets allocated. Standard creation gives the caller an
+explicit `UnitOfWork` to reuse across many transactions. `CreateQuickTransaction` hides the `UnitOfWork` behind the
+`Transaction` it returns, coupling their lifetimes. `CreateReadOnlyTransaction` skips the `UnitOfWork` entirely —
+no durability mode, no registry slot, no `ChangeSet`.
+
+## Sub-features
+
+| Pattern | Entry point | UoW lifetime | Use when |
+|---|---|---|---|
+| [Standard](./transaction-creation-standard.md) | `dbe.CreateUnitOfWork(mode)` then `uow.CreateTransaction()` | Caller-managed, spans N transactions | Game tick, request batch, bulk import |
+| [Quick transaction](./transaction-creation-quick.md) | `dbe.CreateQuickTransaction(mode)` | Disposed together with the one `Transaction` it owns | Single-shot write, REPL, tests |
+| [Read-only transaction](./transaction-creation-readonly.md) | `dbe.CreateReadOnlyTransaction()` | None — no UoW is allocated | Snapshot reads, query dispatch |
+
+## ⚠️ Guarantees & limits
+
+- All three return the same `Transaction` type — there is no read-only-specific or quick-specific subclass; the
+  difference is entirely in how (or whether) a `UnitOfWork` backs it.
+- Every pattern is single-thread-affine and auto-rolls-back on `Dispose()` if not explicitly committed — see
+  [Transaction Lifecycle, Thread Affinity & Pooling](../transaction-lifecycle-pooling.md) for the shared lifecycle
+  guarantees that apply regardless of which pattern created the transaction.
+- Choosing a pattern is a one-time decision per call site, not per transaction instance — there is no API to
+  convert a `Transaction` from one pattern to another after creation (e.g., a read-only transaction can never start
+  writing).
+- `UnitOfWork` instances are not pooled; only `Transaction` instances are (`TransactionChain`, capacity 16).
+
+## 🧪 Tests
+
+- [UnitOfWorkTests](../../../../test/Typhon.Engine.Tests/Execution/UnitOfWorkTests.cs) — standard pattern
+  (`UoW_CreateTransaction_ReturnsValidTx`, `UoW_MultipleTransactions_ShareIdentity`) and quick-transaction pattern
+  (`QuickTx_*`) side by side
+- [TransactionChainTests](../../../../test/Typhon.Engine.Tests/Data/TransactionChainTests.cs) — read-only pattern
+  (`ReadOnly_*`): no `UnitOfWork`, throws on write, snapshot isolation
+
+## 🔗 Related
+
+- Related features: [Transaction Lifecycle, Thread Affinity &
+  Pooling](../transaction-lifecycle-pooling.md) (full lifecycle guarantees), [Unit of
+  Work](../unit-of-work.md) (the durability boundary itself), [Durability Modes](../durability-modes/README.md)
+- Sub-features: [Standard (UnitOfWork + CreateTransaction)](./transaction-creation-standard.md),
+  [CreateQuickTransaction](./transaction-creation-quick.md), [CreateReadOnlyTransaction](./transaction-creation-readonly.md)
+
+<!-- Deep dive: claude/design/Transactions/transaction-overview.md §1 Three-Tier API Hierarchy (#1-three-tier-api-hierarchy) -->
+<!-- Overview: claude/overview/02-execution.md §2.1 Unit of Work (#21-unit-of-work) -->
+<!-- ADR: 001 — Three-Tier API Hierarchy — claude/adr/001-three-tier-api-hierarchy.md -->

--- a/doc/feature-set/Transactions/transaction-creation-patterns/transaction-creation-quick.md
+++ b/doc/feature-set/Transactions/transaction-creation-patterns/transaction-creation-quick.md
@@ -1,0 +1,77 @@
+# CreateQuickTransaction (single-shot, auto-dispose)
+> One call gives you a `UnitOfWork` and a `Transaction` fused into a single disposable.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Transactions](../README.md)
+
+## 🎯 What it solves
+
+Single-shot writes — a REPL command, a test fixture, a one-off background task — don't need a `UnitOfWork` the
+caller manages separately from its one `Transaction`; that's two objects and two `using` statements to express what
+is conceptually one operation. Without this convenience, every single-write call site would repeat the same
+two-line `CreateUnitOfWork` + `CreateTransaction` boilerplate and would need to remember to dispose both in the
+right order.
+
+## ⚙️ How it works (in brief)
+
+`dbe.CreateQuickTransaction(mode, discipline)` allocates a `UnitOfWork` exactly as the standard path does, then
+immediately creates one `Transaction` from it and marks that transaction as owning the UoW
+(`Transaction.OwnsUnitOfWork = true`). When the returned `Transaction` is disposed, its own `Dispose()` also
+disposes the backing `UnitOfWork` — so a single `using var tx = ...` is enough to get correct cleanup of both
+tiers, in the right order, even if the transaction is never explicitly committed.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1, StorageMode = StorageMode.SingleVersion)]
+struct Position { public float X, Y, Z; }
+
+[Archetype(42)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+}
+
+// Single-shot write — UoW and Transaction are created and disposed together.
+using var tx = dbe.CreateQuickTransaction(DurabilityMode.Immediate);
+tx.Spawn<Unit>(Unit.Pos.Set(new Position { X = 1, Y = 0, Z = 0 }));
+tx.Commit();                      // tx.Dispose() also disposes its owning UoW
+
+// Forgetting to commit is safe — Dispose() auto-rolls-back the transaction
+// and still disposes (and, for non-Deferred modes, flushes) the owned UoW.
+using (var tx2 = dbe.CreateQuickTransaction())
+{
+    tx2.Spawn<Unit>(Unit.Pos.Set(new Position { X = 2 }));
+    // no tx2.Commit() here — rolled back automatically on Dispose
+}
+```
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `durabilityMode` | `DurabilityMode.Deferred` | Durability mode of the hidden `UnitOfWork` — see [Durability Modes](../durability-modes/README.md). |
+| `discipline` | `DurabilityDiscipline.TickFence` | `SingleVersion` write discipline for the one transaction — see [Durability Discipline](../durability-discipline/README.md). |
+
+## ⚠️ Guarantees & limits
+
+- Exactly one `Transaction` is created per call; there is no way to draw a second transaction from the hidden
+  `UnitOfWork` — if you need more than one, use the [standard pattern](./transaction-creation-standard.md) instead.
+- Disposal order is fixed: the `Transaction`'s own cleanup (auto-rollback if uncommitted, deferred-cleanup
+  processing, epoch exit) runs before the owned `UnitOfWork` is disposed.
+- `DurabilityMode.Deferred` (the default) means `Dispose()` does **not** flush the owned UoW — the same rule as the
+  standard pattern applies; pick `GroupCommit` or `Immediate` if the single write must be durable before the
+  `using` block exits.
+- This is a convenience wrapper, not a distinct code path — the resulting `Transaction` and `UnitOfWork` behave
+  identically to ones created through the standard pattern once constructed.
+
+## 🧪 Tests
+
+- [UnitOfWorkTests](../../../../test/Typhon.Engine.Tests/Execution/UnitOfWorkTests.cs) —
+  `QuickTx_CommitThenDispose_CleanLifecycle` (fused UoW+tx dispose ordering), `QuickTx_DisposesUoW`,
+  `QuickTx_DurabilityMode_Passthrough` (mode flows through to the hidden `UnitOfWork`)
+
+## 🔗 Related
+
+- Code: `src/Typhon.Engine/Transactions/public/DatabaseEngineExtensions.cs` (`CreateQuickTransaction`)
+- Related features: [Standard creation](./transaction-creation-standard.md), [Unit of Work](../unit-of-work.md)
+- Parent feature: [Transaction Creation Patterns](./README.md)
+
+<!-- Deep dive: claude/design/Transactions/transaction-overview.md §1 Three-Tier API Hierarchy (#1-three-tier-api-hierarchy) -->

--- a/doc/feature-set/Transactions/transaction-creation-patterns/transaction-creation-readonly.md
+++ b/doc/feature-set/Transactions/transaction-creation-patterns/transaction-creation-readonly.md
@@ -1,0 +1,73 @@
+# CreateReadOnlyTransaction (snapshot reads)
+> A `Transaction` with no `UnitOfWork` behind it at all — for callers that never write.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🔵 Core · **Category:** [Transactions](../README.md)
+
+## 🎯 What it solves
+
+A pure read — query dispatch, a REPL inspection command, a background reporting pass — never produces a WAL record,
+so allocating a `UnitOfWork` for it (a durability mode, a scarce UoW Registry slot, a `ChangeSet`) is pure overhead
+with no corresponding benefit. Worse, that slot is shared, bounded capacity that a concurrent write workload could
+otherwise use. `CreateReadOnlyTransaction` is the entry point for "I only need to read at a consistent snapshot" —
+it skips the durability tier entirely while keeping full MVCC read semantics.
+
+## ⚙️ How it works (in brief)
+
+`dbe.CreateReadOnlyTransaction()` draws a `Transaction` from the same pool as every other transaction and gives it
+a TSN and a `TransactionChain` slot — it is fully visible to and governed by MVCC snapshot isolation exactly like a
+write transaction — but no `UnitOfWork` is created and `IsReadOnly` is set, which also skips `ChangeSet`
+allocation. Any write entry point on the returned transaction throws immediately rather than silently no-opping;
+`Commit()` is a no-op that returns `true`, since there is nothing to persist.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1, StorageMode = StorageMode.SingleVersion)]
+struct Position { public float X, Y, Z; }
+
+[Archetype(42)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+}
+
+using var rtx = dbe.CreateReadOnlyTransaction();
+
+if (rtx.TryOpen(unitId, out EntityRef e))
+{
+    ref readonly Position pos = ref e.Read(Unit.Pos);
+    Console.WriteLine($"{pos.X}, {pos.Y}, {pos.Z}");
+}
+
+rtx.Commit();   // no-op, returns true — there is nothing buffered to flush
+```
+
+## ⚠️ Guarantees & limits
+
+- No `UnitOfWork`, no `UowId`, no `ChangeSet` — a read-only transaction never consumes a UoW Registry slot and
+  never contributes to registry back-pressure.
+- Every write entry point (`Spawn`, `Destroy`, component `Write`, collection mutation) throws
+  `InvalidOperationException` immediately, before touching any state — there is no silent no-op fallback.
+- Still occupies a `TransactionChain` slot and TSN — a long-lived read-only transaction holds back `MinTSN` exactly
+  like a write transaction, delaying MVCC revision cleanup. Don't hold one open longer than the read needs.
+- Only `DatabaseEngine.CreateReadOnlyTransaction()` creates one — there is no `UnitOfWork.CreateReadOnlyTransaction()`
+  overload, because by definition this pattern bypasses the UoW tier.
+- Full read surface, identical to a write transaction — `Open`/`TryOpen`, `Read`, index enumeration, and queries
+  all behave the same under the same snapshot-isolation guarantee.
+
+## 🧪 Tests
+
+- [TransactionChainTests](../../../../test/Typhon.Engine.Tests/Data/TransactionChainTests.cs) —
+  `ReadOnly_CanRead_ThrowsOnWrite` (read works, every write entry point throws), `ReadOnly_Dispose_ActiveCountZero`,
+  `ReadOnly_SnapshotIsolation` (doesn't see later commits), `ReadOnly_PoolRecycling_ClearsFlag` (pool reuse across
+  read-only/read-write)
+
+## 🔗 Related
+
+- Code: `src/Typhon.Engine/Transactions/public/DatabaseEngineExtensions.cs` (`CreateReadOnlyTransaction`)
+- Parent feature: [Transaction Creation Patterns](./README.md)
+- Sibling: [Standard (UnitOfWork + CreateTransaction)](./transaction-creation-standard.md) — the write-capable
+  counterpart that does allocate a `UnitOfWork`
+
+<!-- Deep dive: claude/design/Transactions/transaction-overview.md §1 Three-Tier API Hierarchy (#1-three-tier-api-hierarchy) -->
+<!-- ADR: 038 — Transaction Throws on Invalid State — claude/adr/038-transaction-throw-on-invalid-state.md -->

--- a/doc/feature-set/Transactions/transaction-creation-patterns/transaction-creation-standard.md
+++ b/doc/feature-set/Transactions/transaction-creation-patterns/transaction-creation-standard.md
@@ -1,0 +1,81 @@
+# Standard Transaction Creation (UnitOfWork + CreateTransaction)
+> Open a `UnitOfWork` once, draw as many transactions from it as the batch needs.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Transactions](../README.md)
+
+## 🎯 What it solves
+
+Batched workloads — a game tick, a request handler processing several operations, a bulk import — need many
+transactions to share one durability decision: how many writes ride behind a single WAL flush. Creating a fresh
+durability boundary per transaction would mean a fresh `UowId` allocation and a separate flush decision per write,
+defeating the point of batching. The standard pattern gives the caller one long-lived `UnitOfWork` and lets it mint
+transactions on demand, each independently atomic but sharing the same flush policy.
+
+## ⚙️ How it works (in brief)
+
+`dbe.CreateUnitOfWork(mode, timeout)` allocates the `UnitOfWork` — a `UowId` from the registry, an absolute
+deadline, and (for `Deferred`/`GroupCommit`) a shared `ChangeSet`. The caller then calls `uow.CreateTransaction()`
+as many times as needed; each call pulls a `Transaction` from the pooled `TransactionChain`, stamps it with the
+UoW's identity, and returns it ready for use. Each transaction still commits or rolls back independently — the UoW
+only controls *when* the WAL records those commits produced become crash-safe, via `Flush()`/`FlushAsync()` or
+automatically on `Dispose()` (mode-dependent).
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1, StorageMode = StorageMode.SingleVersion)]
+struct Position { public float X, Y, Z; }
+
+[Archetype(42)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+}
+
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.GroupCommit, timeout: TimeSpan.FromSeconds(5));
+
+foreach (var move in pendingMoves)
+{
+    using var tx = uow.CreateTransaction();
+    tx.Spawn<Unit>(Unit.Pos.Set(move.Position));
+    tx.Commit();                  // ~1-2µs, visible immediately, durable within the group-commit window
+}
+
+await uow.FlushAsync();           // wait for this batch's records to reach stable media
+Console.WriteLine(uow.CommittedTransactionCount);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `durabilityMode` | `DurabilityMode.Deferred` | See [Durability Modes](../durability-modes/README.md) — when this UoW's WAL records become crash-safe. |
+| `timeout` | `TimeoutOptions.Current.DefaultUowTimeout` | Absolute deadline shared by every transaction, lock, and flush wait created under this UoW. |
+| `discipline` (on `CreateTransaction`) | `DurabilityDiscipline.TickFence` | Per-transaction `SingleVersion` write discipline — see [Durability Discipline](../durability-discipline/README.md). |
+
+## ⚠️ Guarantees & limits
+
+- One `UnitOfWork` can back any number of sequential or concurrent-on-different-thread transactions; there is no
+  cap on `CreateTransaction()` calls beyond the engine-wide active-transaction limit.
+- The caller owns the `UnitOfWork`'s lifetime explicitly — it is not disposed automatically by any transaction it
+  creates, unlike `CreateQuickTransaction`.
+- UoWs are flat, not nestable — `CreateUnitOfWork()` called while another is "logically" in scope just allocates a
+  second, independent UoW with its own `UowId` and deadline.
+- `TransactionCount`/`CommittedTransactionCount` on the `UnitOfWork` are observational counters; they do not gate
+  `Flush()` or `Dispose()`.
+- `CreateUnitOfWork` blocks (and can throw `ResourceExhaustedException`) if the UoW Registry is full and the
+  deadline expires before a slot frees — the standard pattern is the only one of the three that can hit this,
+  since it is the only one that allocates a registry slot the caller controls the lifetime of.
+
+## 🧪 Tests
+
+- [UnitOfWorkTests](../../../../test/Typhon.Engine.Tests/Execution/UnitOfWorkTests.cs) —
+  `UoW_CreateTransaction_ReturnsValidTx`, `UoW_MultipleTransactions_ShareIdentity` (shared `OwningUnitOfWork`
+  identity), `MultipleUoWs_ConcurrentAccess` (independent UoWs read/write concurrently)
+
+## 🔗 Related
+
+- Code: `src/Typhon.Engine/Transactions/public/UnitOfWork.cs`, `src/Typhon.Engine/Ecs/public/DatabaseEngine.cs`
+  (`CreateUnitOfWork`)
+- Related features: [Unit of Work](../unit-of-work.md), [Durability Modes](../durability-modes/README.md)
+- Parent feature: [Transaction Creation Patterns](./README.md)
+
+<!-- Deep dive: claude/design/Transactions/transaction-overview.md §2 UnitOfWork — public surface (#2-unitofwork--public-surface), claude/design/Transactions/05-unit-of-work.md -->

--- a/doc/feature-set/Transactions/transaction-lifecycle-pooling.md
+++ b/doc/feature-set/Transactions/transaction-lifecycle-pooling.md
@@ -1,0 +1,106 @@
+# Transaction Lifecycle, Thread Affinity & Pooling
+> The internals that make per-tick transaction churn cheap and misuse fail fast instead of corrupting state.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Transactions](./README.md)
+
+## 🎯 What it solves
+
+A game tick or request handler can create and dispose hundreds of `Transaction` objects per second; if each one were
+a fresh heap allocation guarded by a global lock, that churn alone would dominate the tick budget. At the same time,
+a `Transaction` is not thread-safe internally — using one from two threads, or calling CRUD on one that already
+committed, are both programmer errors that must surface immediately and loudly, not corrupt a chunk or silently
+no-op. And because every transaction's lifetime overlaps with MVCC snapshot isolation, *something* has to track which
+transaction is the oldest still active, so revision-chain garbage collection knows how far back it's safe to reclaim.
+This feature is the machinery behind `Transaction` that resolves all three: cheap reuse, fail-fast misuse detection,
+and the bookkeeping that drives MVCC GC.
+
+## ⚙️ How it works (in brief)
+
+Every `Transaction` instance is created on one thread and asserts (`[Conditional("DEBUG")]`) that every subsequent
+call comes from that same thread — `AssertThreadAffinity()` guards every public mutating method. A small state
+machine (`Created → InProgress → Committed`/`Rollbacked`) backs every transaction; `EnsureMutable()` throws
+`InvalidOperationException` if CRUD is attempted on an already-finished transaction, and `TransitionTo()` asserts
+(Debug-only) that only legal transitions occur. Underneath, `TransactionChain` hands out and reclaims `Transaction`
+instances: `CreateTransaction` allocates a monotonic TSN (`Interlocked.Increment`) and pushes the new transaction
+onto a singly-linked chain via a lock-free CAS loop (`PushHead`) — concurrent creators never block each other.
+`Dispose()` removes the transaction under a brief exclusive lock (`Remove`), recycles it into a 16-instance pool, and
+— if the removed transaction was the chain's tail (the oldest active TSN) — recomputes the new minimum TSN, which is
+the horizon the deferred-cleanup GC uses to know which revisions no MVCC snapshot can still see.
+
+## 💻 Usage
+
+```csharp
+[Component("Game.Position", 1, StorageMode = StorageMode.SingleVersion)]
+struct Position { public float X, Y, Z; }
+
+[Archetype(42)]
+partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Pos = Register<Position>();
+}
+
+// Pooling is transparent: each iteration draws/returns a Transaction from TransactionChain's
+// 16-instance pool — no per-tick heap allocation as long as concurrency stays at or below 16.
+for (int tick = 0; tick < 10_000; tick++)
+{
+    using var tx = dbe.CreateQuickTransaction();
+    tx.Spawn<Unit>(Unit.Pos.Set(new Position { X = tick }));
+    tx.Commit();
+}   // Dispose() resets the instance and returns it to the pool
+
+// The state machine fails fast: CRUD after Commit/Rollback throws instead of silently no-opping.
+using var tx2 = dbe.CreateQuickTransaction();
+tx2.Spawn<Unit>(Unit.Pos.Set(new Position { X = 1 }));
+tx2.Commit();                                  // tx2.State == TransactionState.Committed
+try
+{
+    tx2.Spawn<Unit>(Unit.Pos.Set(new Position { X = 2 }));
+}
+catch (InvalidOperationException)
+{
+    // "Cannot perform CRUD on a transaction in state Committed" — programmer error, not a no-op (ADR-038)
+}
+```
+
+## ⚠️ Guarantees & limits
+
+- **Thread affinity is Debug-only** — `AssertThreadAffinity()` is `[Conditional("DEBUG")]`; it is compiled out
+  entirely in Release builds, so cross-thread use of one `Transaction` is caught during development but is undefined
+  behavior (not a runtime exception) in Release. One `Transaction` per thread per tick is the supported pattern.
+- **Fail-fast state machine, no silent sentinels** — `Created → InProgress → Committed`/`Rollbacked` are the only
+  legal transitions; CRUD on an already-finished transaction throws `InvalidOperationException` rather than returning
+  `-1`/`false` (ADR-038). `Commit()`/`Rollback()` themselves are exceptions to this: calling either on an
+  already-finished transaction returns `false`, and on a still-`Created` (no-op) transaction returns `true`.
+- **Lock-free creation, briefly-locked removal** — `PushHead` is a CAS loop with zero blocking between concurrent
+  `CreateTransaction` callers; `Remove` (triggered by `Dispose()`) takes a short exclusive lock to unlink the node,
+  scanning at most `MaxActiveTransactions` nodes (~500ns worst case at 128 active transactions).
+- **Pooling is a perf optimization, not a hard cap** — up to 16 `Transaction` instances are recycled via a
+  `ConcurrentQueue`; beyond that, new instances are heap-allocated. The engine separately caps total *active*
+  transactions (`maxActiveTransactions`); exceeding it throws `ResourceExhaustedException` rather than blocking.
+- **MinTSN drives MVCC GC, not just diagnostics** — only the chain's tail (the transaction holding the oldest active
+  TSN) triggers `DeferredCleanupManager.ProcessDeferredCleanups` on `Dispose()`/`Commit()`/`Rollback()`. A long-lived
+  transaction at the tail stalls revision-chain reclamation engine-wide — the same hazard PostgreSQL's vacuum has
+  against `xmin`.
+- **TSN space is large but finite** — TSNs are assigned via `Interlocked.Increment`; the engine logs a warning as
+  the practical ceiling (`1 << 46`) approaches (no enforcement failure observed at realistic throughput).
+- **Known scaling limit (not yet implemented)** — `Remove`'s exclusive lock and O(n) scan remain a serialization
+  point projected to matter only past ~64-128 cores. A lock-free `TransactionRegistry` redesign is drafted (see
+  Related) but not built; `TransactionChain` is the shipping implementation.
+
+## 🧪 Tests
+
+- [TransactionChainTests](../../../test/Typhon.Engine.Tests/Data/TransactionChainTests.cs) —
+  `MPSC_ConcurrentCreates_AllTSNsUnique` (lock-free `PushHead` under concurrent creation),
+  `MinTSN_DisposeTail_Advances` (MVCC-GC horizon on tail dispose), `Stress_ConcurrentCreateDispose_ActiveCountZeroAtEnd`;
+  the file's second fixture `TransactionChainMaxActiveTests` covers the `maxActiveTransactions` cap and
+  `ResourceExhaustedException`
+- [TransactionTests](../../../test/Typhon.Engine.Tests/Data/TransactionTests.cs) — `TransitionTo_IllegalTransition_DebugAssertFails`
+  (state-machine legality), `CrudAfterCommitOrRollback_ThrowsInvalidOperation`, `Dispose_Idempotent_SecondCallNoOp`
+
+## 🔗 Related
+
+- Related features: [Unit of Work](./unit-of-work.md) (the three-tier API these internals back), [Transaction Creation Patterns](./transaction-creation-patterns/README.md), [Commit / Rollback Pipeline](./commit-rollback-pipeline.md)
+
+<!-- Deep dive: claude/design/Transactions/lock-free-transaction-chain.md, claude/design/Transactions/transaction-registry.md (drafted, not implemented) -->
+<!-- Overview: claude/overview/02-execution.md §2.11 Lock-Free TransactionChain (#211-lock-free-transactionchain), §2.1 Unit of Work — transaction pooling lifecycle (#21-unit-of-work) -->
+<!-- ADR: 038 — Transaction CRUD Throws on Invalid State — claude/adr/038-transaction-throw-on-invalid-state.md -->

--- a/doc/feature-set/Transactions/unit-of-work.md
+++ b/doc/feature-set/Transactions/unit-of-work.md
@@ -1,0 +1,76 @@
+# Unit of Work (durability boundary)
+> Batches one or more Transactions under a single flush/durability boundary.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟢 Start Here · **Category:** [Transactions](./README.md)
+
+## 🎯 What it solves
+
+A single flat `CreateTransaction()` call cannot express "how many writes should share one fsync." Some workloads
+want thousands of writes behind one flush (a game tick), others want every write durable before it returns (a
+financial trade) — and that choice is a property of the *batch*, not of any one write. The Unit of Work is the
+object that owns this choice: it is the durability boundary, separate from the Transaction's atomicity/isolation
+boundary, so callers pick batching granularity once per UoW instead of accepting a one-size-fits-all default per
+write.
+
+## ⚙️ How it works (in brief)
+
+`DatabaseEngine.CreateUnitOfWork(mode, timeout)` allocates a UoW: a `UowId` (stamped on every revision created
+within it, used for crash recovery), an absolute deadline, and — for `Deferred`/`GroupCommit` — a `ChangeSet` shared
+by every `Transaction` the UoW creates. `uow.CreateTransaction()` draws transactions from this scope; each commits
+independently (its own atomicity/isolation), but none of them control *when* their WAL records become crash-safe —
+that is `Flush()`/`FlushAsync()`'s job, driven by the UoW's `DurabilityMode`. `Dispose()` always releases the
+`UowId` back to the registry; for `GroupCommit`/`Immediate` it also flushes for durability, while `Deferred` leaves
+that decision to the caller.
+
+## 💻 Usage
+
+```csharp
+// One UoW batches many transactions; caller controls the flush.
+using var uow = dbe.CreateUnitOfWork(DurabilityMode.GroupCommit, timeout: TimeSpan.FromSeconds(5));
+
+foreach (var move in pendingMoves)
+{
+    using var tx = uow.CreateTransaction();
+    tx.Spawn<Unit>(Unit.Pos.Set(move.Position));
+    tx.Commit();                 // ~1-2µs, visible immediately
+}
+
+await uow.FlushAsync();          // waits for this UoW's records to reach stable media
+Console.WriteLine(uow.CommittedTransactionCount);
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `durabilityMode` | `DurabilityMode.Deferred` | See [Durability Modes](./durability-modes/README.md) — controls when `Flush`/`Dispose` make WAL records crash-safe. |
+| `timeout` | `TimeoutOptions.Current.DefaultUowTimeout` | Absolute deadline for everything created under this UoW (transactions, locks, flush waits). |
+
+## ⚠️ Guarantees & limits
+
+- **Flat, not nestable** — there is no API to open a UoW "inside" another UoW's scope; doing so just creates a
+  second, independent UoW with its own `UowId` and deadline.
+- **One shared `ChangeSet` per UoW** (`Deferred`/`GroupCommit`) — every transaction's dirty pages funnel through it,
+  so the checkpoint (not a per-UoW write) is what eventually persists data pages; `Immediate` gives each transaction
+  its own.
+- **`Deferred` dispose does not flush** — WAL records committed under a `Deferred` UoW stay volatile until an
+  explicit `Flush()`/`FlushAsync()` (or the WAL buffer's own back-pressure forces an earlier write); `GroupCommit`
+  and `Immediate` flush automatically on `Dispose()`.
+- **Bounded registry slots** — `UowId` is allocated from a fixed-size registry; under sustained pressure
+  `CreateUnitOfWork` blocks until a slot frees and throws `ResourceExhaustedException` if its deadline expires first.
+- **Cross-UoW concurrency is cheap** — independent UoWs on different threads contend only if they touch the same
+  page or the same B+Tree index node; otherwise they run fully in parallel.
+- **Counters are observational only** — `TransactionCount`/`CommittedTransactionCount` track activity for
+  diagnostics; they do not gate `Flush()` or `Dispose()`.
+
+## 🧪 Tests
+
+- [UnitOfWorkTests](../../../test/Typhon.Engine.Tests/Execution/UnitOfWorkTests.cs) — lifecycle (`Create`/`Dispose`
+  state transitions), shared UoW identity across transactions, durability-mode preservation, registry-backed
+  `UowId` allocation, empty-UoW `Flush`/`FlushAsync`
+
+## 🔗 Related
+
+- Related features: [Transaction Creation Patterns](./transaction-creation-patterns/README.md) (`CreateQuickTransaction`/`CreateReadOnlyTransaction`), [Transaction Lifecycle, Thread Affinity & Pooling](./transaction-lifecycle-pooling.md), [Durability Modes](./durability-modes/README.md), [Deadline & Cooperative Cancellation](./deadline-cancellation.md)
+
+<!-- Deep dive: claude/design/Transactions/transaction-overview.md, claude/design/Transactions/05-unit-of-work.md -->
+<!-- Overview: claude/overview/02-execution.md §2.1 Unit of Work (#21-unit-of-work) -->
+<!-- ADR: 001 — Three-Tier API Hierarchy — claude/adr/001-three-tier-api-hierarchy.md, 005 — Durability Mode Per UoW — claude/adr/005-durability-mode-per-uow.md -->

--- a/doc/feature-set/Transactions/uow-identity-crash-recovery.md
+++ b/doc/feature-set/Transactions/uow-identity-crash-recovery.md
@@ -1,0 +1,71 @@
+# UoW Identity & Crash-Safe Recovery Boundary
+> A bounded 15-bit ID stamps every revision a UoW writes — crash recovery erases unconfirmed work instantly, with no replay.
+
+**Status:** ✅ Implemented · **Visibility:** Public · **Level:** 🟣 Advanced · **Category:** [Transactions](./README.md)
+
+## 🎯 What it solves
+After a crash, some revisions on disk may belong to work the application never got confirmation for. The read
+path needs an O(1) way to tell "this revision belongs to a UoW that survived the crash" from "this revision
+belongs to one that didn't" — without re-validating or replaying every individual write. The same identity also
+doubles as the resource the engine uses to cap how many UoWs can be in flight at once, so an app that opens UoWs
+faster than it closes them gets pushed back instead of growing the engine's in-flight state without bound.
+
+## ⚙️ How it works (in brief)
+`CreateUnitOfWork` draws a UoW ID (1–32767) from a persistent registry, bitmap-allocated for O(1) claim/release.
+That ID is stamped on every revision any `Transaction` inside the UoW commits. On reopen after a crash, the
+registry's on-disk slot state is cross-referenced against the durable WAL: a UoW whose work made it to durable
+WAL is kept; a UoW still `Pending` is marked `Void` — every revision carrying its ID becomes invisible to readers
+immediately, with no per-row undo. ID `0` is never handed out; it is a reserved sentinel meaning "always
+committed," used internally for writes that aren't UoW-scoped. When all slots are in use, `CreateUnitOfWork`
+blocks (no busy-spin) until one frees or its timeout elapses, then throws.
+
+## 💻 Usage
+```csharp
+try
+{
+    using var uow = dbe.CreateUnitOfWork(DurabilityMode.GroupCommit, timeout: TimeSpan.FromSeconds(2));
+    Console.WriteLine($"UoW id: {uow.UowId}");          // 1..32767 while this UoW is alive
+
+    using var tx = uow.CreateTransaction();
+    tx.Spawn<Position>(Position.X.Set(1.0f));
+    tx.Commit();                                         // revision stamped with uow.UowId
+}
+catch (ResourceExhaustedException ex)
+{
+    // Every UoW registry slot was in use and `timeout` expired before one freed.
+    log.LogWarning("UoW registry saturated: {Usage}/{Limit}", ex.CurrentUsage, ex.Limit);
+}
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `timeout` (on `CreateUnitOfWork`) | `TimeoutOptions.Current.DefaultUowTimeout` (30s) | Max wait for a free UoW ID before throwing `ResourceExhaustedException`; also becomes the new UoW's own deadline. |
+
+## ⚠️ Guarantees & limits
+- **32,767 concurrent UoWs max** — the hard ceiling of the 15-bit ID space (ID `0` is reserved and never assigned
+  to a UoW).
+- **Voiding is per-UoW, not per-transaction** — if a UoW is still `Pending` when the crash happens, every revision
+  stamped with its ID is voided together, even if individual `Transaction.Commit()` calls inside it had already
+  returned successfully; the crash-safety contract belongs to the UoW, not to any one transaction inside it.
+- **No replay needed to hide voided work** — a voided UoW's revisions disappear via the ID check alone; nothing is
+  rewritten, scanned, or undone row by row.
+- **Slot recycling waits on the oldest active reader** — a UoW ID returns to the free pool only once no live
+  transaction's snapshot can still observe its revisions; a long-lived read transaction can stall new-UoW
+  admission under sustained load.
+- **Back-pressure is enforced, not advisory** — `CreateUnitOfWork` throws `ResourceExhaustedException` once the
+  timeout expires with no free slot; this is the engine's defense against an unbounded number of simultaneously
+  open UoWs.
+- **ID reservation, not ID identity** — a UoW's ID is only meaningful while it is allocated; once released, a
+  later, unrelated UoW can be assigned the same value.
+
+## 🧪 Tests
+- [UowRegistryTests](../../../test/Typhon.Engine.Tests/Execution/UowRegistryTests.cs) — ID allocation/release,
+  crash-recovery voiding of `Pending` entries (`Registry_CrashRecovery_VoidsPending`,
+  `Registry_TwoPhaseRecovery_FullWorkflow`), back-pressure wait/timeout/cancellation, capacity growth beyond the
+  initial registry size
+
+## 🔗 Related
+- Related features: [Unit of Work (durability boundary)](./unit-of-work.md), [Commit/Rollback Pipeline](./commit-rollback-pipeline.md), [Durability Modes](./durability-modes/README.md)
+
+<!-- Deep dive: claude/design/Transactions/05-unit-of-work.md §6 — UoW Registry, claude/rules/durability.md — Module: UoW Registry (UR-01..UR-07) -->
+<!-- Overview: claude/overview/02-execution.md — UoW Lifecycle / UoW ID Recycling (#uow-id-recycling) -->

--- a/doc/guide/README.md
+++ b/doc/guide/README.md
@@ -4,6 +4,8 @@ A practical, read-as-you-go guide to **building on** Typhon. It's task-oriented:
 
 > 📖 **Looking for internals?** The [in-depth overview](../in-depth-overview/README.md) is the contributor/power-user reference (struct layouts, algorithms, invariants). This guide links into it whenever you want to go deeper. Start here; go there when you need to.
 
+> 🔍 **Looking for a specific feature?** The [feature catalog](../feature-set/README.md) is the lookup reference — every feature, one page each, with usage snippets and guarantees, organized for Ctrl-F rather than read-through. This guide teaches you the shape of Typhon end-to-end; come back to the catalog once you know what you're looking for.
+
 ---
 
 ## 🐍 What Typhon is 🐍


### PR DESCRIPTION
## Summary

- First commit of the full `doc/feature-set/` engine feature catalog (255 files) into git — previously untracked.
- Learning-level tiering (🟢 Start Here / 🔵 Core / 🟣 Advanced) applied within every category, including a re-tier of Spatial, Subscriptions, Observability, and Profiler, which had every feature flatly tagged Advanced regardless of how foundational it actually was.
- New `Spatial/spatial-architecture-overview.md` — a real "start here" primer explaining that the per-component R-Tree and the engine-wide spatial grid are two independent mechanisms (they share the name "grid" and a `cellSize` parameter but nothing else), since the previous "start here" pages assumed that context.
- Cross-category dedup / link-hygiene pass across every feature file:
  - Removed dead links into the private `claude/` repo — generic folder-level pointers deleted, specific file+section citations preserved as HTML comments (kept for the team, invisible to public readers).
  - Added genuine sibling cross-links to Related sections that only pointed at a parent (or nothing navigable).
  - Fixed plain-text "Related feature: X" mentions with no markdown link (verified via a scripted sweep across the whole catalog — Schema was the only category affected).
- Every category README now recommends the matching `doc/in-depth-overview/` chapter before its feature list, including the three categories folded into another chapter (Hosting → Foundation §9, Profiler → Observability, Subscriptions → Querying §Subscriptions).
- `doc/guide/README.md` now cross-links to the feature catalog, closing the loop between guide (learn) / feature-set (reference) / in-depth-overview (internals).
- Table-format consistency: Resources/Spatial/Subscriptions used a separate `Link` column instead of linking the feature name — normalized to match the other 14 categories.

Closes #439.

## Test plan

- [x] Scripted check: every category table's column count is consistent per row (no truncated/malformed rows from the reorders).
- [x] Scripted check: every new/modified relative link (feature cross-links, in-depth-overview links, guide↔catalog links) resolves to a real file on disk.
- [x] Scripted check: zero live `claude/` links remain outside HTML comments anywhere in `doc/feature-set/`.
- Documentation only — no engine code behavior change, no test suite impact.