### PR TITLE
ci: use pull_request_target in project-sync so fork PRs get board updates

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -14,8 +14,21 @@ name: Project Sync
 on:
   issues:
     types: [opened, closed, reopened]
-  pull_request:
+  # pull_request_target (NOT pull_request): secrets — including PROJECT_TOKEN — are withheld from `pull_request` runs that
+  # originate in a fork, so board sync failed for every external contributor's PR (gh exits 4 on an empty GH_TOKEN).
+  # pull_request_target runs in the BASE repo's context, so the secret is available.
+  #
+  # SAFETY — pull_request_target is only sound because this workflow never trusts fork content:
+  #   1. It does NOT check out the PR's code (no actions/checkout), so no attacker-supplied code is ever executed.
+  #   2. The only fork-controlled values it reads (PR title, head ref) are passed via `env:`, never inlined into `run:`.
+  #   3. `permissions: {}` below strips GITHUB_TOKEN of all scopes.
+  # Adding a checkout of the PR head, or inlining ${{ … }} of any user-controlled field into a shell body, would turn this
+  # into a repository-takeover vector. Do neither.
+  pull_request_target:
     types: [opened, closed]
+
+# The jobs authenticate exclusively with the PROJECT_TOKEN PAT; GITHUB_TOKEN needs no scopes at all.
+permissions: {}
 
 env:
   # Organization-owned project: https://github.com/orgs/Log2n-io/projects/1
@@ -168,7 +181,7 @@ jobs:
   # Link PRs to issues and update status
   link-pr-to-issue:
     name: Link PR and Update Status
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - name: Extract issue number and update status
@@ -244,7 +257,7 @@ jobs:
   # Update status when PR is merged
   update-on-merge:
     name: Update Status on Merge
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Update linked issue status


### PR DESCRIPTION
## Problem

Project Sync fails on **every PR opened from a fork**. First observed on #482 ([failing run](https://github.com/Log2n-io/Typhon/actions/runs/29259370997/job/86888508644)):

```
GH_TOKEN:                     ← empty
Found linked issue: #481
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
##[error]Process completed with exit code 4.
```

GitHub deliberately withholds repository secrets from `pull_request` runs that originate in a fork, so `secrets.PROJECT_TOKEN` resolved to `""` and `gh` exited 4 on the first API call.

This is not caused by anything in #482 — it affects any external contributor's PR. Prior Project Sync runs were all green only because they were `issues` events from the same repo, so the `link-pr-to-issue` job had never run from an untrusted context before.

## Fix

Switch the trigger to `pull_request_target`, which runs in the **base** repo's context where the secret *is* available.

- Updated **both** PR job guards — `link-pr-to-issue` (opened) and `update-on-merge` (closed). Both authenticate with the PAT, so both were broken on forks; changing only the first would have left the merge job silently dead.
- Added workflow-level `permissions: {}` — every job uses `PROJECT_TOKEN`, so `GITHUB_TOKEN` needs no scopes at all.

## Why `pull_request_target` is safe *here*

It's normally a repository-takeover footgun, so the constraints are documented in the trigger comment. It's sound in this workflow only because it never trusts fork content:

1. **No `actions/checkout`** — attacker-supplied code is never fetched, let alone executed.
2. The only fork-controlled values it reads (PR title, head ref) already flow through `env:` and are never inlined into a `run:` body — the existing script-injection guard, which the original author had already got right.
3. `permissions: {}` strips `GITHUB_TOKEN`.

Adding a checkout of the PR head, or inlining `${{ … }}` of any user-controlled field into a shell body, would break this. The comment says so explicitly.

## Verification

- Workflow YAML parses; triggers and all five job guards resolve as intended.
- `grep`: no `actions/checkout` anywhere in the file; no stale bare `pull_request` triggers left behind.
- Surviving `github.event.pull_request.*` references are correct — that payload object exists under `pull_request_target` too, and both are already routed via `env:`.

## Note

`pull_request_target` loads the workflow from the **base branch**, so this only takes effect once merged to `main`. It does **not** retroactively fix #482's red check — that run stays in the history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)