### PR TITLE
Fix the doc-drift no-op guard, and fail loudly when the branch's fixes have no PR

### DIFF
--- a/.github/workflows/doc-accuracy-review.yml
+++ b/.github/workflows/doc-accuracy-review.yml
@@ -394,13 +394,38 @@ jobs:
             exit 1
           fi
 
-          if [ -z "$(git status --porcelain)" ]; then
+          # Stage FIRST, then ask the INDEX whether anything is there. Not `git status --porcelain`: that is a
+          # whole-worktree predicate and is never empty in this job, because download-artifact drops
+          # doc-fix.patch and fixes.txt in the workspace root and they show up as `??` lines. The guard could
+          # therefore never fire, and every no-op night fell through to `git commit` and died on "nothing added
+          # to commit" (run 30689709217, attempt 2) — a red run reporting the wrong cause. Same trap the `patch`
+          # step above calls out by name; the index is the exact question being asked here.
+          # -A so a newly created page counts, not just edits to existing ones.
+          git add -A doc/
+          if git diff --cached --quiet; then
+            # A no-op night is benign ONLY if the fixes already on the branch are visible in a PR. If the branch
+            # carries doc/ changes main does not have and no PR is open, they are STRANDED: the patch is
+            # idempotent, so no later run re-commits them and the create path never fires again for work already
+            # on the branch. That is exactly how #632-#635 ended up invisible (run 30689709217). Returning green
+            # here would report "nothing to do" when the truth is "nothing will ever happen" — so fail, and say
+            # how to recover. Diffing doc/ against main, rather than counting commits, keeps the merge commits
+            # this job creates from reading as stranded work.
+            # Name the files rather than testing `! git diff --quiet`: --quiet exits non-zero for ERRORS (128,
+            # e.g. an unresolvable origin/main) exactly as it does for "differs" (1), so the negation would
+            # report stranded fixes when the real fault was something else entirely. Assigning the output keeps
+            # a genuine git failure fatal under `set -e`, with git's own message instead of a misleading one.
+            UNMERGED=$(git diff --name-only origin/main -- doc/)
+            OPEN_PR=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+            if [ -n "$UNMERGED" ] && [ -z "$OPEN_PR" ]; then
+              echo "::error::$BRANCH carries doc fixes that are not in main and has no open PR — they are stranded. Open one with: gh pr create --repo ${{ github.repository }} --draft --base main --head $BRANCH"
+              printf '  %s\n' $UNMERGED
+              exit 1
+            fi
             echo "::notice::Patch applied to a no-op — these fixes are already on the branch. Nothing to commit."
             echo "committed=0" >> "$GITHUB_ENV"
             exit 0
           fi
 
-          git add -A doc/
           git commit -m "[doc-drift] nightly doc fixes $(date -u +%F) [no-ut] [no-doc]" \
                      -m "$(cat fixes.txt)" \
                      -m "Filed and fixed by doc-accuracy-review.yml. Review the diff — the model fixes only what it is confident about, so the referenced issues may cover more than this commit does."


### PR DESCRIPTION
The nightly doc-accuracy review's `open-pr` job failed on [run 30689709217](https://github.com/Log2n-io/Typhon/actions/runs/30689709217) — the first night since the 2026-07-31 redesign that the reviewer actually produced a patch, so this path had never executed. Two independent bugs, one masking the other.

**The no-op guard could never fire.** `git status --porcelain` is a whole-worktree predicate, and `actions/download-artifact` drops `doc-fix.patch` and `fixes.txt` in the workspace root, so it always reports `?? …`. Every quiet night therefore fell through to `git add -A doc/` (staging nothing) and `git commit`, which exits 1 under `set -euo pipefail` — a red run blaming "nothing added to commit". Staging first and testing the *index* asks the question the step actually means. The `patch` step twelve lines up documents this exact trap by name.

**A quiet night was treated as unconditionally benign.** The patch is idempotent, so once fixes are pushed nothing re-commits them and `gh pr create` never runs again for work already on the branch. When the PR is missing, those fixes are stranded and no later run recovers them — which is precisely what happened to #632–#635 when `createPullRequest` was blocked by the repo's Actions policy. The job now fails and names the unmerged files.

Two details in the second guard are deliberate:
- **Diffing `doc/` against `main`, not counting commits.** This branch is long-lived and gets squash-merged repeatedly, so it sits permanently ahead of `main`; only the content question stays correct after the first merge.
- **Naming files instead of `! git diff --quiet`.** `--quiet` exits non-zero for errors (128, e.g. an unresolvable `origin/main`) exactly as for "differs" (1), so the negation would report stranded fixes when the real fault was something else. Capturing the output keeps a genuine git failure fatal with git's own message.

Verified against throwaway repos reproducing the CI workspace:

| Case | Expected | Result |
|---|---|---|
| No-op night, artifacts in workspace root | commit skipped, `exit 0` | pass |
| Real fix applied | commits | pass |
| Brand-new doc page (untracked) | commits | pass |
| Branch carries fixes, no open PR | fails, names files | pass |
| Same, PR open | `exit 0` | pass |
| Post-merge: 2 commits ahead, no doc delta | `exit 0` | pass |
| `origin/main` unresolvable | dies on git's `fatal:` | pass |

Workflow-only change; no engine code touched. The policy toggle has since been enabled and #636 was opened by hand to rescue the stranded fixes.
