### PR TITLE
#642 Split the PK-fallback paragraph, and stop the doc reviewer revising its own prose

### DIFF
--- a/.github/workflows/doc-accuracy-review.yml
+++ b/.github/workflows/doc-accuracy-review.yml
@@ -264,6 +264,21 @@ jobs:
               State the exemptions, not just the headline. A rule with carve-outs documented as absolute
               teaches readers to expect the wrong thing in precisely the cases that bite.
 
+              VERIFY THE WHOLE PARAGRAPH YOU EDIT, not only the sentence you came for. A paragraph is one
+              unit to a reader, so rewriting half of it and inheriting the rest unchecked signs your name to
+              claims you never read. This has already caused drift: the 2026-08-01 run rewrote the "PK
+              fallback" paragraph in 09-querying.md and inherited a stale cluster-storage sentence beside it,
+              which the next night had to file again as #642.
+
+              NEVER write a linking phrase — "in either case", "likewise", "the same applies", "in both
+              paths" — into prose you have not verified THIS run. A connector widens the scope of the claim
+              it points at; widening an unverified claim is precisely how a fix manufactures new drift. That
+              is the exact mechanism behind #642: "In either case ..." was added in front of a sentence that
+              was only ever true for non-cluster archetypes, and the connector made it read as universal.
+
+              If a neighbouring claim is wrong and you are not confident how to fix it, SPLIT the paragraph
+              instead of bridging across it, and file the remainder as its own issue.
+
             Your edits will be pushed to a long-lived `doc-drift/nightly` branch and opened as a DRAFT PR
             for the maintainer to review, adjust or merge. The issues you filed are referenced from it and
             close on merge.
@@ -434,6 +449,42 @@ jobs:
             echo "::notice::Patch applied to a no-op — these fixes are already on the branch. Nothing to commit."
             echo "committed=0" >> "$GITHUB_ENV"
             exit 0
+          fi
+
+          # Ping-pong guard. Is this patch rewriting prose a PREVIOUS [doc-drift] run wrote? Touching the same
+          # PAGE two nights running is fine and expected (--3way exists for it). Rewriting the same LINES is not:
+          # it means the reviewer is arguing with itself, and since each run only sees the current text, neither
+          # side knows a round trip is happening. #642 was that — the 2026-08-01 fix bridged into a claim it had
+          # not checked, and 2026-08-02 filed the result. Blame the PRE-IMAGE line ranges of each hunk (HEAD is
+          # still pre-patch here; the patch is staged, not committed) and refuse if any land on a recent
+          # [doc-drift] commit. Recent, not ever: prose the bot wrote months ago legitimately needs revising when
+          # the code moves, and a permanent ban would freeze those pages.
+          PINGPONG=""
+          NOW=$(date +%s)
+          for f in $(git diff --cached --name-only); do
+            for hunk in $(git diff --cached -U0 -- "$f" | sed -n 's/^@@ -\([0-9,]*\).*/\1/p'); do
+              start=${hunk%,*}
+              len=${hunk#*,}
+              [ "$hunk" = "$start" ] && len=1          # "@@ -12 @@" means one line, no comma
+              [ "$len" = 0 ] && continue               # pure insertion — touches nobody's prose
+              end=$((start + len - 1))
+              for sha in $(git blame -L "$start,$end" --porcelain HEAD -- "$f" 2>/dev/null \
+                             | grep -oE '^[0-9a-f]{40}' | sort -u); do
+                case "$(git log -1 --format=%s "$sha")" in
+                  '[doc-drift]'*)
+                    age=$(( (NOW - $(git log -1 --format=%ct "$sha")) / 86400 ))
+                    if [ "$age" -le 30 ]; then
+                      PINGPONG="$PINGPONG  $f:$start-$end was written ${age}d ago by ${sha:0:7}"$'\n'
+                    fi
+                    ;;
+                esac
+              done
+            done
+          done
+          if [ -n "$PINGPONG" ]; then
+            echo "::error::This patch rewrites lines a recent [doc-drift] run wrote — the reviewer is revising its own output, which is how a fix turns into a round trip. Findings remain filed as issues; apply them by hand after deciding which reading is right."
+            printf '%s' "$PINGPONG"
+            exit 1
           fi
 
           # There is something to commit — hold it to the same mechanical bar every other doc change clears.

--- a/doc/in-depth-overview/09-querying.md
+++ b/doc/in-depth-overview/09-querying.md
@@ -147,7 +147,18 @@ Singleton (`PlanBuilder.Instance`). Two stages:
 | `EstimatedCounts` | Per-evaluator cardinality (parallel array). |
 | `UsesSecondaryIndex` | `PrimaryFieldIndex >= 0`. |
 
-**On the "PK fallback":** When `SelectPrimaryStream` cannot narrow a range — in practice an all-`!=` predicate, since `NotEqual` is excluded from range selection — `BuildPlanWithPrimarySelection` now calls `SelectFullScanStream`, which picks any indexed field referenced by the predicate and scans its full type range, leaving every evaluator to filter. For the typical NE-only case the plan is therefore executable with a non-negative `PrimaryFieldIndex`. `PrimaryFieldIndex = -1` and a **non-executable plan** are still produced in two remaining cases: OrderBy PK (`orderByFieldIndex == -1`, because no secondary index reproduces PK order) and the degenerate case where no evaluator carries a usable index (unreachable in practice — `WhereField` rejects non-indexed fields). In either case `PipelineExecutor.ExecuteCore` short-circuits when `UsesSecondaryIndex` is false; `Count` returns 0 directly. The PK B+Tree that the historical full-table-scan fallback used was removed; the engine relies on every query reaching a secondary index. Cluster-storage ordered scans separately handle a `-1` plan by using the OrderBy field's per-archetype B+Tree directly (see `ExecuteOrderedClustered` in `EcsQuery.cs`).
+**On the "PK fallback" — non-cluster storage:** When `SelectPrimaryStream` cannot narrow a range — in practice an all-`!=` predicate, since `NotEqual` is excluded from range selection — `BuildPlanWithPrimarySelection` calls `SelectFullScanStream`, which picks any indexed field referenced by the predicate and scans its full type range, leaving every evaluator to filter. For the typical NE-only case the plan is therefore executable with a non-negative `PrimaryFieldIndex`. `PrimaryFieldIndex = -1` and a **non-executable plan** are still produced in two remaining cases: OrderBy PK (`orderByFieldIndex == -1`, because no secondary index reproduces PK order) and the degenerate case where no evaluator carries a usable index (unreachable in practice — `WhereField` rejects non-indexed fields). Against **non-cluster** archetypes such a plan yields nothing: `PipelineExecutor.ExecuteCore` runs the scan only when `UsesSecondaryIndex` is true, and `PipelineExecutor.Count` returns 0 outright. The PK B+Tree that the historical full-table-scan fallback used was removed; the engine relies on every non-cluster query reaching a secondary index.
+
+**Cluster storage never takes that path — ordered or unordered.** A `-1` plan *is* executable against cluster archetypes, because each one carries per-archetype B+Trees and `EcsQuery` dispatches to them before `PipelineExecutor` is consulted at all:
+
+| Query shape | Entry point |
+|---|---|
+| Unordered | `ExecuteTargeted` → `ScanPerArchetypeBTree` — the non-selective branch, taken whenever `UsesSecondaryIndex` is false |
+| Ordered, every archetype clustered | `ExecuteOrderedClustered` — K-way merge over the OrderBy field's per-archetype B+Trees |
+| Ordered, mixed cluster + non-cluster | `ExecuteOrderedViaSortFallback` |
+| `Count()` with any cluster archetype in the mask | `ExecuteTargeted().Count` — `PipelineExecutor.Count` is never reached, so the `return 0` above does not apply |
+
+All four scan real data and return correct results (`src/Typhon.Engine/Ecs/public/EcsQuery.cs`). In particular, a cluster query is never empty and `Count` is never 0 *merely because of plan shape*.
 
 ### `FieldEvaluator`
 


### PR DESCRIPTION
Fixes #642.

### It was not a reversal — but the shape was worrying for a good reason

The clause #642 objects to sits on the **`-` side** of #636's diff: it predates last night and was carried through verbatim. #633 was about a *different* clause in the same paragraph. So one paragraph held two independent errors; night 1 fixed one and inherited the other, then bridged into it with **"In either case ..."** — widening a claim that was only ever true for non-cluster archetypes. That connector is the actual defect: it signed the reviewer's name to prose it had never read.

### The prose

`09-querying.md:150` packed seven independently verifiable claims into a single paragraph — `SelectFullScanStream`, both `-1` cases, the `ExecuteCore` short-circuit, `Count`=0, PK B+Tree removal, and cluster ordered scans. A reviewer told to "fix only what it is confident about" will nibble one clause per night forever. Split into a non-cluster paragraph and a cluster one, with the cluster dispatch as a table so each entry point stands alone.

Verified against the code before writing, so this is not a third round:

| Query shape | Entry point | Source |
|---|---|---|
| Unordered | `ExecuteTargeted` → `ScanPerArchetypeBTree` | `EcsQuery.cs:1209-1216` |
| Ordered, all clustered | `ExecuteOrderedClustered` | `EcsQuery.cs:830-834` |
| Ordered, mixed | `ExecuteOrderedViaSortFallback` | `EcsQuery.cs:837` |
| `Count()` w/ any cluster archetype | `ExecuteTargeted().Count` | `EcsQuery.cs:2176-2181` |

`PipelineExecutor.Count`'s `return 0` (`PipelineExecutor.cs:51-58`) is reachable only from the non-cluster path.

### Two guards

**Prompt.** Verify every claim in a paragraph you edit, not just the sentence you came for. And never write a linking phrase — "in either case", "likewise", "the same applies" — into prose not verified that run, because a connector widens the scope of whatever it points at.

**Mechanical.** `open-pr` now blames the pre-image line ranges of each hunk and refuses to commit when they were written by a `[doc-drift]` commit **less than 30 days old**. Touching the same *page* two nights running is expected — `--3way` exists for it. Rewriting the same *lines* means the reviewer is arguing with itself, and neither run can tell, because each only ever sees the current text. Recent rather than ever, so prose the bot wrote months ago can still be revised when the code moves.

Findings stay filed as issues when it trips, matching how the step already handles a conflicting merge: stop rather than resolve.

### Verification

| Case | Expected | Result |
|---|---|---|
| Edit a human-written line | silent | pass |
| Edit a line a recent `[doc-drift]` commit wrote | **fires** | pass |
| Edit a line a >30-day-old `[doc-drift]` commit wrote | silent | pass |
| Pure insertion | silent | pass |
| **Live:** this PR's own doc edit | **fires** against `30baae7` (1d) | pass |

Link lint clean (329 files, 1872 links, 0 findings). Workflow YAML parses.
