### PR TITLE
Stop DagScheduler.Shutdown stranding worker and timer threads that then spin a core forever

### DIFF
--- a/src/Typhon.Engine/Runtime/public/DagScheduler.Logging.cs
+++ b/src/Typhon.Engine/Runtime/public/DagScheduler.Logging.cs
@@ -28,4 +28,17 @@ public sealed partial class DagScheduler
     [LoggerMessage(Level = LogLevel.Warning,
         Message = "Overload level changed: {PreviousLevel} -> {NewLevel} at tick {TickNumber}")]
     private partial void LogOverloadLevelChanged(OverloadLevel previousLevel, OverloadLevel newLevel, long tickNumber);
+
+    // Error, not Warning: the thread is still alive and still consuming CPU, and nothing will ever reclaim it. Silence here is what let stranded workers
+    // accumulate one per shutdown until the process was starved of cores.
+    [LoggerMessage(Level = LogLevel.Error,
+        Message = "Worker {WorkerId} (thread {ManagedThreadId}) did not exit within the shutdown join window and is still running — it will keep consuming CPU "
+                  + "for the lifetime of this process")]
+    private partial void LogWorkerJoinTimeout(int workerId, int managedThreadId);
+
+    // Expected only when Shutdown races a tick dispatch, which leaves systems nobody will ever run. The work of that tick is lost — say so, rather than
+    // letting a silently truncated tick look like a clean stop.
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "Track {TrackIndex} was abandoned during shutdown with {SystemsRemaining} system(s) unfinished — that tick's work did not complete")]
+    private partial void LogTickDrainAbandonedOnShutdown(int trackIndex, int systemsRemaining);
 }

--- a/src/Typhon.Engine/Runtime/public/DagScheduler.cs
+++ b/src/Typhon.Engine/Runtime/public/DagScheduler.cs
@@ -250,7 +250,21 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
     private int _tickGeneration;
     private int _tickInProgress;
+    /// <summary>
+    /// Set once to stop the worker pool. Every access goes through <see cref="Volatile"/> — this is the stop signal two SPIN loops key on (the worker's
+    /// within-tick dispatch loop and the timer thread's completion barrier in <c>DispatchTrackMultiThreaded</c>), and a plain read inside a spin loop may be
+    /// hoisted out of it by the JIT once tiered compilation optimises the method, after which the thread can never observe the store. On arm64 the plain
+    /// store carries no ordering guarantee either. Cheap: acquire/release are plain movs on x64, and this is read once per spin iteration, never per element.
+    /// </summary>
     private int _workerShutdown;
+
+    /// <summary>
+    /// How long the tick-completion barrier tolerates a STALL — no system completing at all — after shutdown has been requested, before abandoning the tick.
+    /// Not a cap on tick duration: the timer resets on every completion, so an actively-progressing tick is never cut short however slow its systems are.
+    /// Sits well under <c>JoinWorkers</c>'s 5 s join window on purpose — the barrier must give up FIRST so it can clear <c>_tickInProgress</c> and release
+    /// the workers, which then exit inside their own window.
+    /// </summary>
+    private static readonly TimeSpan ShutdownDrainGrace = TimeSpan.FromMilliseconds(250);
     private CacheLinePaddedInt _systemsRemaining;
     private long _nextTickTimestamp;       // Used by GetNextTick for metronome advancement
     private long _currentTickNumber;
@@ -362,7 +376,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     /// <inheritdoc />
     protected override long GetNextTick()
     {
-        if (_workerShutdown != 0)
+        if (Volatile.Read(ref _workerShutdown) != 0)
         {
             return long.MaxValue;
         }
@@ -379,7 +393,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     /// <inheritdoc />
     protected override void ExecuteCallbacks(long scheduledTick, long actualTick)
     {
-        if (_workerShutdown != 0)
+        if (Volatile.Read(ref _workerShutdown) != 0)
         {
             return;
         }
@@ -681,14 +695,23 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     }
 
     /// <summary>
-    /// Shuts down the scheduler: stops accepting new ticks, waits for the current tick to finish, joins worker threads, then stops the timer thread.
+    /// Stops the worker pool: signals shutdown, releases any worker parked between ticks, and joins them.
+    /// <para>
+    /// A tick already in flight is ABANDONED, not drained. That is not a choice so much as an admission: this method signals every worker to stop before it
+    /// waits, so the systems remaining in that tick have nobody left to run them, and "waiting for the current tick to finish" could only ever mean waiting
+    /// forever. A caller that needs the in-flight tick's work to land must stop dispatching and let the tick complete BEFORE calling this.
+    /// </para>
+    /// <para>
+    /// Does NOT stop the timer thread — <see cref="Dispose(bool)"/> does, via the base class. The thread stays alive but stops producing ticks, so
+    /// <see cref="CurrentTickNumber"/> is stable once this returns.
+    /// </para>
     /// </summary>
     public void Shutdown()
     {
         LogShutdownRequested();
 
         // Signal workers to exit
-        _workerShutdown = 1;
+        Volatile.Write(ref _workerShutdown, 1);
         Interlocked.Increment(ref _tickGeneration);
         _tickStartSignal.Set(); // Wake any blocked workers
 
@@ -707,7 +730,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
         if (disposing)
         {
             // Ensure workers are signaled to stop
-            _workerShutdown = 1;
+            Volatile.Write(ref _workerShutdown, 1);
             Interlocked.Increment(ref _tickGeneration);
             _tickStartSignal.Set();
             JoinWorkers();
@@ -1125,7 +1148,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
         var lastGen = _tickGeneration;
 
-        while (_workerShutdown == 0)
+        while (Volatile.Read(ref _workerShutdown) == 0)
         {
             // ═══ Between-tick: kernel wait on signal ═══
             // Workers block here with zero CPU cost. The timer thread signals _tickStartSignal when the next tick fires. Wake latency is ~1-5µs
@@ -1134,7 +1157,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             var btStart = Stopwatch.GetTimestamp();
             while (_tickGeneration == lastGen)
             {
-                if (_workerShutdown != 0)
+                if (Volatile.Read(ref _workerShutdown) != 0)
                 {
                     betweenTickSpan.WakeReason = 1; // shutdown
                     var btEnd = Stopwatch.GetTimestamp();
@@ -1155,7 +1178,7 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
                 TyphonEvent.EmitSchedulerWorkerWake((byte)workerId, (uint)Math.Min(btUs2, uint.MaxValue));
             }
 
-            if (_workerShutdown != 0)
+            if (Volatile.Read(ref _workerShutdown) != 0)
             {
                 return;
             }
@@ -1175,6 +1198,10 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
             // Started when idleSpins first goes from 0 → 1; ended when work is found.
             var idleSpan = default(SchedulerWorkerIdleEvent);
             var idleSpellStart = 0L;
+            // Deliberately NOT gated on _workerShutdown: a worker that is mid-tick must finish the tick, or shutdown silently drops the work of the tick in
+            // flight (it cost a real regression to learn this — Telemetry_ReadyTick_NotInflatedBySibling went red with ReadyTick 0 because the last tick was
+            // abandoned). The escape hatch is _tickInProgress, which the completion barrier in DispatchTrackMultiThreaded now always clears — including when
+            // it gives up on a tick that can no longer complete. That is what stops this loop spinning forever.
             while (_tickInProgress == 1 && _systemsRemaining.Value > 0)
             {
                 var sysIdx = FindReadySystem();
@@ -1910,13 +1937,24 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
     // Helpers
     // ═══════════════════════════════════════════════════════════════
 
+    /// <summary>
+    /// Joins the worker threads, bounded so a wedged worker cannot hang the caller forever. A worker that misses its join window is REPORTED: discarding
+    /// <see cref="Thread.Join(TimeSpan)"/>'s result is what turned a transient shutdown hang into permanent silent damage — the thread stays alive spinning
+    /// at ~100% of a core for the life of the process while Shutdown returns as though it had stopped cleanly, so the cost lands on whatever runs next.
+    /// </summary>
     private void JoinWorkers()
     {
-        foreach (var worker in _workers)
+        for (var i = 0; i < _workers.Length; i++)
         {
-            if ((worker.ThreadState & System.Threading.ThreadState.Unstarted) == 0)
+            var worker = _workers[i];
+            if ((worker.ThreadState & System.Threading.ThreadState.Unstarted) != 0)
             {
-                worker.Join(TimeSpan.FromSeconds(5));
+                continue;
+            }
+
+            if (!worker.Join(TimeSpan.FromSeconds(5)))
+            {
+                LogWorkerJoinTimeout(i, worker.ManagedThreadId);
             }
         }
     }
@@ -2056,11 +2094,42 @@ public sealed partial class DagScheduler : HighResolutionTimerServiceBase
 
         // Wait for the track's systems to complete. The timer thread must spin — Thread.Yield() on Windows can stall up to 15.6 ms, cascading into every
         // subsequent tick.
+        //
+        // This wait used to be UNBOUNDED, and there is a race that makes it unsatisfiable. Shutdown() bumps _tickGeneration — the same field workers use to
+        // detect a new tick — so a Shutdown landing between the Increment above and the workers waking makes every worker take the `_workerShutdown != 0`
+        // exit in WorkerLoop and return WITHOUT processing a single system. _systemsRemaining then never reaches 0, and this loop span forever at ~100% of a
+        // core for the remaining life of the process, while JoinWorkers() timed out, discarded its result, and let Shutdown() report success. On a machine
+        // with spare cores nobody noticed; pinned to the 3 cores of the arm64 nightly runner, each leaked spinner permanently removed a third of the box and
+        // the suite eventually failed VSTest's heartbeat and was killed as "Test host process crashed".
+        //
+        // Normal operation is untouched: nothing below runs until shutdown has been requested. After that the drain is bounded by STALL, not by elapsed time
+        // — the clock resets every time a system completes, so a tick that is still making progress is never cut short no matter how slow its systems are,
+        // while the unsatisfiable case (no worker left to decrement anything) gives up one grace period after the last completion. Bounding on elapsed time
+        // instead charged the full grace to every occurrence and cost ~2 s per race; bounding on stall charges it once, only when genuinely stuck.
+        var lastRemaining = -1;
+        var stallStart = 0L;
         while (_systemsRemaining.Value > 0)
         {
+            if (Volatile.Read(ref _workerShutdown) != 0)
+            {
+                var remaining = _systemsRemaining.Value;
+                if (remaining != lastRemaining)
+                {
+                    lastRemaining = remaining;
+                    stallStart = Stopwatch.GetTimestamp();
+                }
+                else if (Stopwatch.GetElapsedTime(stallStart) > ShutdownDrainGrace)
+                {
+                    LogTickDrainAbandonedOnShutdown(trackIndex, remaining);
+                    break;
+                }
+            }
+
             Thread.SpinWait(1);
         }
 
+        // Always cleared, including on the abandoned path above — this is the escape hatch the workers' within-tick dispatch loop keys on, so leaving it set
+        // would strand every worker still inside the tick.
         _tickInProgress = 0;
         _tickStartSignal.Reset();
     }

--- a/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/DagSchedulerTests.cs
@@ -352,6 +352,77 @@ public class DagSchedulerTests
             "No more ticks should execute after shutdown");
     }
 
+    // Regression: a scheduler lifecycle must not leave a thread running. Shutdown() bumps _tickGeneration — the same field workers use to detect a new tick —
+    // so a Shutdown landing on a tick dispatch made every worker take the shutdown exit WITHOUT processing a system. _systemsRemaining never reached 0, the
+    // timer thread's completion barrier span forever at ~100% of a core, and JoinWorkers() timed out, discarded its result and let Shutdown() report success.
+    // One core lost per occurrence, permanently, silently.
+    //
+    // Invisible on a dev box — 32 cores absorb it and the suite still passes in 50 s. On the 3-core arm64 nightly runner the spinners accumulated until the
+    // host could not answer VSTest's heartbeat and was killed as "Test host process crashed", after silently dropping ~160 tests. This asserts the property
+    // directly: threads created by the cycles below must all be gone or idle afterwards, because a leaked spinner burns a core forever.
+    // Sensitive: the assertion is a CPU-duty measurement, so it belongs in the gate's serial pass rather than beside 40 other fixtures competing for cores.
+    // 200 cycles is not padding — at 20 the race never fired on a 32-core box and the test passed with the bug still present, which is worse than no test.
+    [Test]
+    [CancelAfter(60_000)]
+    [NonParallelizable]
+    [Category("Sensitive")]
+    public void SchedulerLifecycle_RacingShutdownAgainstTick_LeavesNoRunningThread()
+    {
+        const int cycles = 200;
+
+        static Dictionary<int, TimeSpan> SnapshotThreads()
+        {
+            var map = new Dictionary<int, TimeSpan>();
+            foreach (System.Diagnostics.ProcessThread t in System.Diagnostics.Process.GetCurrentProcess().Threads)
+            {
+                // A thread can die between enumeration and access; it is then not one of ours to worry about.
+                try { map[t.Id] = t.TotalProcessorTime; } catch { /* exited */ }
+            }
+            return map;
+        }
+
+        var before = SnapshotThreads();
+
+        // Shutdown deliberately lands as close to a tick dispatch as possible — that is the race. 20 cycles at 1 kHz makes hitting it near-certain; before the
+        // fix this leaked roughly one spinner every few cycles.
+        for (var i = 0; i < cycles; i++)
+        {
+            using var registry = new ResourceRegistry(new ResourceRegistryOptions { Name = $"LeakProbe{i}" });
+            using var scheduler = NewDag(workerCount: 4)
+                .CallbackSystem("A", _ => { })
+                .CallbackSystem("B", _ => { }, after: "A")
+                .Build(registry.Runtime);
+            scheduler.Start();
+            SpinWait.SpinUntil(() => scheduler.CurrentTickNumber >= 1, TimeSpan.FromSeconds(5));
+            scheduler.Shutdown();
+        }
+
+        // Measure over a window with nothing of ours running: any thread born during the cycles that is still burning CPU is a leak. Duty, not total CPU, so a
+        // busy CI box running other fixtures cannot fail this — only a thread spinning on its own can.
+        var settle = SnapshotThreads();
+        Thread.Sleep(500);
+        var after = SnapshotThreads();
+
+        var spinners = new List<string>();
+        foreach (var (tid, cpuAfter) in after)
+        {
+            if (before.ContainsKey(tid) || !settle.TryGetValue(tid, out var cpuSettle))
+            {
+                continue; // pre-existing thread, or born during the measurement window itself
+            }
+
+            var duty = (cpuAfter - cpuSettle).TotalMilliseconds / 500.0;
+            if (duty >= 0.5)
+            {
+                spinners.Add($"tid {tid} at {duty * 100:F0}% duty");
+            }
+        }
+
+        Assert.That(spinners, Is.Empty,
+            "every thread created by a scheduler lifecycle must be stopped by Shutdown/Dispose — a survivor spins on a core for the life of the process: "
+            + string.Join(", ", spinners));
+    }
+
     [Test]
     public void SingleThreadedMode_Works()
     {


### PR DESCRIPTION
This is the root cause of the "intermittent multi-minute shard3 stall" flagged in #689. It was never a stall, and never memory.

## The bug

`Shutdown()` bumps `_tickGeneration` to wake parked workers — **the same field workers use to detect that a new tick started**. So a `Shutdown()` landing on a track dispatch makes every worker wake, take the `_workerShutdown` exit, and return **without processing a single system**.

`_systemsRemaining` never reaches 0. The timer thread's completion barrier in `DispatchTrackMultiThreaded` had no bound and no shutdown check, so it span there at **~100% of a core for the rest of the process's life**. `JoinWorkers()` then waited 5 s per worker, **discarded `Join`'s return value**, and let `Shutdown()` report success.

One core lost per occurrence. Permanently. With no error anywhere.

## Why it only ever hurt CI

On 32 cores a few spinners vanish into idle capacity and the suite still passes in 50 s. Pinned to the 3 cores of the arm64 nightly runner, measured during a hung run:

| t | hot threads | share of process CPU |
|---|---|---|
| 145 s | 4 | **97%** |
| 182 s | 6 | — |

Born at +6.7 s, +8.7 s, +11.0 s and +37.5 s — inside `ChunksPerWorkerTests` and `DagSchedulerTests` — and still burning at 57–89% duty minutes after those fixtures finished. Per-test cost rose ~450× across the run (deciles 1–8 normal at 10–35 ms; decile 10 at 9,137 ms mean, max 26 s). The host then failed VSTest's heartbeat and was killed as *"Test host process crashed"*, having **silently dropped 164 of 547 tests while `dotnet test` still printed `Passed!`**.

Ruled out along the way, with measurements: disk (152 GB free), handles, thread count, and memory — healthy runs peaked **higher** than hung ones (3,428 MB vs 2,119–2,492 MB).

## The fix

**Bound the barrier on stall, not elapsed time.** Nothing changes until shutdown is requested; after that the clock resets on every system completion, so a tick still making progress is never cut short however slow its systems are, while one that can no longer complete gives up 250 ms after the last completion, logs it, and clears `_tickInProgress` — the escape hatch the workers' own dispatch loop keys on.

**`_workerShutdown` is `Volatile` at every access.** It's the stop signal two spin loops key on; a plain read in a spin loop is hoistable once tiering optimises the method, and on arm64 the plain store carries no ordering guarantee at all.

**`JoinWorkers()` no longer discards `Join`'s result** — a missed window is logged at Error. That discarded bool is exactly what converted a transient hang into permanent silent damage.

**Corrected `Shutdown()`'s XML doc**, which claimed it waits for the current tick and stops the timer thread. Neither was true.

### Two approaches tried and rejected — both recorded in the code

- **Gating the workers' within-tick loop on `_workerShutdown`** abandons the in-flight tick instead of draining it, and broke `Telemetry_ReadyTick_NotInflatedBySibling` (`ReadyTick = 0`). The old code drained correctly whenever draining was *possible*; it only span forever when it was impossible. Trading a hang for silently dropped work is not an improvement in a database.
- **Bounding on elapsed time** charged the full grace to every occurrence: 168 s → 24 s against a ~10 s baseline. Stall-based bounding charges nothing to a healthy tick.

## Verification

| | before | after |
|---|---|---|
| 3-fixture pinned repro | 168 s, 5 accumulating spinners | **8–9 s, hot=0** — 5/5 runs |
| shard3 pinned ×6 | **3/6 hung** at 900 s, 0 tests recorded | **0/6 hung**, 547/547 every run |
| full suite | 4268 | **4269 passed, 0 failed** |

**The regression test needs its 200 cycles.** At 20 the race never fired on a 32-core box and the test passed *with the bug still present* — worse than no test. Validated by restoring the unbounded behaviour, where it fails with 7 threads at ~100% duty; passes 3/3 with the fix. Marked `Category("Sensitive")` so the gate runs it in the serial pass, since the assertion is a CPU-duty measurement.

## Note

No issue was filed for this — it went straight from investigation to fix. Happy to open one retroactively for the board if you want the trail.

Unrelated, seen once during verification on a heavily loaded box (79 GB commit baseline, host peaked at 10.7 GB): `SpscStressWithChainExtension_MaintainsOrdering` hit its 60 s cap. Five of six iterations ran it clean. Flagging, not claiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyk6dYYGXN4u1NfDL85Ayj