### PR TITLE
fix: make concurrency/storage primitives arm64-correct (explicit acquire/release barriers)

### DIFF
--- a/src/Typhon.Engine/Durability/internals/WalCommitBuffer.cs
+++ b/src/Typhon.Engine/Durability/internals/WalCommitBuffer.cs
@@ -424,7 +424,7 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
         if (_swapState == SwapRequested)
         {
             var atBoundary = scanPos >= BufferCapacity;
-            var atPadding = !atBoundary && ((WalFrameHeader*)(buffer + scanPos))->FrameLength == WalFrameHeader.PaddingSentinel;
+            var atPadding = !atBoundary && Volatile.Read(ref ((WalFrameHeader*)(buffer + scanPos))->FrameLength) == WalFrameHeader.PaddingSentinel;  // acquire
             if (atBoundary || atPadding)
             {
                 PerformSwap(buffer);
@@ -442,7 +442,9 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
         while (scanPos < tail && scanPos < BufferCapacity)
         {
             var frameHeader = (WalFrameHeader*)(buffer + scanPos);
-            var frameLength = frameHeader->FrameLength;
+            // Acquire load: pairs with the producer's Interlocked.Exchange release on FrameLength, so the RecordCount/LastLsn/payload reads below observe the
+            // fully-published frame. Free on x64 (TSO); emits ldar on arm64, where a plain load would be relaxed and could see a published flag before its data.
+            var frameLength = Volatile.Read(ref frameHeader->FrameLength);
 
             if (frameLength == 0)
             {
@@ -536,7 +538,7 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
         else
         {
             var frameHeader = (WalFrameHeader*)(buffer + _drainPosition);
-            if (frameHeader->FrameLength == WalFrameHeader.PaddingSentinel)
+            if (Volatile.Read(ref frameHeader->FrameLength) == WalFrameHeader.PaddingSentinel)  // acquire: pairs with producer release on FrameLength
             {
                 atEnd = true;
             }
@@ -600,7 +602,7 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
         while (_drainPosition < BufferCapacity)
         {
             var frameHeader = (WalFrameHeader*)(buffer + _drainPosition);
-            var frameLength = frameHeader->FrameLength;
+            var frameLength = Volatile.Read(ref frameHeader->FrameLength);  // acquire: pairs with the producer's Interlocked.Exchange release on FrameLength
 
             if (frameLength == 0)
             {

--- a/src/Typhon.Engine/Foundation/Collections/internals/ConcurrentHashMap.cs
+++ b/src/Typhon.Engine/Foundation/Collections/internals/ConcurrentHashMap.cs
@@ -169,7 +169,8 @@ internal unsafe class ConcurrentHashMap<TKey> : IDisposable where TKey : unmanag
         {
             ref var stripe = ref _stripes[stripeIdx];
 
-            int version = stripe.OlcVersion;
+            // Acquire load: orders the following entries/mask/slot reads after this version snapshot (paired with the release in ReleaseStripeLock).
+            int version = Volatile.Read(ref stripe.OlcVersion);
             if ((version & 1) != 0)
             {
                 Thread.SpinWait(1);
@@ -200,7 +201,7 @@ internal unsafe class ConcurrentHashMap<TKey> : IDisposable where TKey : unmanag
                 idx = (idx + 1) & mask;
             }
 
-            if (stripe.OlcVersion != version)
+            if (Volatile.Read(ref stripe.OlcVersion) != version)
             {
                 continue;
             }
@@ -422,10 +423,11 @@ internal unsafe class ConcurrentHashMap<TKey> : IDisposable where TKey : unmanag
     /// <summary>
     /// Release stripe lock and increment version.
     /// OlcVersion is odd (locked): adding 1 makes it even (unlocked) and increments the version in bits 1-31.
-    /// On x64, store-store ordering (TSO) guarantees all prior writes are visible before this version bump.
+    /// Release store: publishes every write made under the lock before the version bump becomes visible.
+    /// Free on x64 (TSO stores are already release-ordered — compiles to a plain mov); emits stlr on arm64, where store-store ordering is not guaranteed.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ReleaseStripeLock(ref Stripe stripe) => stripe.OlcVersion += 1;
+    private static void ReleaseStripeLock(ref Stripe stripe) => Volatile.Write(ref stripe.OlcVersion, stripe.OlcVersion + 1);
 
     // ═══════════════════════════════════════════════════════════════════════
     // Private — backward shift deletion (per-stripe)

--- a/src/Typhon.Engine/Foundation/Collections/internals/ConcurrentHashMapKV.cs
+++ b/src/Typhon.Engine/Foundation/Collections/internals/ConcurrentHashMapKV.cs
@@ -187,7 +187,8 @@ internal unsafe class ConcurrentHashMap<TKey, TValue> : IDisposable where TKey :
         {
             ref var stripe = ref _stripes[stripeIdx];
 
-            int version = stripe.OlcVersion;
+            // Acquire load: orders the following entries/mask/value reads after this version snapshot (paired with the release in ReleaseStripeLock).
+            int version = Volatile.Read(ref stripe.OlcVersion);
             if ((version & 1) != 0)
             {
                 Thread.SpinWait(1);
@@ -221,7 +222,7 @@ internal unsafe class ConcurrentHashMap<TKey, TValue> : IDisposable where TKey :
                 idx = (idx + 1) & mask;
             }
 
-            if (stripe.OlcVersion != version)
+            if (Volatile.Read(ref stripe.OlcVersion) != version)
             {
                 continue;
             }
@@ -691,10 +692,11 @@ internal unsafe class ConcurrentHashMap<TKey, TValue> : IDisposable where TKey :
     /// <summary>
     /// Release stripe lock and increment version.
     /// OlcVersion is odd (locked): adding 1 makes it even (unlocked) and increments the version in bits 1-31.
-    /// On x64, store-store ordering (TSO) guarantees all prior writes are visible before this version bump.
+    /// Release store: publishes every write made under the lock before the version bump becomes visible.
+    /// Free on x64 (TSO stores are already release-ordered — compiles to a plain mov); emits stlr on arm64, where store-store ordering is not guaranteed.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ReleaseStripeLock(ref Stripe stripe) => stripe.OlcVersion = stripe.OlcVersion + 1;
+    private static void ReleaseStripeLock(ref Stripe stripe) => Volatile.Write(ref stripe.OlcVersion, stripe.OlcVersion + 1);
 
     // ═══════════════════════════════════════════════════════════════════════
     // Private — backward shift deletion (per-stripe)

--- a/src/Typhon.Engine/Foundation/Collections/internals/HashMap.cs
+++ b/src/Typhon.Engine/Foundation/Collections/internals/HashMap.cs
@@ -353,10 +353,11 @@ internal unsafe class HashMap<TKey> : IDisposable, IEnumerable<TKey> where TKey 
         var newPoh = GC.AllocateArray<byte>(newSize, true);
         byte* newEntries = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(newPoh));
 
-        // Rehash with software prefetch to hide write latency
+        // Rehash with software prefetch to hide write latency.
+        // Sse.IsSupported is a JIT constant: on non-x86 (e.g. arm64) the whole prefetch block is elided; Prefetch0 is x86-only and would otherwise throw.
         for (int i = 0; i < _capacity; i++)
         {
-            if (i + PrefetchLookahead < _capacity)
+            if (Sse.IsSupported && i + PrefetchLookahead < _capacity)
             {
                 byte* future = _entries + (long)(i + PrefetchLookahead) * stride;
                 uint fh = *(uint*)future;

--- a/src/Typhon.Engine/Foundation/Collections/internals/HashMapKV.cs
+++ b/src/Typhon.Engine/Foundation/Collections/internals/HashMapKV.cs
@@ -487,10 +487,11 @@ internal unsafe class HashMap<TKey, TValue> : IDisposable where TKey : unmanaged
             newManagedValues = new TValue[newCapacity];
         }
 
-        // Rehash with software prefetch to hide write latency
+        // Rehash with software prefetch to hide write latency.
+        // Sse.IsSupported is a JIT constant: on non-x86 (e.g. arm64) the whole prefetch block is elided; Prefetch0 is x86-only and would otherwise throw.
         for (int i = 0; i < _capacity; i++)
         {
-            if (i + PrefetchLookahead < _capacity)
+            if (Sse.IsSupported && i + PrefetchLookahead < _capacity)
             {
                 byte* future = _entries + (long)(i + PrefetchLookahead) * stride;
                 uint fh = *(uint*)future;

--- a/src/Typhon.Engine/Foundation/Concurrency/internals/AccessControlSmall.cs
+++ b/src/Typhon.Engine/Foundation/Concurrency/internals/AccessControlSmall.cs
@@ -19,6 +19,13 @@ namespace Typhon.Engine.Internals;
 /// Use this when memory is constrained and you don't need waiter tracking.</para>
 /// <para>For blocking operations, pass <c>ref WaitContext</c> to control timeout and cancellation.
 /// Use <c>ref WaitContext.Null</c> for infinite wait with zero overhead.</para>
+/// <para><b>Thread limit: 32,767 simultaneously-live threads.</b> The thread id occupies bits 16-31 of a
+/// signed <see cref="int"/>, so a managed thread id of 32,768 or above would set the sign bit and
+/// <see cref="LockedByThreadId"/> would sign-extend on read. This is half the 65,535 that
+/// <see cref="AccessControl"/> supports, and it is an accepted bound: the runtime allocates managed thread
+/// ids lowest-available-first (ids are recycled when threads die), so the ceiling applies to threads alive
+/// at the same instant, not to threads created over the process lifetime. 32K concurrent threads is far
+/// beyond any workload this engine targets.</para>
 /// </remarks>
 [StructLayout(LayoutKind.Sequential)]
 [PublicAPI]
@@ -30,7 +37,7 @@ internal struct AccessControlSmall
     // Bit layout, from least to most significant:
     // 15 Shared counter        (bits 0-14, max 32,767)
     //  1 Contention flag       (bit 15)
-    // 16 Thread Id             (bits 16-31)
+    // 16 Thread Id             (bits 16-31, max 32,767 — signed backing field, see <remarks>)
 
     private const int ThreadIdShift = 16;
     private const int SharedUsedCounterMask = 0x0000_7FFF;  // Bits 0-14 (15 bits, max 32,767)

--- a/src/Typhon.Engine/Indexing/internals/OlcLatch.cs
+++ b/src/Typhon.Engine/Indexing/internals/OlcLatch.cs
@@ -21,12 +21,12 @@ internal readonly ref struct OlcLatch
 
     /// <summary>
     /// Read version. Returns 0 if locked or obsolete (caller must restart).
-    /// On x64 (TSO), loads are never reordered with other loads — no acquire barrier needed.
+    /// Acquire load: orders the caller's subsequent node reads after this version snapshot. Free on x64 (TSO — plain mov); emits ldar on arm64.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int ReadVersion()
     {
-        int v = _version;
+        int v = Volatile.Read(ref _version);
         return (v & 0b11) == 0 ? v : 0;  // locked (bit 0) or obsolete (bit 1) -> restart
     }
 
@@ -36,7 +36,7 @@ internal readonly ref struct OlcLatch
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ValidateVersion(int expected)
     {
-        var actual = _version;
+        var actual = Volatile.Read(ref _version);  // acquire: pairs with the release in WriteUnlock
         if (actual == expected)
         {
             return true;
@@ -54,7 +54,7 @@ internal readonly ref struct OlcLatch
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ValidateVersionLocked(int expectedUnlockedVersion)
     {
-        var actual = _version;
+        var actual = Volatile.Read(ref _version);  // acquire: pairs with the release in WriteUnlock
         var expectedLocked = expectedUnlockedVersion | 1;
         if (actual == expectedLocked)
         {
@@ -93,10 +93,10 @@ internal readonly ref struct OlcLatch
     public void WriteUnlock()
     {
         // Increment version (bits 2-31), clear locked (bit 0), preserve obsolete (bit 1)
-        // On x64 (TSO), stores are never reordered with other stores — no release barrier needed.
+        // Release store: publishes every write made under the lock before the unlock is visible. Free on x64 (TSO — plain mov); emits stlr on arm64.
         int v = _version;
         var newV = ((v >> 2) + 1) << 2 | (v & 0b10);  // version++, keep obsolete, clear lock
-        _version = newV;
+        Volatile.Write(ref _version, newV);
         TyphonEvent.EmitConcurrencyOlcLatchWriteUnlock((uint)v, (uint)newV);
     }
 
@@ -116,7 +116,7 @@ internal readonly ref struct OlcLatch
     /// This avoids unnecessary version bumps that would cause cascading restarts.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AbortWriteLock() => _version = _version & ~0b1;  // Clear locked bit (bit 0) without changing version counter or obsolete bit
+    public void AbortWriteLock() => Volatile.Write(ref _version, _version & ~0b1);  // Release-clear locked bit (bit 0), leaving version counter and obsolete bit unchanged
 
     /// <summary>Check if locked (for diagnostics only).</summary>
     public bool IsLocked => (_version & 0b1) != 0;

--- a/src/Typhon.Engine/Profiler/internals/TraceRecordRing.cs
+++ b/src/Typhon.Engine/Profiler/internals/TraceRecordRing.cs
@@ -27,9 +27,11 @@ namespace Typhon.Engine.Internals;
 /// <para>
 /// <b>Synchronization:</b> two monotonic 64-bit counters (<c>_head</c> producer-written, <c>_tail</c> consumer-written), each wrapped in a
 /// <see cref="CacheLinePaddedLong"/> so they live on distinct cache lines — avoids the producer/consumer false-sharing ping-pong that is textbook
-/// for SPSC rings (Tracy pads them for the same reason). On x64 TSO, plain field reads and writes of 64-bit primitives are naturally atomic and
-/// ordered, so no <see cref="System.Threading.Volatile"/> fences are needed — same as <c>ThreadTraceBuffer</c> does for the same reason
-/// (see CLAUDE.md).
+/// for SPSC rings (Tracy pads them for the same reason). A 64-bit primitive read/write is naturally atomic on x64, so neither counter tears; but
+/// cross-thread <i>ordering</i> is not free on weakly-ordered architectures. The producer publishes payload bytes before advancing <c>_head</c>, and
+/// the consumer frees space before advancing <c>_tail</c>, so the cursor stores/loads carry release/acquire semantics via
+/// <see cref="System.Threading.Volatile"/> (<c>Publish</c>/<c>Drain</c>/<c>IsEmpty</c>). This is free on x64 (TSO — a plain <c>mov</c>) and emits
+/// <c>stlr</c>/<c>ldar</c> on arm64, where a relaxed store could otherwise expose an advanced cursor before the data it guards.
 /// </para>
 /// <para>
 /// <b>Even-size invariant:</b> all reservations are rounded UP to an even byte count. Since <see cref="Capacity"/> is a power of 2, this guarantees
@@ -122,7 +124,7 @@ internal sealed class TraceRecordRing
     /// Consumer-only non-destructive emptiness check. Returns <c>true</c> when no records are pending for drain. Used by the consumer thread to
     /// decide whether a retiring slot can be freed.
     /// </summary>
-    public bool IsEmpty => _tail.Value == _head.Value;
+    public bool IsEmpty => _tail.Value == Volatile.Read(ref _head.Value);  // acquire on _head: observe the producer's latest published head so a not-yet-drained record isn't mistaken for empty
 
     /// <summary>
     /// Number of bytes pending for drain. Single-writer for both counters, so the math is consistent; still may race across threads, use as an
@@ -220,8 +222,8 @@ internal sealed class TraceRecordRing
             throw new ArgumentOutOfRangeException(nameof(size), $"Record size {evenSize} cannot fit in a buffer of capacity {Capacity}");
         }
 
-        var head = _head.Value;
-        var tail = _tail.Value;
+        var head = _head.Value;                     // producer owns _head — plain read of its own cursor
+        var tail = Volatile.Read(ref _tail.Value);  // acquire: observe the consumer's freed space before deciding to overwrite (pairs with Drain's release)
         var headOffset = (int)(head & _mask);
         var wrapBytes = 0;
 
@@ -259,9 +261,9 @@ internal sealed class TraceRecordRing
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Publish() =>
-        // On x64 TSO, this plain 64-bit store is naturally release-ordered relative to the preceding payload writes (all writes complete before
-        // any later write is visible). The consumer's plain read of _head sees either the old value or the new value, never a torn 64-bit store.
-        _head.Value = _pendingHead;
+        // Release store: publishes the payload bytes written into the reserved span before the consumer can observe the advanced _head (paired with the
+        // acquire load in Drain/IsEmpty). Free on x64 (TSO); emits stlr on arm64, where a plain store would be relaxed and could expose _head before its data.
+        Volatile.Write(ref _head.Value, _pendingHead);
 
     // ═══════════════════════════════════════════════════════════════════════
     // Consumer API
@@ -279,8 +281,8 @@ internal sealed class TraceRecordRing
     /// </remarks>
     public int Drain(Span<byte> destination)
     {
-        var tail = _tail.Value;
-        var head = _head.Value;
+        var tail = _tail.Value;                     // consumer owns _tail — plain read of its own cursor
+        var head = Volatile.Read(ref _head.Value);  // acquire: pairs with Publish's release so the record bytes copied below are fully visible
         var bytesWritten = 0;
 
         while (tail < head)
@@ -317,7 +319,7 @@ internal sealed class TraceRecordRing
             tail += evenSize;
         }
 
-        _tail.Value = tail;
+        Volatile.Write(ref _tail.Value, tail);  // release: only after the record bytes are copied out may the producer observe the freed space and reuse the slot
         return bytesWritten;
     }
 

--- a/src/Typhon.Engine/Querying/internals/ViewDeltaRingBuffer.cs
+++ b/src/Typhon.Engine/Querying/internals/ViewDeltaRingBuffer.cs
@@ -124,9 +124,9 @@ internal sealed unsafe class ViewDeltaRingBuffer : IDisposable
             _componentTags[index] = componentTag;
 
             // Signal that this slot is ready to consume.
-            // On x86 TSO, the preceding stores are visible before this store to any core
-            // that observes _written[index] == 1.
-            _written[index] = 1;
+            // Release store: guarantees the preceding payload stores are visible to any core that observes _written[index] == 1
+            // (paired with the acquire load in TryPeek). Free on x64 (TSO); emits stlr on arm64, where store-store ordering is not guaranteed.
+            Volatile.Write(ref _written[index], (byte)1);
 
             return true;
         }
@@ -157,9 +157,10 @@ internal sealed unsafe class ViewDeltaRingBuffer : IDisposable
 
         var index = (int)(head & _capacityMask);
 
-        // Spin until the producer has finished writing this slot
+        // Spin until the producer has finished writing this slot.
+        // Acquire load: orders the following payload reads after observing the flag (paired with the release store in TryPush).
         var spinner = new SpinWait();
-        while (_written[index] == 0)
+        while (Volatile.Read(ref _written[index]) == 0)
         {
             spinner.SpinOnce();
         }

--- a/src/Typhon.Engine/Resources/public/ResourceExhaustedException.cs
+++ b/src/Typhon.Engine/Resources/public/ResourceExhaustedException.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using System;
+using System.Globalization;
 
 namespace Typhon.Engine;
 
@@ -109,6 +110,9 @@ public class ResourceExhaustedException : TyphonException
     /// </summary>
     public override bool IsTransient => true;
 
+    // InvariantCulture: this is a diagnostic/log-facing message. Without it, N0/F1 use the ambient CurrentCulture (e.g. "1 000" / "95,0%" under en-FR) — locale-dependent output.
     private static string FormatMessage(string resourcePath, long currentUsage, long limit) =>
-        $"Resource '{resourcePath}' exhausted: {currentUsage:N0} / {limit:N0} ({(limit > 0 ? (double)currentUsage / limit * 100 : 100):F1}% utilization)";
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"Resource '{resourcePath}' exhausted: {currentUsage:N0} / {limit:N0} ({(limit > 0 ? (double)currentUsage / limit * 100 : 100):F1}% utilization)");
 }

--- a/src/Typhon.Engine/Runtime/public/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/public/DagScheduler.cs
@@ -1121,7 +1121,8 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     {
         for (var i = 0; i < AllSystemCount; i++)
         {
-            if (_isReady[i].Value != 1)
+            // Acquire load: pairs with the release in MarkSystemReady, so observing ready==1 guarantees this worker also sees TotalChunks/_remainingChunks for system i.
+            if (Volatile.Read(ref _isReady[i].Value) != 1)
             {
                 continue;
             }
@@ -1438,7 +1439,8 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
         Systems[sysIdx].TotalChunks = totalChunks;
         _remainingChunks[sysIdx].Value = totalChunks;
-        // MEMORY: relies on x86 TSO for store ordering — needs release/acquire barrier on ARM
+        // Publish: MarkSystemReady stores _isReady with release semantics, ordering the two data stores above ahead of the ready flag. Workers gate on _isReady
+        // with an acquire load (FindReadySystem), so a worker that observes ready==1 also observes TotalChunks/_remainingChunks. Correct on arm64; free on x64 (TSO).
         MarkSystemReady(sysIdx);
     }
 
@@ -1714,7 +1716,8 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void MarkSystemReady(int sysIdx) => _isReady[sysIdx].Value = 1;
+    // Release store: orders the preceding TotalChunks/_remainingChunks writes ahead of the ready flag (paired with the acquire load in FindReadySystem). Free on x64 (TSO); stlr on arm64.
+    private void MarkSystemReady(int sysIdx) => Volatile.Write(ref _isReady[sysIdx].Value, 1);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void RecordFirstChunkGrab(int sysIdx, long timestamp)


### PR DESCRIPTION
## Summary

Several concurrency and storage primitives relied on **x86/x64 Total Store Order (TSO)** for cross-thread ordering — plain loads/stores on publication flags and version counters, with comments explicitly citing "on x64, stores/loads are never reordered." That reasoning does not hold on **arm64**, which is weakly ordered: a plain store can be exposed before the data it guards, and a plain load can observe a published flag before the payload it protects.

This branch makes the release/acquire pairing **explicit** where correctness depends on it. On x64 the barriers are free (`Volatile` compiles to a plain `mov` under TSO); on arm64 they emit `stlr`/`ldar`, which is what the code needed all along.

## Changes

**Explicit acquire/release barriers** (replacing bare field access on the ordering-critical flag/counter):

| File | What now carries the barrier |
|---|---|
| `Durability/internals/WalCommitBuffer.cs` | acquire loads on `WalFrameHeader.FrameLength` (pairs with the producer's `Interlocked.Exchange` release) |
| `Foundation/Collections/internals/ConcurrentHashMap.cs` / `ConcurrentHashMapKV.cs` | OLC stripe `OlcVersion` — acquire on read, release on `ReleaseStripeLock` |
| `Indexing/internals/OlcLatch.cs` | `ReadVersion` / `ValidateVersion` / `WriteUnlock` / `AbortWriteLock` |
| `Profiler/internals/TraceRecordRing.cs` | `_head`/`_tail` cursor publication (`Publish`/`Drain`/`IsEmpty`) + the class `<remarks>` that still claimed no fences were needed |
| `Querying/internals/ViewDeltaRingBuffer.cs` | per-slot `_written` flag |
| `Runtime/public/DagScheduler.cs` | `_isReady[i]` vs `TotalChunks`/`_remainingChunks` publication |

**Non-barrier portability fixes:**
- `Foundation/Collections/internals/HashMap.cs` / `HashMapKV.cs` — gate `Sse.Prefetch0` behind `Sse.IsSupported` (an x86-only intrinsic that would otherwise throw on arm64; the JIT elides the whole block as a constant on non-x86).
- `Resources/public/ResourceExhaustedException.cs` — format the diagnostic message with `InvariantCulture` so `N0`/`F1` don't pick up the ambient culture.

Plus a doc-only note on `AccessControlSmall`'s 32,767 simultaneously-live-thread ceiling (signed backing field for the thread id), as a separate commit.

## Verification

Run on **Apple Silicon (osx-arm64)** — the actual weakly-ordered target, so the JIT emits `ldar`/`stlr` for the new `Volatile` calls rather than an x64 proxy.

- **Full suite: 3999 passed / 2 failed / 39 skipped.** No deadlock (`--blame-hang` never fired).
- **All 405 tests covering the 10 changed files pass** (1 skipped).
- The 2 failures (`CpuSampleParserTests.Parse_MergesFramesByMethod`, `Parse_ResolvesEngineFrameToSource`) are **unrelated and branch-independent**: they touch none of the changed files, **pass in isolation on both this branch and `main` (18/18)**, and fail only inside the full parallel suite — both assert that a short CPU-burn method appears in captured samples, a load-sensitive check starved by 13 minutes of 8-core saturation.

### What this proves — and what it doesn't

A green arm64 run confirms **no regression, no deadlock, and correct execution on the target hardware**. It does **not** prove the barriers were strictly necessary or that every latent reordering race is eliminated — missing-barrier bugs are probabilistic and rarely tripped by a functional suite. The stronger guarantee lives with the concurrency TLA+ specs and a dedicated stress/interleaving harness, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
