### PR TITLE
AntHill demo: fix the ReadsSnapshot<Genetics> schedule error, add an on-screen control reference and a README

### DIFF
--- a/demo/AntHill/AntHill.Core/ECS/Systems/RenderSystems.cs
+++ b/demo/AntHill/AntHill.Core/ECS/Systems/RenderSystems.cs
@@ -41,7 +41,12 @@ internal sealed class FillRenderBufferSystem : QuerySystem
         .Parallel()
         .Reads<WorldBounds>()
         .Reads<AntState>()
-        .ReadsSnapshot<Genetics>()
+        // Genetics is SingleVersion — no MVCC history, so ReadsSnapshot is rejected at Build() (AC-05 / CM-04).
+        // Plain Reads is correct and behaviour-identical here: the sole writer (AntUpdate) sits in the Simulation
+        // phase, so the cross-phase deriver emits the same writer→reader edge ReadsSnapshot did, and a snapshot
+        // read whose writer is in an earlier phase already degenerated to fresh semantics anyway (RFC 07,
+        // "Semantic shift: cross-phase ReadsSnapshot"). Matches Bounds/State above, written by the same system.
+        .Reads<Genetics>()
         .ReadsResource("CameraAABB")
         .ReadsResource("TierMirror")
         .WritesResource("RenderBuffers")

--- a/demo/AntHill/AntHill.Demo/README.md
+++ b/demo/AntHill/AntHill.Demo/README.md
@@ -1,0 +1,251 @@
+# AntHill — Typhon's real-time showcase
+
+**AntHill runs 100,000 ants as live database entities.** Every ant's position, velocity, genome and
+state lives in [Typhon](../../../README.md) — a real-time ACID database engine — and is read, mutated
+and committed **60 times per second** by a scheduled system graph running across 16 worker threads.
+Godot 4 is only the front-end: it draws whatever the database published this tick.
+
+That is the point of the demo. A conventional database would be nowhere near this loop; AntHill exists
+to show that Typhon's transaction, MVCC, spatial-index and scheduling machinery is fast enough to *be*
+the simulation state, not a place you flush it to afterwards.
+
+<!-- Screenshot: drop a capture here when one is current. -->
+
+---
+
+## What you're actually looking at
+
+| | |
+|---|---|
+| **100,000 ants** | 5 colonies, 4 castes (worker / soldier / larva / queen), foraging, fighting, dying, respawning |
+| **5 nests · 50 food sources** | food carried home builds per-nest reserves; sources deplete |
+| **8 spiders** | predators that hunt via a spatial proximity query; once killed they sit out 30 s, then respawn at a random world edge |
+| **Pheromone field** | 1000×1000 cells, 3 channels (food trail / home trail / fight alarm), deposited at 60 Hz, evaporated at 10 Hz |
+| **Fire** | Drossel–Schwabl forest-fire cellular automaton at 10 Hz |
+| **Vegetation** | 100,000 plants that burn and despawn as the fire front passes |
+| **Day/night + Daisyworld** | 600 sim-second cycle driving terrain, ant and sky brightness |
+
+World size is 20,000 simulation units, rendered as a 100 m × 100 m terrain with a procedural Perlin
+heightmap. Ants walk the slopes; the camera refuses to fly below it.
+
+---
+
+## Running it
+
+**Requirements:** [Godot 4.6+ **.NET/Mono** build](https://godotengine.org/download) and the
+**.NET 10 SDK**. (`Godot.NET.Sdk/4.6.2`, `net10.0` — see `AntHill.Demo.csproj`.) On Windows the
+renderer requests D3D12.
+
+**From the Godot editor** — open `demo/AntHill/AntHill.Demo/project.godot`, then <kbd>F5</kbd>.
+
+**From the command line:**
+
+```bash
+godot --path demo/AntHill/AntHill.Demo
+```
+
+**Build only** (useful for a fast compile check without launching):
+
+```bash
+dotnet build demo/AntHill/AntHill.Demo/AntHill.Demo.csproj
+```
+
+The engine creates its database next to the running binary and **deletes it on every startup** — each
+run begins from a fresh spawn. The write-ahead log stays enabled, so the durability cost you see in the
+profiler is real, not an artefact of a disabled WAL.
+
+> Expect a moment of silence at launch while 100,000 entities are spawned and committed.
+
+---
+
+## Controls
+
+Press <kbd>F1</kbd> in-game for this same list, bottom-left. Both come from the same handlers
+(`GameCamera.cs`, `Main._UnhandledInput`) — if they ever disagree, the code wins.
+
+### Camera — free-flight, FPS-style
+
+| Input | Action |
+|---|---|
+| <kbd>W</kbd> <kbd>A</kbd> <kbd>S</kbd> <kbd>D</kbd> | Fly along the camera's own axes — pitch down and <kbd>W</kbd> dives toward the ground |
+| <kbd>Space</kbd> / <kbd>Ctrl</kbd> | Climb / descend on the world axis, independent of where you're looking |
+| <kbd>Shift</kbd> | Sprint |
+| **Right-drag** | Mouselook (yaw + pitch). Cursor is captured until you release |
+| **Mouse wheel** | Adjust *movement speed* — this is a free-cam, not an orbit rig, so there is no zoom |
+| <kbd>T</kbd> | Toggle top-down ↔ isometric tilt |
+| <kbd>Ctrl</kbd>+<kbd>T</kbd> | Cinematic tilt (85°) |
+
+The camera never drops below 2 m of terrain clearance — fly at a hill and it rides over the top.
+
+### Layers & panels
+
+| Input | Action |
+|---|---|
+| <kbd>H</kbd> | Pheromone heatmap overlay on the ground |
+| <kbd>M</kbd> | Minimap (bottom-right) — **click it to fly there** |
+| <kbd>F1</kbd> | Debug HUD + the on-screen control reference |
+| <kbd>Esc</kbd> | Settings panel |
+
+### Time
+
+| Input | Action |
+|---|---|
+| <kbd>`</kbd> | Pause / resume |
+| <kbd>[</kbd> <kbd>]</kbd> | Step speed through 0 · 0.5× · 1× · 2× · 4× · 10× |
+
+Speed is a `dt` multiplier applied inside the system bodies, not a runtime throttle: the engine keeps
+ticking at 60 Hz even at 0×, every system still runs, and frames are still published. Pausing therefore
+freezes the world without freezing the loop — you can fly around a stopped simulation and inspect it,
+and the profiler keeps recording the tick cost of doing nothing.
+
+### God-game tools
+
+Pick a tool, then **left-click the ground** to apply it.
+
+| Key | Tool | Effect |
+|---|---|---|
+| <kbd>1</kbd> | Pointer | Neutral — clicks do nothing |
+| <kbd>2</kbd> | Food | Drop a new food source (8,000 units) |
+| <kbd>3</kbd> | Rock | Place an obstacle ants must path around |
+| <kbd>4</kbd> | Cull | Kill every ant within a 1 m radius |
+| <kbd>5</kbd> | Ignite | Start a fire — watch it spread through the vegetation |
+| <kbd>P</kbd> | Pause | One-shot pause toggle; the palette springs back to Pointer |
+
+Tool clicks are queued from Godot's input thread and drained by `ToolCommandSystem` in the **Input**
+phase, so a placement lands in the *same tick* the simulation runs — no one-frame lag.
+
+Settings offers a *"Snap tools to 1 m grid"* toggle if you want tidy rock walls.
+
+---
+
+## Reading the HUD
+
+Everything below is toggled by <kbd>F1</kbd> (or the settings checkbox — they stay in sync).
+
+**Top-left** — simulation state: time scale, ant and nest counts, foraging vs returning split, food
+sources remaining, food delivered, nest reserves, deaths.
+
+**Below it** — engine and render telemetry: FPS, draw calls, visible ants, per-system tick timings, LOD
+band, and the instance-texture upload size.
+
+**LOD band** tells you which rendering regime you're in, derived from the visible ground width at the
+camera's focus point:
+
+| Band | Visible width | What you get |
+|---|---|---|
+| **Loupe** | < 5 m | Individual ants, full detail |
+| **Foot** | 5 – 30 m | Individuals, cross-fading toward density |
+| **Patch** | > 30 m | Density field — the ant carpet as a heat surface |
+
+**Simulation tiers** (`T0`–`T3` in the HUD) are a different axis: concentric rings around the camera
+that control *simulation* fidelity, not rendering. On-camera cells run every tick at T0; distant cells
+are amortized down to T3, with per-step rate multipliers that keep the time-integrated behaviour
+(pheromone deposits, energy decay) correct despite running less often. This is why 100k ants stay
+affordable — you only pay full price for what you're looking at.
+
+---
+
+## How the demo is built
+
+Three projects, one logical demo:
+
+```
+demo/AntHill/
+├── AntHill.Core/            Simulation + all Typhon usage. ZERO Godot dependency.
+├── AntHill.Demo/            ← you are here. Godot app: rendering, UI, input.
+├── AntHill.Harness/         Headless console runner — same simulation, no renderer.
+└── AntHill.Harness.Tests/   Tests for the harness's scenario tooling.
+```
+
+The Godot-free split is deliberate: it lets `AntHill.Harness` run the identical workload headlessly for
+benchmarking and CI-style validation, and it keeps engine-facing code honest — nothing in `AntHill.Core`
+can quietly reach for a `Node`.
+
+### The tick pipeline
+
+`TyphonBridge.BuildSchedule` declares one DAG named `AntHill` with four phases. Systems declare which
+components and resources they read and write; the engine **derives the dependency graph from those
+declarations** rather than from a hand-maintained edge list, and rejects undeclared conflicts at startup.
+
+| Phase | Systems | Work |
+|---|---|---|
+| **Input** | `ToolCommand`, `EnvironmentTick`, `TierAssignment` | drain tool clicks · advance day/night · re-tier the spatial grid from the camera |
+| **Simulation** | `AntUpdate`, `SpiderUpdate` | the whole ant model in one parallel cluster walk; then predator hunting |
+| **Trail** | `PheroDecay`, `FireTick`, `VegetationTick` | ambient environment sweeps at 10 Hz |
+| **Render** | `AntStatsAggregator`, `PrepareRenderBuffer`, `HeatmapRgbaPack`, `FillRenderBuffer`, `PublishRenderFrame` | aggregate events · downsample the pheromone field · fill per-worker instance buffers · publish the frame |
+
+`AntUpdate` is the hot one — a single walk per cluster doing energy decay and respawn, position
+integration with edge bounce, food/nest interaction, pheromone steering and pheromone deposit, all in
+registers. It replaced a 14-system tier-split topology that paid for redundant cluster walks every tick.
+
+Phases are an ordering *contract*, not a barrier: the scheduler dispatches a later-phase system eagerly
+as soon as its actual data dependencies are satisfied, rather than waiting for the whole phase to drain.
+
+### Simulation ↔ render handoff
+
+Each worker fills its **own** render buffer (12 floats per visible ant) — no locks on the write side.
+`PublishRenderFrame` swaps them into a frame that Godot picks up on its next `_Process`. The renderer
+packs that into a single `MultiMeshInstance3D` plus one RGBA32F state texture at **16 bytes per
+instance**; a vertex shader unpacks position, yaw, colour and flags per ant. One draw call, 100k ants.
+
+### Typhon features on display
+
+| Feature | Where |
+|---|---|
+| ECS archetypes & components | `Ant` = `WorldBounds` + `Velocity` + `Genetics` + `AntState` (`ECS/Archetypes.cs`) |
+| `SingleVersion` storage mode | every AntHill component — no MVCC history needed for entities rewritten every tick |
+| Spatial index | `[SpatialIndex]` on `WorldBounds.Bounds`; 20×20 grid of 1000-unit cells with 5% migration hysteresis |
+| Proximity queries | `EcsQuery.WhereNearby` — spider hunting, food smelling |
+| Declarative system scheduling | `Reads`/`Writes`/`ReadsResource`/`ReadsEvents` → auto-derived DAG |
+| Event queues | `AntDied`, `FoodPickedUp`, `FoodDelivered` → producer→consumer edges in the graph |
+| Parallel chunked systems | `.Parallel().ChunksPerWorker(...)` on the ant walk and the heatmap reduce |
+| WAL durability | enabled, at 60 Hz, under full load |
+| Profiler & tracing | see below |
+
+---
+
+## Profiling
+
+Profiling is configured by [`typhon.telemetry.json`](./typhon.telemetry.json), copied to the output
+directory. It ships with essentially everything on — GC, allocations, CPU sampling, scheduler, tick
+fence, storage, spatial, query.
+
+Pass profiler arguments after Godot's `++` user-arg separator:
+
+```bash
+# Write a trace file
+godot --path demo/AntHill/AntHill.Demo ++ --trace anthill.typhon-trace
+
+# Or open a live TCP session the Workbench can attach to
+godot --path demo/AntHill/AntHill.Demo ++ --live
+```
+
+`--live [port]` takes an optional port; `--live-wait <ms>` blocks startup until a client connects.
+Traces open in the Typhon Workbench, where the System DAG view will show the graph described above —
+including the event-queue arrows between `AntUpdate` and `AntStatsAggregator`.
+
+---
+
+## Headless runs
+
+For benchmarking without a renderer, use the sibling harness:
+
+```bash
+cd demo/AntHill/AntHill.Harness
+dotnet run -c Release -- --duration 10                    # ad-hoc, prints per-system p50/p99
+dotnet run -c Release -- --scenario <scenario.yaml>       # declarative validation scenario
+```
+
+Scenarios can vary ant count, worker count, RNG seed and tier mode — including a `ForceTier0` mode that
+disables camera-distance amortization so the *entire* world runs at full fidelity, which is the
+worst-case stress configuration. See
+[`claude/design/AntHill/ScriptableValidationHarness.md`](../../../claude/design/AntHill/ScriptableValidationHarness.md).
+
+---
+
+## Related reading
+
+- [`claude/overview/13-runtime.md`](../../../claude/overview/13-runtime.md) — the scheduler and system dispatch this demo exercises
+- [`claude/design/Runtime/07-system-access-declarations.md`](../../../claude/design/Runtime/07-system-access-declarations.md) — how access declarations become a DAG
+- [`claude/overview/04-data.md`](../../../claude/overview/04-data.md) — MVCC, component tables, storage modes
+- [`claude/rules/runtime-scheduling.md`](../../../claude/rules/runtime-scheduling.md) — the invariants the schedule is validated against at startup

--- a/demo/AntHill/AntHill.Demo/Scripts/Main.cs
+++ b/demo/AntHill/AntHill.Demo/Scripts/Main.cs
@@ -54,6 +54,7 @@ public partial class Main : Node3D
     // HUD
     private Label _hudLeft;
     private Label _hudRight;
+    private Label _hudHelp;
 
     // Persisted window state — path is a user:// URI so Godot resolves it to the platform app-data dir (on Windows:
     // %APPDATA%/Godot/app_userdata/<project-name>/window_state.cfg), keeping the file out of the project folder and per-user.
@@ -111,7 +112,10 @@ public partial class Main : Node3D
         BuildToolCursor();
 
         _bridge.Start();
-        GD.Print("AntHill: Runtime started. WASD=pan, wheel=zoom, T=tilt, Ctrl+T=cinematic, mid-drag=yaw, `=pause, 1-4=speed, H=pheromone overlay, M=minimap toggle, Esc=settings, F1=debug HUD, tools 1/2/3/4/5/P.");
+        // Deliberately does NOT restate the keybindings: the on-screen cheat-sheet (HelpText) is the single
+        // list, and the copy that used to live here had drifted (it claimed wheel=zoom, mid-drag=yaw and
+        // 1-4=speed — none of which are the current bindings).
+        GD.Print("AntHill: Runtime started. F1 toggles the debug HUD + the on-screen control reference.");
     }
 
     private void BuildSettings()
@@ -127,10 +131,7 @@ public partial class Main : Node3D
         {
             if (_terrain != null) _terrain.ShowPheromone = enabled;
         };
-        _settings.DebugToggled += enabled =>
-        {
-            if (_hudRight != null) _hudRight.Visible = enabled;
-        };
+        _settings.DebugToggled += SetDebugHudVisible;
         _settings.SnapToGridChanged += enabled => _snapToGrid = enabled;
         _settings.LuminosityChanged += val =>
         {
@@ -269,7 +270,62 @@ public partial class Main : Node3D
         StyleLabel(_hudRight, 14);
         hud.AddChild(_hudRight);
 
+        // Keybinding cheat-sheet, bottom-left, visibility tied to the debug HUD (see SetDebugHudVisible).
+        //
+        // Anchored rather than positioned: _hudLeft/_hudRight sit at fixed top-left pixel coords, but this one
+        // must stay glued to the bottom edge across window resizes (the demo persists window state — see
+        // WindowStatePath). Point-anchors at the bottom-left corner (Anchor{Top,Bottom}=1, Anchor{Left,Right}=0)
+        // give a zero-sized rect; GrowVertical=Begin / GrowHorizontal=End then let Godot inflate it to the
+        // label's own minimum size upward and rightward from that corner, so the text block's bottom-left stays
+        // pinned 10 px off both edges no matter how many lines it has.
+        _hudHelp = new Label
+        {
+            Text = HelpText,
+            AnchorLeft = 0f, AnchorRight = 0f, AnchorTop = 1f, AnchorBottom = 1f,
+            OffsetLeft = 10, OffsetRight = 10, OffsetTop = -10, OffsetBottom = -10,
+            GrowHorizontal = Control.GrowDirection.End,
+            GrowVertical = Control.GrowDirection.Begin,
+            Visible = _hudRight.Visible,
+        };
+        StyleLabel(_hudHelp, 13);
+        // Dimmer than the stat HUDs — reference material, not live data.
+        _hudHelp.AddThemeColorOverride("font_color", new Color(0.78f, 0.80f, 0.84f));
+        hud.AddChild(_hudHelp);
+
         AddChild(hud);
+    }
+
+    /// <summary>
+    /// Keybindings, transcribed from the actual handlers: camera from <see cref="GameCamera"/>
+    /// (<c>_UnhandledInput</c> + <c>_Process</c>), everything else from <see cref="_UnhandledInput"/> below.
+    /// Keep in sync when a shortcut moves — this is the only user-facing list.
+    /// </summary>
+    /// <remarks>
+    /// Kept to a narrow column on purpose: the minimap is anchored bottom-right at 256 px (BuildMinimap), so a
+    /// wide block down here would collide with it once the window drops below ~1150 px. Godot's default theme
+    /// font is proportional, which rules out a space-aligned two-column layout — hence one indented column.
+    /// </remarks>
+    private const string HelpText =
+        "Camera\n" +
+        "   WASD fly · Space / Ctrl up-down · Shift sprint\n" +
+        "   right-drag look · wheel move speed\n" +
+        "   T tilt · Ctrl+T cinematic\n" +
+        "Layers\n" +
+        "   H pheromone · M minimap · F1 debug HUD + this help\n" +
+        "Time\n" +
+        "   ` pause · [ ] speed step (0 · 0.5× · 1× · 2× · 4× · 10×)\n" +
+        "Tools\n" +
+        "   1 pointer · 2 food · 3 rock · 4 cull · 5 ignite · P pause\n" +
+        "   left-click applies · Esc settings · click minimap to fly there";
+
+    /// <summary>
+    /// Single owner of debug-overlay visibility: the stat HUD and the keybinding cheat-sheet show and hide
+    /// together. Both the F1 key and the settings checkbox route through here so the two can't drift apart.
+    /// </summary>
+    private void SetDebugHudVisible(bool visible)
+    {
+        if (_hudRight != null) _hudRight.Visible = visible;
+        if (_hudHelp != null) _hudHelp.Visible = visible;
     }
 
     private static void StyleLabel(Label label, int fontSize)
@@ -421,7 +477,14 @@ void fragment() {
                     }
                     break;
                 case Key.M: if (_minimapRect != null) _minimapRect.Visible = !_minimapRect.Visible; break;
-                case Key.F1: if (_hudRight != null) _hudRight.Visible = !_hudRight.Visible; break;
+                case Key.F1:
+                    // Mirrors the H/pheromone route: flip the state, then push it back into the settings
+                    // checkbox so the panel doesn't show a stale tick. Re-entrancy is bounded — assigning
+                    // ButtonPressed the value it already holds emits nothing.
+                    var debugOn = _hudRight == null || !_hudRight.Visible;
+                    SetDebugHudVisible(debugOn);
+                    _settings?.SetDebugToggle(debugOn);
+                    break;
             }
         }
         else if (@event is InputEventMouseButton mb && mb.Pressed && mb.ButtonIndex == MouseButton.Left)

--- a/demo/AntHill/AntHill.Demo/Scripts/SettingsPanel.cs
+++ b/demo/AntHill/AntHill.Demo/Scripts/SettingsPanel.cs
@@ -10,7 +10,7 @@ namespace AntHill.Demo;
 ///   • Time-scale slider (0× / 0.5× / 1× / 2× / 4× / 10×)
 ///   • Tilt mode (90° top-down / 45° iso / 85° cinematic)
 ///   • Pheromone overlay toggle
-///   • Debug overlay toggle (right-side HUD visibility)
+///   • Debug overlay toggle (stat HUD + bottom-left control reference, same visibility — see Main.SetDebugHudVisible)
 /// </summary>
 public partial class SettingsPanel : CanvasLayer
 {
@@ -159,6 +159,12 @@ public partial class SettingsPanel : CanvasLayer
     public void SetPheromoneToggle(bool enabled)
     {
         if (_pheromoneCheck != null) _pheromoneCheck.ButtonPressed = enabled;
+    }
+
+    /// <summary>Push the debug-overlay state back into the checkbox after an F1 press, so the panel never shows a stale tick.</summary>
+    public void SetDebugToggle(bool enabled)
+    {
+        if (_debugCheck != null) _debugCheck.ButtonPressed = enabled;
     }
 
     /// <summary>


### PR DESCRIPTION
## Why

The AntHill demo has failed to start for ~5 weeks:

```
System.InvalidOperationException: System 'FillRenderBuffer' declares ReadsSnapshot<Genetics>,
but 'Genetics' is a SingleVersion component. Snapshot reads require MVCC history — only
Versioned components have it. (CM-04 / runtime-scheduling.md AC-05)
   at Typhon.Engine.RuntimeSchedule.Build(...)
```

Not a recent regression — the two halves have simply been inconsistent since the validation landed:

| Commit | Date | Event |
|---|---|---|
| `a179e510` (#352) | — | added `.ReadsSnapshot<Genetics>()` to `FillRenderBuffer` |
| `cbef4b61` (#392/#395) | 2026-06-26 | added the AC-05 validation → **demo broke here** |
| `3f3b88b1` (#514) | 2026-07-19 | touched the demo (source-gen registry) but nobody ran it |

The `NullReferenceException` flood that follows in `Main._Process` is pure cascade: `_Ready()` aborted before the HUD labels were assigned.

## The fix

`.ReadsSnapshot<Genetics>()` → `.Reads<Genetics>()`. **Behaviour-identical**, not a compromise:

- `AntUpdate` (the sole `Genetics` writer) is in the **Simulation** phase; `FillRenderBuffer` is in **Render**. AC-02 only forbids plain `Reads` against a *same-phase* writer, so this is legal.
- Both variants trigger the identical cross-phase edge `AntUpdate → FillRenderBuffer` (deriver table row 1: `sys_a.Writes<T> ∩ sys_b.{Writes,Reads,ReadsFresh,ReadsSnapshot}<T>`). The DAG is unchanged.
- Per RFC 07 *"Semantic shift: cross-phase ReadsSnapshot"*, a snapshot read whose writer sits in an **earlier** phase already degenerated to `ReadsFresh` semantics. The observed value is the same this-tick value it was before.
- It also removes a self-inconsistency: `WorldBounds` and `AntState` in that same system are written by the same `AntUpdate` and already used plain `Reads`. Only `Genetics` was the odd one out — leftover from when Phase 5 promoted it from `Reads` to `Writes` on the sim side.

## Also in this PR

**On-screen control reference** (bottom-left, toggled with the debug HUD). Anchored rather than positioned — point-anchors at the bottom-left corner with `GrowVertical = Begin` / `GrowHorizontal = End`, so it stays pinned across window resizes (the demo persists window geometry). Kept to a narrow column because the minimap is anchored bottom-right at 256 px.

**Single owner for debug-overlay visibility.** `SetDebugHudVisible()` now drives both the stat HUD and the help panel; `F1` and the settings checkbox both route through it. `F1` additionally pushes state back into the checkbox via the new `SettingsPanel.SetDebugToggle()` — previously `F1` mutated `_hudRight` directly and left the settings panel showing a stale tick. Mirrors how `H`/pheromone already worked.

**Deleted the drifted startup control list.** The `GD.Print` at `Main.cs:114` claimed `wheel=zoom`, `mid-drag=yaw` and `1-4=speed` — none of which are the current bindings (wheel sets camera *move speed*, right-drag is mouselook, `[`/`]` step the time scale, 1-5 select tools). `Space`/`Ctrl` altitude and `Shift` sprint were undocumented entirely. Replaced with a pointer to the on-screen panel rather than a second hand-maintained copy.

**`README.md` for `AntHill.Demo`** — what the demo is and what it simulates, how to run it, the full control reference, how to read the HUD (including LOD bands vs. simulation tiers), the four-phase tick pipeline, the sim→render handoff, profiling via `++ --trace` / `--live`, and the headless harness. Every figure sourced from code; all 7 relative links verified to resolve.

## Verification

- `AntHill.Harness --duration 3` (headless, no Godot): **schedule builds, 181 ticks, clean shutdown**, `FillRenderBuffer` at 526 µs p50.
- `AntHill.Demo` and `AntHill.Harness` both build: 0 warnings, 0 errors.

## Known gap, not addressed here

`grep AntHill .github/workflows/` returns nothing. The demo is in `Typhon.slnx` so it *compiles* in CI, but no job ever calls `RuntimeSchedule.Build()` on it — which is exactly why this class of breakage survived five weeks. A ~1 s smoke test constructing the AntHill runtime and asserting `Build()` succeeds would surface every future AC-0x tightening on the PR that lands it. Left out of this PR deliberately; happy to file it separately.

There is no tracking issue for this — the commit is unprefixed rather than pointing at an invented number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETHnFHUeFTho3EAnXmXNdS