### PR TITLE
Enforce StorageMode is fixed per (component, revision); fixes parallel-fixture data-loss

### DIFF
--- a/coverage/docs-affected-map.json
+++ b/coverage/docs-affected-map.json
@@ -18,6 +18,7 @@
 
   "src/Typhon.Engine/Ecs/": [
     "doc/in-depth-overview/06-ecs.md",
+    "doc/in-depth-overview/04-schema.md",
     "doc/key-concepts/entity.md",
     "doc/key-concepts/component.md",
     "doc/key-concepts/component-collection.md",

--- a/doc/feature-set/Ecs/storage-modes/README.md
+++ b/doc/feature-set/Ecs/storage-modes/README.md
@@ -20,8 +20,9 @@ position and a `Transient` animation cursor.
 
 ## ⚙️ How it works (in brief)
 
-`StorageMode` is set via `[Component(StorageMode = ...)]` at registration and is immutable for the life of the
-database (changing it requires recreating the database). `Versioned` keeps a full MVCC revision chain
+`StorageMode` is set via `[Component(StorageMode = ...)]` and is fixed for a given `(component name, revision)`:
+changing how a component is stored requires bumping the `[Component]` revision — re-using the same revision with a
+different mode throws `InvalidOperationException` on reopen. `Versioned` keeps a full MVCC revision chain
 (snapshot isolation, zero loss); `SingleVersion` stores one in-place HEAD slot with WAL tick-fence durability
 (≤1 tick loss); `Transient` is heap-only and never persisted. All three are read and written through the same
 `EntityRef.Read<T>()` / `Write<T>()` calls — only the cost and guarantees differ, not the API. A runtime
@@ -39,7 +40,7 @@ without paying for a revision chain.
 
 ## ⚠️ Guarantees & limits
 
-- `StorageMode` is immutable once a component is registered — there is no in-place migration between modes.
+- `StorageMode` is fixed for a given `(name, revision)`; changing a component's mode requires a new `[Component]` revision (there is no in-place mode migration yet — tracked in #546).
 - An entity can freely mix component types across all three modes (`Spawn`/`Open`/`OpenMut`/`Destroy` work
   uniformly); rollback semantics differ per mode — see each sub-feature.
 - Indexes, spatial queries, and ECS lifecycle (Spawn/Destroy/Enable) are available in all three modes, but with
@@ -52,7 +53,8 @@ without paying for a revision chain.
 ## 🧪 Tests
 
 - [StorageModeReadWriteTests](https://github.com/Log2n-io/Typhon/blob/main/test/Typhon.Engine.Tests/Data/StorageModeReadWriteTests.cs) — an entity mixing all three modes, uniform `Read`/`Write` across them, per-mode rollback/dirty-bitmap behavior
-- [StorageModeInfrastructureTests](https://github.com/Log2n-io/Typhon/blob/main/test/Typhon.Engine.Tests/Data/StorageModeInfrastructureTests.cs) — `[Component(StorageMode = ...)]` attribute defaults/overrides, per-mode segment allocation differences
+- [StorageModeInfrastructureTests](https://github.com/Log2n-io/Typhon/blob/main/test/Typhon.Engine.Tests/Data/StorageModeInfrastructureTests.cs) — `[Component(StorageMode = ...)]` attribute defaults, per-mode segment allocation differences
+- [StorageModeRevisionLockTests](https://github.com/Log2n-io/Typhon/blob/main/test/Typhon.Engine.Tests/Data/ECS/StorageModeRevisionLockTests.cs) — a `(name, revision)` re-declared with a different `StorageMode` on reopen throws
 
 ## 🔗 Related
 

--- a/doc/in-depth-overview/04-schema.md
+++ b/doc/in-depth-overview/04-schema.md
@@ -325,8 +325,7 @@ The two public entry points on `DatabaseEngine`:
 ```csharp
 public bool RegisterComponentFromAccessor<T>(
     ChangeSet changeSet = null,
-    SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce,
-    StorageMode? storageModeOverride = null
+    SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce
 ) where T : unmanaged
 ```
 
@@ -356,17 +355,16 @@ The non-generic overload for runtime-discovered types — e.g. the Workbench loa
 public bool RegisterComponentByType(
     Type componentType,
     ChangeSet changeSet = null,
-    SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce,
-    StorageMode? storageModeOverride = null);
+    SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce);
 ```
 
 Throws `ArgumentException` if `componentType` is a reference type or an open generic — the `unmanaged` constraint is verified at specialization time by the CLR.
 
 > **Note on the diagram:** Older docs and the embedded SVG still use the name `RegisterComponent<T>()` for the entry point. The actual API surface has been `RegisterComponentFromAccessor<T>` / `RegisterComponentByType` for some time. Don't go looking for `RegisterComponent<T>` in current code.
 
-### Storage mode override
+### StorageMode is fixed per `(name, revision)`
 
-`storageModeOverride` lets a caller force a Versioned-by-default component into SingleVersion or Transient at registration time without editing the struct's `[Component]` attribute. The override is applied to the `DBComponentDefinition` *before* the `ComponentTable` is built so the chunk layout (overhead size, `EntityPKOverheadSize`) reflects the override correctly.
+`StorageMode` comes solely from the component's `[Component]` attribute — there is no per-registration override. On reopen, re-declaring a persisted component at the **same revision** with a different `StorageMode` throws `InvalidOperationException` (`definition.Revision == persisted.Comp.SchemaRevision && declared != persisted`): reinterpreting persisted bytes under a different storage discipline would be silent corruption. Changing how a component is stored requires a new `[Component]` revision. (Full data migration across a mode change on a revision bump is not yet wired — tracked in #546.)
 
 ---
 

--- a/doc/key-concepts/storage-mode.md
+++ b/doc/key-concepts/storage-mode.md
@@ -8,7 +8,7 @@ description: 'A per-component, design-time choice of memory layout and ACID guar
 
 > **In one line:** a **per-component**, design-time choice of memory layout and ACID guarantees — `Versioned`, `SingleVersion`, or `Transient`.
 
-Set on the `[Component]` attribute and **immutable after registration**. Because it lives on the component *type*, one archetype freely mixes all three. The mode decides whether MVCC/[isolation](xref:concept-snapshot-isolation) exists at all — and what a write costs.
+Set on the `[Component]` attribute and **fixed for a given `(component name, revision)`** — to change the mode, bump the `[Component]` revision; re-using the same revision with a different mode throws `InvalidOperationException` on reopen. Because it lives on the component *type*, one archetype freely mixes all three. The mode decides whether MVCC/[isolation](xref:concept-snapshot-isolation) exists at all — and what a write costs.
 
 | Mode | Isolation | Durability | Write cost (Zen 4) |
 |---|---|---|---|

--- a/src/Typhon.Engine/Ecs/public/DatabaseEngine.cs
+++ b/src/Typhon.Engine/Ecs/public/DatabaseEngine.cs
@@ -2251,13 +2251,11 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
     /// </param>
     /// <param name="changeSet">Optional transactional change set. See <see cref="RegisterComponentFromAccessor{T}"/>.</param>
     /// <param name="schemaValidation">Schema validation policy (default: <see cref="SchemaValidationMode.Enforce"/>).</param>
-    /// <param name="storageModeOverride">Optional override for the storage mode declared by the component.</param>
     /// <returns>Forwarded from <see cref="RegisterComponentFromAccessor{T}"/> — <see langword="true"/> on success.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="componentType"/> is null.</exception>
     /// <exception cref="ArgumentException"><paramref name="componentType"/> is not a closed value type.</exception>
     /// <seealso cref="RegisterComponentFromAccessor{T}"/>
-    public bool RegisterComponentByType(Type componentType, ChangeSet changeSet = null, SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce,
-        StorageMode? storageModeOverride = null)
+    public bool RegisterComponentByType(Type componentType, ChangeSet changeSet = null, SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce)
     {
         ArgumentNullException.ThrowIfNull(componentType);
         if (!componentType.IsValueType || componentType.IsGenericTypeDefinition)
@@ -2270,7 +2268,7 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
         var generic = method.MakeGenericMethod(componentType);
         try
         {
-            return (bool)generic.Invoke(this, [changeSet, schemaValidation, storageModeOverride])!;
+            return (bool)generic.Invoke(this, [changeSet, schemaValidation])!;
         }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
@@ -2292,11 +2290,10 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
     /// <typeparam name="T">A closed unmanaged value type tagged with <c>[Component]</c>.</typeparam>
     /// <param name="changeSet">Optional change set to enlist the registration writes in.</param>
     /// <param name="schemaValidation">How a persisted schema is reconciled with the runtime type; default <see cref="SchemaValidationMode.Enforce"/>.</param>
-    /// <param name="storageModeOverride">Optional <see cref="StorageMode"/> overriding the mode declared on the component.</param>
     /// <returns><see langword="true"/> on success; <see langword="false"/> when the component definition could not be built.</returns>
     /// <exception cref="InvalidOperationException">A Transient component declares a <c>ComponentCollection</c> field.</exception>
-    public bool RegisterComponentFromAccessor<T>(ChangeSet changeSet = null, SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce,
-        StorageMode? storageModeOverride = null) where T : unmanaged
+    public bool RegisterComponentFromAccessor<T>(ChangeSet changeSet = null, SchemaValidationMode schemaValidation = SchemaValidationMode.Enforce)
+        where T : unmanaged
     {
         // Track this component Type for the registry lifecycle pairing in Dispose. Adding even on early-return / failure branches below is safe:
         // UnregisterEngineUse is idempotent on Types it doesn't know about, and any Type the engine touched MAY have ended up in
@@ -2331,14 +2328,9 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
             return false;
         }
 
-        var storageMode = storageModeOverride ?? definition.StorageMode;
-
-        // Apply storage mode override to definition so computed properties (EntityPKOverheadSize, etc.) reflect the override.
-        // NOTE: this must happen BEFORE ComponentTable construction so the segment layout includes the correct overhead.
-        if (storageModeOverride.HasValue && definition.StorageMode != storageModeOverride.Value)
-        {
-            definition.StorageMode = storageModeOverride.Value;
-        }
+        // StorageMode is fixed by the [Component] attribute for a given (name, revision) — there is no per-registration override. Changing how a component is
+        // stored requires a new [Component] revision. See rules/ecs.md; the reopen path below rejects a same-revision mode change.
+        var storageMode = definition.StorageMode;
 
         // Transient ComponentCollection is not supported (out of scope; its buffers live in a persistent VSBS while the component is heap-volatile, which would
         // orphan them on restart). Fail fast at registration rather than leaking silently. Versioned and SingleVersion ComponentCollection are supported.
@@ -2446,6 +2438,18 @@ public partial class DatabaseEngine : ResourceNode, IMetricSource, IDebugPropert
                     $"Invalid StorageMode byte {persistedModeByte} for component '{schemaName}'. Expected 0 (Versioned), 1 (SingleVersion), or 2 (Transient).");
             }
             var persistedMode = (StorageMode)persistedModeByte;
+
+            // StorageMode is fixed for a given (component name, revision). A same-revision mode change would silently reinterpret persisted data under a
+            // different storage discipline (e.g. Versioned revision chains read as SingleVersion in-place) — reject it loudly. Changing how a component is
+            // stored requires a new [Component] revision (which routes through the schema-evolution path above). See rules/ecs.md ARCH-01.
+            if (definition.Revision == persisted.Comp.SchemaRevision && definition.StorageMode != persistedMode)
+            {
+                throw new InvalidOperationException(
+                    $"Component '{schemaName}' revision {definition.Revision} is persisted as StorageMode.{persistedMode} but the code now declares "
+                    + $"StorageMode.{definition.StorageMode}. StorageMode is fixed for a given (component, revision) — increase the [Component] revision "
+                    + "to change how the component is stored.");
+            }
+
             if (persistedMode == StorageMode.Transient)
             {
                 componentTable = new ComponentTable(this, definition, this, StorageMode.Transient);

--- a/test/Typhon.Engine.Tests/Data/ECS/StorageModeRevisionLockTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/StorageModeRevisionLockTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Typhon.Schema.Definition;
+
+namespace Typhon.Engine.Tests;
+
+// Two CLR types deliberately sharing the SAME durable schema identity ("Typhon.Test.ModeLock", revision 1) but declaring DIFFERENT StorageModes. This is the
+// illegal state rules/ecs.md ARCH-01 forbids: StorageMode is fixed for a given (component, revision). Re-opening a database that persisted the component one way
+// while the code now declares it the other way must fail loudly (changing the mode requires a revision bump), never silently reinterpret persisted bytes.
+[Component("Typhon.Test.ModeLock", 1, StorageMode = StorageMode.Versioned)]
+[StructLayout(LayoutKind.Sequential)]
+struct ModeLockVersioned
+{
+    public int V;
+    public int W; // pad — a component's storage must total >= 8 bytes
+    public ModeLockVersioned(int v) { V = v; W = 0; }
+}
+
+[Component("Typhon.Test.ModeLock", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+struct ModeLockSingleVersion
+{
+    public int V;
+    public int W;
+    public ModeLockSingleVersion(int v) { V = v; W = 0; }
+}
+
+[TestFixture]
+[NonParallelizable]
+class StorageModeRevisionLockTests : TestBase<StorageModeRevisionLockTests>
+{
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+    }
+
+    [Test]
+    public void Reopen_SameRevision_DifferentStorageMode_Throws()
+    {
+        // Session 1 — create the DB persisting "Typhon.Test.ModeLock" v1 as Versioned.
+        using (var scope = ServiceProvider.CreateScope())
+        using (var dbe = scope.ServiceProvider.GetRequiredService<DatabaseEngine>())
+        {
+            Assert.That(dbe.RegisterComponentFromAccessor<ModeLockVersioned>(), Is.True);
+            dbe.InitializeArchetypes();
+        }
+
+        // Session 2 — reopen the SAME database, now declaring the same (name, revision) as SingleVersion. Must throw, not silently reinterpret.
+        using (var scope2 = ServiceProvider.CreateScope())
+        using (var dbe2 = scope2.ServiceProvider.GetRequiredService<DatabaseEngine>())
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => dbe2.RegisterComponentFromAccessor<ModeLockSingleVersion>());
+            Assert.That(ex.Message, Does.Contain("StorageMode").And.Contain("revision"),
+                "the error must explain the (name, revision) mode lock and point at a revision bump");
+        }
+    }
+}

--- a/test/Typhon.Engine.Tests/Data/ECS/SvEcsTestSchema.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/SvEcsTestSchema.cs
@@ -1,0 +1,54 @@
+using System.Runtime.InteropServices;
+using Typhon.Schema.Definition;
+
+namespace Typhon.Engine.Tests;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SingleVersion twins of the EcsPosition/Velocity/Health + EcsUnit/EcsSoldier schema.
+//
+// StorageMode is fixed per (component name, revision) — there is no per-registration
+// override (see rules/ecs.md). Tests that need the SingleVersion storage path (change
+// filters, view deltas, subscription/output deltas — all of which require the SV
+// DirtyBitmap) use THESE declared-SV types instead of overriding the Versioned Ecs*
+// components. Field layouts and constructors mirror the Versioned originals.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+[Component("Typhon.Test.SvEcs.Position", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+public struct SvEcsPosition
+{
+    public float X, Y, Z;
+
+    public SvEcsPosition(float x, float y, float z) { X = x; Y = y; Z = z; }
+}
+
+[Component("Typhon.Test.SvEcs.Velocity", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+public struct SvEcsVelocity
+{
+    public float Dx, Dy, Dz;
+
+    public SvEcsVelocity(float dx, float dy, float dz) { Dx = dx; Dy = dy; Dz = dz; }
+}
+
+[Component("Typhon.Test.SvEcs.Health", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+public struct SvEcsHealth
+{
+    public int Current, Max;
+
+    public SvEcsHealth(int current, int max) { Current = current; Max = max; }
+}
+
+[Archetype]
+partial class SvEcsUnit : Archetype<SvEcsUnit>
+{
+    public static readonly Comp<SvEcsPosition> Position = Register<SvEcsPosition>();
+    public static readonly Comp<SvEcsVelocity> Velocity = Register<SvEcsVelocity>();
+}
+
+[Archetype]
+partial class SvEcsSoldier : Archetype<SvEcsSoldier, SvEcsUnit>
+{
+    public static readonly Comp<SvEcsHealth> Health = Register<SvEcsHealth>();
+}

--- a/test/Typhon.Engine.Tests/Data/StorageModeInfrastructureTests.cs
+++ b/test/Typhon.Engine.Tests/Data/StorageModeInfrastructureTests.cs
@@ -143,21 +143,8 @@ class StorageModeInfrastructureTests : TestBase<StorageModeInfrastructureTests>
         Assert.That(table.TransientDefaultIndexSegment, Is.Not.Null);
     }
 
-    [Test]
-    public void Register_StorageModeOverride_OverridesAttribute()
-    {
-        using var scope = ServiceProvider.CreateScope();
-        using var dbe = scope.ServiceProvider.GetRequiredService<DatabaseEngine>();
-
-        // Attribute says Transient, but override says Versioned
-        dbe.RegisterComponentFromAccessor<CompSmTransientOverride>(storageModeOverride: StorageMode.Versioned);
-
-        var table = dbe.GetComponentTable<CompSmTransientOverride>();
-        Assert.That(table.StorageMode, Is.EqualTo(StorageMode.Versioned));
-        Assert.That(table.ComponentSegment, Is.Not.Null, "Override to Versioned → persistent segments");
-        Assert.That(table.CompRevTableSegment, Is.Not.Null);
-        Assert.That(table.TransientComponentSegment, Is.Null);
-    }
+    // (Removed Register_StorageModeOverride_OverridesAttribute: StorageMode is now fixed by the [Component] attribute per (name, revision) — there is no
+    //  per-registration override. Changing a component's storage mode requires a new revision. See rules/ecs.md.)
 
     // ── Chunk allocation smoke tests ──
 

--- a/test/Typhon.Engine.Tests/Runtime/ChangeFilterTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/ChangeFilterTests.cs
@@ -24,9 +24,9 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
     {
         var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
         // Register as SingleVersion so DirtyBitmap is available for change filter tracking
-        dbe.RegisterComponentFromAccessor<EcsPosition>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsVelocity>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsHealth>(storageModeOverride: StorageMode.SingleVersion);
+        dbe.RegisterComponentFromAccessor<SvEcsPosition>();
+        dbe.RegisterComponentFromAccessor<SvEcsVelocity>();
+        dbe.RegisterComponentFromAccessor<SvEcsHealth>();
         dbe.InitializeArchetypes();
         return dbe;
     }
@@ -43,7 +43,7 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         {
             TyphonRuntime.Create(dbe, schedule =>
             {
-                schedule.PublicTrack.DeclareDag("Test").QuerySystem("Bad", _ => { }, changeFilter: [typeof(EcsPosition)]);
+                schedule.PublicTrack.DeclareDag("Test").QuerySystem("Bad", _ => { }, changeFilter: [typeof(SvEcsPosition)]);
             }, new RuntimeOptions { WorkerCount = 1, BaseTickRate = 1000 });
         });
     }
@@ -57,13 +57,13 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
     {
         using var dbe = SetupEngine();
         using var tx = dbe.CreateQuickTransaction();
-        var view = tx.Query<EcsUnit>().ToView();
+        var view = tx.Query<SvEcsUnit>().ToView();
 
         using var runtime = TyphonRuntime.Create(dbe, schedule =>
         {
             schedule.PublicTrack.DeclareDag("Test").QuerySystem("Filtered", _ => { },
                 input: () => view,
-                changeFilter: [typeof(EcsPosition)]);
+                changeFilter: [typeof(SvEcsPosition)]);
         }, new RuntimeOptions { WorkerCount = 1, BaseTickRate = 1000 });
 
         Assert.That(runtime.Scheduler.SystemCount, Is.EqualTo(1));
@@ -75,7 +75,7 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
     {
         using var dbe = SetupEngine();
         using var tx = dbe.CreateQuickTransaction();
-        var view = tx.Query<EcsUnit>().ToView();
+        var view = tx.Query<SvEcsUnit>().ToView();
 
         var ex = Assert.Throws<InvalidOperationException>(() =>
         {
@@ -103,14 +103,14 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         // Pre-spawn entities so the View is non-empty
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
         using var txView = dbe.CreateQuickTransaction();
-        var view = txView.Query<EcsUnit>().ToView();
+        var view = txView.Query<SvEcsUnit>().ToView();
 
         var executeCount = 0;
         var ticksSeen = 0;
@@ -124,7 +124,7 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
             dag.QuerySystem("Filtered", ctx =>
             {
                 Interlocked.Increment(ref executeCount);
-            }, input: () => view, changeFilter: [typeof(EcsPosition)], after: "Tick");
+            }, input: () => view, changeFilter: [typeof(SvEcsPosition)], after: "Tick");
         }, new RuntimeOptions { WorkerCount = 1, BaseTickRate = 1000 });
 
         runtime.Start();
@@ -149,14 +149,14 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         EntityId entityId;
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            entityId = tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            entityId = tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
         using var txView = dbe.CreateQuickTransaction();
-        var view = txView.Query<EcsUnit>().ToView();
+        var view = txView.Query<SvEcsUnit>().ToView();
 
         var executeCount = 0;
         var ticksSeen = 0;
@@ -168,14 +168,14 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
             dag.CallbackSystem("Writer", ctx =>
             {
                 Interlocked.Increment(ref ticksSeen);
-                ref var pos = ref ctx.Transaction.OpenMut(entityId).Write(EcsUnit.Position);
+                ref var pos = ref ctx.Transaction.OpenMut(entityId).Write(SvEcsUnit.Position);
                 pos.X += 1.0f;
             });
 
             dag.QuerySystem("Filtered", ctx =>
             {
                 Interlocked.Increment(ref executeCount);
-            }, input: () => view, changeFilter: [typeof(EcsPosition)], after: "Writer");
+            }, input: () => view, changeFilter: [typeof(SvEcsPosition)], after: "Writer");
         }, new RuntimeOptions { WorkerCount = 1, BaseTickRate = 1000 });
 
         runtime.Start();
@@ -200,8 +200,8 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         // Diagnostic: verify DirtyBitmap works for SV components
         using var dbe = SetupEngine();
 
-        var posTable = dbe.GetComponentTable(typeof(EcsPosition));
-        Assert.That(posTable, Is.Not.Null, "EcsPosition ComponentTable should exist");
+        var posTable = dbe.GetComponentTable(typeof(SvEcsPosition));
+        Assert.That(posTable, Is.Not.Null, "SvEcsPosition ComponentTable should exist");
         Assert.That(posTable.StorageMode, Is.EqualTo(StorageMode.SingleVersion), "Should be SV");
         Assert.That(posTable.DirtyBitmap, Is.Not.Null, "SV table should have DirtyBitmap");
         Assert.That(posTable.Definition.EntityPKOverheadSize, Is.EqualTo(8), "SV should have EntityPK overhead");
@@ -210,9 +210,9 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         EntityId e1;
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            e1 = tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            e1 = tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -226,12 +226,12 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         // Write a component to trigger DirtyBitmap
         using (var tx2 = dbe.CreateQuickTransaction())
         {
-            ref var pos = ref tx2.OpenMut(e1).Write(EcsUnit.Position);
+            ref var pos = ref tx2.OpenMut(e1).Write(SvEcsUnit.Position);
             pos.X = 99f;
             tx2.Commit();
         }
 
-        var clusterState = dbe._archetypeStates[Archetype<EcsUnit>.Metadata.ArchetypeId]?.ClusterState;
+        var clusterState = dbe._archetypeStates[Archetype<SvEcsUnit>.Metadata.ArchetypeId]?.ClusterState;
         if (clusterState != null)
         {
             Assert.That(clusterState.ClusterDirtyBitmap.HasDirty, Is.True, "ClusterDirtyBitmap should be dirty after Write<T>");
@@ -256,16 +256,16 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         EntityId e1, e2;
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos1 = new EcsPosition(1, 0, 0);
-            var pos2 = new EcsPosition(2, 0, 0);
-            var vel = new EcsVelocity(0, 0, 0);
-            e1 = tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos1), EcsUnit.Velocity.Set(in vel));
-            e2 = tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos2), EcsUnit.Velocity.Set(in vel));
+            var pos1 = new SvEcsPosition(1, 0, 0);
+            var pos2 = new SvEcsPosition(2, 0, 0);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            e1 = tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos1), SvEcsUnit.Velocity.Set(in vel));
+            e2 = tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos2), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
         using var txView = dbe.CreateQuickTransaction();
-        var view = txView.Query<EcsUnit>().ToView();
+        var view = txView.Query<SvEcsUnit>().ToView();
 
         var maxEntitiesReceived = 0;
         var ticksSeen = 0;
@@ -280,7 +280,7 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
                 var tick = Interlocked.Increment(ref ticksSeen);
                 if (tick == 2)
                 {
-                    ref var pos = ref ctx.Transaction.OpenMut(e1).Write(EcsUnit.Position);
+                    ref var pos = ref ctx.Transaction.OpenMut(e1).Write(SvEcsUnit.Position);
                     pos.X = 99f;
                     Interlocked.Exchange(ref writerDone, 1);
                 }
@@ -299,7 +299,7 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
                         if (count <= prev) break;
                     } while (Interlocked.CompareExchange(ref maxEntitiesReceived, count, prev) != prev);
                 }
-            }, input: () => view, changeFilter: [typeof(EcsPosition)], after: "Writer");
+            }, input: () => view, changeFilter: [typeof(SvEcsPosition)], after: "Writer");
         }, new RuntimeOptions { WorkerCount = 1, BaseTickRate = 1000 });
 
         runtime.Start();
@@ -327,18 +327,18 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         EntityId soldier;
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 0, 0);
-            var vel = new EcsVelocity(0, 0, 0);
-            var hp = new EcsHealth(100, 100);
-            soldier = tx.Spawn<EcsSoldier>(
-                EcsUnit.Position.Set(in pos),
-                EcsUnit.Velocity.Set(in vel),
-                EcsSoldier.Health.Set(in hp));
+            var pos = new SvEcsPosition(1, 0, 0);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            var hp = new SvEcsHealth(100, 100);
+            soldier = tx.Spawn<SvEcsSoldier>(
+                SvEcsUnit.Position.Set(in pos),
+                SvEcsUnit.Velocity.Set(in vel),
+                SvEcsSoldier.Health.Set(in hp));
             tx.Commit();
         }
 
         using var txView = dbe.CreateQuickTransaction();
-        var view = txView.Query<EcsSoldier>().ToView();
+        var view = txView.Query<SvEcsSoldier>().ToView();
 
         var executeCount = 0;
         var ticksSeen = 0;
@@ -352,7 +352,7 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
                 var tick = Interlocked.Increment(ref ticksSeen);
                 if (tick == 2)
                 {
-                    ref var hp = ref ctx.Transaction.OpenMut(soldier).Write(EcsSoldier.Health);
+                    ref var hp = ref ctx.Transaction.OpenMut(soldier).Write(SvEcsSoldier.Health);
                     hp.Current = 50;
                 }
             });
@@ -364,7 +364,7 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
                 {
                     Interlocked.Increment(ref executeCount);
                 }
-            }, input: () => view, changeFilter: [typeof(EcsPosition), typeof(EcsHealth)], after: "Writer");
+            }, input: () => view, changeFilter: [typeof(SvEcsPosition), typeof(SvEcsHealth)], after: "Writer");
         }, new RuntimeOptions { WorkerCount = 1, BaseTickRate = 1000 });
 
         runtime.Start();
@@ -391,15 +391,15 @@ class ChangeFilterTests : TestBase<ChangeFilterTests>
         // Spawn two entities
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 0, 0);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 0, 0);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
         using var txView = dbe.CreateQuickTransaction();
-        var view = txView.Query<EcsUnit>().ToView();
+        var view = txView.Query<SvEcsUnit>().ToView();
 
         var entityCount = -1;
         var captured = 0;

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/OutputPhaseTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/OutputPhaseTests.cs
@@ -25,9 +25,9 @@ class OutputPhaseTests : TestBase<OutputPhaseTests>
     private DatabaseEngine SetupEngine()
     {
         var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
-        dbe.RegisterComponentFromAccessor<EcsPosition>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsVelocity>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsHealth>(storageModeOverride: StorageMode.SingleVersion);
+        dbe.RegisterComponentFromAccessor<SvEcsPosition>();
+        dbe.RegisterComponentFromAccessor<SvEcsVelocity>();
+        dbe.RegisterComponentFromAccessor<SvEcsHealth>();
         dbe.InitializeArchetypes();
         return dbe;
     }
@@ -37,7 +37,7 @@ class OutputPhaseTests : TestBase<OutputPhaseTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var subsView = viewTx.Query<EcsUnit>().ToView();
+        var subsView = viewTx.Query<SvEcsUnit>().ToView();
 
         var spawnedOnTick = -1;
         var clientReady = 0;
@@ -55,9 +55,9 @@ class OutputPhaseTests : TestBase<OutputPhaseTests>
                 // Spawn once
                 if (spawnedOnTick < 0)
                 {
-                    var pos = new EcsPosition(1, 2, 3);
-                    var vel = new EcsVelocity(0, 0, 0);
-                    ctx.Transaction.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                    var pos = new SvEcsPosition(1, 2, 3);
+                    var vel = new SvEcsVelocity(0, 0, 0);
+                    ctx.Transaction.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
                     Interlocked.Exchange(ref spawnedOnTick, (int)ctx.TickNumber);
                 }
             });
@@ -147,7 +147,7 @@ class OutputPhaseTests : TestBase<OutputPhaseTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var subsView = viewTx.Query<EcsUnit>().ToView();
+        var subsView = viewTx.Query<SvEcsUnit>().ToView();
 
         var clientReady = 0;
         var totalSpawned = 0;
@@ -161,9 +161,9 @@ class OutputPhaseTests : TestBase<OutputPhaseTests>
                 // Spawn 5 entities every tick
                 for (var i = 0; i < 5; i++)
                 {
-                    var pos = new EcsPosition(ctx.TickNumber, i, 0);
-                    var vel = new EcsVelocity(0, 0, 0);
-                    ctx.Transaction.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                    var pos = new SvEcsPosition(ctx.TickNumber, i, 0);
+                    var vel = new SvEcsVelocity(0, 0, 0);
+                    ctx.Transaction.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
                     Interlocked.Increment(ref totalSpawned);
                 }
             });

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/SubscriptionStressTests.cs
@@ -34,9 +34,9 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
     private DatabaseEngine SetupEngine()
     {
         var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
-        dbe.RegisterComponentFromAccessor<EcsPosition>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsVelocity>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsHealth>(storageModeOverride: StorageMode.SingleVersion);
+        dbe.RegisterComponentFromAccessor<SvEcsPosition>();
+        dbe.RegisterComponentFromAccessor<SvEcsVelocity>();
+        dbe.RegisterComponentFromAccessor<SvEcsHealth>();
         dbe.InitializeArchetypes();
         return dbe;
     }
@@ -90,7 +90,7 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
 
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var subsView = viewTx.Query<EcsUnit>().ToView();
+        var subsView = viewTx.Query<SvEcsUnit>().ToView();
 
         var spawnCount = 0;
 
@@ -104,9 +104,9 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
                     // Spawn 10 entities per tick for 5 ticks = 50 total
                     for (var i = 0; i < 10; i++)
                     {
-                        var pos = new EcsPosition(ctx.TickNumber, i, 0);
-                        var vel = new EcsVelocity(0, 0, 0);
-                        ctx.Transaction.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                        var pos = new SvEcsPosition(ctx.TickNumber, i, 0);
+                        var vel = new SvEcsVelocity(0, 0, 0);
+                        ctx.Transaction.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
                         Interlocked.Increment(ref spawnCount);
                     }
                 }
@@ -203,7 +203,7 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
 
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var subsView = viewTx.Query<EcsUnit>().ToView();
+        var subsView = viewTx.Query<SvEcsUnit>().ToView();
 
         using var runtime = TyphonRuntime.Create(dbe, schedule =>
         {
@@ -289,7 +289,7 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
 
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var subsView = viewTx.Query<EcsUnit>().ToView();
+        var subsView = viewTx.Query<SvEcsUnit>().ToView();
 
         var totalSpawned = 0;
         var clientReady = 0;
@@ -307,9 +307,9 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
                 // Spawn entities every tick
                 for (var i = 0; i < entitiesPerTick; i++)
                 {
-                    var pos = new EcsPosition(ctx.TickNumber, i, 0);
-                    var vel = new EcsVelocity(1, 0, 0);
-                    ctx.Transaction.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                    var pos = new SvEcsPosition(ctx.TickNumber, i, 0);
+                    var vel = new SvEcsVelocity(1, 0, 0);
+                    ctx.Transaction.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
                     Interlocked.Increment(ref totalSpawned);
                 }
             });
@@ -397,7 +397,7 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
 
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var subsView = viewTx.Query<EcsUnit>().ToView();
+        var subsView = viewTx.Query<SvEcsUnit>().ToView();
 
         using var runtime = TyphonRuntime.Create(dbe, schedule =>
         {
@@ -406,9 +406,9 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
                 // Spawn many entities to generate large deltas
                 for (var i = 0; i < 50; i++)
                 {
-                    var pos = new EcsPosition(ctx.TickNumber * 100 + i, i, 0);
-                    var vel = new EcsVelocity(0, 0, 0);
-                    ctx.Transaction.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                    var pos = new SvEcsPosition(ctx.TickNumber * 100 + i, i, 0);
+                    var vel = new SvEcsVelocity(0, 0, 0);
+                    ctx.Transaction.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
                 }
             });
         }, new RuntimeOptions
@@ -496,10 +496,10 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
 
         using var dbe = SetupEngine();
         using var viewTx1 = dbe.CreateQuickTransaction();
-        var viewA = viewTx1.Query<EcsUnit>().ToView();
+        var viewA = viewTx1.Query<SvEcsUnit>().ToView();
 
         using var viewTx2 = dbe.CreateQuickTransaction();
-        var viewB = viewTx2.Query<EcsUnit>().ToView();
+        var viewB = viewTx2.Query<SvEcsUnit>().ToView();
 
         var setSubCount = 0;
 
@@ -610,7 +610,7 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
 
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var subsView = viewTx.Query<EcsUnit>().ToView();
+        var subsView = viewTx.Query<SvEcsUnit>().ToView();
 
         var spawnDone = 0;
 
@@ -623,9 +623,9 @@ class SubscriptionStressTests : TestBase<SubscriptionStressTests>
                 {
                     for (var i = 0; i < entitiesPerTick; i++)
                     {
-                        var pos = new EcsPosition(ctx.TickNumber, i, 0);
-                        var vel = new EcsVelocity(1, 0, 0);
-                        ctx.Transaction.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                        var pos = new SvEcsPosition(ctx.TickNumber, i, 0);
+                        var vel = new SvEcsVelocity(1, 0, 0);
+                        ctx.Transaction.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
                     }
 
                     if (ctx.TickNumber == 14)

--- a/test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/Subscriptions/ViewDeltaTests.cs
@@ -21,9 +21,9 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     private DatabaseEngine SetupEngine()
     {
         var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
-        dbe.RegisterComponentFromAccessor<EcsPosition>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsVelocity>(storageModeOverride: StorageMode.SingleVersion);
-        dbe.RegisterComponentFromAccessor<EcsHealth>(storageModeOverride: StorageMode.SingleVersion);
+        dbe.RegisterComponentFromAccessor<SvEcsPosition>();
+        dbe.RegisterComponentFromAccessor<SvEcsVelocity>();
+        dbe.RegisterComponentFromAccessor<SvEcsHealth>();
         dbe.InitializeArchetypes();
         return dbe;
     }
@@ -37,7 +37,7 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Refresh with no entities
         using var tx = dbe.CreateQuickTransaction();
@@ -53,15 +53,15 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Spawn entities
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -80,14 +80,14 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Spawn entities
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -115,15 +115,15 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Spawn entity A
         EntityId idA;
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 0, 0);
-            var vel = new EcsVelocity(0, 0, 0);
-            idA = tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 0, 0);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            idA = tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -138,9 +138,9 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
         // Spawn entity B
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(2, 0, 0);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(2, 0, 0);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -164,7 +164,7 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Simulate tick 1: no clients → RefreshAllViews (empties View, no entities)
         using (var tx = dbe.CreateQuickTransaction())
@@ -185,11 +185,11 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
         // Spawn entities
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -209,15 +209,15 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Spawn entities BEFORE client subscribes
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -243,15 +243,15 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Spawn entities
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -286,7 +286,7 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         // Tick 1: no entities, subscribe, sync completes immediately
         using (var tx = dbe.CreateQuickTransaction())
@@ -303,11 +303,11 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
         // Tick 2: spawn 5 entities
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
             for (var i = 0; i < 5; i++)
             {
-                tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             }
 
             tx.Commit();
@@ -326,11 +326,11 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
         // Tick 3: spawn 3 more
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(4, 5, 6);
-            var vel = new EcsVelocity(0, 0, 0);
+            var pos = new SvEcsPosition(4, 5, 6);
+            var vel = new SvEcsVelocity(0, 0, 0);
             for (var i = 0; i < 3; i++)
             {
-                tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+                tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             }
 
             tx.Commit();
@@ -355,17 +355,17 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         var published = PublishedView.CreateShared("test", view, SubscriptionPriority.Normal);
 
         // Spawn entities
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -388,7 +388,7 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
     {
         using var dbe = SetupEngine();
         using var viewTx = dbe.CreateQuickTransaction();
-        var view = viewTx.Query<EcsUnit>().ToView();
+        var view = viewTx.Query<SvEcsUnit>().ToView();
 
         var published = PublishedView.CreateShared("test", view, SubscriptionPriority.Normal);
         var builder = new DeltaBuilder();
@@ -396,10 +396,10 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
         // Tick 1: spawn 2 entities, build delta
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(1, 2, 3);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(1, 2, 3);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 
@@ -415,9 +415,9 @@ class ViewDeltaTests : TestBase<ViewDeltaTests>
         // Tick 2: spawn 1 more entity
         using (var tx = dbe.CreateQuickTransaction())
         {
-            var pos = new EcsPosition(4, 5, 6);
-            var vel = new EcsVelocity(0, 0, 0);
-            tx.Spawn<EcsUnit>(EcsUnit.Position.Set(in pos), EcsUnit.Velocity.Set(in vel));
+            var pos = new SvEcsPosition(4, 5, 6);
+            var vel = new SvEcsVelocity(0, 0, 0);
+            tx.Spawn<SvEcsUnit>(SvEcsUnit.Position.Set(in pos), SvEcsUnit.Velocity.Set(in vel));
             tx.Commit();
         }
 


### PR DESCRIPTION
## Problem

Enabling parallel test fixtures in `Typhon.Engine.Tests` (removing the bare `[NonParallelizable]` markers) surfaced one deterministic, silent-wrong-data failure: `EntitySpawnTests.ReadAll_InheritedArchetype_IncludesParentComponents` read back `Health = 0` for an inherited archetype's own component (~1×/run).

**Root cause:** the cluster-layout fields (`IsClusterEligible`, `ClusterLayout`, entity-record size, slot masks) live on the **process-shared** `ArchetypeMetadata`, but they are derived from each engine's component `StorageMode`. A peer fixture that registered the same components as `SingleVersion` (via the test-only `storageModeOverride`) made the archetype cluster-eligible and **stomped** the shared metadata for a concurrent pure-Versioned engine — truncating the entity record so the child's own top slot read back as default (`0`). Inherited slots below it survived.

## Fix — enforce the schema invariant instead of tolerating divergence

`StorageMode` is part of a component's schema identity: it is **fixed per `(component name, revision)`**. The *only* thing that let two engines disagree for the same archetype was `storageModeOverride`, a test-only knob with **no production caller**. Rather than make the engine robust to an incoherent input, this PR makes the incoherent input impossible:

- **Removed `storageModeOverride`** from `RegisterComponentFromAccessor` / `RegisterComponentByType` — `StorageMode` now comes solely from the `[Component]` attribute.
- **Reopen guard:** re-declaring a persisted component at the **same revision** with a different `StorageMode` now throws (`definition.Revision == persisted.Comp.SchemaRevision && declared != persisted`). Changing the mode requires a `[Component]` revision bump.
- Tests that faked `SingleVersion` via the override now use **declared-SV twin types** (`SvEcsTestSchema`): `ChangeFilterTests`, `ViewDeltaTests`, `SubscriptionStressTests`, `OutputPhaseTests`. Removed the now-obsolete `StorageModeInfrastructureTests.Register_StorageModeOverride_OverridesAttribute`.
- New `StorageModeRevisionLockTests` verifies the guard via a two-session reopen (same name + revision, different mode ⇒ throws).

With this, an archetype's components resolve to the same `StorageMode` in every engine, so the shared cluster-layout fields are globally consistent — the stomp is **impossible by construction**, and the fields legitimately stay on the shared `ArchetypeMetadata`.

## Testing

- Full `Typhon.Engine.Tests` suite green: **4029 passed, 0 failed, 38 skipped**.
- New `StorageModeRevisionLockTests` covers the reopen enforcement.

## Follow-ups (not in this PR)

- **#546** — schema migration should support a `StorageMode` change across a revision bump (the sanctioned escape hatch is not yet wired end-to-end).
- The `[NonParallelizable]` marker strip (the original motivation) is now **unblocked** but intentionally out of scope here.
- Documentation (`rules/ecs.md` SCHEMA-01) lands in the separate **typhon-claude** repo (its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rY7C3gqgTJe1GbE9tA9P