### PR TITLE
#624 Fix an ABA in the WAL commit buffer's back-pressure wait that wedged producers until their deadline

### DIFF
--- a/src/Typhon.Engine/Durability/internals/WalCommitBuffer.cs
+++ b/src/Typhon.Engine/Durability/internals/WalCommitBuffer.cs
@@ -134,6 +134,22 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
     private int _swapState;
     private int _inflightCount;
 
+    /// <summary>
+    /// Monotonic count of completed buffer swaps. This — not <see cref="_activeBufferIndex"/> — is what a producer parked in the back-pressure loop waits on.
+    /// </summary>
+    /// <remarks>
+    /// The active index ping-pongs between 0 and 1, so "wait until the index differs from the one I captured" is an ABA test on a single bit. A producer that
+    /// is off-CPU while TWO swaps complete sees the index back at its captured value and goes on waiting for a transition that has already happened — twice.
+    /// Nothing recovers it: the only thing that advances the index is another producer overflowing the buffer, so once every live producer is in that state
+    /// the buffer sits drained and idle until each one's <see cref="WaitContext"/> deadline expires and it throws
+    /// <see cref="WalBackPressureTimeoutException"/> on a commit that had space available the whole time.
+    /// <para>
+    /// A 64-bit monotonic counter cannot ABA. Incremented last in <see cref="PerformSwap"/> — after the index, the reset claim word and the folded LSN base
+    /// are all published — so a producer that observes a new generation observes everything the new generation needs.
+    /// </para>
+    /// </remarks>
+    private long _swapGeneration;
+
     // ═══════════════════════════════════════════════════════════════════════
     // Signaling
     // ═══════════════════════════════════════════════════════════════════════
@@ -300,6 +316,12 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
     /// <summary>Current swap state (0=Normal, 1=Requested, 2=Draining).</summary>
     internal int SwapState => _swapState;
 
+    /// <summary>Number of buffer swaps completed so far — see <see cref="_swapGeneration"/>. Test hook.</summary>
+    internal long SwapGeneration => Volatile.Read(ref _swapGeneration);
+
+    /// <summary>Test hook over the back-pressure loop predicate — see <see cref="WaitingForSwap"/>.</summary>
+    internal bool IsStillWaitingForSwap(long observedGeneration) => WaitingForSwap(true, observedGeneration);
+
     // ═══════════════════════════════════════════════════════════════════════
     // TryClaim — Atomic Space Allocation (Producer, lock-free)
     // ═══════════════════════════════════════════════════════════════════════
@@ -354,6 +376,7 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
             int bufferIndex;
             byte* buffer;
             var gotSlot = false;
+            var swapGeneration = 0L;
 
             if (Volatile.Read(ref _swapState) != SwapDraining)
             {
@@ -397,14 +420,21 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
             }
             else
             {
-                // Backed out: a swap is draining. Nothing was claimed, so there is no slot to abandon and no hole to leave.
+                // Backed out: a swap is draining. Nothing was claimed, so there is no slot to abandon and no hole to leave — and, as the wait
+                // predicate records, no swap is owed to us either. The active index deliberately goes UNREAD here: sampling it was how this path
+                // used to arm a wait for a transition it had no stake in.
                 offset = 0;
-                bufferIndex = _activeBufferIndex;
                 buffer = null;
             }
 
             if (gotSlot)
             {
+                // Sample the swap generation while the claim gate is STILL HELD. That is what makes this value trustworthy: having observed
+                // _swapState != SwapDraining while registered, no swap can complete until we release the gate (the Dekker pair above), so this
+                // is necessarily the generation our over-capacity claim belongs to — the one the wait below needs to see superseded. Reading it
+                // here rather than beside _activeBufferIndex also keeps it off the CASE A fast path, which never waits.
+                swapGeneration = Volatile.Read(ref _swapGeneration);
+
                 // CASE B: This producer straddles the boundary (overlap initiator).
                 // offset < BufferCapacity: the claim starts inside the buffer but extends past the end.
                 //   Write a padding sentinel at the claim offset so TryDrain/CompleteDrain knows to stop.
@@ -436,8 +466,10 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
             // slot after claiming one would leave an unpublished frame header, and TryDrain stops at the first of those — a permanent drain stall.
             Interlocked.Decrement(ref _claimsInProgress);
 
-            // CASE B & C: Wait for the buffer swap to complete.// Poll _activeBufferIndex — when it changes, a swap happened and the fresh buffer is ready.
-            // AdaptiveWaiter provides spin → yield → sleep(1) progression.
+            // Wait for the swap this producer needs, then loop round and re-claim. What "the swap this producer needs" MEANS differs by case, and
+            // conflating the two was a liveness bug (see WaitingForSwap):
+            //   CASE B & C (gotSlot): we hold an over-capacity claim. Only a NEW generation can serve it — wait for _swapGeneration to move.
+            //   Backed out: we hold nothing at all. We only need the draining window to pass, then retry; there is no swap owed to us.
             // Phase 8: Backpressure span — captures how long this producer blocked waiting for the writer thread to swap buffers.
             // Emitted on the calling (producer) thread, not the writer. Parents under whatever span the producer is in (e.g. TransactionPersist).
             var bpStart = System.Diagnostics.Stopwatch.GetTimestamp();
@@ -445,11 +477,16 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
             try
             {
                 var retries = 0;
-                while (_activeBufferIndex == bufferIndex)
+                while (WaitingForSwap(gotSlot, swapGeneration))
                 {
                     if (!Unsafe.IsNullRef(ref ctx) && ctx.ShouldStop)
                     {
-                        ThrowHelper.ThrowWalBackPressureTimeout(frameSize, ctx.Deadline.Remaining);
+                        // Report how long we ACTUALLY waited, not Deadline.Remaining — that is TimeSpan.Zero by definition here, because
+                        // ShouldStop is only true once the deadline has passed. Deadline stores the expiry timestamp and not the start, so
+                        // it cannot compute elapsed on its own; the waiter has to. Passing Remaining made every such exception read
+                        // "timeout after 0ms", which destroys the one number that says whether the wait was the configured budget or a
+                        // pathological stall — exactly what you need when this fires from CI.
+                        ThrowHelper.ThrowWalBackPressureTimeout(frameSize, System.Diagnostics.Stopwatch.GetElapsedTime(bpStart));
                     }
 
                     ThrowIfDisposed();
@@ -458,6 +495,7 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
                     // swap that lands in microseconds is caught in user mode; a slow one parks the thread rather than burning a core.
                     // The bounded timeout is a liveness backstop only — it caps the cost of a lost wake-up (an event reset that
                     // raced a completing swap) at one iteration, and lets ShouldStop / disposal be re-checked on a fixed cadence.
+                    // It is NOT what bounds an ABA miss: a missed generation would never be re-observed, however often we re-checked.
                     _swapCompletedEvent.Wait(SwapWaitBackstopMs);
                     retries++;
                 }
@@ -747,15 +785,20 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
         _lsnBase += LsnOffsetOf(finalClaim);
         _drainPosition = 0;
 
-        // This Exchange acts as a release fence: producers spinning on _activeBufferIndex will see _tailPosition = 0 before they see
-        // the new index, because both stores went through Interlocked.Exchange which provides sequential consistency.
+        // This Exchange acts as a release fence: producers will see _claim = 0 before they see the new index, because both stores went
+        // through Interlocked.Exchange which provides sequential consistency.
         Interlocked.Exchange(ref _activeBufferIndex, newIndex);
 
         // SwapNormal must be last — some code paths check _swapState
         Interlocked.Exchange(ref _swapState, SwapNormal);
 
-        // Release every producer parked in TryClaim. Set AFTER _activeBufferIndex is published, so a woken producer's re-read of
-        // the index always observes the new buffer.
+        // The producers' actual wake condition, published LAST so that observing it implies observing everything above: the fresh index, the
+        // reset claim word and the folded LSN base. Interlocked.Increment is a full fence on both x64 and arm64, which is what the parked
+        // producers' Volatile.Read acquire pairs with. Once per swap, so its cost is irrelevant.
+        Interlocked.Increment(ref _swapGeneration);
+
+        // Release every producer parked in TryClaim. Set AFTER the generation is published, so a woken producer's re-read always
+        // observes the new generation rather than going back to sleep for another backstop interval.
         _swapCompletedEvent.Set();
     }
 
@@ -828,6 +871,28 @@ internal sealed unsafe class WalCommitBuffer : IDisposable
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int Align8(int value) => (value + 7) & ~7;
+
+    /// <summary>
+    /// Back-pressure loop predicate: must this producer keep waiting before it retries its claim?
+    /// </summary>
+    /// <param name="gotSlot">True if the producer holds an over-capacity claim (CASE B/C); false if it backed out at the claim gate holding nothing.</param>
+    /// <param name="observedGeneration">The value of <see cref="_swapGeneration"/> sampled under the claim gate. Meaningful only when <paramref name="gotSlot"/>.</param>
+    /// <remarks>
+    /// Both arms are deliberately EDGE-FREE — they test a value against a monotonic reference, or test a state directly. Neither can miss a transition that
+    /// happened while this thread was off-CPU, which is what the previous <c>_activeBufferIndex != capturedIndex</c> test could do (see
+    /// <see cref="_swapGeneration"/>).
+    /// <para>
+    /// A backed-out producer must NOT wait on the generation. It claimed nothing, so no swap is owed to it — and the generation it could sample is already
+    /// racing the in-progress swap, which would reintroduce the same missed-edge hazard through a different door. Waiting on the <see cref="SwapDraining"/>
+    /// state and then retrying is both correct and strictly simpler: the state is a level, not an edge.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool WaitingForSwap(bool gotSlot, long observedGeneration)
+        => gotSlot
+            ? Volatile.Read(ref _swapGeneration) == observedGeneration
+            : Volatile.Read(ref _swapState) == SwapDraining;
+
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfDisposed()

--- a/src/Typhon.Engine/Durability/internals/WalWriter.cs
+++ b/src/Typhon.Engine/Durability/internals/WalWriter.cs
@@ -214,11 +214,15 @@ internal sealed unsafe class WalWriter : ResourceNode, IMetricSource
         // via the TLS open-span chain, so the viewer shows "Commit contained a WAL wait of N µs".
         using var waitScope = TyphonEvent.BeginWalWait(lsn);
 
+        var waitStart = Stopwatch.GetTimestamp();
+
         while (Interlocked.Read(ref _durableLsn) < lsn)
         {
             if (!Unsafe.IsNullRef(ref ctx) && ctx.ShouldStop)
             {
-                ThrowHelper.ThrowWalBackPressureTimeout(0, ctx.Deadline.Remaining);
+                // Elapsed, not Deadline.Remaining — Remaining is TimeSpan.Zero whenever ShouldStop is true, so the exception could only
+                // ever say "timeout after 0ms". See the same fix in WalCommitBuffer.TryClaim's back-pressure loop.
+                ThrowHelper.ThrowWalBackPressureTimeout(0, Stopwatch.GetElapsedTime(waitStart));
             }
 
             if (_fatalError != null)

--- a/test/Typhon.Engine.Tests/Durability/WalCommitBufferConcurrencyTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/WalCommitBufferConcurrencyTests.cs
@@ -782,11 +782,13 @@ public class WalCommitBufferConcurrencyTests : AllocatorTestBase
                 }
                 else
                 {
-                    // Park instead of re-trying hot — every other consumer in this fixture does the same. Without it this
-                    // loop burns a whole core polling an empty buffer while `threadCount` producers compete for what is
-                    // left; where threads outnumber cores that starves the producers this consumer exists to unblock,
-                    // until their 20 s claim deadline expires (observed on a 3-core CI runner: producer 0 threw
-                    // WalBackPressureTimeoutException).
+                    // Park instead of re-trying hot — every other consumer in this fixture does the same. Without it this loop burns a
+                    // whole core polling an empty buffer while `threadCount` producers compete for what is left.
+                    //
+                    // This was ALSO once credited with fixing this test's CI failures. It did not: it only narrowed the window. The
+                    // failure was an ABA in WalCommitBuffer's own back-pressure wait (producers keyed on the ping-pong _activeBufferIndex
+                    // and missed a double swap), which is fixed in the engine and pinned by
+                    // BackPressureWait_ProducerLappedByTwoSwaps_IsNotStillWaiting below.
                     buffer.WaitForData(5);
                 }
             }
@@ -858,6 +860,102 @@ public class WalCommitBufferConcurrencyTests : AllocatorTestBase
         var tooBig = WalCommitBuffer.MaxBufferCapacity + 64;
         var ex = Assert.Throws<ArgumentException>(() => _ = CreateBuffer(tooBig));
         Assert.That(ex.Message, Does.Contain("at most"), "the rejection should name the ceiling");
+    }
+
+    /// <summary>
+    /// A producer parked in back-pressure must be released by the swap that serves it, even when the active buffer index has since ping-ponged back to the
+    /// value the producer started from.
+    /// </summary>
+    /// <remarks>
+    /// Regression test. The wait used to be <c>while (_activeBufferIndex == bufferIndex)</c>, an ABA test on a single bit: a producer that was off-CPU while
+    /// TWO swaps completed found the index back at its captured value and went on waiting for an edge that had already passed twice. Nothing recovered it —
+    /// the only thing that advances the index is another producer overflowing the buffer — so once every live producer was in that state the buffer sat
+    /// drained and idle until each deadline expired and threw <c>WalBackPressureTimeoutException</c> on a commit that had space available throughout.
+    /// <para>
+    /// The two swaps below are driven deterministically, so this test does not depend on losing a scheduling race to be meaningful. It asserts the predicate
+    /// directly rather than trying to reproduce the race: reproducing it needed a producer descheduled across two whole swaps, which took a 2-core machine to
+    /// hit and never happened on a developer box (found on a 3-core macOS CI runner; reproduced locally only under a 2-CPU affinity mask).
+    /// </para>
+    /// </remarks>
+    [Test]
+    [CancelAfter(10_000)]
+    public void BackPressureWait_ProducerLappedByTwoSwaps_IsNotStillWaiting()
+    {
+        using var buffer = CreateBuffer(64 * 1024);
+
+        var startIndex = buffer.ActiveBufferIndex;
+        var producerGeneration = buffer.SwapGeneration;
+
+        DriveOneSwap(buffer);
+        DriveOneSwap(buffer);
+
+        Assert.That(buffer.ActiveBufferIndex, Is.EqualTo(startIndex),
+            "two swaps must bring the ping-pong index back to where it started — that is the premise of the bug this test guards.");
+        Assert.That(buffer.SwapGeneration, Is.EqualTo(producerGeneration + 2), "the generation counter must NOT ping-pong");
+        Assert.That(buffer.IsStillWaitingForSwap(producerGeneration), Is.False,
+            "a producer that captured the pre-swap generation has been served twice over; keying the wait on the buffer index instead would leave it "
+            + "blocked here until its deadline expired.");
+    }
+
+    /// <summary>
+    /// Fills the active buffer, has a background producer take the over-capacity claim that requests a swap, and drains until the swap completes.
+    /// </summary>
+    private static void DriveOneSwap(WalCommitBuffer buffer)
+    {
+        const int payloadSize = 200;
+        var frameSize = WalCommitBuffer.Align8(WalFrameHeader.SizeInBytes + payloadSize);
+
+        // Fill to just under capacity. These all take CASE A and never block.
+        while (buffer.TailPosition + frameSize <= buffer.BufferCapacity)
+        {
+            var ctx = WaitContext.FromTimeout(TimeSpan.FromSeconds(5));
+            var claim = buffer.TryClaim(payloadSize, 1, ref ctx);
+            claim.DataSpan.Fill(0xAB);
+            buffer.Publish(ref claim);
+        }
+
+        // The next claim overflows: it writes the padding sentinel, requests the swap and parks. It has to run off-thread because this thread is the
+        // consumer that has to drain before the swap can happen.
+        var startGeneration = buffer.SwapGeneration;
+        Exception producerFailure = null;
+        var producer = new Thread(() =>
+        {
+            try
+            {
+                var ctx = WaitContext.FromTimeout(TimeSpan.FromSeconds(5));
+                var claim = buffer.TryClaim(payloadSize, 1, ref ctx);
+                claim.DataSpan.Fill(0xCD);
+                buffer.Publish(ref claim);
+            }
+            catch (Exception ex)
+            {
+                producerFailure = ex;
+            }
+        })
+        { IsBackground = true };
+        producer.Start();
+
+        // Drain until the swap lands. TryDrain performs it once the drain position reaches the padding sentinel.
+        while (buffer.SwapGeneration == startGeneration)
+        {
+            if (buffer.TryDrain(out var data, out _))
+            {
+                buffer.CompleteDrain(data.Length);
+            }
+            else
+            {
+                buffer.WaitForData(5);
+            }
+        }
+
+        Assert.That(producer.Join(TimeSpan.FromSeconds(5)), Is.True, "the producer that requested the swap should have been released by it");
+        Assert.That(producerFailure, Is.Null, $"producer failed: {producerFailure}");
+
+        // Leave the fresh buffer drained so the next call starts from a clean position.
+        while (buffer.TryDrain(out var rest, out _))
+        {
+            buffer.CompleteDrain(rest.Length);
+        }
     }
 
     #endregion


### PR DESCRIPTION
Closes #647

The first real catch from the macOS arm64 nightly (#624) — and it turned out not to be an arm64 problem at all.

## The bug

A producer whose claim overflows the active WAL buffer parks in `WalCommitBuffer.TryClaim` until a swap gives it a fresh one. It waited on `_activeBufferIndex`:

```csharp
while (_activeBufferIndex == bufferIndex) { ... _swapCompletedEvent.Wait(2); }
```

That index ping-pongs 0↔1. It is an ABA test on a single bit. A producer descheduled while **two** swaps complete finds the index back at the value it captured and goes on waiting for an edge that has already passed — twice.

Nothing recovers it. The only thing that advances the index is *another* producer overflowing the buffer, so once every live producer is parked that way the buffer sits drained and idle until each `WaitContext` deadline expires and throws `WalBackPressureTimeoutException` on a commit that had space available the whole time.

The frozen state from an instrumented run is the whole story:

```
swapState=SwapNormal  activeIdx=0  inflight=0
drainPos=58968  tail=58968        ← fully drained, 64 KiB buffer, nothing pending
prod=[0,151,303,3000,2879,0]      ← producer 3 finished; the other five wedged
```

## Not arm64 — core count

It reproduces on **x64/Windows** under a 2-CPU affinity mask. The variable is core count, not architecture:

| CPUs | Result |
|---|---|
| 1 | passes (2 s) — strict serialisation always leaves another producer runnable to trigger the next swap |
| **2** | **hangs** — 20 s deadline burn |
| 3 | passes (91 ms) — a producer is rarely off-CPU across two whole swaps |

The 16-core gate's hardware is precisely what hid this. The 3-core hosted macOS runner is what surfaced it.

## The fix

Producers wait on `_swapGeneration` — a 64-bit monotonic counter incremented once per completed swap, **sampled under the claim gate**. The Dekker pair with `SwapDraining` guarantees no swap can complete between the sample and the park, so the sampled value is necessarily the generation the claim belongs to. `PerformSwap` increments it **last** — after the new index, the reset claim word and the folded LSN base — so observing a new generation implies observing everything it depends on.

A producer that **backed out at the claim gate holding nothing** no longer waits on a swap at all. It is owed none, and any generation it could sample is already racing the in-progress swap — the same missed-edge hazard through a different door. It waits only while `_swapState == SwapDraining`, then retries. Both arms of the predicate are edge-free by construction.

The loop's bounded `_swapCompletedEvent.Wait(2ms)` backstop did not rescue this and was never going to: a backstop caps a lost *wake-up*; a missed generation is not re-observable however often you re-check.

## Also in here

- **The reporting bug.** Both `ThrowWalBackPressureTimeout` call sites (`WalCommitBuffer`, `WalWriter`) passed `ctx.Deadline.Remaining`, which is `TimeSpan.Zero` *by definition* once `ShouldStop` is true — so the exception could only ever read `timeout after 0ms`. `Deadline` stores the expiry timestamp and not the start, so the waiter has to measure. Now `Stopwatch.GetElapsedTime`. This cost us the one number worth having every time the bug fired, and fixing it first is what made the rest of the investigation legible.
- **A correction.** The `WaitForData(5)` added to this fixture's consumer in f4c7befa was credited with fixing these CI failures. It did not — it only narrowed the window. That comment is corrected rather than left to mislead the next reader.
- **`WP-13`** in `claude/rules/durability.md` (`requires: WP-06`), plus the same point in `WAL-Design.md` §4.5 where the ping-pong swap is introduced. `check-rule-scopes.py` passes. Docs pushed as `Typhon-Claude@e4840ca`.

## Testing

`BackPressureWait_ProducerLappedByTwoSwaps_IsNotStillWaiting` drives two swaps **deterministically** and asserts the predicate directly, rather than trying to lose a scheduling race — reproducing the race needed a producer descheduled across two whole swaps, which never happens on a developer box.

Verified **red against the old index compare** (the producer is never released) and green against the fix.

| Check | Result |
|---|---|
| Pinned 2-CPU repro, the mask that hung | was 5/8 failing → **10/10 then 6/6 green**; 20 s → 45 ms |
| Full engine suite, Debug | 4108 passed, **0 failed**, 56 skipped |
| Full engine suite, Release | 4108 passed, **0 failed**, 56 skipped |
| `check-rule-scopes.py` | all scope symbols resolve |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDPx9FsFqDx3stceu2Rbv3


