### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #481)

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: benchmark
 description: Run regression benchmarks, track results, and generate trend reports
-argument-hint: [--quick] [--report-only] [--list] [--btree-fast] [--btree-medium] [--btree-full]
+argument-hint: "[--quick] [--report-only] [--list] [--btree-fast] [--btree-medium] [--btree-full]"
 ---
 
 # Benchmark Regression Tracking

--- a/.claude/skills/complete-subtask/SKILL.md
+++ b/.claude/skills/complete-subtask/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: complete-subtask
 description: Complete a sub-issue of an umbrella issue - close it, check parent checkbox, update design doc
-argument-hint: [sub-issue number]
+argument-hint: "[sub-issue number]"
 ---
 
 # Complete a Sub-Issue (Subtask)

--- a/.claude/skills/complete-task/SKILL.md
+++ b/.claude/skills/complete-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: complete-task
 description: Complete work on a GitHub issue - close issue, update artifacts, prompt for doc updates
-argument-hint: [issue number]
+argument-hint: "[issue number]"
 ---
 
 # Complete Work on a GitHub Issue

--- a/.claude/skills/coverage/SKILL.md
+++ b/.claude/skills/coverage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: coverage
 description: Run code coverage analysis, track class-level results, and generate trend reports
-argument-hint: [--report-only]
+argument-hint: "[--report-only]"
 ---
 
 # Code Coverage Tracking

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-issue
 description: Create a GitHub issue and add it to the Typhon org project
-argument-hint: [title] or leave empty for interactive mode
+argument-hint: "[title] or leave empty for interactive mode"
 ---
 
 # Create GitHub Issue for Typhon

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement-feature
 description: Implement a GitHub issue end-to-end — scope it (whole issue or specific phases), build an acceptance-criteria plan from its design doc, get the plan approved, then develop autonomously with tests and a mandatory code review.
-argument-hint: [issue number]
+argument-hint: "[issue number]"
 ---
 
 # Implement a Feature from a GitHub Issue

--- a/.claude/skills/start-design/SKILL.md
+++ b/.claude/skills/start-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-design
 description: Start design for a GitHub issue - creates design doc from research/ideas, updates status to Todo
-argument-hint: [issue number or title] [--deep]
+argument-hint: "[issue number or title] [--deep]"
 ---
 
 # Start Design for a GitHub Issue

--- a/.claude/skills/start-research/SKILL.md
+++ b/.claude/skills/start-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-research
 description: Start research on a GitHub issue - creates research doc, links ideas, updates status
-argument-hint: [issue number or title] [--deep]
+argument-hint: "[issue number or title] [--deep]"
 ---
 
 # Start Research on a GitHub Issue

--- a/.claude/skills/start-subtask/SKILL.md
+++ b/.claude/skills/start-subtask/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-subtask
 description: Start working on a sub-issue of an umbrella issue - updates status, validates dependencies, updates design doc
-argument-hint: [sub-issue number]
+argument-hint: "[sub-issue number]"
 ---
 
 # Start Working on a Sub-Issue (Subtask)

--- a/.claude/skills/start-task/SKILL.md
+++ b/.claude/skills/start-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: start-task
 description: Start working on a GitHub issue - updates status, creates branch, verifies design
-argument-hint: [issue number or title]
+argument-hint: "[issue number or title]"
 ---
 
 # Start Work on a GitHub Issue

--- a/CONTRIB.md
+++ b/CONTRIB.md
@@ -388,7 +388,7 @@ Output:
 ---
 name: create-issue
 description: Create a GitHub issue and add it to the Typhon dev project
-argument-hint: [title] or leave empty for interactive mode
+argument-hint: "[title] or leave empty for interactive mode"
 ---
 
 Actions:
@@ -405,7 +405,7 @@ Actions:
 ---
 name: start-task
 description: Start working on a GitHub issue
-argument-hint: [issue number or title]
+argument-hint: "[issue number or title]"
 ---
 
 Actions:
@@ -424,7 +424,7 @@ Actions:
 ---
 name: start-subtask
 description: Start working on a sub-issue of an umbrella issue
-argument-hint: [sub-issue number]
+argument-hint: "[sub-issue number]"
 ---
 
 Actions:
@@ -441,7 +441,7 @@ Actions:
 ---
 name: complete-subtask
 description: Complete a sub-issue of an umbrella issue
-argument-hint: [sub-issue number]
+argument-hint: "[sub-issue number]"
 ---
 
 Actions:
@@ -470,7 +470,7 @@ Actions:
 ---
 name: complete-task
 description: Mark work complete and update all artifacts
-argument-hint: [issue number]
+argument-hint: "[issue number]"
 ---
 
 Actions:


### PR DESCRIPTION
Closes #481.

## Summary

Purely mechanical single-character transform to 11 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (11)

- `.claude/skills/coverage/SKILL.md`
- `.claude/skills/benchmark/SKILL.md`
- `CONTRIB.md`
- `.claude/skills/start-task/SKILL.md`
- `.claude/skills/start-subtask/SKILL.md`
- `.claude/skills/complete-subtask/SKILL.md`
- `.claude/skills/complete-task/SKILL.md`
- `.claude/skills/create-issue/SKILL.md`
- `.claude/skills/implement-feature/SKILL.md`
- `.claude/skills/start-design/SKILL.md`
- `.claude/skills/start-research/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
