### PR TITLE
Fix five timing-dependent test defects that were failing the arm64 nightly

### DIFF
--- a/test/Typhon.Engine.Tests/Concurrency/AccessControlTests.cs
+++ b/test/Typhon.Engine.Tests/Concurrency/AccessControlTests.cs
@@ -350,6 +350,7 @@ public class AccessControlTests
 
         // Create single WaitContext with 500ms timeout
         var ctx = WaitContext.FromTimeout(TimeSpan.FromMilliseconds(500));
+        var deadlineAtEntry = ctx.Deadline;
 
         // First lock
         var r1 = control1.EnterExclusiveAccess(ref ctx);
@@ -362,8 +363,13 @@ public class AccessControlTests
         var r2 = control2.EnterExclusiveAccess(ref ctx);
         Assert.That(r2, Is.True);
 
-        // The total time used is ~100ms, remaining should be ~400ms
-        Assert.That(ctx.Remaining.TotalMilliseconds, Is.GreaterThan(300), "Remaining time should not restart");
+        // "Not accumulated" is an identity property of the deadline INSTANT, not a duration: restarting the deadline would push the expiry out by another
+        // 500 ms, so comparing the instants tests exactly the thing this fixture is named for, with zero dependence on how fast the machine is. The previous
+        // assertion (Remaining > 300 ms) was a LOWER bound on elapsed time, so it measured the OS scheduler rather than the subject — Thread.Sleep(100) is a
+        // floor, not a duration, and on the loaded 3-core nightly runner it overshot to ~211 ms, leaving 289.18 ms and failing a test whose subject had
+        // behaved perfectly (nightly arm64 run 31075437612, and again in run 30979273000).
+        Assert.That(ctx.Deadline, Is.EqualTo(deadlineAtEntry),
+            "nested Enters must share the original deadline instant — a restart would move the expiry out by another 500 ms");
 
         control2.ExitExclusiveAccess();
         control1.ExitExclusiveAccess();

--- a/test/Typhon.Engine.Tests/Profiler/Events/TraceRecordChainTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/Events/TraceRecordChainTests.cs
@@ -353,6 +353,7 @@ public sealed class TraceRecordChainTests
         // only have 1 byte; we encode a 4-byte sequence number into the record body to verify ordering.
         var producer = Task.Run(() =>
         {
+            var backoff = new SpinWait();
             for (var seq = 0; seq < recordCount; seq++)
             {
                 while (true)
@@ -362,10 +363,13 @@ public sealed class TraceRecordChainTests
                         BinaryPrimitives.WriteUInt16LittleEndian(dst, (ushort)recordSize);
                         BinaryPrimitives.WriteInt32LittleEndian(dst[12..], seq);
                         ringUsed.Publish();
+                        backoff = new SpinWait();
                         break;
                     }
-                    // Pool exhausted — back off briefly to let consumer recycle
-                    Thread.SpinWait(50);
+                    // Pool exhausted — only the CONSUMER can free a slot, so this back-off must hand the core over. Thread.SpinWait is a pause loop that
+                    // never yields the quantum: on a core-starved box the producer burned the whole budget spinning for a consumer that could not get
+                    // scheduled, and the 10 s cap fired (nightly arm64 run 31075437612). SpinWait escalates to Thread.Yield / Sleep(0) / Sleep(1).
+                    backoff.SpinOnce();
                 }
             }
         });
@@ -375,10 +379,12 @@ public sealed class TraceRecordChainTests
         var consumer = Task.Run(() =>
         {
             Span<byte> tmp = new byte[64 * 1024];
+            var backoff = new SpinWait();
             while (consumed.Count < recordCount)
             {
                 var head = slot.ChainHead;
-                if (head == null) { Thread.SpinWait(20); continue; }
+                if (head == null) { backoff.SpinOnce(); continue; }
+                backoff = new SpinWait();
                 int drained = head.Drain(tmp);
                 int pos = 0;
                 while (pos < drained)
@@ -405,8 +411,10 @@ public sealed class TraceRecordChainTests
             }
         });
 
-        Assert.That(Task.WaitAll(new[] { producer, consumer }, TimeSpan.FromSeconds(10)), Is.True,
-            "stress test should complete within 10 s");
+        // A CAP, not an expectation — this completes in well under a second on an idle box. It exists so a genuine producer/consumer livelock fails the test
+        // instead of hanging the run, and it is sized for the 3-core nightly runner rather than for a dev machine.
+        Assert.That(Task.WaitAll(new[] { producer, consumer }, TimeSpan.FromSeconds(60)), Is.True,
+            "stress test should complete within 60 s");
         Assert.That(consumed.Count, Is.EqualTo(recordCount));
         for (var i = 0; i < recordCount; i++)
         {

--- a/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
@@ -223,32 +223,53 @@ public class DagSchedulerTests
         Assert.That(chunkCounter, Is.GreaterThanOrEqualTo(totalChunks));
     }
 
+    // Chunk dispatch is any-worker PULL: workers claim chunks by CAS, and the between-tick wait is a ManualResetEventSlim built with spinCount: 0, so a
+    // worker that is not already running starts from a kernel wait (overview/13-runtime.md §Fence-DAG, §Worker Thread Model). This test used to emit 100
+    // chunks of Thread.SpinWait(50) and assert that more than one thread had picked one up — but that entire workload costs less than a single thread wake,
+    // so ONE worker draining all 100 uncontended is the correct outcome of a pull model, not a scheduler fault. It only ever passed because a 16-core box
+    // happened to have peer workers already spinning; pinned to 3 cores it fails ~40% of the time, and it took the nightly red as a false "regression"
+    // (run 31075437612, previously flaked in run 30790280128 — reproduced locally 3x, Debug and Release).
+    //
+    // Assert the property the scheduler actually owes instead: a chunk queue is claimable by more than one worker. The first worker to arrive PARKS inside
+    // its chunk, so it cannot also drain the rest — the other 99 chunks stay on the queue and a second worker must claim one for the tick to finish. The
+    // park is bounded, so a scheduler that genuinely never dispatches to a second worker fails the assertion below instead of hanging the tick.
     [Test]
+    [CancelAfter(20_000)]
     public void PipelineSystem_MultiWorkerDistribution()
     {
-        var workerThreadIds = new ConcurrentBag<int>();
-        var captured = 0;
         const int totalChunks = 100;
+        const int requiredWorkers = 2;
+        const int rendezvousTimeoutMs = 5_000;
 
-        using var scheduler = NewDag(workerCount: 4)
-            .PipelineSystem("Physics", (chunk, total) =>
-            {
-                if (captured == 0)
-                {
-                    workerThreadIds.Add(Environment.CurrentManagedThreadId);
-                    Thread.SpinWait(50);
-                    if (chunk == total - 1)
-                    {
-                        Interlocked.Exchange(ref captured, 1);
-                    }
-                }
-            }, totalChunks)
-            .Build(_registry.Runtime);
-        RunOneTick(scheduler);
+        var seenWorkers = new ConcurrentDictionary<int, byte>();
+        using var enoughWorkers = new ManualResetEventSlim(false);
 
-        var distinctWorkers = new HashSet<int>(workerThreadIds);
-        Assert.That(distinctWorkers.Count, Is.GreaterThan(1),
-            "Multiple workers should have participated in chunk processing");
+        // Scoped so the scheduler is torn down before the event the system body captures.
+        using (var scheduler = NewDag(workerCount: 4)
+                   .PipelineSystem("Physics", (chunk, total) =>
+                   {
+                       if (enoughWorkers.IsSet)
+                       {
+                           return;
+                       }
+
+                       seenWorkers.TryAdd(Environment.CurrentManagedThreadId, 0);
+                       if (seenWorkers.Count >= requiredWorkers)
+                       {
+                           enoughWorkers.Set();
+                           return;
+                       }
+
+                       enoughWorkers.Wait(rendezvousTimeoutMs);
+                   }, totalChunks)
+                   .Build(_registry.Runtime))
+        {
+            RunOneTick(scheduler);
+        }
+
+        Assert.That(seenWorkers.Count, Is.GreaterThanOrEqualTo(requiredWorkers),
+            $"the first worker parked inside its chunk, leaving {totalChunks - 1} chunks claimable — a second worker must have taken one; seeing only one "
+            + "worker here means chunk dispatch never reaches the other workers at all");
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -288,8 +309,19 @@ public class DagSchedulerTests
         scheduler.Shutdown();
 
         var ticksCompleted = scheduler.CurrentTickNumber;
-        Assert.That(totalChunksProcessed, Is.EqualTo(chunksPerTick * ticksCompleted),
-            $"Each of {ticksCompleted} ticks should process exactly {chunksPerTick} chunks");
+
+        // The chunk counter and CurrentTickNumber are published by DIFFERENT threads — workers vs the tick driver — and the tick number only advances once a
+        // tick's chunks are done, so the pair cannot be sampled atomically: the final tick's chunks are counted while CurrentTickNumber still reads the
+        // previous value. Asserting the exact product therefore failed with "Expected: 70200 But was: 70220" — off by exactly ONE tick of chunks — on a
+        // core-starved box where the test thread was descheduled long enough for thousands of ticks to elapse before SpinUntil observed its condition.
+        // Assert what "chunks reset each tick" actually means, and tolerate exactly that one-tick sampling skew.
+        Assert.That(totalChunksProcessed % chunksPerTick, Is.EqualTo(0),
+            $"every tick must dispatch exactly {chunksPerTick} chunks — a partial tick's worth means chunks leaked across a tick boundary");
+
+        var ticksWorth = totalChunksProcessed / chunksPerTick;
+        Assert.That(ticksWorth, Is.InRange(ticksCompleted, ticksCompleted + 1),
+            $"chunk work must track the tick count — a per-tick reset failure shows up as runaway chunks; saw {ticksWorth} ticks' worth of chunks against "
+            + $"{ticksCompleted} completed ticks");
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -305,6 +337,13 @@ public class DagSchedulerTests
         scheduler.Start();
         SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 3, TimeSpan.FromSeconds(5));
         scheduler.Shutdown();
+
+        // Shutdown() signals and JOINS the workers, but _currentTickNumber++ lives in the tick's telemetry finalizer, which runs on the TIMER thread — so the
+        // tick already in flight when Shutdown() was called can land its increment just after Shutdown() returns. Pinning the baseline immediately raced that
+        // last increment and failed with "Expected: 346 But was: 347" (1 run in 10 pinned to 3 cores). Let the in-flight tick's accounting settle, THEN pin
+        // the baseline. The property under test — that no FURTHER ticks execute — is unaffected and genuinely holds: a probe measured delta 0 across 9 trials
+        // even with a 1 s observation window, so the timer thread stops producing ticks even though only Dispose() actually stops the thread.
+        Thread.Sleep(50);
 
         // Verify the scheduler stopped (no more ticks)
         var tickAfterShutdown = scheduler.CurrentTickNumber;


### PR DESCRIPTION
Test-only change. Three files, +83/−30, no `src/` touched.

The [Aug 6 arm64 nightly](https://github.com/Log2n-io/Typhon/actions/runs/31075437612) went red on `PipelineSystem_MultiWorkerDistribution` and flagged two more tests as flakes. None of the five fixed here is an engine fault — every one asserts a property of a moving target by sampling it, and three sample two independently-published values and assert an exact relationship between them.

## The fixes

| Test | Was | Now |
|---|---|---|
| `PipelineSystem_MultiWorkerDistribution` | hoped a 2nd worker won a race | first worker **parks** in its chunk, forcing 99 to stay claimable |
| `NestedCalls_ShareWaitContext_…` | `Remaining > 300 ms` — a lower bound on elapsed time | `ctx.Deadline` instant equality — exact, machine-speed independent |
| `PipelineSystem_ChunksResetEachTick` | exact product of two independently-published counters | whole ticks + count within the one-tick sampling skew |
| `Shutdown_Clean` | baseline sampled before the in-flight tick's accounting landed | settle, then pin the baseline |
| `SpscStress…MaintainsOrdering` | `Thread.SpinWait` back-off + 10 s cap | `SpinWait.SpinOnce()` (yields) + documented livelock cap |

### Why `MultiWorkerDistribution` was unfixable as written

Chunk dispatch is any-worker **pull** with a CAS claim, and the between-tick wait is a `ManualResetEventSlim` built with `spinCount: 0` — so a worker that is not already running starts from a kernel wait. That costs more than the test's entire 100-chunk `Thread.SpinWait(50)` workload. One worker draining all 100 uncontended is the *correct* outcome of a pull model; the assertion was pinned on an OS scheduling accident and passed only because a 16-core box happened to have peers already spinning.

Validated by reverting to `workerCount: 1`, where it fails as a clean assertion (not a hang) with its diagnostic message.

### Why the `Deadline` fix is the interesting one

"The deadline is shared, not restarted" is an **identity** property of an instant, not a duration. Comparing `WaitContext.Deadline` before and after makes the assertion exact and unfalsifiable by a slow runner. Widening the tolerance instead would have kept the test flaky *and* hidden a real restart bug behind the slack.

### `Shutdown_Clean` — the one that looked like an engine bug

`Shutdown()`'s XML doc claims it "stops the timer thread." It doesn't — only `Dispose()` does. A throwaway probe measured **zero** further ticks across 9 trials even over a 1 s window, so the timer keeps *running* but stops *producing ticks*: the observable contract holds and only the doc wording is loose. Test-side sampling defect, not an engine defect.

## Verification

- **12/12 pinned to three physical cores** — the condition that broke them. It was 1/10 failing before the `Shutdown_Clean` fix (which surfaced during this verification, hence five and not four).
- `PipelineSystem_MultiWorkerDistribution` reproduced 3× locally before the fix, Debug and Release.
- **Full suite: 4268 passed, 0 failed** (also re-run in the worktree after rebasing onto `76fb0c8b`).

## Deliberately not included

The one **genuine engine defect** this nightly surfaced is filed as **#688** — a Versioned HEAD reading `0` instead of `500` after an unclean reopen of a mixed cluster archetype. That is silent data loss on the recovery path and needs its own fix, not a test change. It is P1, and it is not touched here.

Also unaddressed, and not filed: shard3 shows an intermittent multi-minute stall under core starvation in Release (27 s baseline, observed 263 s and 552 s). Unexplained; worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyk6dYYGXN4u1NfDL85Ayj