### PR TITLE
#567 Opt-in strict tick-abort policy — cancel the rest of the tick on a fatal system exception

### DIFF
--- a/src/Typhon.Engine/Runtime/public/DagScheduler.Diagnostic.cs
+++ b/src/Typhon.Engine/Runtime/public/DagScheduler.Diagnostic.cs
@@ -15,14 +15,17 @@ public sealed partial class DagScheduler
     // Per-system "most recent exception" capture. Populated by the system-execution catch
     // blocks via <see cref="CaptureSystemException"/>; surfaced in <see cref="DumpHangDiagnostic"/>
     // so a hang caused by a runaway exception gives the user the actual stack trace, not just a
-    // "Skip=Exception" enum value. Lazy-allocated so DAG schedulers built without diagnostic
-    // need don't pay the per-system slot cost.
-    private Exception[] _lastSystemException;
+    // "Skip=Exception" enum value. Allocated eagerly alongside the other per-system arrays in the constructor. It used to be lazy (`??=`) to spare schedulers
+    // with no diagnostic need the per-system slot cost, but that races: several workers throwing in the same tick can each evaluate the `??=` and allocate,
+    // and every capture but the winner's is silently dropped. An array of null references is 8 bytes per system — not a cost worth a race.
+    private readonly Exception[] _lastSystemException;
 
     internal void CaptureSystemException(int sysIdx, Exception ex)
     {
-        var arr = _lastSystemException ??= new Exception[AllSystemCount];
-        if ((uint)sysIdx < (uint)arr.Length) arr[sysIdx] = ex;
+        if ((uint)sysIdx < (uint)_lastSystemException.Length)
+        {
+            _lastSystemException[sysIdx] = ex;
+        }
     }
 
     /// <summary>
@@ -101,23 +104,23 @@ public sealed partial class DagScheduler
         // Surface any captured exceptions so a hang caused by a system throwing surfaces the
         // stack trace inline — without this the user would have to check the logger output
         // (which may be filtered) to know what went wrong.
-        if (_lastSystemException != null)
+        sb.AppendLine();
+        sb.AppendLine("Captured exceptions (most recent per system):");
+        var anyEx = false;
+        for (var i = 0; i < AllSystemCount; i++)
         {
-            sb.AppendLine();
-            sb.AppendLine("Captured exceptions (most recent per system):");
-            var anyEx = false;
-            for (var i = 0; i < AllSystemCount; i++)
+            var ex = _lastSystemException[i];
+            if (ex == null)
             {
-                var ex = _lastSystemException[i];
-                if (ex == null) continue;
-                anyEx = true;
-                sb.Append("  System ").Append(i).Append(" '").Append(Systems[i].Name).Append("':").AppendLine();
-                sb.AppendLine(ex.ToString());
+                continue;
             }
-            if (!anyEx)
-            {
-                sb.AppendLine("  (no exceptions captured)");
-            }
+            anyEx = true;
+            sb.Append("  System ").Append(i).Append(" '").Append(Systems[i].Name).Append("':").AppendLine();
+            sb.AppendLine(ex.ToString());
+        }
+        if (!anyEx)
+        {
+            sb.AppendLine("  (no exceptions captured)");
         }
 
         return sb.ToString();

--- a/src/Typhon.Engine/Runtime/public/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/public/DagScheduler.cs
@@ -1,4 +1,4 @@
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
@@ -114,6 +114,129 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     // Reset templates (immutable after construction)
     private readonly int[] _templateDeps;
     private readonly int[] _templateChunks;
+
+    // ═══════════════════════════════════════════════════════════════
+    // Strict tick abort (#567) — RuntimeOptions.SystemExceptionPolicy = AbortTickAndStop
+    // ═══════════════════════════════════════════════════════════════
+
+    // Terminal abort latch. 0 = running, 1 = a fatal system exception cancelled a tick and this scheduler is dead.
+    //
+    // NOT per-tick state, despite living next to the arrays above: `AbortTickAndStop` is terminal by design, so this is deliberately excluded from
+    // ResetTickState / the `Array.Clear(_systemFailed)` sites. Clearing it would silently resume ticking on a simulation whose systems only partly ran.
+    //
+    // Padded because every worker reads it on the dispatch path. It is written exactly once in the scheduler's lifetime, so the read is a shared-clean hit in
+    // steady state; padding keeps that line from being invalidated by the hot counters either side of it.
+    private CacheLinePaddedInt _tickAborted;
+
+    // First-failure record, written by whichever thread wins the CAS on _tickAborted — see TryRecordTickAbort for why the latch is taken before these are
+    // written, and why that ordering is safe.
+    private int _abortedSystemIndex = -1;
+    private Exception _abortedException;
+    private long _abortedTickNumber;
+
+    private readonly SystemExceptionPolicy _exceptionPolicy;
+
+    /// <summary>
+    /// True once a fatal system exception has aborted a tick under <see cref="SystemExceptionPolicy.AbortTickAndStop"/>.
+    /// Terminal — never cleared. No further ticks execute.
+    /// </summary>
+    public bool IsTickAborted => Volatile.Read(ref _tickAborted.Value) != 0;
+
+    /// <summary>
+    /// Records the first fatal system failure of a tick and latches the terminal abort, exactly once across all workers.
+    /// No-op unless the policy is <see cref="SystemExceptionPolicy.AbortTickAndStop"/> and the system belongs to an application track — a throw on an engine
+    /// track is a different class (rule D3) and never aborts a tick.
+    /// </summary>
+    /// <returns>True if THIS call latched the abort (the caller is the first-failure recorder).</returns>
+    private bool TryRecordTickAbort(int sysIdx, Exception ex)
+    {
+        if (_exceptionPolicy != SystemExceptionPolicy.AbortTickAndStop)
+        {
+            return false;
+        }
+        if ((uint)sysIdx < (uint)_systemIsEngine.Length && _systemIsEngine[sysIdx])
+        {
+            return false;
+        }
+
+        // Latch FIRST, then record. The CAS elects exactly one winner (AC11); writing the detail before it would let racing losers stomp the winner's record.
+        // The inverse hazard — a reader seeing the latch before the detail is written — cannot bite: the dispatch gates only ever test the latch, never the
+        // detail, and the detail is read (via AbortedOutcome) at tick end, after `_systemsRemaining` has drained to zero. That drain is a barrier every
+        // worker passes through, so it orders the winner's stores ahead of any read of them.
+        if (Interlocked.CompareExchange(ref _tickAborted.Value, 1, 0) != 0)
+        {
+            return false;   // another worker got there first — its failure is THE first failure
+        }
+
+        _abortedSystemIndex = sysIdx;
+        _abortedException = ex;
+        _abortedTickNumber = _currentTickNumber;
+        return true;
+    }
+
+    /// <summary>
+    /// The single funnel for "a system failed with this exception": logs it, captures it for <see cref="DumpHangDiagnostic"/>, and —
+    /// under <see cref="SystemExceptionPolicy.AbortTickAndStop"/> — latches the terminal tick abort. Every catch site in the system-execution paths calls this
+    /// and nothing else, so a new catch site cannot accidentally opt out of one of the three.
+    /// </summary>
+    private void RecordSystemFailure(int sysIdx, string systemName, Exception ex)
+    {
+        LogSystemException(sysIdx, systemName, ex);
+        CaptureSystemException(sysIdx, ex);
+        TryRecordTickAbort(sysIdx, ex);
+    }
+
+    /// <summary>
+    /// Marks a system cancelled by a tick abort and drives its completion so the tick's countdown still drains.
+    /// Cancellation in Typhon is dispatch-and-skip, never halt-dispatch: whoever claims the system must complete it, or
+    /// <c>_systemsRemaining</c> never reaches zero and the tick hangs.
+    /// </summary>
+    private void SkipSystemForTickAbort(int sysIdx, int workerId, bool trackUtilization)
+    {
+        _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.TickAborted;
+        InspectorSystemSkipped(sysIdx, SkipReason.TickAborted, Stopwatch.GetTimestamp());
+        OnSystemComplete(sysIdx, workerId, trackUtilization);
+    }
+
+    /// <summary>
+    /// Cancels a parallel / pipeline system whose chunk 0 this worker just claimed as the tick aborted. Claiming chunk 0 is the "this system begins" decision
+    /// and it is atomic — the counter hands 0 to exactly one worker — so the abort is decided once per system (rule D1: granularity is the system, never the chunk).
+    /// </summary>
+    /// <remarks>
+    /// <c>_systemFailed</c> is set first so peers still ahead of their own top-of-loop check divert into the drain instead of claiming fresh chunks. A peer that
+    /// already claimed a chunk runs it — that is in-flight work, which finishes by design. The tick is partially applied by construction anyway (systems that
+    /// ran before the failure committed), so a stray chunk is inside the envelope the policy already accepts, not a new failure mode.
+    /// </remarks>
+    private void AbortSystemFromChunkZero(int sysIdx, int workerId, bool trackUtilization)
+    {
+        _systemFailed[sysIdx] = true;
+        _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.TickAborted;
+        InspectorSystemSkipped(sysIdx, SkipReason.TickAborted, Stopwatch.GetTimestamp());
+
+        // Account for the chunk 0 we claimed but will not run. If it was the only chunk this completes the system.
+        if (Interlocked.Decrement(ref _remainingChunks[sysIdx].Value) == 0)
+        {
+            RecordSystemDone(sysIdx, Stopwatch.GetTimestamp());
+            SystemEndCallback?.Invoke(sysIdx, false);
+            OnSystemComplete(sysIdx, workerId, trackUtilization);
+            return;
+        }
+
+        // Chunks 1..N-1 go through the same drain the per-system failure path uses (correction C2): a not-yet-started system must still drive its counter to
+        // zero, and the drain's claim/decrement protocol is already race-safe across the several workers that can enter it at once.
+        DrainFailedSystemChunks(sysIdx, workerId, trackUtilization);
+    }
+
+    /// <summary>The outcome describing the abort. Only meaningful once <see cref="IsTickAborted"/> is true.</summary>
+    internal TickOutcome AbortedOutcome
+    {
+        get
+        {
+            var idx = _abortedSystemIndex;
+            var name = (uint)idx < (uint)Systems.Length ? Systems[idx].Name : null;
+            return new TickOutcome(_abortedTickNumber, TickOutcomeReason.SystemException, idx, name, _abortedException);
+        }
+    }
 
     // ═══════════════════════════════════════════════════════════════
     // Workers
@@ -261,6 +384,14 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             return;
         }
 
+        // Terminal tick-abort (#567). AbortTickAndStop leaves the simulation logically incomplete — some systems ran, some never did — so the runtime must
+        // not silently resume on top of it. The host is expected to have stopped us from its OnTickAborted handler; this is the backstop for the ticks that
+        // fire before it gets there.
+        if (IsTickAborted)
+        {
+            return;
+        }
+
         // Outer safety net — this runs on the timer thread (HighResolutionTimerServiceBase.TimerLoop), a RAW thread with no catch of its own. An
         // exception escaping a tick here would propagate unhandled and ABORT THE PROCESS (a "Test host process crashed" / production host crash) —
         // strictly worse than a dropped tick. The single-threaded path (ExecuteTickSingleThreaded) runs the whole tick inline on this thread, so it has
@@ -355,6 +486,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         _topologicalOrder = topologicalOrder;
         AllSystemCount = systems.Length;
         _options = options;
+        _exceptionPolicy = options.SystemExceptionPolicy;   // hoisted: read on the dispatch path, never changes after construction
         _eventQueues = eventQueues ?? [];
         // Assign stable queue IDs (#311) so the per-queue telemetry path can carry a small u16 instead of the queue's name on the wire.
         // QueueId == array index here; the cache builder writes a parallel `QueueNameTable` section so consumers can map index → name.
@@ -417,6 +549,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         _remainingDeps = new CacheLinePaddedInt[AllSystemCount];
         _isReady = new CacheLinePaddedInt[AllSystemCount];
         _systemFailed = new bool[AllSystemCount];
+        _lastSystemException = new Exception[AllSystemCount];   // eager: the lazy `??=` it replaced raced across workers — see DagScheduler.Diagnostic.cs
 
         // Build reset templates
         _templateDeps = new int[AllSystemCount];
@@ -756,6 +889,20 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
         InspectorSystemReady(sysIdx, readyTick);
 
+        // Strict tick-abort (#567) — single-threaded dispatch path. Same gate as the multi-worker paths; without it a WorkerCount == 1 runtime would keep
+        // executing systems after the abort.
+        if (IsTickAborted && !_systemIsEngine[sysIdx])
+        {
+            _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.TickAborted;
+            InspectorSystemSkipped(sysIdx, SkipReason.TickAborted, Stopwatch.GetTimestamp());
+            foreach (var succ in sys.Successors)
+            {
+                _systemFailed[succ] = true;
+            }
+
+            return;
+        }
+
         // Check if a predecessor failed
         if (_systemFailed[sysIdx])
         {
@@ -774,8 +921,17 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         bool shouldRunSingle = sys.ShouldRun?.Invoke() ?? true;
         if (shouldRunSingle && sys.Instance is ChunkedCallbackSystem ccsSingle)
         {
-            try { shouldRunSingle = ccsSingle.OnShouldRun(); }
-            catch { _systemFailed[sysIdx] = true; return; }
+            try
+            {
+                shouldRunSingle = ccsSingle.OnShouldRun();
+            }
+            catch (Exception ex)
+            {
+                _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
+                _systemFailed[sysIdx] = true;
+                RecordSystemFailure(sysIdx, sys.Name, ex);
+                return;
+            }
         }
         if (!shouldRunSingle)
         {
@@ -788,8 +944,17 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         if (sys.Instance is ChunkedCallbackSystem ccsSingle2)
         {
             int chunks;
-            try { chunks = ccsSingle2.OnPrepare(); }
-            catch { _systemFailed[sysIdx] = true; return; }
+            try
+            {
+                chunks = ccsSingle2.OnPrepare();
+            }
+            catch (Exception ex)
+            {
+                _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
+                _systemFailed[sysIdx] = true;
+                RecordSystemFailure(sysIdx, sys.Name, ex);
+                return;
+            }
 
             if (chunks == 0)
             {
@@ -858,7 +1023,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                             chunkFailed = true;
                             _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                             _systemFailed[sysIdx] = true;
-                            LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
+                            RecordSystemFailure(sysIdx, sys.Name, ex);
                             foreach (var succ in sys.Successors)
                             {
                                 _systemFailed[succ] = true;
@@ -890,7 +1055,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                     {
                         _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                         _systemFailed[sysIdx] = true;
-                        LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
+                        RecordSystemFailure(sysIdx, sys.Name, ex);
                         foreach (var succ in sys.Successors)
                         {
                             _systemFailed[succ] = true;
@@ -914,7 +1079,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                 {
                     _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                     _systemFailed[sysIdx] = true;
-                    LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
+                    RecordSystemFailure(sysIdx, sys.Name, ex);
                     // Propagate failure to successors
                     foreach (var succ in sys.Successors)
                     {
@@ -1048,8 +1213,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                             _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
                         }
                         var sysName = (uint)sysIdx < (uint)Systems.Length ? Systems[sysIdx].Name : "<unknown>";
-                        LogSystemException(sysIdx, sysName, ex);
-                        CaptureSystemException(sysIdx, ex);
+                        RecordSystemFailure(sysIdx, sysName, ex);
                         try { UnhandledExceptionCallback?.Invoke(sysIdx, sysName, ex); }
                         catch { /* swallow — the callback itself threw; we're the last line of defense */ }
                     }
@@ -1172,6 +1336,17 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         {
             return;
         }
+
+        // Strict tick-abort gate (#567, correction C1). Deliberately AFTER the claim, never inside FindReadySystem:
+        // this worker now owns the system, so it is the one obliged to drive the countdown. Returning -1 at find time would leave _isReady set and
+        // _systemsRemaining unadvanced — the tick would hang, which is precisely the failure this gate exists to prevent. Engine tracks are exempt
+        // (rule D3) — the fence runs no matter what.
+        if (IsTickAborted && !_systemIsEngine[sysIdx])
+        {
+            SkipSystemForTickAbort(sysIdx, workerId, trackUtilization);
+            return;
+        }
+
         TyphonEvent.EmitSchedulerDispense((ushort)sysIdx, 0, (byte)workerId);
 
         // ShouldRun was already evaluated at dispatch time (OnSystemComplete or root marking).
@@ -1192,7 +1367,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             success = false;
             _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
             _systemFailed[sysIdx] = true;
-            LogSystemException(sysIdx, Systems[sysIdx].Name, ex); CaptureSystemException(sysIdx, ex);
+            RecordSystemFailure(sysIdx, Systems[sysIdx].Name, ex);
         }
         finally
         {
@@ -1244,6 +1419,12 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
             if (chunk == 0)
             {
+                // Strict tick-abort start gate — see the identical gate in ProcessParallelQuery.
+                if (IsTickAborted && !_systemIsEngine[sysIdx])
+                {
+                    AbortSystemFromChunkZero(sysIdx, workerId, trackUtilization);
+                    return;
+                }
                 RecordFirstChunkGrab(sysIdx, Stopwatch.GetTimestamp());
             }
 
@@ -1258,7 +1439,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             {
                 _systemFailed[sysIdx] = true;
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
-                LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
+                RecordSystemFailure(sysIdx, sys.Name, ex);
             }
             finally
             {
@@ -1360,6 +1541,14 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
             if (chunk == 0)
             {
+                // Strict tick-abort start gate (#567, corrections C1/C2). The atomic counter hands chunk 0 to exactly one worker, so this is the system's
+                // single "does it begin?" decision — rule D1, granularity is the system, never the chunk. Folded into a branch that already existed, so it
+                // is free on the hot path.
+                if (IsTickAborted && !_systemIsEngine[sysIdx])
+                {
+                    AbortSystemFromChunkZero(sysIdx, workerId, trackUtilization);
+                    return;
+                }
                 RecordFirstChunkGrab(sysIdx, Stopwatch.GetTimestamp());
             }
 
@@ -1374,7 +1563,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             {
                 _systemFailed[sysIdx] = true;
                 _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
-                LogSystemException(sysIdx, sys.Name, ex); CaptureSystemException(sysIdx, ex);
+                RecordSystemFailure(sysIdx, sys.Name, ex);
             }
             finally
             {
@@ -1483,8 +1672,19 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                     TyphonEvent.EmitSchedulerDependencyReady((ushort)sysIdx, (ushort)succIdx, (ushort)successors.Length, 0);
                     var succ = Systems[succIdx];
 
+                    // Strict tick-abort (#567) — checked BEFORE the failed-predecessor branch and before EvaluateShouldRunAndPrepare, so no user
+                    // ShouldRun / Prepare body runs once the tick is cancelled.
+                    // Reported as TickAborted rather than DependencyFailed: this system has no failed predecessor, the tick was cancelled out from under it.
+                    // Engine tracks are exempt (rule D3).
+                    if (IsTickAborted && !_systemIsEngine[succIdx])
+                    {
+                        _currentTickSystemMetrics[succIdx].SkipReason = SkipReason.TickAborted;
+                        InspectorSystemSkipped(succIdx, SkipReason.TickAborted, Stopwatch.GetTimestamp());
+                        fanOutSkipped++;
+                        OnSystemComplete(succIdx, workerId, trackUtilization);
+                    }
                     // Check if any predecessor failed — skip this system entirely
-                    if (_systemFailed[succIdx])
+                    else if (_systemFailed[succIdx])
                     {
                         _currentTickSystemMetrics[succIdx].SkipReason = SkipReason.DependencyFailed;
                         InspectorSystemSkipped(succIdx, SkipReason.DependencyFailed, Stopwatch.GetTimestamp());
@@ -1563,9 +1763,11 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             {
                 shouldRun = ccs.OnShouldRun();
             }
-            catch
+            catch (Exception ex)
             {
+                _currentTickSystemMetrics[succIdx].SkipReason = SkipReason.Exception;
                 _systemFailed[succIdx] = true;
+                RecordSystemFailure(succIdx, succ.Name, ex);
                 fanOutSkipped++;
                 OnSystemComplete(succIdx, workerId, trackUtilization);
                 return false;
@@ -1589,9 +1791,11 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             {
                 chunks = ccs2.OnPrepare();
             }
-            catch
+            catch (Exception ex)
             {
+                _currentTickSystemMetrics[succIdx].SkipReason = SkipReason.Exception;
                 _systemFailed[succIdx] = true;
+                RecordSystemFailure(succIdx, succ.Name, ex);
                 fanOutSkipped++;
                 OnSystemComplete(succIdx, workerId, trackUtilization);
                 return false;
@@ -1637,7 +1841,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             success = false;
             _currentTickSystemMetrics[sysIdx].SkipReason = SkipReason.Exception;
             _systemFailed[sysIdx] = true;
-            LogSystemException(sysIdx, Systems[sysIdx].Name, ex); CaptureSystemException(sysIdx, ex);
+            RecordSystemFailure(sysIdx, Systems[sysIdx].Name, ex);
         }
         finally
         {

--- a/src/Typhon.Engine/Runtime/public/RuntimeOptions.cs
+++ b/src/Typhon.Engine/Runtime/public/RuntimeOptions.cs
@@ -40,6 +40,15 @@ public class RuntimeOptions
     public OverloadOptions Overload { get; set; } = new();
 
     /// <summary>
+    /// What an unhandled system exception means for the rest of the tick. Default:
+    /// <see cref="Typhon.Engine.SystemExceptionPolicy.Isolate"/> — fault isolation, the behaviour Typhon has always had.
+    /// Set <see cref="Typhon.Engine.SystemExceptionPolicy.AbortTickAndStop"/> for hosts that treat one tick as the unit
+    /// of publication and must not publish a partially-executed tick (issue #567). That policy is <b>terminal</b>: the
+    /// runtime stops ticking after the first fatal system exception.
+    /// </summary>
+    public SystemExceptionPolicy SystemExceptionPolicy { get; set; } = SystemExceptionPolicy.Isolate;
+
+    /// <summary>
     /// Minimum number of entities per chunk for parallel QuerySystem dispatch.
     /// Controls granularity: fewer entities per chunk = more parallelism but more overhead (Transaction creation per chunk).
     /// Entity sets smaller than this value still use the parallel chunk path with <c>totalChunks=1</c>.

--- a/src/Typhon.Engine/Runtime/public/SkipReason.cs
+++ b/src/Typhon.Engine/Runtime/public/SkipReason.cs
@@ -30,5 +30,11 @@ public enum SkipReason : byte
     Exception = 6,
 
     /// <summary>System was skipped because a predecessor system failed with an exception.</summary>
-    DependencyFailed = 7
+    DependencyFailed = 7,
+
+    /// <summary>
+    /// System was cancelled because the tick was aborted by an earlier fatal system exception under <see cref="SystemExceptionPolicy.AbortTickAndStop"/>
+    /// (issue #567). Distinct from <see cref="DependencyFailed"/>: the system has no failed predecessor, the whole tick was cancelled out from under it.
+    /// </summary>
+    TickAborted = 8
 }

--- a/src/Typhon.Engine/Runtime/public/SystemExceptionPolicy.cs
+++ b/src/Typhon.Engine/Runtime/public/SystemExceptionPolicy.cs
@@ -1,0 +1,30 @@
+using JetBrains.Annotations;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Controls what an unhandled exception thrown by a system means for the rest of the tick. Set via <see cref="RuntimeOptions.SystemExceptionPolicy"/>; the
+/// default is <see cref="Isolate"/>, which is the behaviour Typhon has always had.
+/// </summary>
+/// <remarks>
+/// This axis is about <b>cancelling work in progress</b>, not about durability. Under every policy the tick fence and the Unit-of-Work flush run to completion
+/// (rule <c>TP-01a</c>), because SingleVersion writes receive their WAL record at the fence — skipping it would leave un-logged mutations on dirty pages for
+/// the checkpoint thread to persist. Transactions committed by systems that ran before the failure stay committed; a commit is irrevocable (rule
+/// <c>AP-02</c>). See <c>claude/design/Runtime/08-strict-tick-abort.md</c>.
+/// </remarks>
+[PublicAPI]
+public enum SystemExceptionPolicy
+{
+    /// <summary>
+    /// Fault isolation — the default, and Typhon's behaviour before issue #567. A throwing system is marked failed and its successors are skipped with
+    /// <see cref="SkipReason.DependencyFailed"/>, but independent branches keep running and tick-end processing is unaffected. The runtime stays usable.
+    /// </summary>
+    Isolate = 0,
+
+    /// <summary>
+    /// Strict abort — the first unhandled system exception cancels the remainder of the tick. No system that has not already started is executed (they
+    /// report <see cref="SkipReason.TickAborted"/>); systems already running finish normally, since nothing is interrupted mid-body. The subscription output
+    /// phase is suppressed, so a failed tick is never published. The runtime then enters a <b>terminal</b> failed state — subsequent ticks do not run.
+    /// </summary>
+    AbortTickAndStop = 1
+}

--- a/src/Typhon.Engine/Runtime/public/TickOutcome.cs
+++ b/src/Typhon.Engine/Runtime/public/TickOutcome.cs
@@ -1,0 +1,78 @@
+using System;
+using JetBrains.Annotations;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Why a tick ended the way it did. Carried by <see cref="TickOutcome.Reason"/>.
+/// </summary>
+[PublicAPI]
+public enum TickOutcomeReason : byte
+{
+    /// <summary>
+    /// The tick completed as its policy promises. Note this includes a tick under <see cref="SystemExceptionPolicy.Isolate"/> in which a system threw and its
+    /// branch was skipped — fault isolation is that policy's contract, so such a tick did not fail. Per-system detail lives in
+    /// <see cref="SkipReason.Exception"/> in the telemetry ring.
+    /// </summary>
+    Success = 0,
+
+    /// <summary>
+    /// A system threw under <see cref="SystemExceptionPolicy.AbortTickAndStop"/> and the rest of the tick was cancelled. The runtime is now terminal.
+    /// </summary>
+    SystemException = 1,
+
+    /// <summary>
+    /// A system on an engine-internal track (the Fence DAG) threw. This is an engine fault rather than a user-system failure, and it is never reported as a
+    /// tick abort — the fence is the work that must complete, so there is no "rest of the tick" left to cancel.
+    /// </summary>
+    FenceFailure = 2
+}
+
+/// <summary>
+/// Outcome of the most recently completed tick, exposed by <see cref="TyphonRuntime.LastTickOutcome"/> and passed to <see cref="TyphonRuntime.OnTickAborted"/>.
+/// </summary>
+/// <remarks>
+/// This is a <b>tick-level</b> verdict, not a system-level one, and it is refreshed on every tick under every policy — a stale outcome can never be mistaken
+/// for a fresh one. Overload shedding never produces a non-<see cref="Succeeded"/> outcome: a shed system is skipped by design, not by failure. Degradation is
+/// read from the overload level; failure is read from here. The two are orthogonal.
+/// </remarks>
+[PublicAPI]
+public readonly struct TickOutcome
+{
+    /// <summary>The tick this outcome describes.</summary>
+    public long TickNumber { get; }
+
+    /// <summary>Why the tick ended the way it did.</summary>
+    public TickOutcomeReason Reason { get; }
+
+    /// <summary>Index of the first system to fail, or <c>-1</c> when <see cref="Succeeded"/> is true.</summary>
+    public int FailedSystemIndex { get; }
+
+    /// <summary>Name of the first system to fail, or <c>null</c> when <see cref="Succeeded"/> is true.</summary>
+    public string FailedSystemName { get; }
+
+    /// <summary>The exception that ended the tick, or <c>null</c> when <see cref="Succeeded"/> is true.</summary>
+    public Exception FailedSystemException { get; }
+
+    /// <summary>True when the tick completed as its policy promises.</summary>
+    public bool Succeeded => Reason == TickOutcomeReason.Success;
+
+    /// <summary>Creates an outcome. Use <see cref="ForSuccess"/> for the success case.</summary>
+    /// <param name="tickNumber">The tick this outcome describes.</param>
+    /// <param name="reason">Why the tick ended the way it did.</param>
+    /// <param name="failedSystemIndex">Index of the first failing system, or <c>-1</c>.</param>
+    /// <param name="failedSystemName">Name of the first failing system, or <c>null</c>.</param>
+    /// <param name="failedSystemException">The exception that ended the tick, or <c>null</c>.</param>
+    public TickOutcome(long tickNumber, TickOutcomeReason reason, int failedSystemIndex, string failedSystemName, Exception failedSystemException)
+    {
+        TickNumber = tickNumber;
+        Reason = reason;
+        FailedSystemIndex = failedSystemIndex;
+        FailedSystemName = failedSystemName;
+        FailedSystemException = failedSystemException;
+    }
+
+    /// <summary>Creates the outcome for a tick that completed as its policy promises.</summary>
+    /// <param name="tickNumber">The tick this outcome describes.</param>
+    public static TickOutcome ForSuccess(long tickNumber) => new(tickNumber, TickOutcomeReason.Success, -1, null, null);
+}

--- a/src/Typhon.Engine/Runtime/public/TyphonRuntime.cs
+++ b/src/Typhon.Engine/Runtime/public/TyphonRuntime.cs
@@ -154,6 +154,27 @@ public sealed partial class TyphonRuntime : IDisposable
     /// <summary>Fires when overload reaches <see cref="OverloadLevel.PlayerShedding"/>. Game code decides what to do (migrate, disconnect, split).</summary>
     public event Action<TyphonRuntime> OnCriticalOverload;
 
+    /// <summary>
+    /// Outcome of the most recently completed tick. Refreshed every tick under every
+    /// <see cref="RuntimeOptions.SystemExceptionPolicy"/>, so it is never stale.
+    /// </summary>
+    /// <remarks>
+    /// This is the primary surface for a host that gates its own publication on tick success: it is pull-checkable, so the host's next loop iteration can ask
+    /// "did that tick succeed?" without having subscribed to anything, and a host that wires up late does not silently miss the answer.
+    /// <see cref="OnTickAborted"/> is the push counterpart.
+    /// </remarks>
+    public TickOutcome LastTickOutcome { get; private set; }
+
+    /// <summary>
+    /// Fires once when a tick is aborted under <see cref="SystemExceptionPolicy.AbortTickAndStop"/>, on the tick thread, after the tick has fully drained.
+    /// Never fires for a successful tick, and never fires twice — the runtime is terminal after an abort. The handler should stop the runtime
+    /// (<see cref="FatalStop"/>) and let the host decide whether to exit or rebuild the engine.
+    /// </summary>
+    public event Action<TyphonRuntime, TickOutcome> OnTickAborted;
+
+    // Latches OnTickAborted to a single invocation. Only ever touched on the TickDriver thread inside OnTickEndInternal.
+    private bool _tickAbortedNotified;
+
     // ═══════════════════════════════════════════════════════════════
     // Factory
     // ═══════════════════════════════════════════════════════════════
@@ -318,7 +339,20 @@ public sealed partial class TyphonRuntime : IDisposable
     /// <summary>
     /// Gracefully shuts down the runtime. Stops the subscription server, fires <see cref="OnShutdown"/>, then stops the scheduler.
     /// </summary>
-    public void Shutdown()
+    public void Shutdown() => StopInternal(true);
+
+    /// <summary>
+    /// Stops the runtime **without** running the <see cref="OnShutdown"/> hook — the fatal path, for a host reacting to <see cref="OnTickAborted"/> (issue #567).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="OnShutdown"/> deliberately runs its handlers inside an <see cref="DurabilityMode.Immediate"/> transaction, which is the right thing for an
+    /// orderly stop and the wrong thing after a fatal tick: the abort means the simulation is logically incomplete, so committing a final round of shutdown
+    /// writes on top of it would persist state derived from a tick that never finished. Everything else — subscription server, profiler, scheduler — is
+    /// torn down exactly as in <see cref="Shutdown"/>.
+    /// </remarks>
+    public void FatalStop() => StopInternal(false);
+
+    private void StopInternal(bool runOnShutdown)
     {
         // Begin the async CPU-sampler stop first so its (seconds-long) .nettrace transcode overlaps the rest of teardown.
         // No-op unless the profiler was self-wired by ProfilerBootstrap.TryStart.
@@ -328,7 +362,7 @@ public sealed partial class TyphonRuntime : IDisposable
         _tcpServer?.Shutdown();
 
         // Execute OnShutdown callback with a dedicated transaction
-        if (OnShutdown != null)
+        if (runOnShutdown && OnShutdown != null)
         {
             using var tx = Engine.CreateQuickTransaction(DurabilityMode.Immediate);
             var ctx = new TickContext
@@ -1961,18 +1995,38 @@ public sealed partial class TyphonRuntime : IDisposable
         // Issue #234: compute per-tier budget metrics from this tick's system telemetry, for the next tick's TickContext.
         ComputeTierBudgetMetrics();
 
+        // Publish this tick's outcome BEFORE the output phase, so a host reading LastTickOutcome from a subscription callback already sees the verdict.
+        // Written on EVERY tick under EVERY policy (#567 AC8b) — a stale outcome must never be mistaken for a fresh one. Under Isolate this is always Success:
+        // a tick in which a system threw and its branch was skipped completed exactly as that policy promises. Per-system detail stays in SkipReason.
+        var tickAborted = scheduler.IsTickAborted;
+        LastTickOutcome = tickAborted ? scheduler.AbortedOutcome : TickOutcome.ForSuccess(scheduler.CurrentTickNumber);
+
         // #199: Output phase — subscription deltas.
         // Runs AFTER WriteTickFence so that:
         //   1. Ring buffer has ALL entries (commit-time + shadow-time) for correct View membership
         //   2. PreviousTickDirtyBitmap has this tick's dirty chunks for Modified detection
         //   3. All state is quiescent (no concurrent writers)
-        InspectorPhase(TickPhase.OutputPhase, () =>
+        //
+        // Suppressed on an aborted tick (#567): publication is the ONE tick-end act carrying tick-wide "this was a good tick" semantics, so it is the only one
+        // of the three that may be skipped. The fence and the flush above ran unconditionally and must keep doing so — rule TP-01a.
+        if (!tickAborted)
         {
-            using var subSpan = TyphonEvent.BeginRuntimeSubscriptionOutputExecute(
-                scheduler.CurrentTickNumber, (byte)Scheduler.CurrentOverloadLevel);
-            _subscriptionOutputPhase?.Execute(scheduler.CurrentTickNumber, Scheduler.CurrentOverloadLevel);
-            // Stats fields (clientCount, viewsRefreshed, deltasPushed, overflowCount) populated when Phase 9 wires per-tick subscription metrics back from SubscriptionOutputPhase.
-        });
+            InspectorPhase(TickPhase.OutputPhase, () =>
+            {
+                using var subSpan = TyphonEvent.BeginRuntimeSubscriptionOutputExecute(
+                    scheduler.CurrentTickNumber, (byte)Scheduler.CurrentOverloadLevel);
+                _subscriptionOutputPhase?.Execute(scheduler.CurrentTickNumber, Scheduler.CurrentOverloadLevel);
+                // Stats fields (clientCount, viewsRefreshed, deltasPushed, overflowCount) populated when Phase 9 wires per-tick subscription metrics back from
+                // SubscriptionOutputPhase.
+            });
+        }
+        else if (!_tickAbortedNotified)
+        {
+            // Fires once, on the TickDriver, after the tick has fully drained — so every worker's stores are ordered ahead of the handler reading the outcome.
+            // Subsequent ticks never reach here: DagScheduler.ExecuteCallbacks returns early once the abort latch is set.
+            _tickAbortedNotified = true;
+            OnTickAborted?.Invoke(this, LastTickOutcome);
+        }
     }
 
     /// <summary>

--- a/test/Typhon.Engine.Tests/Runtime/StrictTickAbortRuntimeTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/StrictTickAbortRuntimeTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace Typhon.Engine.Tests.Runtime;
+
+/// <summary>
+/// Engine-level acceptance tests for the strict tick-abort policy (issue #567) — the parts that need a real
+/// <see cref="DatabaseEngine"/> and <see cref="TyphonRuntime"/>: the outcome surface, tick-end phase behaviour, and the
+/// fatal-stop path. The dispatch-level cancellation is covered by <c>StrictTickAbortTests</c>.
+/// </summary>
+[TestFixture]
+class StrictTickAbortRuntimeTests : TestBase<StrictTickAbortRuntimeTests>
+{
+    private DatabaseEngine SetupEngine()
+    {
+        var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        dbe.RegisterComponentFromAccessor<EcsPosition>();
+        dbe.RegisterComponentFromAccessor<EcsVelocity>();
+        dbe.InitializeArchetypes();
+        return dbe;
+    }
+
+    private static RuntimeOptions Strict() => new()
+    {
+        WorkerCount = 2,
+        BaseTickRate = 1000,
+        SystemExceptionPolicy = SystemExceptionPolicy.AbortTickAndStop,
+    };
+
+    [Test]
+    public void AbortedTick_StillRunsFenceAndFlush()
+    {
+        // AC5 + AC6 — the fence and the UoW flush are unconditional (rule TP-01a); only the output phase is gated.
+        //
+        // LastTickOutcome is assigned inside OnTickEndInternal *after* the WriteTickFence and UoW.Flush statements. So
+        // observing a populated abort outcome proves control flow reached past both — had either been skipped by a
+        // stray gate, or thrown, the assignment below would never have happened.
+        using var dbe = SetupEngine();
+        using var runtime = TyphonRuntime.Create(dbe, schedule =>
+        {
+            schedule.PublicTrack.DeclareDag("Test").CallbackSystem("Thrower", _ => throw new InvalidOperationException("boom"));
+        }, Strict());
+
+        runtime.Start();
+        SpinWait.SpinUntil(() => !runtime.LastTickOutcome.Succeeded, TimeSpan.FromSeconds(3));
+        runtime.FatalStop();
+
+        Assert.That(runtime.LastTickOutcome.Reason, Is.EqualTo(TickOutcomeReason.SystemException),
+            "tick-end processing must run to completion on an aborted tick — fence and flush are never skipped");
+    }
+
+    [Test]
+    public void AbortedTick_PublishesOutcome_AndFiresOnTickAbortedExactlyOnce()
+    {
+        // AC8 — the outcome surface reports the first failing system and its exception, and the event fires once.
+        var fireCount = 0;
+        TickOutcome captured = default;
+
+        using var dbe = SetupEngine();
+        using var runtime = TyphonRuntime.Create(dbe, schedule =>
+        {
+            schedule.PublicTrack.DeclareDag("Test").CallbackSystem("Thrower", _ => throw new InvalidOperationException("boom"));
+        }, Strict());
+
+        runtime.OnTickAborted += (_, outcome) =>
+        {
+            Interlocked.Increment(ref fireCount);
+            captured = outcome;
+        };
+
+        runtime.Start();
+        SpinWait.SpinUntil(() => Volatile.Read(ref fireCount) > 0, TimeSpan.FromSeconds(3));
+        // The runtime is terminal, so no further tick can fire the event. Give it a window to prove that.
+        SpinWait.SpinUntil(() => Volatile.Read(ref fireCount) > 1, TimeSpan.FromMilliseconds(150));
+        runtime.FatalStop();
+
+        Assert.That(Volatile.Read(ref fireCount), Is.EqualTo(1), "OnTickAborted must fire exactly once");
+        Assert.That(captured.Succeeded, Is.False);
+        Assert.That(captured.Reason, Is.EqualTo(TickOutcomeReason.SystemException));
+        Assert.That(captured.FailedSystemName, Is.EqualTo("Thrower"), "the first failing system must be named");
+        Assert.That(captured.FailedSystemException, Is.TypeOf<InvalidOperationException>());
+        Assert.That(runtime.LastTickOutcome.FailedSystemIndex, Is.GreaterThanOrEqualTo(0));
+    }
+
+    [Test]
+    public void SuccessfulTick_ReportsSuccess_AndDoesNotFireOnTickAborted()
+    {
+        // AC8b (success half) — LastTickOutcome is refreshed every tick, so a host can read it unconditionally.
+        var fireCount = 0;
+
+        using var dbe = SetupEngine();
+        using var runtime = TyphonRuntime.Create(dbe, schedule =>
+        {
+            schedule.PublicTrack.DeclareDag("Test").CallbackSystem("Noop", _ => { });
+        }, Strict());
+
+        runtime.OnTickAborted += (_, _) => Interlocked.Increment(ref fireCount);
+
+        runtime.Start();
+        SpinWait.SpinUntil(() => runtime.CurrentTickNumber >= 3, TimeSpan.FromSeconds(3));
+        runtime.Shutdown();
+
+        Assert.That(runtime.LastTickOutcome.Succeeded, Is.True);
+        Assert.That(runtime.LastTickOutcome.FailedSystemIndex, Is.EqualTo(-1));
+        Assert.That(runtime.LastTickOutcome.FailedSystemException, Is.Null);
+        Assert.That(Volatile.Read(ref fireCount), Is.Zero, "OnTickAborted must never fire for a successful tick");
+    }
+
+    [Test]
+    public void IsolatePolicy_SystemThrows_TickStillReportsSuccess()
+    {
+        // AC8b (the subtle half) — under Isolate, a tick in which a system threw and its branch was skipped completed
+        // exactly as that policy promises. Reporting it as a failure would misdescribe the contract; the per-system
+        // detail stays in SkipReason.Exception.
+        using var dbe = SetupEngine();
+        using var runtime = TyphonRuntime.Create(dbe, schedule =>
+        {
+            schedule.PublicTrack.DeclareDag("Test").CallbackSystem("Thrower", _ => throw new InvalidOperationException("boom"));
+        }, new RuntimeOptions { WorkerCount = 2, BaseTickRate = 1000 });   // default policy = Isolate
+
+        runtime.Start();
+        SpinWait.SpinUntil(() => runtime.CurrentTickNumber >= 3, TimeSpan.FromSeconds(3));
+        runtime.Shutdown();
+
+        Assert.That(runtime.CurrentTickNumber, Is.GreaterThanOrEqualTo(3), "Isolate keeps ticking through a throwing system");
+        Assert.That(runtime.LastTickOutcome.Succeeded, Is.True, "fault isolation is Isolate's contract — such a tick did not fail");
+    }
+
+    [Test]
+    public void FatalStop_DoesNotRunOnShutdown()
+    {
+        // AC9 — OnShutdown runs its handlers inside an Immediate-durability transaction, which is the wrong thing after
+        // a fatal tick: it would commit shutdown writes derived from a tick that never finished.
+        var shutdownRan = 0;
+
+        using var dbe = SetupEngine();
+        using var runtime = TyphonRuntime.Create(dbe, schedule =>
+        {
+            schedule.PublicTrack.DeclareDag("Test").CallbackSystem("Noop", _ => { });
+        }, Strict());
+
+        runtime.OnShutdown += _ => Interlocked.Increment(ref shutdownRan);
+
+        runtime.Start();
+        SpinWait.SpinUntil(() => runtime.CurrentTickNumber >= 2, TimeSpan.FromSeconds(3));
+        runtime.FatalStop();
+
+        Assert.That(Volatile.Read(ref shutdownRan), Is.Zero, "FatalStop must not fire the OnShutdown Immediate transaction");
+    }
+
+    [Test]
+    public void Shutdown_StillRunsOnShutdown()
+    {
+        // Guards the refactor that extracted StopInternal — the graceful path must be unchanged.
+        var shutdownRan = 0;
+
+        using var dbe = SetupEngine();
+        using var runtime = TyphonRuntime.Create(dbe, schedule =>
+        {
+            schedule.PublicTrack.DeclareDag("Test").CallbackSystem("Noop", _ => { });
+        }, new RuntimeOptions { WorkerCount = 1, BaseTickRate = 1000 });
+
+        runtime.OnShutdown += _ => Interlocked.Increment(ref shutdownRan);
+
+        runtime.Start();
+        SpinWait.SpinUntil(() => runtime.CurrentTickNumber >= 2, TimeSpan.FromSeconds(3));
+        runtime.Shutdown();
+
+        Assert.That(Volatile.Read(ref shutdownRan), Is.EqualTo(1), "graceful Shutdown must still run OnShutdown");
+    }
+}

--- a/test/Typhon.Engine.Tests/Runtime/StrictTickAbortTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/StrictTickAbortTests.cs
@@ -1,0 +1,272 @@
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace Typhon.Engine.Tests.Runtime;
+
+/// <summary>
+/// Acceptance tests for the strict tick-abort policy (issue #567). These drive <see cref="DagScheduler"/> directly —
+/// the cancellation lives entirely in dispatch, so no <see cref="DatabaseEngine"/> is needed and the tests stay fast.
+/// </summary>
+[TestFixture]
+class StrictTickAbortTests
+{
+    private ResourceRegistry _registry;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _registry = new ResourceRegistry(new ResourceRegistryOptions { Name = "StrictAbortTest" });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _registry?.Dispose();
+    }
+
+    private static RuntimeOptions Strict(int workerCount) => new()
+    {
+        WorkerCount = workerCount,
+        BaseTickRate = 1000,
+        SystemExceptionPolicy = SystemExceptionPolicy.AbortTickAndStop,
+    };
+
+    [Test]
+    public void Default_Policy_Is_Isolate()
+    {
+        // AC1 — the feature is strictly opt-in. The five ExceptionHandlingTests cover the behaviour itself; this pins
+        // the default so a change to it cannot pass silently.
+        Assert.That(new RuntimeOptions().SystemExceptionPolicy, Is.EqualTo(SystemExceptionPolicy.Isolate));
+    }
+
+    [Test]
+    public void AbortTickAndStop_IndependentSystem_DoesNotRun()
+    {
+        // AC2 — under Isolate this is exactly SystemException_WorkerSurvives_TickContinues, where "After" DOES run.
+        // Single worker: topological order guarantees Thrower is dispatched before After, with no race.
+        var afterCount = 0;
+
+        var dag = RuntimeSchedule.Create(Strict(1)).PublicTrack.DeclareDag("Test");
+        dag
+            .CallbackSystem("Thrower", _ => throw new InvalidOperationException("boom"))
+            .CallbackSystem("After", _ => Interlocked.Increment(ref afterCount));
+
+        using var scheduler = dag.Build(_registry.Runtime);
+        scheduler.Start();
+        SpinWait.SpinUntil(() => scheduler.IsTickAborted, TimeSpan.FromSeconds(2));
+        scheduler.Shutdown();
+
+        Assert.That(scheduler.IsTickAborted, Is.True, "the throw should have latched the terminal abort");
+        Assert.That(afterCount, Is.Zero, "an independent system that had not started must not run after the abort");
+    }
+
+    [Test]
+    public void AbortTickAndStop_TickStillCompletes_NoWedge()
+    {
+        // AC4 — the regression this whole design is shaped around. Cancellation must be dispatch-and-drain: if the
+        // abort simply stopped handing out work, _systemsRemaining would never reach 0 and the TickDriver would spin
+        // forever. Telemetry is only recorded AFTER the tick body drains, so a recorded tick proves it completed.
+        var dag = RuntimeSchedule.Create(Strict(4)).PublicTrack.DeclareDag("Test");
+        dag
+            .CallbackSystem("Thrower", _ => throw new InvalidOperationException("boom"))
+            .CallbackSystem("A", _ => { })
+            .CallbackSystem("B", _ => { }, after: "A")
+            .CallbackSystem("C", _ => { }, after: "B");
+
+        using var scheduler = dag.Build(_registry.Runtime);
+        scheduler.Start();
+        var aborted = SpinWait.SpinUntil(() => scheduler.IsTickAborted, TimeSpan.FromSeconds(2));
+        var completed = SpinWait.SpinUntil(() => scheduler.Telemetry.TotalTicksRecorded > 0, TimeSpan.FromSeconds(2));
+        scheduler.Shutdown();
+
+        Assert.That(aborted, Is.True, "abort should latch");
+        Assert.That(completed, Is.True, "the aborted tick must still run to completion — a wedged tick records no telemetry");
+    }
+
+    [Test]
+    public void AbortTickAndStop_ReadyButUnclaimedRoot_DoesNotRun()
+    {
+        // AC13 — the claim-time gate (correction C1). Gating only the successor path would let this pass wrongly, so
+        // the DAG is built to make the root demonstrably unclaimed at abort time:
+        //   2 workers, 3 roots. FindReadySystem scans in index order, so Blocker(0) and Thrower(1) take both workers
+        //   and Victim(2) cannot be claimed until one frees up — which only happens after we release Blocker, well
+        //   after the abort has latched.
+        var blocker = new ManualResetEventSlim(false);
+        var throwerReached = new ManualResetEventSlim(false);
+        var victimCount = 0;
+
+        var dag = RuntimeSchedule.Create(Strict(2)).PublicTrack.DeclareDag("Test");
+        dag
+            .CallbackSystem("Blocker", _ => blocker.Wait(TimeSpan.FromSeconds(5)))
+            .CallbackSystem("Thrower", _ =>
+            {
+                throwerReached.Set();
+                throw new InvalidOperationException("boom");
+            })
+            .CallbackSystem("Victim", _ => Interlocked.Increment(ref victimCount));
+
+        using var scheduler = dag.Build(_registry.Runtime);
+        scheduler.Start();
+
+        throwerReached.Wait(TimeSpan.FromSeconds(2));
+        var aborted = SpinWait.SpinUntil(() => scheduler.IsTickAborted, TimeSpan.FromSeconds(2));
+        blocker.Set();                                  // free a worker — Victim becomes claimable only now
+        SpinWait.SpinUntil(() => scheduler.Telemetry.TotalTicksRecorded > 0, TimeSpan.FromSeconds(2));
+        scheduler.Shutdown();
+
+        Assert.That(aborted, Is.True, "abort should latch before the blocker is released");
+        Assert.That(victimCount, Is.Zero, "a root that was ready but unclaimed when the tick aborted must not run");
+    }
+
+    [Test]
+    public void AbortTickAndStop_RunningSystem_FinishesNormally()
+    {
+        // AC3 — nothing is interrupted mid-body. The abort fires while "LongRunner" is inside its callback; it must
+        // still reach its own last statement.
+        var throwerReached = new ManualResetEventSlim(false);
+        var longRunnerFinished = false;
+
+        var dag = RuntimeSchedule.Create(Strict(2)).PublicTrack.DeclareDag("Test");
+        dag
+            .CallbackSystem("LongRunner", _ =>
+            {
+                throwerReached.Wait(TimeSpan.FromSeconds(2));
+                Thread.Yield();
+                longRunnerFinished = true;              // must be reached despite the abort latching mid-body
+            })
+            .CallbackSystem("Thrower", _ =>
+            {
+                throwerReached.Set();
+                throw new InvalidOperationException("boom");
+            });
+
+        using var scheduler = dag.Build(_registry.Runtime);
+        scheduler.Start();
+        SpinWait.SpinUntil(() => scheduler.Telemetry.TotalTicksRecorded > 0, TimeSpan.FromSeconds(3));
+        scheduler.Shutdown();
+
+        Assert.That(longRunnerFinished, Is.True, "a system already running when the tick aborts must finish its body");
+    }
+
+    [Test]
+    public void AbortTickAndStop_IsTerminal_NoFurtherTicks()
+    {
+        // AC10 — after an abort the runtime must not silently resume on a simulation that only partly ran.
+        var runsAfterAbort = 0;
+
+        var dag = RuntimeSchedule.Create(Strict(1)).PublicTrack.DeclareDag("Test");
+        dag.CallbackSystem("Thrower", _ =>
+        {
+            if (Volatile.Read(ref runsAfterAbort) >= 0)
+            {
+                Interlocked.Increment(ref runsAfterAbort);
+            }
+            throw new InvalidOperationException("boom");
+        });
+
+        using var scheduler = dag.Build(_registry.Runtime);
+        scheduler.Start();
+        SpinWait.SpinUntil(() => scheduler.IsTickAborted, TimeSpan.FromSeconds(2));
+
+        var runsAtAbort = Volatile.Read(ref runsAfterAbort);
+        // BaseTickRate 1000 — without the terminal latch this window is ~100 further ticks.
+        SpinWait.SpinUntil(() => Volatile.Read(ref runsAfterAbort) > runsAtAbort, TimeSpan.FromMilliseconds(100));
+        scheduler.Shutdown();
+
+        Assert.That(Volatile.Read(ref runsAfterAbort), Is.EqualTo(runsAtAbort),
+            "no system should execute on any tick after the abort");
+    }
+
+    [Test]
+    public void AbortTickAndStop_ConcurrentThrows_RecordsExactlyOneFirstFailure()
+    {
+        // AC11 — several workers throwing in the same tick must elect exactly one first failure.
+        var gate = new ManualResetEventSlim(false);
+
+        var dag = RuntimeSchedule.Create(Strict(4)).PublicTrack.DeclareDag("Test");
+        for (var i = 0; i < 4; i++)
+        {
+            dag.CallbackSystem($"Thrower{i}", _ =>
+            {
+                gate.Wait(TimeSpan.FromSeconds(2));     // release all four as simultaneously as the pool allows
+                throw new InvalidOperationException("boom");
+            });
+        }
+
+        using var scheduler = dag.Build(_registry.Runtime);
+        scheduler.Start();
+        gate.Set();
+        SpinWait.SpinUntil(() => scheduler.IsTickAborted, TimeSpan.FromSeconds(2));
+        scheduler.Shutdown();
+
+        Assert.That(scheduler.IsTickAborted, Is.True);
+        Assert.That(scheduler.AbortedOutcome.Reason, Is.EqualTo(TickOutcomeReason.SystemException));
+        Assert.That(scheduler.AbortedOutcome.FailedSystemIndex, Is.InRange(0, 3), "the recorded failure must be one of the throwers");
+        Assert.That(scheduler.AbortedOutcome.FailedSystemException, Is.Not.Null, "the first failure's exception must be captured");
+    }
+
+    [Test]
+    public void AbortTickAndStop_StartedParallelSystem_RunsEveryChunk()
+    {
+        // AC12 / rule D1 — abort granularity is the SYSTEM, never the chunk. Chunk 0 is claimed before the abort, so
+        // the system is committed to run; every remaining chunk must execute rather than being drained.
+        const int totalChunks = 4;
+        var chunksRun = 0;
+        var chunkZeroEntered = new ManualResetEventSlim(false);
+        DagScheduler scheduler = null;
+
+        var dag = RuntimeSchedule.Create(Strict(4)).PublicTrack.DeclareDag("Test");
+        dag
+            .QuerySystem("Parallel", _ => { }, input: () => null, parallel: true)
+            .CallbackSystem("Thrower", _ =>
+            {
+                chunkZeroEntered.Wait(TimeSpan.FromSeconds(2));   // ensure the system has STARTED before we abort
+                throw new InvalidOperationException("boom");
+            });
+
+        using (scheduler = dag.Build(_registry.Runtime))
+        {
+            scheduler.ParallelQueryPrepareCallback = _ => totalChunks;
+            scheduler.ParallelQueryChunkCallback = (_, chunk, _, _) =>
+            {
+                if (chunk == 0)
+                {
+                    chunkZeroEntered.Set();
+                    SpinWait.SpinUntil(() => scheduler.IsTickAborted, TimeSpan.FromSeconds(2));
+                }
+                Interlocked.Increment(ref chunksRun);
+            };
+            scheduler.ParallelQueryCleanupCallback = _ => false;
+
+            scheduler.Start();
+            SpinWait.SpinUntil(() => scheduler.Telemetry.TotalTicksRecorded > 0, TimeSpan.FromSeconds(3));
+            scheduler.Shutdown();
+        }
+
+        Assert.That(Volatile.Read(ref chunksRun), Is.EqualTo(totalChunks),
+            "a parallel system whose chunk 0 was claimed before the abort must execute all of its chunks");
+    }
+
+    [Test]
+    public void AbortTickAndStop_CancelledSystem_ReportsTickAborted()
+    {
+        // Telemetry must distinguish "cancelled by the tick abort" from "my predecessor failed" — otherwise an aborted
+        // tick reads as a dependency cascade in the Workbench.
+        var dag = RuntimeSchedule.Create(Strict(1)).PublicTrack.DeclareDag("Test");
+        dag
+            .CallbackSystem("Thrower", _ => throw new InvalidOperationException("boom"))
+            .CallbackSystem("Independent", _ => { });
+
+        using var scheduler = dag.Build(_registry.Runtime);
+        scheduler.Start();
+        SpinWait.SpinUntil(() => scheduler.Telemetry.TotalTicksRecorded > 0, TimeSpan.FromSeconds(2));
+        scheduler.Shutdown();
+
+        var ring = scheduler.Telemetry;
+        var systems = ring.GetSystemMetrics(ring.NewestTick);
+        Assert.That(systems[0].SkipReason, Is.EqualTo(SkipReason.Exception), "the throwing system reports Exception");
+        Assert.That(systems[1].SkipReason, Is.EqualTo(SkipReason.TickAborted),
+            "an independent system cancelled by the abort reports TickAborted, not DependencyFailed");
+    }
+}


### PR DESCRIPTION
Closes #567.

`RuntimeOptions.SystemExceptionPolicy = AbortTickAndStop` makes the first unhandled system exception cancel the remainder of the tick. Default stays `Isolate` — today's fault isolation, unchanged.

**The objective is cancellation, not durability suppression.** The issue asked for `WriteTickFence` and `UoW.Flush()` to be skipped so a failed tick would not become a durability boundary. That was rejected: SingleVersion components are written *in place* and receive their WAL record at the fence, so skipping it leaves the page mutated, dirty and un-logged for the checkpoint thread to persist later — a durable mutation with no log record behind it, which is exactly AP-01's `[fatal][silent]` failure mode. Skipping the fence would have *created* an illegal durability boundary rather than avoiding one. Fence and flush now run on every tick, aborted or not, and that is recorded as new rule **TP-01a**.

What the abort actually does: nothing that hasn't started runs, running systems finish normally, the output phase is suppressed so a failed tick is never published, and the runtime goes terminal.

### How cancellation works

Typhon cancels by **dispatch-and-drain**, never by halting dispatch — a tick terminates when `_systemsRemaining` reaches zero, so a system that is never dispatched hangs the tick. `_systemFailed` propagation was already a cancellation protocol with per-system scope; this adds a tick-scoped latch read at the three gates that already read it.

Two design corrections found during implementation, both folded back into the design doc:

- **C1** — the doc put the third gate in `FindReadySystem`. That reintroduces the very hang it exists to prevent. It must be *after* the claim succeeds. Verified by negative control: with the gate disabled, `AbortTickAndStop_ReadyButUnclaimedRoot_DoesNotRun` fails with `victimCount == 1`.
- **C2** — `DrainFailedSystemChunks` *is* used, for systems that have not started. What rule D1 forbids is draining a system that already has.

### Deviation from the design

The design called for an `OnCriticalOverload`-style internal callback bridge for the abort event. Not done, deliberately: that would fire host code on a worker thread mid-tick. `OnTickAborted` is raised from `OnTickEndInternal` instead — TickDriver, after the tick drains, so ordering is trivial and "exactly once" falls out for free.

### Prerequisite fixes (independent of the feature)

- **Four** silent `catch { flag; return; }` sites fixed — `OnShouldRun`/`OnPrepare` on both the single-threaded *and* multi-worker successor paths. All four swallowed the exception with no log, no capture, no `SkipReason`.
- `CaptureSystemException` no longer lazy-allocates; the `??=` raced across concurrent workers and silently dropped every capture but one.
- `RecordSystemFailure` now funnels log → capture → maybe-latch, replacing 12 hand-rolled call pairs.

### Public surface

`SystemExceptionPolicy`, `TickOutcome` / `TickOutcomeReason`, `SkipReason.TickAborted`, `TyphonRuntime.LastTickOutcome`, `TyphonRuntime.OnTickAborted`, `TyphonRuntime.FatalStop()`.

### Performance

Free when off. Six checks, the hottest being one per successor edge; the two chunk-loop gates sit inside a pre-existing `if (chunk == 0)` branch, so the per-chunk inner loop pays nothing. The latch is a padded, write-once int — shared-clean in every core's L1, no coherence traffic, and `_systemIsEngine[]` short-circuits so it is never loaded unless an abort fired.

### Testing

15 new tests across two fixtures (~2 s). Full suite **4076 passed / 0 failed**.

Two ACs are **not** covered by tests and are flagged as inspection-only in the design doc rather than quietly ticked:
- output-phase suppression — needs a live subscription server, too heavy/flaky for a unit test;
- Fence-DAG-throw routing — no fault-injection hook exists on the Fence systems.

Design doc: `claude/design/Runtime/08-strict-tick-abort.md` (Status: Implemented) in `typhon-claude`, same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcg4vW8vJ4QjNyj6NQabHs