### PR TITLE
#624 Nightly macOS: run the gate's own shard plan sequentially, on a RAM disk

### DIFF
--- a/.github/workflows/nightly-macos-arm64.yml
+++ b/.github/workflows/nightly-macos-arm64.yml
@@ -91,40 +91,55 @@ jobs:
       - name: Build engine test project (Release)
         run: dotnet build test/Typhon.Engine.Tests/Typhon.Engine.Tests.csproj -c Release
 
-      # ── Execution model: ONE serial process, not the gate's 8 shards. ──────────────────────────────────
-      # The gate runs K=8 `dotnet test` processes at workers=1 on 16 PHYSICAL cores — 0.5 processes per core.
-      # K=16 (1.0 per core) was measured FLAKY (claude/design/Infrastructure/ci-merge-gate.md). A GitHub-hosted
-      # macos-15 runner has 3 cores, so the gate's own plan would land at ~2.7 processes per core: far past the
-      # flaky threshold, and a nightly that cries wolf gets ignored. Wall-clock is not scarce at 03:00; trust is.
+      # Test databases live on a RAM disk. The suite roots every database directory at Path.GetTempPath() (58 files
+      # do; TestBase and AllocatorTestBase both build their per-fixture dirs from it), and on Unix .NET resolves
+      # that through TMPDIR — so one env var moves ALL test I/O, main database file and WAL alike, off the runner's
+      # disk. It is the same lever the self-hosted c6id gate pulls with TMPDIR=/nvme in bench/aws/run-gate.sh.
       #
-      # So we hand shard.py a ONE-shard plan. That reuses its whole apparatus unchanged — the catch-all filter,
-      # the serial `Category=Sensitive` quiet pass, and (the reason this matters) the 2-attempt RETRY of failures
-      # run alone. Without the retry, a single timing flake reds the nightly. shard.py's own comment notes those
-      # windows are tightest on slow CI cores, which is exactly where we are.
+      # WHY: two runs of IDENTICAL code took 113 s and 616 s, and the 500 s was concentrated in fsync-heavy reopen
+      # tests (WAL_*_SurvivesReopen, WalSegmentReclaimReopen, UowRegistry overflow pages). The same commit runs in
+      # 90 s on a developer machine. Hosted-runner disk throughput is the variable, not the engine.
       #
-      # The plan is GENERATED from shard.py's own catchall_filter() rather than hand-written, so if the gate ever
-      # excludes another category the nightly follows automatically instead of silently drifting.
-      - name: Generate the single-shard (serial) plan
+      # macOS has no tmpfs, so hdiutil + diskutil is the equivalent. 2 GiB against a measured ~32 MiB suite
+      # footprint — the GiB-scale temp dirs on a dev box belong to benchmarks and AOT POCs, not this suite. The
+      # summary reports actual usage so this can be right-sized rather than guessed at again.
+      - name: Mount a RAM disk for test databases
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json, sys
-          sys.path.insert(0, "bench/aws")
-          import shard
-          plan = [{"filter": shard.catchall_filter([]), "classes": ["<catch-all>"]}]
-          json.dump(plan, open("shards-serial.json", "w"), indent=1)
-          print("filter:", plan[0]["filter"])
-          PY
+          DEV=$(hdiutil attach -nomount ram://4194304)     # 4194304 sectors x 512 B = 2 GiB
+          diskutil eraseVolume HFS+ typhon-ramdisk "$DEV"
+          echo "TMPDIR=/Volumes/typhon-ramdisk" >> "$GITHUB_ENV"
+          df -h /Volumes/typhon-ramdisk
 
-      - name: Run engine suite (serial + Sensitive pass + retries)
+      # ── Execution model: the GATE'S OWN PLAN, run one shard at a time. ────────────────────────────────
+      # Concurrency and selection are separate concerns, and conflating them was a real bug here.
+      #
+      # Concurrency: the gate runs K=8 `dotnet test` processes at workers=1 on 16 PHYSICAL cores — 0.5 per core.
+      # K=16 (1.0 per core) was measured FLAKY (claude/design/Infrastructure/ci-merge-gate.md). This runner has 3
+      # cores, where that plan lands at ~2.7 per core: far past the flaky threshold. SHARD_CONCURRENCY=1 caps how
+      # many run at once WITHOUT touching the plan. Wall-clock is not scarce at 03:00; trust is.
+      #
+      # Selection: an earlier revision instead handed shard.py a custom one-shard catch-all plan. That quietly ran
+      # 32 tests the gate deliberately skips — NUnit runs [Explicit] tests when it reads the filter as naming them,
+      # and a 2-term category filter qualifies where the gate's 305-term one does not. Those tests say why that is
+      # wrong here: "spawns 16-32 threads, run manually to avoid thread pool saturation in parallel CI" and
+      # "Performance benchmarks — run manually". Thread-saturating stress tests on a 3-core hosted runner measure
+      # the runner. Reusing shards.json keeps nightly and gate selection identical BY CONSTRUCTION rather than by
+      # two mechanisms that have to be kept in agreement. (NUnit's ExplicitMode runsettings knob was tried first
+      # and had no effect at any value.)
+      #
+      # Everything else in shard.py still applies: the serial Category=Sensitive quiet pass, and — the part that
+      # matters most on a noisy hosted runner — the 2-attempt RETRY of failures re-run alone.
+      - name: Run engine suite (gate plan, 1 shard at a time, + Sensitive pass + retries)
         id: tests
         env:
           SHARD_REPO: ${{ github.workspace }}
           SHARD_CONFIG: Release
-          SHARD_PLAN: shards-serial.json
+          SHARD_CONCURRENCY: 1
         run: |
           set -o pipefail
           mkdir -p ci-out
+          echo "TMPDIR=$TMPDIR"
           python3 bench/aws/shard.py run --results-dir ci-out 2>&1 | tee ci-out/engine.log
 
       # if: always() — the report matters most precisely when the run went red.
@@ -135,7 +150,14 @@ jobs:
           {
             echo "## Nightly arm64 (macOS) — Typhon.Engine"
             echo
-            echo "Runner: \`macos-15\` · $(uname -m) · $(sysctl -n hw.ncpu) logical cores · Release · serial (workers=1)"
+            echo "Runner: \`macos-15\` · $(uname -m) · $(sysctl -n hw.ncpu) logical cores · Release · gate plan, 1 shard at a time"
+            echo
+            # RAM-disk headroom. Reported so the 2 GiB can be right-sized from data; a suite that ever fills it
+            # would fail with a confusing ENOSPC, so this is the number to watch, not a decoration.
+            echo "RAM disk (\`\$TMPDIR\`) after the run:"
+            echo '```'
+            df -h "${TMPDIR:-/Volumes/typhon-ramdisk}" 2>&1 || echo "(no RAM disk mounted)"
+            echo '```'
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -160,7 +182,11 @@ jobs:
           print(f"| **arm64 (this run)** | {tot} | {pas} | {fail} | {skip} |")
           print(f"| x64 gate baseline | 4156 | 4103 | 0 | 53 |")
           print()
-          print("_Skip counts are expected to differ: `DatabaseFileLockingTests` carries a `[Platform(\"Win\")]`"
+          print("_These totals are comparable BY CONSTRUCTION: this job runs the gate's own `shards.json`, so the"
+                " same tests are selected on both. A total that drifts from the gate's means the plan changed, not"
+                " the platform — investigate rather than shrug._")
+          print()
+          print("_Skip counts still differ legitimately: `DatabaseFileLockingTests` carries a `[Platform(\"Win\")]`"
                 " test that self-skips off Windows. Enumerate any other delta rather than assuming it._")
           print()
           if not files:

--- a/.github/workflows/nightly-macos-arm64.yml
+++ b/.github/workflows/nightly-macos-arm64.yml
@@ -106,7 +106,11 @@ jobs:
       - name: Mount a RAM disk for test databases
         run: |
           set -euo pipefail
-          DEV=$(hdiutil attach -nomount ram://4194304)     # 4194304 sectors x 512 B = 2 GiB
+          # `hdiutil attach -nomount` PADS its output ("/dev/disk6          "), and diskutil will not resolve a
+          # device path carrying trailing whitespace — it fails with "Unable to find disk for /dev/disk6", where
+          # the padding is invisible in the message. tr strips it. Do not drop this pipe.
+          DEV=$(hdiutil attach -nomount ram://4194304 | tr -d '[:space:]')     # 4194304 sectors x 512 B = 2 GiB
+          echo "ram disk device: '$DEV'"
           diskutil eraseVolume HFS+ typhon-ramdisk "$DEV"
           echo "TMPDIR=/Volumes/typhon-ramdisk" >> "$GITHUB_ENV"
           df -h /Volumes/typhon-ramdisk

--- a/bench/aws/README.md
+++ b/bench/aws/README.md
@@ -29,10 +29,15 @@ Three tasks are launched by GitHub Actions, not by hand. Full design:
 A fourth workflow uses `shard.py` **without** AWS: `.github/workflows/nightly-macos-arm64.yml` runs the
 engine suite nightly on a GitHub-hosted `macos-15` runner (Apple Silicon — the arm64 platform Typhon
 supports for developers, which the x64 gate cannot exercise; see `claude/rules/durability.md` → SL-07).
-That runner has 3 cores, so the committed K=8 `shards.json` would oversubscribe it ~2.7×. It instead
-generates a **single-shard plan** at runtime from `shard.py`'s own `catchall_filter([])` and points
-`SHARD_PLAN` at it — a serial `workers=1` run that still inherits the `Category=Sensitive` quiet pass and
-the 2-attempt retry of failures. Non-blocking; never a required check.
+That runner has 3 cores, where the committed K=8 plan would land at ~2.7 processes per core, so the job sets
+**`SHARD_CONCURRENCY=1`** — the *same* `shards.json`, one shard at a time. It also points `TMPDIR` at a RAM
+disk, the macOS equivalent of the self-hosted gate's `TMPDIR=/nvme`. Non-blocking; never a required check.
+
+> **Cap concurrency, never swap the plan.** An earlier revision gave that job a custom single-shard catch-all
+> filter instead. It silently ran 32 `[Explicit]` stress/perf tests the gate deliberately skips — NUnit runs
+> `[Explicit]` tests when it reads the filter as naming them, and a 2-term category filter qualifies where the
+> gate's 305-term one does not. Reusing `shards.json` keeps selection identical by construction. (NUnit's
+> `ExplicitMode` runsettings knob was tried first and had no effect at any value.)
 
 The AntHill runbook below is for **manual** trace-capture runs, unrelated to CI.
 

--- a/bench/aws/shard.py
+++ b/bench/aws/shard.py
@@ -27,7 +27,15 @@ regenerating for BALANCE, never for coverage (same contract as the
 test-affected map).
 
 Env knobs (run mode): SHARD_REPO (repo root, default cwd), SHARD_CONFIG (default
-Release).
+Release), SHARD_CONCURRENCY (shards to run at once, default = all of them).
+
+SHARD_CONCURRENCY=1 runs the SAME plan strictly sequentially. That is what the macOS
+arm64 nightly uses: a 3-core hosted runner cannot take K=8 concurrent processes (the
+gate's K is sized for 16 physical cores), but running a DIFFERENT, looser filter there
+silently changed which tests were selected -- NUnit runs [Explicit] tests when it reads
+the filter as naming them, and a 2-term category filter qualifies where the gate's
+305-term one does not. Reusing the gate's plan keeps nightly and gate selection
+identical by construction instead of by two mechanisms that have to agree.
 """
 import argparse, json, os, subprocess, sys, time
 import xml.etree.ElementTree as ET
@@ -178,11 +186,14 @@ def all_results(path):
 def cmd_run(results_dir):
     shards = json.load(open(SHARDS_JSON))
     os.makedirs(results_dir, exist_ok=True)
-    print(f"[shard] {len(shards)} parallel shards (workers=1) + serial Sensitive pass; "
+    # Default = every shard at once (the gate). SHARD_CONCURRENCY caps it without touching the PLAN, so a
+    # core-poor runner slows down instead of silently testing a different set.
+    conc = max(1, int(os.environ.get("SHARD_CONCURRENCY") or len(shards)))
+    print(f"[shard] {len(shards)} shards (workers=1, {conc} at a time) + serial Sensitive pass; "
           f"cfg={CFG} repo={REPO}", flush=True)
     t0 = time.time()
     results = []
-    with ThreadPoolExecutor(max_workers=len(shards)) as ex:
+    with ThreadPoolExecutor(max_workers=conc) as ex:
         futs = [ex.submit(run_one, str(i), s["filter"], results_dir)
                 for i, s in enumerate(shards)]
         for f in futs:


### PR DESCRIPTION
Follow-up to #638. Two problems with that first revision, both fixed by separating **how much runs at once** from **what runs**.

## Selection — the nightly was running tests the gate deliberately skips

The nightly handed `shard.py` a custom single-shard catch-all plan instead of the gate's `shards.json`. That silently ran **32 extra tests**: NUnit runs `[Explicit]` tests when it reads the filter as naming them, and a 2-term category filter qualifies where the gate's 305-term one does not. So a change made purely for *concurrency* reasons quietly changed the test **set**.

Those tests say why that is wrong on a 3-core hosted runner, in their own attributes:

> `[Explicit("Stress test — spawns 16-32 threads, run manually to avoid thread pool saturation in parallel CI")]`
> `[Explicit("Performance benchmarks — run manually")]`

**Fix:** a new `SHARD_CONCURRENCY` knob in `shard.py` caps how many shards run at once *without touching the plan*. The nightly now runs the gate's `shards.json` with `SHARD_CONCURRENCY=1` — nightly and gate selection are identical **by construction**, not by two mechanisms that have to be kept in agreement.

`SHARD_CONCURRENCY` defaults to `len(shards)`, so the gate and every local run are unchanged. Verified by re-running the default path against the modified script: `8 shards, 8 at a time`, 4158 tests, green.

> **Dead end worth recording:** NUnit's `ExplicitMode` runsettings knob was tried first and had **no effect at any value**. If someone reaches for it later — its default is `Strict`, which only stops Explicit tests being *mixed* with non-Explicit ones, and the value the docs recommend for CI is `None`. Neither changed the count here.

## I/O — test databases move to a RAM disk

The suite roots every database directory at `Path.GetTempPath()` (58 files, including `TestBase` and `AllocatorTestBase`), and .NET resolves that through `TMPDIR` on Unix. So one env var moves **all** test I/O — main database file and WAL alike — off the runner's disk. Same lever the self-hosted c6id gate pulls with `TMPDIR=/nvme` in `run-gate.sh`.

Why: two runs of **identical code** took 113 s and 616 s, with the 500 s concentrated in fsync-heavy reopen tests (`WAL_*_SurvivesReopen`, `WalSegmentReclaimReopen`, `UowRegistry` overflow pages), while the same commit runs in 90 s on a developer machine. Hosted-runner disk throughput is the variable, not the engine.

Sized at 2 GiB against a measured ~32 MiB suite footprint (the GiB-scale temp dirs on a dev box belong to benchmarks and AOT POCs, not this suite). The job summary prints `df` so it can be right-sized from data rather than guessed at twice.

## Verified locally

- Sequential gate plan: **4191 → 4158 tests**, green, 107 s.
- Absent: `OlcBTreeStressTests`, `OlcBTreeRaceStressTests`, `SpatialPerfTests`, `SubscriptionStressTests`, `ConcurrencyTracingStressTests`, `DagSchedulerCpuTests`, `RawValueHashMapScaleRepro`.
- Mixed-class check: the three `[Explicit]` benchmarks in `DagSchedulerLatencyTests` are excluded while its plain test still runs.
- Default gate path re-run against the modified `shard.py`: unchanged, green.
- YAML, every shell block and both embedded Python blocks parse.

**Not verifiable off-runner:** the RAM-disk step itself (`hdiutil` / `diskutil` are macOS-only). **The run on this PR is that test.**

## Still open, unchanged by this PR

- `WalCommitBuffer.cs:452` passes `ctx.Deadline.Remaining` as the wait duration to `ThrowWalBackPressureTimeout`. `Remaining` is ~0 by definition once the deadline has expired, so the exception can only ever report "timeout after 0ms" — it should carry elapsed wait time.
- 4 **non**-`[Explicit]` tests run under a plain catch-all filter but not under the gate's K=8 plan (`SeqlockCounterSlotReuseTests.SlotReuseUnderCachePressure_…`, `WalSegmentReclaimReopenTests` ×2, `PagedHashMapTests.Stress_Torture_32Threads_AllOperations`). Selection parity means the nightly now misses them too. Not root-caused; a gate coverage hole in its own right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKFzE7MqQUj13s8a7q895D