### PR TITLE
#438 Audit doc/in-depth-overview/ against durability & storage-mode increments

### DIFF
--- a/doc/in-depth-overview/01-foundation.md
+++ b/doc/in-depth-overview/01-foundation.md
@@ -382,6 +382,7 @@ Some types Typhon engine users *will* touch don't live in `Typhon.Engine` — th
 | [`FieldType`](../../src/Typhon.Schema.Definition/FieldType.cs) | Enum of supported component field kinds (full set incl. `Unsigned` / `DoubleFloat` flags and AABB/BSphere variants) |
 | [`Attributes`](../../src/Typhon.Schema.Definition/Attributes.cs) | Component / field attributes (`[SpatialIndex]`, `[Unique]`, etc.) |
 | [`StorageMode`](../../src/Typhon.Schema.Definition/StorageMode.cs) | Per-component storage policy: Versioned / SingleVersion / Transient |
+| [`DurabilityDiscipline`](../../src/Typhon.Schema.Definition/DurabilityDiscipline.cs) | Per-transaction escalation for `SingleVersion` components: `TickFence` (default, batched) or `Commit` (atomic, zero-loss, O(1) rollback) — see [06-ecs §8](06-ecs.md) |
 | [`MurmurHash2`](../../src/Typhon.Schema.Definition/MurmurHash2.cs) | Hash algorithm used in keying / partitioning |
 | [`ComponentCollection`](../../src/Typhon.Schema.Definition/ComponentCollection.cs) | Container type for component metadata |
 

--- a/doc/in-depth-overview/06-ecs.md
+++ b/doc/in-depth-overview/06-ecs.md
@@ -309,15 +309,29 @@ Cluster storage is opt-in per archetype (`IsClusterEligible` on `ArchetypeMetada
 
 ¹ The lone exception: if you `Spawn<T>` an entity whose component set includes SV fields, and then `Rollback`, the freshly-allocated SV chunks are freed and the entity is never published to the `EntityMap`, so its SV bytes effectively vanish with it. *Mutating an existing entity's SV slot* is the unrollbackable case.
 
+### `DurabilityDiscipline` — a second, orthogonal axis on SingleVersion
+
+The table above describes `SingleVersion` under its default discipline, [`DurabilityDiscipline.TickFence`](../../src/Typhon.Schema.Definition/DurabilityDiscipline.cs). A second discipline, `Commit`, is selected **per transaction** and is **not a fourth `StorageMode`** — it shares the identical SV cluster layout and only changes the rows below for the writes it covers:
+
+| Aspect | `TickFence` (default) | `Commit` |
+|---|---|---|
+| Visibility to other transactions | immediate — dirty read, before your tx commits | only at `Transaction.Commit` — read-committed, no partial visibility |
+| Rollback | cannot be reverted | **O(1)** — the staged value is discarded; HEAD was never touched |
+| Durability | tick-fence WAL, batched at tick boundary (≤1-tick loss) | zero-loss, atomic — WAL'd at `Transaction.Commit` (per `DurabilityMode`), no checkpoint required |
+| Conflict detection | none — last-writer-wins | none — last-writer-wins (unchanged) |
+| Revision chain | none | none |
+
+`Commit` stages writes into a per-transaction buffer (the SV slot itself is untouched until commit), then publishes them in place — read-committed isolation and O(1) rollback without paying for MVCC. It applies only to `SingleVersion` (`Versioned` is always commit-scoped; `Transient` is never durable). See [11-durability](11-durability.md) for the wire format and `claude/design/Ecs/committed-storage-mode.md` for the full spec.
+
 ### What this really means
 
-**Versioned is the only mode inside the transaction's ACID envelope.** SV and Transient writes leak out of the transaction in three ways:
+**Versioned is the only mode inside the transaction's ACID envelope — under the default `TickFence` discipline.** SV and Transient writes leak out of the transaction in three ways:
 
 1. **No isolation**: another transaction (or a PTA worker) reading the same SV/Transient slot during your transaction sees the post-write value immediately, not a snapshot. Multiple concurrent writers on the same SV slot race with no synchronization — "developer owns concurrency" for SV/Transient mutations.
 2. **No atomicity**: if you write to several SV components and then crash or rollback, the writes that already retired stay. There is no "all or nothing".
 3. **Durability follows the tick, not the commit**: SV writes ride the tick-fence WAL pipeline (`DirtyBitmap` → tick-boundary persistence). Whether your transaction commits or rolls back doesn't change what's persisted.
 
-A transaction around SV writes still gives you *thread affinity* and a *consistent read snapshot for any Versioned components in the same archetype*, but it does **not** give you the right to undo an SV mutation. If that matters, use Versioned.
+A transaction around SV writes still gives you *thread affinity* and a *consistent read snapshot for any Versioned components in the same archetype*, but it does **not** give you the right to undo an SV mutation. If that matters, use Versioned — or escalate the SV component to `DurabilityDiscipline.Commit`, above, if you need atomicity and rollback but not snapshot isolation or temporal queries.
 
 ### Picking a mode
 

--- a/doc/in-depth-overview/08-transactions.md
+++ b/doc/in-depth-overview/08-transactions.md
@@ -45,6 +45,8 @@ Every component declares a **storage mode** — `Versioned` (default), `SingleVe
 
 So the **commit path, MVCC conflict detection, `Rollback`, and `DurabilityMode`** sections below govern *Versioned component data*. For SV/Transient components a transaction still gives you entity-lifecycle atomicity, thread affinity, and a consistent read snapshot — but their *data* writes land immediately, can't be rolled back, and don't ride the commit-WAL. See [06-ecs §8](06-ecs.md) for the full per-mode contract.
 
+**Exception:** a `SingleVersion` component written under `DurabilityDiscipline.Commit` (an escalation from the `TickFence` default, selected per transaction) *does* get commit-scoped visibility, all-or-nothing atomicity, O(1) `Rollback`, and commit-WAL durability — without the revision chain or snapshot isolation Versioned pays for. See [06-ecs §8](06-ecs.md) ("`DurabilityDiscipline` — a second, orthogonal axis on SingleVersion").
+
 The doc walks the stack bottom-up: durability semantics (`UnitOfWork` + `DurabilityMode`), then isolation (`Transaction`, commit), then the chain and registry that back them, then deadlines and metrics.
 
 ---

--- a/doc/in-depth-overview/10-runtime.md
+++ b/doc/in-depth-overview/10-runtime.md
@@ -113,7 +113,7 @@ A DAG is built once at `RuntimeSchedule.Build()` time and never mutates. Each sy
 
 Once phases and explicit edges are known, the deriver walks each DAG's systems and:
 
-1. **Validates conflicts** as hard errors (W×W with no ordering, R×W plain without `ReadsFresh` / `ReadsSnapshot`, resource W×W, `ExclusivePhase` violations).
+1. **Validates conflicts** as hard errors (W×W with no ordering, R×W plain without `ReadsFresh` / `ReadsSnapshot`, resource W×W, `ExclusivePhase` violations). `ReadsSnapshot` on a non-`Versioned` component (`SingleVersion` or `Transient`) is *also* a hard `Build()`-time error — SV/Transient have no per-tick consistent snapshot to give, regardless of `DurabilityDiscipline` (rule AC-05 / CM-04).
 2. **Emits intra-phase edges**: `ReadsFresh` ⇒ writer-before-reader, `ReadsSnapshot` ⇒ reader-before-writer (snapshot is the previous-tick value, so the writer can run concurrently *after* the reader started), event producer-before-consumer, resource R/W ordering.
 3. **Emits cross-phase edges only on conflict** (post-2026-05-07 change): a phase-(N+1) system with no access conflict against a phase-N system can run concurrently with it. Phase order is still a coarse contract, but no longer an all-to-all barrier.
 

--- a/doc/in-depth-overview/README.md
+++ b/doc/in-depth-overview/README.md
@@ -104,6 +104,7 @@ Terms that show up across multiple chapters. Each entry points to where the type
 | **`CompRevStorageElement`** | The 12-byte revision element — TSN + UowId + IsolationFlag | [05-revision](05-revision.md) |
 | **DAG** | The directed acyclic graph of systems, edges derived from access patterns | [10-runtime](10-runtime.md) |
 | **`Deadline`** | Monotonic absolute timeout (8 B struct) | [01-foundation](01-foundation.md) |
+| **`DurabilityDiscipline`** | Per-transaction escalation for `SingleVersion` components: `TickFence` (default) or `Commit` (atomic, zero-loss, O(1) rollback) | [06-ecs](06-ecs.md), [11-durability](11-durability.md) |
 | **DurabilityMode** | `Deferred` / `GroupCommit` / `Immediate` — per-UoW persistence policy | [08-transactions](08-transactions.md), [11-durability](11-durability.md) |
 | **`EntityId`** | 64-bit ID: 52-bit monotonic key + 12-bit ArchetypeId | [06-ecs](06-ecs.md) |
 | **`EntityLink<T>`** | Typed entity reference (polymorphic over archetype hierarchy) | [06-ecs](06-ecs.md) |


### PR DESCRIPTION
Closes #438.

## Summary

Audited the 14-chapter `doc/in-depth-overview/` architecture mirror against four recent increments: FPI retirement (Increment D), the Minimal WAL redesign, Committed storage mode (`DurabilityDiscipline`), and the Public/Internal API namespace split.

**Verified accurate, no changes needed:**
- FPI retirement — covered in `02-storage.md` and `11-durability.md`.
- Minimal WAL redesign — `11-durability.md` was rewritten for it.
- Public/Internal namespace split — predates the doc set, consistently applied throughout.

**Fixed — stale/incomplete coverage of `DurabilityDiscipline.Commit` (issue #392, shipped 2026-06-26):**

Chapters 06 and 08 described `SingleVersion` as categorically non-isolated, non-atomic, and unrollbackable. That's only true under the default `TickFence` discipline — the `Commit` discipline (an orthogonal per-transaction knob, not a new `StorageMode`) gives commit-scoped visibility, O(1) rollback, and zero-loss WAL durability for the writes it covers.

- `06-ecs.md` §8 — added a `TickFence` vs `Commit` comparison table and caveats on the three affected claims in "What this really means".
- `08-transactions.md` — added the same exception to its condensed cross-reference table.
- `01-foundation.md` §9 / `README.md` glossary — added the missing `DurabilityDiscipline` entry alongside `StorageMode`.
- `10-runtime.md` §4 — documented that `ReadsSnapshot` on a non-`Versioned` component is a hard `Build()`-time error (rule AC-05/CM-04), not just an available option.

Cross-checked against `claude/design/Ecs/committed-storage-mode.md` (authoritative spec), `claude/design/Durability/MinimalWal/`, `claude/overview/06-durability.md`, and the actual enum sources in `src/Typhon.Schema.Definition/`.

## Test plan

- [x] Docs-only change — no code affected.
- [x] Verified all edited claims against current source (`StorageMode.cs`, `DurabilityDiscipline.cs`) and the authoritative design doc.
- [x] Confirmed remaining chapters (01, 03, 04, 05, 07, 09, 10, 12, 13, README) have no other stale mentions of the four audited topics.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Ax1JSSRz1HHoGVxoqfu9XZ