### PR TITLE
#466 follow-up: idle-stop timer 10 min → 2 min

### DIFF
--- a/bench/aws/runner/idle-stop.sh
+++ b/bench/aws/runner/idle-stop.sh
@@ -8,7 +8,7 @@
 # it cannot misfire between two back-to-back jobs. (Concurrency section of the design.)
 set -euo pipefail
 
-IDLE_MINUTES="${IDLE_MINUTES:-10}"
+IDLE_MINUTES="${IDLE_MINUTES:-2}"
 REGION="${AWS_REGION:-eu-west-1}"
 STATE=/run/typhon-idle-count      # tmpfs — resets to absent on boot, so a fresh box starts its idle count at 0
 

--- a/bench/aws/runner/terraform/variables.tf
+++ b/bench/aws/runner/terraform/variables.tf
@@ -41,7 +41,7 @@ variable "webhook_secret" {
 
 variable "max_uptime_min" {
   type    = number
-  default = 120 # backstop: stop a box running longer than this (a normal gate run is ~10 min; idle-stop fires at 10 min idle)
+  default = 120 # backstop: stop a box running longer than this (a normal gate run is ~10 min; idle-stop fires at 2 min idle)
 }
 
 variable "alert_email" {

--- a/bench/aws/runner/typhon-idle-stop.service
+++ b/bench/aws/runner/typhon-idle-stop.service
@@ -5,6 +5,6 @@ Description=Typhon CI: stop the box after the runner has been idle N minutes
 
 [Service]
 Type=oneshot
-Environment=IDLE_MINUTES=10
+Environment=IDLE_MINUTES=2
 Environment=AWS_REGION=eu-west-1
 ExecStart=/home/ubuntu/typhon-runner/idle-stop.sh


### PR DESCRIPTION
Shortens the persistent runner's idle self-stop from **10 min → 2 min**.

## Why
The 10-min idle tail bought almost nothing: the `bin`/`obj` build cache lives on the **EBS root**, which survives stop/start, so a cold restart only pays the **~20 s** EC2 resume + runner reconnect (measured on the live box) — not build incrementality. Paying up to 10 min of c6id.8xlarge compute (~$0.31) to save ~20 s on a *maybe*-follow-up is a bad trade. Over an active month that idle tail is realistically $20–60.

It also **realigns with the design**: the design doc's Q3 resolution already says *"Stop grace 0–2 min"* — shipping `10` was implementation drift from the spec.

## Changes
- `typhon-idle-stop.service` — `Environment=IDLE_MINUTES=2` (**the effective value on the box**).
- `idle-stop.sh` — fallback default `${IDLE_MINUTES:-2}` (kept consistent).
- `terraform/variables.tf` — corrected the backstop comment ("idle-stop fires at 2 min idle").

The 120-min max-uptime EventBridge backstop is unchanged — still the orphan safety net.

## ⚠️ Two-layer change — the live box needs a manual apply
The **running box's deployed unit still reads `IDLE_MINUTES=10`** until re-applied. Next time the box is up (e.g. the next gate run), SSH in and:
```bash
sudo sed -i 's/IDLE_MINUTES=10/IDLE_MINUTES=2/' /etc/systemd/system/typhon-idle-stop.service
sudo systemctl daemon-reload
```
No restart of the timer needed — the next minute-tick picks up the new value. (Merging this PR only updates the repo; it does not touch the box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)