### PR TITLE
#437 Audit top-level + guide markdown against current public API

### DIFF
--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -56,9 +56,9 @@ The goal is to create a system where:
 │        ▼                   ▼                   ▼                   ▼        │
 │  ┌─────────────────────────────────────────────────────────────────────┐    │
 │  │                    GITHUB PROJECT (Source of Truth)                 │    │
-│  │  ┌─────────┐  ┌──────────┐  ┌────────────┐  ┌─────────┐  ┌───────┐  │    │
-│  │  │ Backlog │─►│ Research │─►│ Ready/Todo │─►│In Prog. │─►│ Done  │  │    │
-│  │  └─────────┘  └──────────┘  └────────────┘  └─────────┘  └───────┘  │    │
+│  ┌─────────┐        ┌──────────────┐        ┌─────────┐                │    │
+│  │  Todo   │───────►│ In Progress  │───────►│  Done   │                │    │
+│  └─────────┘        └──────────────┘        └─────────┘                │    │
 │  └─────────────────────────────────────────────────────────────────────┘    │
 │        │                                                       │            │
 │        ▼                                                       ▼            │
@@ -75,6 +75,8 @@ The goal is to create a system where:
 │                                                                             │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
+
+> 📌 **The Status field is now 3-state** (`Todo` / `In Progress` / `Done`), simplified from an earlier 6-state field (`Backlog`/`Research`/`Ready`/`In Progress`/`Review`/`Done`) as part of the org migration to `log2n-io`. Ideation, research, and design all sit at `Todo` — what stage a `Todo` item is actually at is tracked by which `claude/` doc (if any) it links to, not by a distinct Status value. The Lifecycle Stages section below reflects this.
 
 ### Core Principles
 
@@ -135,7 +137,7 @@ gh release create v0.1.0 --title "v0.1.0 - Telemetry Foundation" --generate-note
 When linking to `claude/` docs in GitHub issues, use the `main` branch:
 
 ```markdown
-[Design Doc](https://github.com/nockawa/Typhon/blob/main/claude/design/FeatureName.md)
+[Design Doc](https://github.com/log2n-io/Typhon/blob/main/claude/design/FeatureName.md)
 ```
 
 ---
@@ -149,7 +151,7 @@ When linking to `claude/` docs in GitHub issues, use the `main` branch:
 | Artifact | Location | Required Fields |
 |----------|----------|-----------------|
 | Idea doc | `claude/ideas/[category]/Name.md` | Date, Status, The Idea, Why It Matters |
-| GitHub Issue | Optional (if worth tracking) | Label: `idea`, Status: `Backlog` |
+| GitHub Issue | Optional (if worth tracking) | Label: `idea`, Status: `Todo` |
 
 **Claude's Role:**
 - Prompt: "Should I capture this as an idea doc?"
@@ -170,7 +172,7 @@ When linking to `claude/` docs in GitHub issues, use the `main` branch:
 | Artifact | Location | Required Fields |
 |----------|----------|-----------------|
 | Research doc | `claude/research/[category]/Name.md` | Context, Questions, Options, Recommendation |
-| GitHub Issue | Required | Label: `research`, Status: `Research` |
+| GitHub Issue | Required | Label: `research`, Status: `Todo` |
 | Linked ADRs | `claude/adr/` | Created when key decisions are made |
 
 **Claude's Role:**
@@ -193,7 +195,7 @@ When linking to `claude/` docs in GitHub issues, use the `main` branch:
 | Artifact | Location | Required Fields |
 |----------|----------|-----------------|
 | Design doc | `claude/design/[category]/Name.md` | Summary, Goals, Non-Goals, Design, Testing Strategy |
-| GitHub Issue | Required | Label: `enhancement`/`bug`, Status: `Ready` |
+| GitHub Issue | Required | Label: `enhancement`/`bug`, Status: `Todo` |
 | Branch | `feature/xxx` or `fix/xxx` | Created when work begins |
 
 **Claude's Role:**
@@ -252,8 +254,7 @@ When linking to `claude/` docs in GitHub issues, use the `main` branch:
 **Example Claude Code Prompts:**
 ```
 "/complete-task 42"  ← closes issue, archives design, updates docs
-"/weekly-review"  ← see what was completed this week
-"/mountain-view"  ← how much work remains overall
+"What got done this week, and what's stale?"  ← /weekly-review was never implemented; ask Claude directly
 "Create an ADR for the decision to use circular buffers for revision chains"
 ```
 
@@ -356,7 +357,7 @@ Both approaches end in the same state: issue In Progress, branch created, Rider 
 1. **Review GitHub Project** — Status fields accurate? Stale items? Anything stuck?
 2. **Check `ideas/`** — Anything to promote or archive?
 3. **Check `research/`** — Any stale research?
-4. **Ask Claude:** `/weekly-review` for a full status summary
+4. **Ask Claude** to walk the project board and `ideas/`/`research/` for stale items — `/weekly-review` (below) was never implemented as a dedicated skill
 
 ---
 
@@ -481,48 +482,6 @@ Actions:
 6. Report summary
 ```
 
-### Skill: `/weekly-review` — Generate Weekly Summary
-
-```markdown
----
-name: weekly-review
-description: Generate weekly development summary
----
-
-Analyzes:
-- Git commits this week
-- Issues closed/opened
-- Docs created/modified
-- Project board changes
-
-Output:
-- Progress summary
-- Stale items warning
-- Suggested cleanups
-- Phase alignment check
-```
-
-### Skill: `/mountain-view` — How Big Is the Mountain?
-
-```markdown
----
-name: mountain-view
-description: Show the full scope of remaining work
----
-
-Aggregates:
-- Backlog items with estimates
-- In-progress work
-- Research items pending
-- Ideas worth exploring
-
-Output:
-- Total estimated effort remaining
-- Breakdown by Area
-- Breakdown by Priority
-- Risk areas (large items, stale items)
-```
-
 ### Hook: Post-Commit Analysis
 
 ```yaml
@@ -567,7 +526,7 @@ jobs:
     steps:
       - name: Add new issues to project
         if: github.event_name == 'issues' && github.event.action == 'opened'
-        run: gh project item-add 7 --owner nockawa --url ${{ github.event.issue.html_url }}
+        run: gh project item-add 1 --owner Log2n-io --url ${{ github.event.issue.html_url }}
 
       - name: Move to Done on close
         if: github.event_name == 'issues' && github.event.action == 'closed'
@@ -619,8 +578,8 @@ jobs:
 
 | Field | Type | Values | Purpose |
 |-------|------|--------|---------|
-| Status | Single-select | Backlog, Research, Ready, In Progress, Review, Done | Workflow stage |
-| Area | Single-select | Database, MVCC, Transactions, Indexes, Schema, Storage, Memory, Concurrency, Primitives | Subsystem |
+| Status | Single-select | Todo, In Progress, Done | Workflow stage |
+| Area | Single-select | Database, MVCC, Transactions, Indexes, Schema, Storage, Memory, Concurrency, Primitives, Observability, Execution, Errors, Workbench | Subsystem |
 | Estimate | Single-select | XS, S, M, L, XL | Effort sizing |
 | Priority | Single-select | P0, P1, P2, P3 | Urgency |
 | Target | Date | Target dates | Roadmap positioning |
@@ -637,7 +596,7 @@ Rider's built-in Task Management connects directly to GitHub Issues and provides
 
 | Setting | Value |
 |---------|-------|
-| Server URL | `https://github.com/nockawa/Typhon` |
+| Server URL | `https://github.com/log2n-io/Typhon` |
 | API Token | Personal access token with `repo` scope |
 | Search query | `assignee:nockawa state:open` |
 
@@ -674,7 +633,7 @@ This produces commit messages like `#42: Query engine foundation`, automatically
 | Setting | Value |
 |---------|-------|
 | Pattern | `#(\d+)` |
-| Link URL | `https://github.com/nockawa/Typhon/issues/$1` |
+| Link URL | `https://github.com/log2n-io/Typhon/issues/$1` |
 
 This makes `#42` references in code comments, commit messages, and changelogs clickable — jumping straight to the GitHub issue.
 
@@ -791,38 +750,6 @@ Claude: "Excellent! Let me wrap this up:
   [If yes to 2]: What was the key decision?"
 ```
 
-### Weekly Review
-
-```
-Developer: "/weekly-review"
-
-Claude: "📊 Week of Jan 20-25, 2026
-
-COMPLETED:
-  - #42 Query Engine foundation
-  - #45 AccessControl telemetry
-
-IN PROGRESS:
-  - #47 PagedMMF telemetry (3 days active)
-
-OPENED:
-  - #50 Query Caching research
-
-⚠️ ATTENTION:
-  - ideas/AsyncCheckpoint.md hasn't been touched in 45 days
-  - research/PersistentViews.md concluded but no design doc yet
-
-📈 MOUNTAIN VIEW:
-  - Backlog: 15 items (~6-8 weeks estimated)
-  - Current phase: 60% complete
-  - Largest items: Query System (XL), WAL (L)
-
-SUGGESTED ACTIONS:
-  1. Archive or promote AsyncCheckpoint idea
-  2. Create design doc for PersistentViews or park it
-  3. Break down Query System into smaller issues"
-```
-
 ---
 
 ## Decisions Made
@@ -832,7 +759,7 @@ These questions were resolved during implementation:
 1. **Iterations/Sprints:** → **Continuous flow** (not sprints)
 2. **Milestones:** → **Phases** via project field (Telemetry, Query, WAL, Reliability, Infrastructure)
 3. **Sub-issues:** → **Yes**, use sub-issues under Phase parent issues
-4. **Notifications:** → Deferred for now (manual `/weekly-review` provides stale detection)
+4. **Notifications:** → Deferred for now (`/weekly-review` was never implemented — stale-item detection is manual today)
 
 ---
 
@@ -841,29 +768,35 @@ These questions were resolved during implementation:
 The following has been implemented:
 
 ### GitHub Project Fields
-- Status: Backlog → Research → Ready → In Progress → Review → Done
+- Status: Todo → In Progress → Done
 - Priority: P0-Critical, P1-High, P2-Medium, P3-Low
 - Phase: Telemetry, Query, WAL, Reliability, Infrastructure
-- Area: Database, MVCC, Transactions, Indexes, Schema, Storage, Memory, Concurrency, Primitives
+- Area: Database, MVCC, Transactions, Indexes, Schema, Storage, Memory, Concurrency, Primitives, Observability, Execution, Errors, Workbench
 - Estimate: XS, S, M, L, XL
 - Target: (date field for Roadmap view)
 
 ### Claude Code Skills
 - `/dev-status` — Show current development status
+- `/start-research #XX` — Start research on an issue
+- `/start-design #XX` — Start design for an issue
 - `/start-task #XX` — Begin work on an issue
 - `/start-subtask #XX` — Start a sub-issue (update status, validate dependencies, update design doc)
 - `/complete-subtask #XX` — Complete a sub-issue (close, check parent checkbox, update design doc)
 - `/complete-task #XX` — Finish work, update artifacts
 - `/create-issue` — Create new issue with all fields
-- `/weekly-review` — Weekly progress summary
-- `/mountain-view` — Full backlog analysis
+- `/implement-feature` — Implement a GitHub issue end-to-end (plan → build → test → review)
+- `/new-panel` — Scaffold a new Workbench panel
+- `/benchmark` — Benchmark regression tracking
+- `/coverage` — Code coverage analysis and trend reports
+- `/profile` — Profile a benchmark workload with dotTrace
+- `/wb-dev` — Start/stop/status the Workbench dev servers
 
 ### Rider Configuration
-- **Task Server:** GitHub → `nockawa/Typhon`, filter: `assignee:nockawa state:open`
+- **Task Server:** GitHub → `log2n-io/Typhon`, filter: `assignee:nockawa state:open`
 - **Changelist name:** `${id} ${summary}`
 - **Branch template:** `feature/${id}-${summary}` (lowercased)
 - **Commit message:** `#${id}: ${summary}` (per-server → Commit Message tab)
-- **Issue navigation:** `#(\d+)` → `https://github.com/nockawa/Typhon/issues/$1`
+- **Issue navigation:** `#(\d+)` → `https://github.com/log2n-io/Typhon/issues/$1`
 
 ### GitHub Actions
 - `.github/workflows/project-sync.yml` — Auto-add issues, sync status on close/merge
@@ -872,7 +805,7 @@ The following has been implemented:
 
 ## References
 
-- [claude/README.md](claude/README.md) — Document lifecycle system
+- [claude/CLAUDE.md](claude/CLAUDE.md) — Document lifecycle system
 - [.claude/skills/](.claude/skills/) — Claude Code skills
-- [GitHub Project](https://github.com/users/nockawa/projects/7) — Source of truth for work tracking
+- [GitHub Project](https://github.com/orgs/Log2n-io/projects/1) — Source of truth for work tracking
 - [GitHub Projects Best Practices](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/best-practices-for-projects)

--- a/README.md
+++ b/README.md
@@ -151,21 +151,21 @@ Typhon/
 │   ├── Typhon.Shell/               # Interactive database shell (tsh)
 │   └── Typhon.Shell.Extensibility/ # Shell extension points
 ├── test/
-│   ├── Typhon.Engine.Tests/        # NUnit test suite (3500+ tests)
-│   ├── Typhon.Client.Tests/        # Client SDK tests
-│   ├── Typhon.Workbench.Tests/     # Workbench server-side tests
-│   ├── Typhon.Benchmark/           # BenchmarkDotNet performance tests
-│   ├── Typhon.ARPG.Schema/         # Example ARPG game schema
-│   ├── Typhon.ARPG.Shell/          # Shell demo with ARPG data
-│   ├── Typhon.MonitoringDemo/      # Observability demo
-│   ├── Typhon.IOProfileRunner/     # Storage I/O profiling sandbox
-│   ├── Typhon.Scheduler.POC/       # DagScheduler POC harness
-│   ├── Typhon.SqliteBenchmark/     # Comparative SQLite benchmark
-│   └── AntHill/                    # Godot-based ant-colony demo (runtime + clusters + spatial tiers)
+│   ├── Typhon.Engine.Tests/         # NUnit test suite (3500+ tests)
+│   ├── Typhon.Analyzers.Tests/      # Roslyn analyzer tests
+│   ├── Typhon.Client.Tests/         # Client SDK tests
+│   ├── Typhon.Workbench.Tests/      # Workbench server-side tests
+│   ├── Typhon.Benchmark/            # BenchmarkDotNet performance tests
+│   ├── Typhon.CompetitiveBenchmark/ # Comparative benchmark vs SQLite/RocksDB/LMDB/FASTER
+│   ├── Typhon.ARPG.Schema/          # Example ARPG game schema
+│   ├── Typhon.ARPG.Shell/           # Shell demo with ARPG data
+│   ├── Typhon.MonitoringDemo/       # Observability demo
+│   └── Typhon.IOProfileRunner/      # Storage I/O profiling sandbox
 ├── tools/
 │   ├── Typhon.Workbench/           # Local dev UI (ASP.NET Core 10 + React 19/Vite) — data browsing, schema, profiler, System DAG, Data Flow timeline, Access Matrix
-│   ├── Typhon.Workbench.Fixtures/  # Dev-only test fixture generators consumed by the Workbench DEBUG tabs
-│   └── CheckDurations/             # Helper utility for tick-duration analysis
+│   └── Typhon.Workbench.Fixtures/  # Dev-only test fixture generators consumed by the Workbench DEBUG tabs
+├── demo/
+│   └── AntHill/                    # Godot-based ant-colony demo (runtime + clusters + spatial tiers)
 ├── claude/                         # Architecture docs, ADRs, design specs (separate nested git repo)
 └── benchmark/                      # Benchmark results
 ```

--- a/doc/guide/01-first-app.md
+++ b/doc/guide/01-first-app.md
@@ -15,29 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Typhon.Engine;            // DatabaseEngine, EntityId, transactions, queries
 using Typhon.Schema.Definition; // [Component], [Archetype], Comp<T>
 
-// ── 1. Declare components (plain structs) ──────────────────────────────
-[Component("Skirmish.Position", 1, StorageMode = StorageMode.Versioned)]
-public struct Position
-{
-    public float X, Y;
-    public Position(float x, float y) { X = x; Y = y; }
-}
-
-[Component("Skirmish.Health", 1, StorageMode = StorageMode.Versioned)]
-public struct Health
-{
-    public int Current, Max;
-    public Health(int current, int max) { Current = current; Max = max; }
-}
-
-// ── 2. Declare an archetype (the shape of an entity) ───────────────────
-[Archetype(1)]
-public sealed partial class Unit : Archetype<Unit>
-{
-    public static readonly Comp<Position> Position = Register<Position>();
-    public static readonly Comp<Health>   Health   = Register<Health>();
-}
-
 // ── 3. Build the engine (once, at startup) ─────────────────────────────
 var services = new ServiceCollection()
     .AddLogging()
@@ -88,6 +65,32 @@ using (var tx = dbe.CreateQuickTransaction())
                     .Where<Health>(h => h.Current < h.Max)
                     .Execute();
     Console.WriteLine($"{wounded.Count} wounded unit(s)");
+}
+
+// ── 1. Declare components (plain structs) ──────────────────────────────
+// C# requires top-level statements to precede type declarations in the same
+// file, so the types come last here. In a real project you'd likely split
+// them into a second file instead — see doc/guide/example/Model.cs.
+[Component("Skirmish.Position", 1, StorageMode = StorageMode.Versioned)]
+public struct Position
+{
+    public float X, Y;
+    public Position(float x, float y) { X = x; Y = y; }
+}
+
+[Component("Skirmish.Health", 1, StorageMode = StorageMode.Versioned)]
+public struct Health
+{
+    public int Current, Max;
+    public Health(int current, int max) { Current = current; Max = max; }
+}
+
+// ── 2. Declare an archetype (the shape of an entity) ───────────────────
+[Archetype(1)]
+public sealed partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<Position> Position = Register<Position>();
+    public static readonly Comp<Health>   Health   = Register<Health>();
 }
 ```
 

--- a/doc/guide/02-modeling.md
+++ b/doc/guide/02-modeling.md
@@ -42,7 +42,7 @@ public sealed partial class Hero : Archetype<Hero, Unit>   // Hero = Unit's comp
 }
 ```
 
-A `Hero` *is-a* `Unit` for typed references: `EntityLink<Unit>` accepts a `Hero`. Use `EntityLink<T>` to point one entity at another with compile-time safety:
+A `Hero` *is-a* `Unit` for typed references: `EntityLink<Unit>` accepts a `Hero`. Use `EntityLink<T>` to point one entity at another — a typed, self-documenting reference. One caveat: `T` is a contract, not an enforced guarantee — the implicit conversion from `EntityId` accepts *any* entity, with no compile-time or runtime check that it's actually a `T` (or descendant).
 
 ```csharp
 [Component("Skirmish.Target", 1)]
@@ -172,7 +172,7 @@ var nearby = tx.Query<Unit>()
                .Execute();
 ```
 
-> ⚠️ **A rule the engine enforces.** A `[SpatialIndex]` field is mutated through the `WriteSpatial` **barrier**, not a plain assignment (an analyzer flags the plain write). So a system that moves entities mirrors each point into its box:
+> ⚠️ **A convention the analyzer flags, not a runtime-enforced rule.** A `[SpatialIndex]` field should be mutated through the `WriteSpatial` **barrier**, not a plain assignment — `ClusterRef.GetSpan<T>`/`Get<T>` calls that touch a spatial-indexed component get a build-time `TYPHON009` **warning** (not an error, and it doesn't guard `EntityRef.Write` at all — nothing stops a plain write from compiling or running, it just silently skips the spatial-index refresh). To get the warning, reference `Typhon.Analyzers.csproj` as an analyzer too — the same `OutputItemType="Analyzer"` pattern as the generator reference earlier in this chapter — without it the plain write compiles silently and the index goes stale. So a system that moves entities mirrors each point into its box:
 >
 > ```csharp
 > cluster.WriteSpatial(Unit.Bounds, slot, new Bounds { Box = new AABB2F { MinX = x, MaxX = x, MinY = y, MaxY = y } });

--- a/doc/guide/04-querying.md
+++ b/doc/guide/04-querying.md
@@ -17,6 +17,8 @@ Everything starts from `tx.Query<TArchetype>()`.
 
 ### Which entities — by component shape
 
+> `Shield`/`Stunned`/`Weapon` below are illustrative — they aren't part of the running `doc/guide/example` model (which only has `Position`/`Bounds`/`Health`/`Velocity`/`Team`). The methods themselves are real and verified against source; this snippet just isn't one you can run as-is.
+
 ```csharp
 tx.Query<Unit>()
   .With<Shield>()        // only units that also have a Shield component
@@ -74,14 +76,14 @@ HashSet<EntityId> ids = q.Execute();   // materialise all matches
 int n               = q.Count();       // just how many
 bool any            = q.Any();         // does at least one match?
 
-foreach (EntityId id in q)             // stream them, no set allocation
+foreach (EntityId id in q)             // iterate matches without a HashSet
 {
     var hp = tx.Open(id).Read(Unit.Health);
     // …react to each match…
 }
 ```
 
-`Execute` is the workhorse; `Count`/`Any` short-circuit when you don't need the entities; the `foreach` form streams without building a `HashSet`.
+`Execute` is the workhorse; `Count`/`Any` short-circuit when you don't need the entities; the `foreach` form iterates its own pre-collected match list instead of building a `HashSet` — cheaper than `Execute`, but not fully allocation-free streaming.
 
 > 💡 **Know which scan you triggered.** `Execute` picks one of three paths automatically: a **targeted** scan when you used `WhereField` (index-driven), a **spatial** scan when you used a spatial predicate (spatial-index-driven), or a **broad** scan otherwise (walk the archetype, apply any `Where` predicate per entity). The takeaway for cost: a `WhereField`/spatial query stays cheap as the archetype grows; a pure-`Where` query is linear in archetype size. Both are correct — choose with your data sizes in mind.
 

--- a/doc/guide/05-systems.md
+++ b/doc/guide/05-systems.md
@@ -136,7 +136,9 @@ The read variants are the interesting part, because they answer *"which version 
 | `ReadsFresh<T>` | I want **this tick's** value | ordered **after** the writer (writer → me) |
 | `ReadsSnapshot<T>` | **last tick's** value is fine | ordered **before** the writer — so we can run **concurrently** |
 
-> 💡 **Why three kinds of read?** Because "do I need the freshest value?" is a real design choice with a real cost. `ReadsFresh` is correctness when you depend on this tick's write — but it serialises you behind the writer. `ReadsSnapshot` says *"yesterday's value is good enough"* — and that one word lets the engine run your reader **alongside** the writer instead of after it, which is often the difference between a tick fitting in budget and not. In our skirmish, a `CombatSystem` that decides targets from positions can `ReadsSnapshot<Position>`: acting on positions that are one tick stale is invisible at 60 Hz, and it means combat and movement run in parallel instead of in sequence.
+> 💡 **Why three kinds of read?** Because "do I need the freshest value?" is a real design choice with a real cost. `ReadsFresh` is correctness when you depend on this tick's write — but it serialises you behind the writer. `ReadsSnapshot` says *"yesterday's value is good enough"* — and that one word lets the engine run your reader **alongside** the writer instead of after it, which is often the difference between a tick fitting in budget and not. One restriction: `ReadsSnapshot<T>` only applies to a **Versioned** `T` — SingleVersion and Transient have no revision history to hand out a stale-but-consistent copy of, and the engine rejects the declaration at `Build()` time if you try (rule CM-04 / `runtime-scheduling.md` AC-05).
+>
+> Our skirmish's `Position` is SingleVersion ([ch.2](02-modeling.md)), so a system can't `ReadsSnapshot<Position>` — it would need `ReadsFresh<Position>` instead (correct, but serialised behind `MovementSystem`) or Position would need to be Versioned. `CombatSystem` sidesteps the question entirely: it doesn't touch `Position` at all, so it has **no declared conflict** with `MovementSystem` and runs alongside it for free, no snapshot needed.
 
 ```csharp
 internal sealed class CombatSystem : QuerySystem
@@ -148,16 +150,14 @@ internal sealed class CombatSystem : QuerySystem
         .Name("Combat")
         .Phase(Phase.Simulation)
         .Input(() => _units)
-        .ReadsSnapshot<Position>()        // last tick's positions — runs alongside Movement
         .Writes<Health>();                // Versioned write → transactional (see §5)
 
     protected override void Execute(TickContext ctx)
     {
         foreach (EntityId id in ctx.Entities)
         {
-            // … find an enemy in range using last-tick positions, then:
-            var e = ctx.Transaction.OpenMut(id);
-            e.Write(Unit.Health).Current -= 10;   // Versioned → goes through the transaction
+            ref var hp = ref ctx.Transaction.OpenMut(id).Write(Unit.Health);
+            if (hp.Current > 0) hp.Current -= 1;   // Versioned → goes through the transaction
         }
     }
 }

--- a/doc/guide/06-operating.md
+++ b/doc/guide/06-operating.md
@@ -82,12 +82,12 @@ The engine manages its own memory: a paged, memory-mapped store with a cache, th
 })
 .AddScopedDatabaseEngine(o =>
 {
-    o.Resources.TotalMemoryBudgetBytes = 4L << 30;   // overall budget, validated at startup
+    o.Resources.TotalMemoryBudgetBytes = 4L << 30;   // overall budget — call o.Resources.Validate() yourself to enforce it
     o.Wal = new WalWriterOptions();                  // enable the WAL (durability)
 });
 ```
 
-The defaults are intentionally *small* — a 2 MB cache out of the box — so development exercises the cache machinery instead of hiding behind RAM. Size it up for real workloads. At startup the engine **validates** that its fixed allocations (cache + WAL + buffers) fit inside `TotalMemoryBudgetBytes` and refuses to start if they don't — you find out at boot, not at 3 a.m.
+The defaults are intentionally *small* — a 2 MB cache out of the box — so development exercises the cache machinery instead of hiding behind RAM. Size it up for real workloads. Call `options.Resources.Validate()` yourself after configuring — it throws if the fixed allocations (cache + WAL + buffers) don't fit inside `TotalMemoryBudgetBytes`. **The engine does not call this automatically at boot** — an oversized configuration is silently accepted unless you validate it yourself.
 
 > 💡 **Cache size is not a database-size cap.** `DatabaseCacheSize` bounds the *resident working set*, not how much you can store — the on-disk database can be many times the cache; cold pages live on disk and page in on demand (persistent data, indexes, and the entity map all page out — only *Transient* components stay RAM-resident). Size the cache for throughput/latency, not capacity. This is the SQL/SQLite model, and it's what sets Typhon apart from in-memory ECS frameworks.
 

--- a/doc/guide/example/Model.cs
+++ b/doc/guide/example/Model.cs
@@ -147,6 +147,10 @@ internal sealed class BoundsSyncSystem : QuerySystem
 }
 
 // Apply a little attrition every tick — a Versioned write, so it goes through the transaction.
+// No access declared on Position: Combat doesn't touch it, so it has no conflict with
+// MovementSystem and runs alongside it for free — no ReadsSnapshot/ReadsFresh needed (and
+// ReadsSnapshot couldn't apply here anyway: Position is SingleVersion, which has no revision
+// history to snapshot — see ch.5 §3).
 internal sealed class CombatSystem : QuerySystem
 {
     private readonly EcsView<Unit> _units;
@@ -156,7 +160,6 @@ internal sealed class CombatSystem : QuerySystem
         .Name("Combat")
         .Phase(Phase.Simulation)
         .Input(() => _units)
-        .ReadsSnapshot<Position>()
         .Writes<Health>();
 
     protected override void Execute(TickContext ctx)


### PR DESCRIPTION
Closes #437.

## Summary

Verified `README.md`, `CONTRIB.md`, and `doc/guide/` (6 chapters + the runnable example) against the current public API, cross-checked against `src/Typhon.Engine`/`src/Typhon.Schema.Definition` and the actual repo/org state.

**Real bugs found and fixed (not just stale prose):**
- The guide's runnable example (`doc/guide/example/`) crashed at ch.5: `CombatSystem` declared `.ReadsSnapshot<Position>()`, but `Position` is `SingleVersion` and a newer engine rule (CM-04) hard-rejects `ReadsSnapshot` on non-`Versioned` components at `RuntimeSchedule.Build()`. Removed the (already-unused) declaration and rewrote ch.5's teaching example to match — verified end-to-end run succeeds.
- Chapter 1's "whole program" listing didn't compile as literally ordered (type declarations before top-level statements is a C# error, CS8803) despite an "✅ verified" badge. Reordered; verified by compiling the exact snippet in isolation.
- Chapter 6 claimed the engine validates memory budgets and refuses to start on overflow — it doesn't; `ResourceOptions.Validate()` exists but the hosting-layer call sites are dead `// TODO` stubs. Corrected to "call it yourself."

**Overstated claims corrected:**
- `EntityLink<T>` "compile-time safety" — no check exists at all (verified the implicit operator); softened to "a contract, not an enforced guarantee."
- The spatial `WriteSpatial` barrier framed as "a rule the engine enforces" — it's an opt-in, `Warning`-severity analyzer (`TYPHON009`) that doesn't even cover `EntityRef.Write`; corrected, and noted the guide never mentioned the analyzer needs its own separate project reference.
- Minor: a query's `foreach` "streams, no set allocation" — it iterates a pre-collected `List`, not a `HashSet`; narrowed the claim.

**Stale facts corrected:**
- README's Project Structure `test/`/`tools/` trees (wrong/missing projects, `AntHill` actually lives under `demo/`).
- CONTRIB.md: `nockawa/Typhon` → `log2n-io/Typhon` throughout, project board `#7` → `orgs/Log2n-io/projects/1`, broken `claude/README.md` link → `claude/CLAUDE.md`, incomplete Area field list, outdated skills list, and the Status field — CONTRIB.md documented the old 6-state lifecycle (Backlog/Research/Ready/.../Done); the board is now 3-state (Todo/In Progress/Done), confirmed via `.github/workflows/project-sync.yml`. Removed the `/weekly-review` and `/mountain-view` sections (never implemented — no such skills exist under `.claude/skills/`).

**Flagged, not fixed here (outside README/CONTRIB/doc/guide scope):** the repo root `CLAUDE.md` documents this same old 6-state lifecycle, and the `/start-task` skill has stale hardcoded Status option IDs from the pre-migration project board — both are the same class of staleness as the CONTRIB.md fix above, just in files outside this issue's stated scope.

## Test plan

- [x] `doc/guide/example` rebuilt and run end-to-end after every fix — confirmed `OK — guide example ran end to end.`
- [x] Chapter 1's reordered listing compiled and run in isolation, produced the exact claimed output.
- [x] Every corrected claim (EntityLink, WriteSpatial/TYPHON009, ResourceOptions.Validate, CM-04) verified directly against current source, not assumed.
- [x] README's project-structure tree checked against `ls test/`, `ls tools/`, `ls demo/`.
- [x] CONTRIB.md's Status-field claim checked against the actual `.github/workflows/project-sync.yml` (which hardcodes and comments the current 3-state field).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Ax1JSSRz1HHoGVxoqfu9XZ