### PR TITLE
Give the by-name reopen fixtures unique databases, and stop the SPSC consumer busy-spinning

### DIFF
--- a/test/Typhon.Engine.Tests/Data/ECS/ClusterMigrationTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/ClusterMigrationTests.cs
@@ -619,7 +619,7 @@ class ClusterMigrationTests : TestBase<ClusterMigrationTests>
     [Test]
     public void ReopenAfterMigration_RebuildsMappingFromNewPosition()
     {
-        var dbName = $"T_ClMigReopen_{Environment.ProcessId}";
+        var dbName = NewUniqueDatabaseName("T_ClMigReopen");
 
         int dstCellKey;
         int srcCellKey;

--- a/test/Typhon.Engine.Tests/Data/ECS/ClusterSpatialCoherenceTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/ClusterSpatialCoherenceTests.cs
@@ -410,7 +410,7 @@ class ClusterSpatialCoherenceTests : TestBase<ClusterSpatialCoherenceTests>
     [Test]
     public void Reopen_RebuildsClusterCellMap_FromPersistedData()
     {
-        var dbName = $"T_ClusterCellRebuild_{Environment.ProcessId}";
+        var dbName = NewUniqueDatabaseName("T_ClusterCellRebuild");
 
         int cellKey1, cellKey2;
         int chunkId1, chunkId2;

--- a/test/Typhon.Engine.Tests/Data/ECS/ClusterSpatialTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/ClusterSpatialTests.cs
@@ -638,7 +638,7 @@ class ClusterSpatialTests : TestBase<ClusterSpatialTests>
     [Test]
     public void Reopen_PerArchetypeSpatialLoaded_QueryWorks()
     {
-        var dbName = $"T_ClSpatialReopen_{Environment.ProcessId}";
+        var dbName = NewUniqueDatabaseName("T_ClSpatialReopen");
         EntityId id1, id2;
 
         // Session 1: create database, spawn entities

--- a/test/Typhon.Engine.Tests/Profiler/Events/TraceRecordChainTests.cs
+++ b/test/Typhon.Engine.Tests/Profiler/Events/TraceRecordChainTests.cs
@@ -384,7 +384,6 @@ public sealed class TraceRecordChainTests
             {
                 var head = slot.ChainHead;
                 if (head == null) { backoff.SpinOnce(); continue; }
-                backoff = new SpinWait();
                 int drained = head.Drain(tmp);
                 int pos = 0;
                 while (pos < drained)
@@ -395,6 +394,7 @@ public sealed class TraceRecordChainTests
                     pos += size;
                 }
                 // Walk: if head empty AND has Next, recycle and advance
+                var advanced = false;
                 if (head.IsEmpty)
                 {
                     var next = head.Next;
@@ -406,7 +406,22 @@ public sealed class TraceRecordChainTests
                         {
                             SpilloverRingPool.Release(spent);
                         }
+                        advanced = true;
                     }
+                }
+
+                // Back off only on a pass that made NO progress — nothing drained and no spillover retired. That case, not `head == null`, is the consumer's
+                // dominant wait: ChainHead is the primary buffer and non-null from the first iteration, so keying the back-off on null (and resetting the
+                // spinner every other iteration) left "the producer hasn't written yet" spinning hot with no yield at all — 8-10x slower under core
+                // contention, and invisible when the test runs alone with a core to spare, which is why it survived review. The back-off deliberately sits
+                // AFTER the recycle above: an empty head with a successor is progress, and skipping the advance to back off early would wedge the drain.
+                if (drained == 0 && !advanced)
+                {
+                    backoff.SpinOnce();
+                }
+                else
+                {
+                    backoff = new SpinWait();
                 }
             }
         });

--- a/test/Typhon.Engine.Tests/TestBase.cs
+++ b/test/Typhon.Engine.Tests/TestBase.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -429,6 +430,55 @@ abstract class TestBase<T> : TestBase
     /// </summary>
     protected virtual void ConfigureEngineOptions(DatabaseEngineOptions o) => TestWalProfile.Apply(o, _testDatabaseDir);
 
+    /// <summary>
+    /// A database name unique to this run, for the reopen fixtures that build their own engine by name (they need one name that is stable across the two
+    /// sessions of a single test, but never shared with any other run).
+    /// <para>
+    /// These names used to be keyed on <c>Environment.ProcessId</c>, which is not unique: the OS recycles PIDs, and nothing deleted the databases afterwards.
+    /// That was harmless while CI ran on ephemeral runners — a fresh workspace each run cannot collide with anything — and became a real failure once the gate
+    /// moved to the persistent self-hosted runner (#466), where <c>bin/Release/net10.0/</c> accumulates bundles across runs AND across engine format
+    /// versions. A recycled PID then finds not merely stale data but a file the current engine refuses to open:
+    /// <c>"Incompatible database format: file version 4, engine version 5"</c>, which is how this surfaced.
+    /// </para>
+    /// </summary>
+    protected string NewUniqueDatabaseName(string prefix)
+    {
+        var name = $"{prefix}_{Guid.NewGuid():N}";
+        _namedDatabases.Add(name);
+        return name;
+    }
+
+    /// <summary>Names handed out by <see cref="NewUniqueDatabaseName"/>, drained by <see cref="TearDown"/> so cleanup still happens when a test throws.</summary>
+    private readonly List<string> _namedDatabases = [];
+
+    /// <summary>
+    /// Removes both halves of a database created via <see cref="NewUniqueDatabaseName"/>: the bundle under
+    /// <see cref="PagedMMFOptions.DatabaseDirectory"/> (the process working directory, i.e. the test bin folder) and the separate WAL directory those
+    /// fixtures place under the temp path. Unique names alone stop the collisions; deleting stops the disk filling — 784 stale WAL directories had piled up
+    /// locally by the time this was found. Best-effort: a failure here must never fail a test that otherwise passed.
+    /// </summary>
+    private static void DeleteNamedDatabase(string dbName)
+    {
+        foreach (var path in new[]
+                 {
+                     Path.Combine(Environment.CurrentDirectory, dbName + ".typhon"),
+                     Path.Combine(Path.GetTempPath(), dbName)
+                 })
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch
+            {
+                // ignored — leftover files are untidy, a failed cleanup masking a real result would be worse
+            }
+        }
+    }
+
     [TearDown]
     public virtual void TearDown()
     {
@@ -437,6 +487,14 @@ abstract class TestBase<T> : TestBase
 
         // Clean up the database file after each test to prevent accumulation
         CleanupDatabaseFile();
+
+        // Same for any by-name database a fixture built for itself — those bypass CleanupDatabaseFile entirely, which is how 784 stale WAL directories
+        // accumulated locally. Runs after the ServiceProvider dispose above, since an open data handle blocks the recursive delete.
+        foreach (var dbName in _namedDatabases)
+        {
+            DeleteNamedDatabase(dbName);
+        }
+        _namedDatabases.Clear();
     }
 
     private void CleanupDatabaseFile()


### PR DESCRIPTION
Test-only. Two unrelated defects, both latent for a long time and both activated by the *environment* rather than by any code change.

## 1 — `Reopen_RebuildsClusterCellMap_FromPersistedData`: not a spatial bug

It flaked in #689's gate. The actual error, from the gate's trx:

```
System.InvalidOperationException : Incompatible database format: file version 4, engine version 5.
File: .../bin/Release/net10.0/T_ClusterCellRebuild_2662.typhon/data
```

The database was named `T_ClusterCellRebuild_{Environment.ProcessId}` and nothing ever deleted it, so a recycled PID reopened a bundle written by an **older engine format** — thrown before any rebuild ran. **Nothing to do with #688**, and nothing to do with spatial.

> **Why now.** This could not bite while CI used ephemeral runners: a fresh workspace each run collides with nothing. Moving the gate to the persistent self-hosted runner (#466) made `bin/Release/net10.0/` accumulate bundles across runs *and across format versions*, at which point a PID collision stopped being harmless. The test never changed; its environment did.

Three fixtures shared the pattern, all reopen tests needing one name stable across two sessions: `ClusterSpatialCoherenceTests`, `ClusterMigrationTests`, `ClusterSpatialTests`.

`TestBase` now hands out a GUID-suffixed name and drains the ones it handed out in `TearDown`, deleting **both** halves — the bundle under the working directory, and the separate WAL directory these fixtures place under the temp path. Unique names remove the collision; the deletion stops the accumulation, which stood at **784 stale WAL directories** locally. Cleanup runs after the `ServiceProvider` dispose (an open `data` handle blocks the recursive delete) and swallows failures — untidy leftovers beat a failed cleanup masking a real result.

## 2 — `SpscStress…MaintainsOrdering`: the yield fix missed the consumer

The back-off added in #689 fixed the producer and keyed the consumer's on `head == null` — a branch essentially never taken, since `ChainHead` is the primary buffer and non-null from the first iteration. The dominant wait — *the producer hasn't written yet* — fell through and spun hot with no yield at all, resetting the spinner every iteration.

It now backs off on any pass that made **no progress**: nothing drained and no spillover retired. The check deliberately sits *after* the recycle step rather than short-circuiting to it — an empty head with a successor is progress, and backing off early there would wedge the drain.

| two pinned cores + 3 CPU burners | test duration |
|---|---|
| before | 352–409 ms |
| after | **173–285 ms** |

Alone it takes 23–55 ms either way — which is exactly why a hot spin in the dominant path survived review. It costs nothing until something else wants the core.

**What this does not explain:** the observed 60 s failure was on a box at **79 of 84 GB commit** with the host peaked at 10.7 GB, so memory pressure from other work remains the likelier cause. The busy-spin is worth removing on its own merits and the 60 s cap looks correctly sized — neither claim rests on that one occurrence.

## Verification

- The three fixtures pass and leave **zero** directories behind. (PID-named ones did appear during the run — they belong to another agent building concurrently on the same box, which is itself a nice confirmation of the collision mechanism.)
- Full suite **4269 passed, 0 failed**, twice. A third run had one failure I did not capture before it re-ran clean; flagging rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lyk6dYYGXN4u1NfDL85Ayj