### PR TITLE
feat(docs): agent-guidance page + evidence-based llms.txt preamble (#498)

### DIFF
--- a/doc/guide/01-first-app.md
+++ b/doc/guide/01-first-app.md
@@ -19,6 +19,7 @@ Here it is end-to-end. We'll walk through it piece by piece below.
 ```csharp
 using Typhon.Engine;            // DatabaseEngine, EntityId, transactions, queries
 using Typhon.Schema.Definition; // [Component], [Archetype], Comp<T>
+using Skirmish;                 // the component + archetype types declared at the bottom
 
 // ── 3. Open the engine (once, at startup) ──────────────────────────────
 // One call: names the on-disk database (a "skirmish.typhon" directory in the
@@ -57,30 +58,34 @@ using (var tx = dbe.CreateQuickTransaction())
     Console.WriteLine($"{wounded.Count} wounded unit(s)");
 }
 
-// ── 1. Declare components (plain structs) ──────────────────────────────
-// C# requires top-level statements to precede type declarations in the same
-// file, so the types come last here. In a real project you'd likely split
-// them into a second file instead — see doc/guide/example/Model.cs.
-[Component("Skirmish.Position", 1, StorageMode = StorageMode.Versioned)]
-public struct Position
+// ── 1. Declare components + archetype (inside a namespace) ─────────────
+// These types must live in a namespace — the archetype source generator can't
+// emit valid code for types in the file's global namespace. Top-level statements
+// can't sit in a namespace, so the types go in a `namespace { }` block after them
+// (in a real project you'd split them into their own file — see doc/guide/example/Model.cs).
+namespace Skirmish
 {
-    public float X, Y;
-    public Position(float x, float y) { X = x; Y = y; }
-}
+    [Component("Skirmish.Position", 1, StorageMode = StorageMode.Versioned)]
+    public struct Position
+    {
+        public float X, Y;
+        public Position(float x, float y) { X = x; Y = y; }
+    }
 
-[Component("Skirmish.Health", 1, StorageMode = StorageMode.Versioned)]
-public struct Health
-{
-    public int Current, Max;
-    public Health(int current, int max) { Current = current; Max = max; }
-}
+    [Component("Skirmish.Health", 1, StorageMode = StorageMode.Versioned)]
+    public struct Health
+    {
+        public int Current, Max;
+        public Health(int current, int max) { Current = current; Max = max; }
+    }
 
-// ── 2. Declare an archetype (the shape of an entity) ───────────────────
-[Archetype(1)]
-public sealed partial class Unit : Archetype<Unit>
-{
-    public static readonly Comp<Position> Position = Register<Position>();
-    public static readonly Comp<Health>   Health   = Register<Health>();
+    // ── 2. Declare an archetype (the shape of an entity) ───────────────
+    [Archetype(1)]
+    public sealed partial class Unit : Archetype<Unit>
+    {
+        public static readonly Comp<Position> Position = Register<Position>();
+        public static readonly Comp<Health>   Health   = Register<Health>();
+    }
 }
 ```
 

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -43,6 +43,8 @@ spelling out. Add `[Index]` to a field to make it fast to filter on.
 ```csharp
 using Typhon.Schema.Definition; // [Component], [Field], [Index], [Archetype], Comp<T>
 
+namespace Skirmish;   // component + archetype types must live in a namespace, not the global one
+
 [Component("Skirmish.Position", 1, StorageMode = StorageMode.Versioned)]
 public struct Position
 {

--- a/doc/guide/toc.yml
+++ b/doc/guide/toc.yml
@@ -16,3 +16,5 @@
   href: 06-operating.md
 - name: Cheat sheet — Isolation & durability
   href: isolation-durability-cheatsheet.md
+- name: Using Typhon with an AI coding agent
+  href: using-with-ai-coding-agents.md

--- a/doc/guide/using-with-ai-coding-agents.md
+++ b/doc/guide/using-with-ai-coding-agents.md
@@ -1,0 +1,141 @@
+---
+uid: guide-ai-coding-agents
+title: Using Typhon with an AI coding agent
+description: How to ground a coding agent (Claude, Cursor, …) so it writes idiomatic, compiling Typhon code against the NuGet package on the first try.
+---
+
+# Using Typhon with an AI coding agent
+
+Typhon is new — it is in **no model's training data**. A coding agent asked to "use the Typhon
+database" will, by default, pattern-match to SQL or a generic ORM and produce code that does not
+compile or does not behave the way you expect. This page shows how to ground the agent so it writes
+idiomatic Typhon on the first try, and lists the specific idioms agents get wrong.
+
+## 1. Point the agent at the docs
+
+Typhon publishes machine-readable documentation for exactly this purpose:
+
+- **`https://doc.typhondb.io/llms.txt`** — a map of the whole doc set. Most agent tools probe this
+  automatically; if yours doesn't, paste the URL into your prompt.
+- **Every page has a clean-markdown twin** at `<url>.md` (e.g. `.../key-concepts/transaction.html.md`) —
+  no navigation chrome, ideal for a context window.
+- **`https://doc.typhondb.io/latest/llms-full.txt`** — the Guide, Key Concepts, and In-Depth Overview
+  concatenated into one file, for when you want to load the whole mental model at once.
+
+The XML documentation shipped inside the NuGet package grounds *API signatures* on disk; the docs above
+add the *conceptual layer* (how the pieces fit) that signatures alone don't convey.
+
+## 2. The one-paragraph mental model
+
+Typhon is an **ECS (Entity-Component-System) database, not a relational one**. You don't define tables
+and rows; you define **components** — small blittable structs — and attach them to **entities**
+identified by an `EntityId`. A **transaction** under **MVCC snapshot isolation** is how you read and
+change data. You query with a fluent **view** API, not SQL or LINQ-to-SQL.
+
+## 3. Idioms agents get wrong (give these to your agent)
+
+These are ranked by how often a naive agent trips on them. Each is a hard requirement of the current
+API, not a style preference.
+
+| # | Do | Don't |
+|---|----|-------|
+| 1 | Declare `[Component]` / `[Archetype]` types **inside a `namespace`** | Declare them in the global namespace of a top-level-statements file — the source generator can't emit valid code and you get a wall of errors in generated files |
+| 2 | Make components **≥ 8 bytes** with **`public`** fields | Use a single 4-byte field, or `private` padding — the schema sizes on public fields, not `sizeof(T)` |
+| 3 | Query with the fluent builder `tx.Query<TArch>().Where<TComp>(x => …).Count()` | Write LINQ-to-SQL style `tx.Query(x => x.Score >= 50)` — the filtered component is a separate generic argument |
+| 4 | **Read/mutate each entity via `tx.Open(id)`** (query to *find*, open to *read*) | Read directly off the reference the query enumerator yields |
+| 5 | Spawn with `tx.Spawn<TArch>(TArch.Handle.Set(new TComp{…}))` | Pass field values or a constructed instance to `Spawn` |
+| 6 | Bootstrap with `DatabaseEngine.Open(path, …)`, or DI `services.AddTyphon(…)` **plus `AddLogging()`** | `new DatabaseEngine(...)` (no public constructor); DI without `AddLogging()` throws an opaque logger error |
+| 7 | `using Typhon.Schema.Definition;` for the attributes | Rely on `using Typhon.Engine;` alone — `Archetype<T>` (base class) and `[Archetype]` (attribute) share a name and collide |
+| 8 | Do all writes **inside a transaction** and `Commit()` | Assume `Commit()` implies durability — that depends on the unit-of-work's durability mode |
+| 9 | Pick a **storage mode per component** (`Versioned` = full ACID, `SingleVersion`, `Transient`, `Committed`) | Treat storage/ACID as a global switch |
+
+## 4. A minimal program that compiles
+
+This is the smallest correct end-to-end example — declare a component and archetype, spawn, mutate,
+and read back. Split into two files so the top-level `Program.cs` stays clean.
+
+**`Model.cs`**
+
+```csharp
+using Typhon.Engine;
+using Typhon.Schema.Definition;
+
+namespace Skirmish;   // (1) types live in a namespace, never the global one
+
+// (2) a component is a blittable struct, >= 8 bytes, public fields
+[Component("Skirmish.UnitData", 1, StorageMode = StorageMode.Versioned)]  // (9) per-component storage mode
+public struct UnitData
+{
+    public int X;
+    public int Health;
+}
+
+// an archetype is the entity's shape: partial class : Archetype<TSelf>, one Comp<T> handle per component
+[Archetype(1)]
+public sealed partial class Unit : Archetype<Unit>
+{
+    public static readonly Comp<UnitData> Data = Register<UnitData>();
+}
+```
+
+**`Program.cs`**
+
+```csharp
+using Typhon.Engine;
+using Skirmish;
+
+using var dbe = DatabaseEngine.Open("game.typhon", o => o   // (6) bootstrap
+    .Register<UnitData>()
+    .RegisterArchetype<Unit>());
+
+// (5) spawn inside a transaction; (8) Commit
+EntityId id;
+using (var tx = dbe.CreateQuickTransaction())
+{
+    id = tx.Spawn<Unit>(Unit.Data.Set(new UnitData { X = 0, Health = 100 }));
+    tx.Commit();
+}
+
+// mutate: OpenMut for a writable handle
+using (var tx = dbe.CreateQuickTransaction())
+{
+    tx.OpenMut(id).Write(Unit.Data).Health -= 10;
+    tx.Commit();
+}
+
+// (3) query to FIND, (4) Open to READ
+using (var tx = dbe.CreateQuickTransaction())
+{
+    foreach (var e in tx.Query<Unit>())
+    {
+        var u = tx.Open(e.Id).Read(Unit.Data);
+        Console.WriteLine($"X={u.X} Health={u.Health}");   // X=0 Health=90
+    }
+}
+```
+
+Install the package first: `dotnet add package Typhon --prerelease` (Typhon is pre-alpha, so the
+prerelease flag is required).
+
+## 5. A primer to paste into your agent
+
+If your agent isn't reading `llms.txt` automatically, paste this block into your prompt:
+
+```text
+Typhon is an ECS database (not SQL) from the `Typhon` NuGet package. Rules:
+- Model data as [Component] blittable structs (>= 8 bytes, public fields), declared inside a namespace
+  (never the global namespace of a top-level-statements file). Add `using Typhon.Schema.Definition;`.
+- An archetype is `[Archetype] partial class Foo : Archetype<Foo>` with
+  `public static readonly Comp<T> X = Register<T>();`.
+- Open the engine with DatabaseEngine.Open(path, o => o.Register<T>().RegisterArchetype<Foo>()).
+- All changes happen in a transaction: `using var tx = dbe.CreateQuickTransaction(); … tx.Commit();`.
+  Spawn: `tx.Spawn<Foo>(Foo.X.Set(new T{…}))`. Mutate: `tx.OpenMut(id).Write(Foo.X).Field = …`.
+- Query with the fluent view API: `tx.Query<Foo>().Where<T>(x => …).Count()` — NOT LINQ. To read an
+  entity, use `tx.Open(id).Read(Foo.X)`, not the query-enumerated reference.
+- Full docs: https://doc.typhondb.io/llms.txt
+```
+
+## See also
+
+- [Getting Started](getting-started.md) — the guided first app.
+- [Key Concepts](https://doc.typhondb.io/latest/key-concepts/) — the conceptual reference.

--- a/doc/llms-preamble.md
+++ b/doc/llms-preamble.md
@@ -1,19 +1,27 @@
 <!--
   Preamble injected verbatim into the generated /llms.txt (see scripts/gen-llms-txt.py).
-  Keep it short — it primes an agent BEFORE it reads the map. The distilled
-  agent-guidance gotchas from #498 land here (tracked as #500). HTML comments
-  like this one are stripped from the emitted preamble.
+  Keep it short — it primes an agent BEFORE it reads the map. HTML comments are stripped.
+  The gotchas below are empirically ranked from an agent-consumption study (#498). Full
+  guidance: doc/guide/using-with-ai-coding-agents.md.
 -->
-Typhon is an **ECS database, not SQL**. Before writing code against the `Typhon`
-NuGet package, load the mental model: read **Key Concepts** first, then the **Guide**.
+Typhon is an **ECS database, not SQL**. Load the mental model before writing code: read
+**Key Concepts**, then the **Guide** — and for the idioms coding agents get wrong by default,
+read **Using Typhon with an AI coding agent** (https://doc.typhondb.io/latest/guides/using-with-ai-coding-agents.html).
 
-Non-negotiable idioms an agent gets wrong by default:
+The idioms that trip up first attempts:
 
-- **Data = blittable-struct components**, addressed by `EntityId` — there are no tables, rows, or SQL.
-- **All mutation happens inside a transaction**; `Commit()` returning does *not* imply on-disk durability unless the unit of work uses a durable mode.
-- **Storage mode sets the ACID scope** (Versioned / SingleVersion / Transient / Committed) — pick it per component, it is not a global switch.
-- **Transactions are single-thread-affine**; never share one across threads.
-- **Query with the ECS view API**, not LINQ-to-SQL — see Key Concepts › View.
+- **Data = blittable-struct components** addressed by `EntityId` — no tables, rows, or SQL. A component
+  must be **≥ 8 bytes** and its fields **`public`** (private fields are invisible to the schema).
+- **Component/archetype types must be declared inside a `namespace`** — not the global namespace of a
+  top-level-statements file. Add `using Typhon.Schema.Definition;` for the `[Component]` / `[Archetype]` attributes.
+- **An archetype is** `[Archetype] partial class Foo : Archetype<Foo>` with `public static readonly Comp<T> X = Register<T>();`;
+  spawn via `tx.Spawn<Foo>(Foo.X.Set(new T{…}))`.
+- **All mutation happens inside a transaction.** `Commit()` returning does not imply on-disk durability
+  unless the unit of work uses a durable mode. Open an entity with `tx.OpenMut(id)` to write.
+- **Query with the fluent view API** — `tx.Query<Foo>().Where<T>(x => …).Count()` — **not** LINQ-to-SQL; then
+  **read/mutate each entity via `tx.Open(id)`**, not the query-enumerated reference.
+- **Bootstrap** with `DatabaseEngine.Open(path, …)`, or via DI with `services.AddTyphon(…)` **plus `AddLogging()`**.
+- **Storage mode sets the ACID scope** (Versioned / SingleVersion / Transient / Committed) — chosen per component.
 
-Every page listed below is also available as clean markdown at `<url>.md`, and the
-whole conceptual core is at https://doc.typhondb.io/latest/llms-full.txt.
+Every page below also exists as clean markdown at `<url>.md`; the whole conceptual core is at
+https://doc.typhondb.io/latest/llms-full.txt.

--- a/src/Typhon.Engine/PACKAGE.md
+++ b/src/Typhon.Engine/PACKAGE.md
@@ -31,6 +31,20 @@ This single package bundles the full public surface:
 A **source generator** ships alongside it: decorate a partial class with `[Archetype]` and Typhon generates
 the strongly-typed, zero-copy component accessors for it at compile time.
 
+## Using with an AI coding agent
+
+Typhon is new — it's in no model's training data, so a coding agent will guess a SQL-shaped API by
+default. Point it at **<https://doc.typhondb.io/llms.txt>** (most agent tools probe it automatically),
+or paste this primer:
+
+> Typhon is an ECS database (not SQL). Model data as `[Component]` blittable structs (≥ 8 bytes, public
+> fields) declared **inside a namespace**; an archetype is `[Archetype] partial class Foo : Archetype<Foo>`
+> with `public static readonly Comp<T> X = Register<T>();`. Open with `DatabaseEngine.Open(...)`; do all
+> writes in `using var tx = dbe.CreateQuickTransaction(); … tx.Commit();`. Query with
+> `tx.Query<Foo>().Where<T>(x => …)` (not LINQ); read an entity via `tx.Open(id).Read(Foo.X)`.
+
+Full guide: <https://doc.typhondb.io/latest/guides/using-with-ai-coding-agents.html>
+
 ## Requirements
 
 - **.NET 10** (`net10.0`).


### PR DESCRIPTION
Implements Feature #498 (tasks #499, #500, #501): a consumer-facing "Using Typhon with an AI coding agent" page + the evidence-based `llms.txt` preamble, grounded in a naive-agent A/B doc-consumption study.

## What
- **New page** `doc/guide/using-with-ai-coding-agents.md` — the idioms a coding agent gets wrong (ECS-not-SQL, the `namespace` requirement, ≥8-byte public-field components, fluent query vs LINQ, query-then-`Open`, bootstrap + `AddLogging`, storage modes). Its end-to-end example is **verified to compile and run** (`X=0 Health=90`).
- **`doc/llms-preamble.md`** rewritten with the empirically-ranked idioms → upgrades the live `/llms.txt` preamble that primes every agent probing the docs.
- **Doc-accuracy fix:** the `getting-started` + `01-first-app` guide snippets declared archetype types in the **global namespace**, which does not compile (the archetype source generator emits invalid code — see #505). Wrapped in a `namespace`; the corrected `01-first-app` program is verified to compile and print its documented output.
- **`PACKAGE.md`** (the `Typhon` nuget.org readme) gains an "Using with an AI coding agent" pointer + primer.

## Evidence
Grounded in the A/B study behind #492/#498: four fresh Sonnet agents (2 tasks × {XML-docs-only, +`llms.txt`}) built against the published `Typhon 0.0.1-alpha.2`. All four solved the tasks (ceiling effect), but the friction + failure list drove this page's gotchas and surfaced bugs #504 / #505 / #506.

## Validation
Clean `scripts/build-docs.sh`: 0 errors, link gate clean; the page builds, folds into `llms.txt` under `## Guide` (now 329 per-page `.md`), and is referenced from the preamble.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01E8KzH4pPW5Dq7Y94NXfgrM