### PR TITLE
Document the strict tick-abort policy across doc/ (#604-#608)

### DIFF
--- a/doc/feature-set/Runtime/system-types/README.md
+++ b/doc/feature-set/Runtime/system-types/README.md
@@ -50,6 +50,12 @@ same DAG and the same tick; class-based registration is required to use RFC-07 a
   `Commit()`/`Dispose()` themselves.
 - A thrown exception rolls back that system's own Transaction and skips its successors
   (`SkipReason.DependencyFailed`); independent DAG branches still execute — one failure doesn't abort the tick.
+  That is the default, `RuntimeOptions.SystemExceptionPolicy = Isolate`.
+- Under the opt-in `SystemExceptionPolicy.AbortTickAndStop` the first throw cancels the rest of the tick instead:
+  every user system not already started is skipped with `SkipReason.TickAborted`, the runtime becomes terminal
+  (no further ticks), and `TyphonRuntime.OnTickAborted` fires. Two exemptions — engine tracks (the parallel fence)
+  never observe the abort, and a system that has already started runs to completion, because abort granularity is
+  the system, never the chunk.
 - `CompoundSystem.Add(...)` expands each sub-system into its own DAG registration at `dag.Add(compound)` time —
   there is no aggregate group name; from outside the compound is atomic (all children complete before the
   compound's successors start), but other systems depend on individual sub-system names, not the group.

--- a/doc/feature-set/Runtime/system-types/callback-system.md
+++ b/doc/feature-set/Runtime/system-types/callback-system.md
@@ -62,7 +62,10 @@ dag.CallbackSystem("ZoneRotation", ctx => RotateZone(ctx),
 - Gets its own `Transaction` per tick (`ctx.Transaction`), created and committed by the runtime — never call
   `Commit()`/`Dispose()` inside `Execute`.
 - A thrown exception rolls back the system's Transaction and skips its successors
-  (`SkipReason.DependencyFailed`); other DAG branches continue.
+  (`SkipReason.DependencyFailed`); other DAG branches continue. That is the default,
+  `RuntimeOptions.SystemExceptionPolicy = Isolate`; under the opt-in `AbortTickAndStop` the rest of the tick is
+  cancelled instead — every user system not already started is skipped with `SkipReason.TickAborted` and the
+  runtime stops permanently.
 - `b.Parallel()` is not valid on a plain `CallbackSystem` — use `ChunkedCallbackSystem` and `b.ChunkedParallel(N)`
   for chunk-parallel non-entity work.
 - Registered via `dag.Add(new MySystem())` (class-based) or `dag.CallbackSystem(name, ctx => ..., ...)` (lambda)

--- a/doc/feature-set/Runtime/system-types/compound-system.md
+++ b/doc/feature-set/Runtime/system-types/compound-system.md
@@ -62,7 +62,11 @@ dag.CallbackSystem("Cleanup", ctx => ctx.FlushDestroys(), after: "Steering");
 - All members must have unique names across the *whole* schedule (not just within the compound) — `Build()`
   rejects duplicates the same way it does for any two systems.
 - A member that throws rolls back only its own Transaction and skips only its own successors; it does not abort
-  sibling members in the same compound unless they have a declared dependency on it.
+  sibling members in the same compound unless they have a declared dependency on it. That holds under the default
+  `RuntimeOptions.SystemExceptionPolicy = Isolate`. Under the opt-in `AbortTickAndStop` a member throw aborts the
+  whole tick, so siblings that have not started are skipped with `SkipReason.TickAborted` whether or not they
+  depend on it — members expand into ordinary DAG registrations, leaving no compound-level boundary to contain the
+  abort.
 
 ## 🧪 Tests
 

--- a/doc/feature-set/Runtime/system-types/pipeline-system.md
+++ b/doc/feature-set/Runtime/system-types/pipeline-system.md
@@ -62,7 +62,10 @@ dag.Add(new RenderPipeline());   // throws NotSupportedException — pending Pat
 - `b.Parallel()` is rejected for `PipelineSystem` — it has its own chunk-parallel model (`totalChunks`), not the
   `QuerySystem` parallel path.
 - A chunk action that throws fails the whole system: remaining chunks are drained without running, successors
-  are skipped (`SkipReason.DependencyFailed`); other DAG branches continue.
+  are skipped (`SkipReason.DependencyFailed`); other DAG branches continue. That is the default,
+  `RuntimeOptions.SystemExceptionPolicy = Isolate`; under the opt-in `AbortTickAndStop` the tick is cancelled
+  instead — a system that has not yet claimed its first chunk is skipped with `SkipReason.TickAborted`, while one
+  already running finishes every chunk, because abort granularity is the system, never the chunk.
 - Inside a `CompoundSystem`, a `PipelineSystem` child hits the same `NotSupportedException` as top-level
   registration — compounds cannot currently contain a working `PipelineSystem` member.
 

--- a/doc/in-depth-overview/10-runtime.md
+++ b/doc/in-depth-overview/10-runtime.md
@@ -223,7 +223,9 @@ Once awake, each worker loops `FindReadySystem` → `ProcessSystem` until `_syst
 - `ProcessSystem` claims the system (CAS on `_isReady` for single-shot systems, `Interlocked.Increment(_nextChunk)` for multi-chunk).
 - Idle workers (no ready work) spin briefly with PAUSE for the first ~100 iterations, then `Thread.Yield` until work appears or the tick ends.
 
-Failure isolation: if a system throws, the worker marks `_systemFailed[sysIdx] = true`, propagates failure to all successors, and emits a `SkipReason.DependencyFailed` for them. An outer safety-net `try/catch` in `WorkerLoop` ensures even a bug inside a catch handler can't kill the worker — the simulation would otherwise freeze with `_systemsRemaining > 0` forever.
+Failure isolation (the default, `SystemExceptionPolicy.Isolate`): if a system throws, the worker marks `_systemFailed[sysIdx] = true`, propagates failure to its successors, and emits a `SkipReason.DependencyFailed` for them; independent DAG branches keep running. An outer safety-net `try/catch` in `WorkerLoop` ensures even a bug inside a catch handler can't kill the worker — the simulation would otherwise freeze with `_systemsRemaining > 0` forever.
+
+Strict tick-abort (`SystemExceptionPolicy.AbortTickAndStop`, opt-in): the first throw in a non-engine system latches a terminal tick-wide abort flag. Every user system that has not already started is then cancelled with `SkipReason.TickAborted` — not `DependencyFailed`, and not limited to the failing system's successors: the flag is also read at *claim* time, so a ready-but-unclaimed DAG root cannot slip through. Two exemptions: engine tracks ([§7](#7-parallel-fence)'s fence) never observe the flag, and a system already running drains all of its chunks — abort granularity is the system, never the chunk. Cancellation is dispatch-and-skip rather than halt-dispatch, because a system that is never dispatched never decrements `_systemsRemaining` and the tick would hang. The runtime is terminal afterwards; `TyphonRuntime.OnTickAborted` fires once the tick has drained ([§9](#9-lifecycle)).
 
 ---
 
@@ -304,12 +306,16 @@ The chain is sticky in both directions — `EscalationTicks` consecutive overrun
 ### Tick-level hooks (events)
 
 ```csharp
-runtime.OnFirstTick += ctx => { /* rebuild transient state after crash recovery */ };
-runtime.OnShutdown  += ctx => { /* save player state, cleanup */ };
+runtime.OnFirstTick   += ctx => { /* rebuild transient state after crash recovery */ };
+runtime.OnShutdown    += ctx => { /* save player state, cleanup */ };
+runtime.OnTickAborted += (rt, outcome) => { /* the tick was cancelled — the runtime is dead */ rt.FatalStop(); };
 ```
 
 - **`OnFirstTick`** — fires once on the first tick after engine open. The callback receives a valid `TickContext` with a fresh `Transaction` so it can spawn or repair entities. Used to restore transient state that doesn't survive a crash.
 - **`OnShutdown`** — fires during `Shutdown()`. The callback receives a dedicated `Transaction` with `Immediate` durability — its writes are durable on commit, independent of the regular per-tick UoW.
+- **`OnTickAborted`** — fires at most once, only under `SystemExceptionPolicy.AbortTickAndStop` ([§6](#6-workers)), on the TickDriver thread *after* the aborted tick has fully drained. The handler receives the `TickOutcome` naming the failing system and its exception.
+- **`LastTickOutcome`** — the pull-side counterpart, written on **every** tick so a host that subscribed late (or not at all) can still ask "did the last tick succeed?". It reports `Success` under `Isolate` even on a tick where a system threw — that tick completed exactly as the policy promises; per-system failure detail stays in `SkipReason.Exception` telemetry.
+- **`FatalStop()`** — stops the runtime **without** running `OnShutdown`. This is the path for a host reacting to `OnTickAborted`, where the `Immediate`-durability shutdown transaction is precisely what you don't want to run on a simulation whose systems only partly ran.
 
 ### Per-tick observability
 
@@ -325,6 +331,7 @@ Every tick, on advance, the driver emits a **`Scheduler.Overload.TickMultiplier`
 | **`ParallelQueryMinChunkSize`** | **64** | Floor on entities per chunk for parallel `QuerySystem` dispatch. Smaller entity sets still use the parallel path with `totalChunks = 1`. |
 | `EnableParallelFence` | `true` | Off switch for [§7](#7-parallel-fence) — falls back to serial `WriteTickFence`. |
 | `FenceChunkOversubscription` | 2 | Fence chunk cap = `factor × WorkerCount`. Smooths preemption jitter. |
+| `SystemExceptionPolicy` | `Isolate` | What an unhandled system exception costs. `Isolate` skips only the failing branch; `AbortTickAndStop` cancels the rest of the tick and makes the runtime terminal — see [§6](#6-workers). |
 | `Overload` | new() | The `OverloadOptions` from [§8](#8-overload-management). |
 
 ---


### PR DESCRIPTION
Fixes #604
Fixes #605
Fixes #606
Fixes #607
Fixes #608

PR #601 added `RuntimeOptions.SystemExceptionPolicy` but nothing in `doc/` moved, so four feature-set pages and the runtime overview still assert fault-isolation semantics as unconditional — *"one failure doesn't abort the tick"*, *"other DAG branches continue"*, *"it does not abort sibling members"*. All five statements are correct only under the default `Isolate`.

## Approach

Each fix **qualifies** the existing sentence as the `Isolate` default rather than replacing it, then states what `AbortTickAndStop` does instead. The existing prose isn't wrong — it's the exact contract of the policy every current user is on, and rewriting it would make the common path read as the exception.

All five also carry two exemptions that none of the filed issues mention, both from `claude/design/Runtime/08-strict-tick-abort.md`:

- **D3 — engine tracks never observe the abort flag.** "The tick aborts" naturally reads as "everything stops", which would imply the fence doesn't run. `claude/rules/runtime-scheduling.md` TP-01a marks skipping the fence `[fatal][silent]` (durable un-WAL'd page mutations), so the simplified version would teach readers to expect the corruption case.
- **D1 — abort granularity is the system, never the chunk.** A system already running drains all of its chunks; the flag is only consulted when deciding whether to *begin* one.

## Verified against code, not just the issue text

- `DagScheduler.cs:1344` / `:894` / `:1679` — the gate is `IsTickAborted && !_systemIsEngine[sysIdx]`, read at **claim** time as well as fan-out, which is why "independent branches continue" is wrong and why a ready-but-unclaimed DAG root can't slip through.
- `:1679` sits *before* the `_systemFailed` branch at `:1687` — `TickAborted` wins over `DependencyFailed`.
- `TyphonRuntime.cs:2023-2028` — `OnTickAborted` fires only when `IsTickAborted` latched, and `TryRecordTickAbort:153` no-ops unless the policy is `AbortTickAndStop`. (`TickOutcomeReason.FenceFailure` is declared but never produced anywhere in `src`, so "only under `AbortTickAndStop`" holds.)

## Changes

| File | Fix |
|---|---|
| `feature-set/Runtime/system-types/README.md` | #604 — new bullet for the opt-in policy + both exemptions |
| `feature-set/Runtime/system-types/callback-system.md` | #606 |
| `feature-set/Runtime/system-types/pipeline-system.md` | #606 — plus D1, which matters most here |
| `feature-set/Runtime/system-types/compound-system.md` | #607 — members expand into ordinary DAG registrations, so no compound-level boundary contains the abort |
| `in-depth-overview/10-runtime.md` | #605 (§6 failure-isolation split into two policy paragraphs) and #608 (§9 gains `OnTickAborted` / `LastTickOutcome` / `FatalStop`; knobs table gains `SystemExceptionPolicy`) |

Docs only, no code. `claude/scripts/check-doc-drift.py` green (no drift in enforced docs). Section anchors verified against the actual headings.

Not in scope: `chunked-callback-system.md` has no failure-semantics bullet at all, so nothing there is wrong and no issue covers it — but D1 applies to it too, worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVvtTh6p1AJoSX85AGcAhF