### PR TITLE
Link-check doc-drift fixes before committing them, and clear the Node 20 and Terminal.Gui warnings

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -145,7 +145,11 @@ jobs:
           printf 'User-agent: *\nAllow: /\n\nSitemap: https://doc.typhondb.io/latest/sitemap.xml\n' > _publish/robots.txt
           touch _publish/.nojekyll
 
-      - uses: actions/upload-pages-artifact@v3
+      # v5, not v3: upload-pages-artifact is a composite that calls upload-artifact internally, and v3 still pins the
+      # Node-20 v4 of it — which is what the runner's "Node.js 20 is deprecated" annotation was pointing at, even though
+      # no workflow here references upload-artifact@v4 directly. v5 pins v7 (Node 24). Nothing else in the repo is on a
+      # Node-20 action; everything else is already checkout@v5 / setup-dotnet@v5 / upload-artifact@v6.
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _publish
 

--- a/.github/workflows/doc-accuracy-review.yml
+++ b/.github/workflows/doc-accuracy-review.yml
@@ -386,6 +386,16 @@ jobs:
             git switch -c "$BRANCH"
           fi
 
+          # Layer 1 (scripts/check-doc-links.py) gates doc/ on every PR through build-docs.yml — but never on
+          # THIS one. GitHub suppresses `pull_request` workflows for PRs created with GITHUB_TOKEN, so a
+          # bot-opened doc-drift PR is the one doc change in the repo that no link check ever sees. Run the same
+          # lint here instead, which is strictly stronger than the check it stands in for: it refuses to COMMIT
+          # a dead link rather than annotating one after it is already on the branch.
+          # Baseline BEFORE the patch, because the lint covers all of doc/ and main can in principle arrive
+          # already broken. Without this, inherited breakage would be reported as "tonight's fixes broke a
+          # link", and a nightly that misattributes its failures is one people learn to ignore.
+          python3 scripts/check-doc-links.py --quiet && BASE_OK=1 || BASE_OK=0
+
           # --3way so a hunk that already moved (because an earlier night touched the same page) merges
           # instead of hard-failing on context mismatch.
           if ! git apply --3way doc-fix.patch; then
@@ -424,6 +434,16 @@ jobs:
             echo "::notice::Patch applied to a no-op — these fixes are already on the branch. Nothing to commit."
             echo "committed=0" >> "$GITHUB_ENV"
             exit 0
+          fi
+
+          # There is something to commit — hold it to the same mechanical bar every other doc change clears.
+          if ! python3 scripts/check-doc-links.py; then
+            if [ "$BASE_OK" = 0 ]; then
+              echo "::warning::doc/ link lint was ALREADY failing before tonight's patch — committing anyway, this breakage is inherited from main and not caused by these fixes."
+            else
+              echo "::error::Tonight's doc fixes introduce a dead link, a stale anchor or an unresolvable src/ path. Refusing to commit them. The findings remain filed as issues and the next run retries from a clean tree."
+              exit 1
+            fi
           fi
 
           git commit -m "[doc-drift] nightly doc fixes $(date -u +%F) [no-ut] [no-doc]" \

--- a/src/Typhon.Shell/Telemetry/TelemetryEditor.cs
+++ b/src/Typhon.Shell/Telemetry/TelemetryEditor.cs
@@ -53,8 +53,12 @@ internal sealed class TelemetryEditor
     /// <summary>Run the editor; returns true if the user saved.</summary>
     public bool Run()
     {
-        Application.Init();
-        try
+        // Terminal.Gui 2.4 deprecated the static Application gateway ("the legacy static Application object is going away").
+        // Application.Create().Init() hands back the IApplication that replaces it, and disposing that instance does what
+        // Application.Shutdown() used to — release the driver and restore terminal settings — so the old try/finally is now
+        // the `using`. The library actively refuses to mix the two models (ApplicationImpl.ERROR_LEGACY_AFTER_MODERN), which
+        // is why every call in this file moves at once rather than one at a time.
+        using (var app = Application.Create().Init())
         {
             // Keep the editor transparent: Color.None resolves to the terminal's own (default) background, so the
             // TUI blends with the surrounding shell instead of painting a solid slab. On a One Dark terminal that
@@ -142,7 +146,7 @@ internal sealed class TelemetryEditor
                 (" cancel", _fgDefault),
             ]);
 
-            tree.Toggle = r =>
+            tree.ToggleFlag = r =>
             {
                 Cycle(r);
                 if (TelemetryFlagCatalog.Children(r.Index).Any())
@@ -155,9 +159,9 @@ internal sealed class TelemetryEditor
             tree.SaveQuit = () =>
             {
                 _save = true;
-                Application.RequestStop();
+                app.RequestStop();
             };
-            tree.Cancel = () => Application.RequestStop();
+            tree.Cancel = () => app.RequestStop();
             tree.ToggleTrace = () => ToggleTrace(traceLabel);
             tree.SelectionChanged += (_, e) =>
             {
@@ -183,12 +187,8 @@ internal sealed class TelemetryEditor
             {
                 win.Add(v);
             }
-            Application.Run(win);
-            win.Dispose();
-        }
-        finally
-        {
-            Application.Shutdown();
+            app.Run(win);
+            win.Dispose();   // Run(IRunnable) does not take ownership — only the generic Run<T>() disposes what it created
         }
 
         if (_save)
@@ -384,7 +384,9 @@ internal sealed class TelemetryEditor
     /// <summary>TreeView specialization that turns key presses into editor actions.</summary>
     private sealed class FlagTree : TreeView<FlagRef>
     {
-        public Action<FlagRef> Toggle;
+        // Not `Toggle`: TreeView<T> already declares Toggle(T?) for expand/collapse, and a field of the same name hides it
+        // (CS0108). Different concept anyway — this one flips the flag's VALUE, so the name should not have collided.
+        public Action<FlagRef> ToggleFlag;
         public Action SaveQuit;
         public Action Cancel;
         public Action ToggleTrace;
@@ -395,7 +397,7 @@ internal sealed class TelemetryEditor
             {
                 if (SelectedObject != null)
                 {
-                    Toggle?.Invoke(SelectedObject);
+                    ToggleFlag?.Invoke(SelectedObject);
                 }
                 return true;
             }


### PR DESCRIPTION
Three small follow-ups from [run 30691086389](https://github.com/Log2n-io/Typhon/actions/runs/30691086389), which was green but noisy.

**Layer 1 never sees the doc-drift PR.** GitHub suppresses `pull_request` workflows for PRs created with `GITHUB_TOKEN`, so the nightly's own PR is the one doc change in the repo that `scripts/check-doc-links.py` never runs against. Rather than plumbing a PAT or a `workflow_run` trigger to route around the recursion guard, `open-pr` now runs the same lint directly — which is stronger than the check it stands in for, because it refuses to *commit* a dead link instead of annotating one already on the branch. Baselined before the patch so breakage inherited from `main` is reported as inherited; a nightly that misattributes its own failures is one people learn to ignore.

**Node 20 deprecation.** The runner's annotation named `actions/upload-artifact@v4`, which no workflow here references — it arrives transitively, since `upload-pages-artifact@v3` is a composite that calls it. `@v5` pins `upload-artifact@v7` (Node 24), confirmed by reading v5's `action.yml`. Nothing else in the repo is on a Node 20 action.

**Six compiler warnings in `Typhon.Shell`.** Terminal.Gui 2.4 deprecated the static `Application` gateway; `Application.Create().Init()` returns the `IApplication` that replaces it, and disposing it does what `Shutdown()` did, so the `try`/`finally` becomes a `using`. All five calls move together because `ApplicationImpl` refuses to mix the two models (`ERROR_LEGACY_AFTER_MODERN`) — a half-migrated file fails at runtime, not compile time. `FlagTree.Toggle` becomes `ToggleFlag`: it is a callback field colliding with `TreeView<T>.Toggle(T?)`, and since the concepts differ (base expands a node, ours flips a flag's value) `new` would have been the wrong fix. Rewriting `try {` as `using (…) {` kept the ~130-line body's indentation, so the diff is the eight lines that actually changed.

`Typhon.Shell` now builds **0 warnings, 0 errors** (was 6). Shell tests 22/22.

**Not verified:** no test covers `TelemetryEditor` — the shell suite covers docs, scaffold, telemetry-file and ui commands only, so the TUI change is verified by compilation and the vendor's documented pattern, not by execution. Worth a manual `typhon telemetry edit` before this is trusted: it should open, Space should toggle a flag, `s` save, `q` cancel, and the terminal should be restored on exit.
