### PR TITLE
Run the OLC stress fixture in CI, and stop multi-component WhereField answering wrongly

### DIFF
--- a/src/Typhon.Engine/Ecs/public/EcsQuery.cs
+++ b/src/Typhon.Engine/Ecs/public/EcsQuery.cs
@@ -356,12 +356,35 @@ public unsafe struct EcsQuery<TArchetype> where TArchetype : class
     /// Filter entities by an indexed-field predicate, enabling incremental view refresh via <see cref="ViewDeltaRingBuffer"/>.
     /// The expression is parsed into <see cref="FieldEvaluator"/> for boundary crossing detection. Requires indexed fields.
     /// </summary>
+    /// <remarks>
+    /// Chained calls AND together, and every call must target the SAME component — a second call naming a different one throws. Predicates are merged into
+    /// one branch set that records field names but not which component each came from, so a cross-component chain has no way to resolve correctly; see the
+    /// guard below. To filter on a second component use <see cref="Where{T}"/>, which opens the entity and reads each component by its own type.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// <typeparamref name="T"/> is not registered, or a previous <c>WhereField</c> on this query targeted a different component.
+    /// </exception>
     public EcsQuery<TArchetype> WhereField<T>(Expression<Func<T, bool>> predicate) where T : unmanaged
     {
         var ct = _tx.DBE.GetComponentTable<T>();
         if (ct == null)
         {
             throw new InvalidOperationException($"Component type {typeof(T).Name} is not registered.");
+        }
+
+        // Reject a second WhereField on a DIFFERENT component instead of answering it wrongly. Each call's branches are cross-producted into one flat
+        // FieldPredicate[][] below, and a FieldPredicate carries only a field NAME — never the component it came from — while _whereComponentTable is
+        // overwritten by whichever call ran last. So every predicate ends up resolved against the LAST component: a name unique to the first component
+        // throws deep in QueryResolverHelper, and a name both components share (Code, Score, Level...) resolves silently against the wrong one and the
+        // query returns the wrong rows. The information is not mis-propagated, it is never captured, so there is nothing to recover at execution time.
+        // Cross-component predicates ARE supported — through ExpressionParser.Parse<T1, T2>, which splits by lambda PARAMETER (see NavigationQueryBuilder).
+        // Routing WhereField through that is a feature, tracked separately; until then, raising beats a silent wrong answer.
+        if (_whereComponentTable != null && !ReferenceEquals(_whereComponentTable, ct))
+        {
+            throw new InvalidOperationException(
+                $"WhereField cannot combine predicates on two different components ('{_whereComponentTable.Definition.Name}' then "
+                + $"'{ct.Definition.Name}'). Chained WhereField calls must all target the same component. Use Where<T>(...) for the second component — "
+                + "it evaluates per entity and composes correctly across components.");
         }
 
         var branches = ExpressionParser.ParseDnf(predicate);

--- a/test/Typhon.Engine.Tests/Data/ECS/MultiWhereFieldTests.cs
+++ b/test/Typhon.Engine.Tests/Data/ECS/MultiWhereFieldTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using System;
+using System.Runtime.InteropServices;
+using Typhon.Schema.Definition;
+
+namespace Typhon.Engine.Tests;
+
+// Two components on ONE archetype, each carrying an indexed field that shares a name with the other's (Code) and one that does not (AlphaOnly / BetaOnly).
+// The shared name is the point: EcsQuery.WhereField merges every call's predicate branches into one flat FieldPredicate[][], and FieldPredicate stores only
+// a field NAME - no component identity - while _whereComponentTable is overwritten by each call. So a second WhereField on a different component leaves the
+// FIRST call's predicates to be resolved against the SECOND call's component. A name that exists on both resolves silently against the wrong one.
+[Component("Typhon.Test.ECS.MultiWhere.Alpha", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+struct MwfAlpha
+{
+    [Index(AllowMultiple = true)] public int Code;
+    [Index(AllowMultiple = true)] public int AlphaOnly;
+
+    public MwfAlpha(int code, int alphaOnly)
+    {
+        Code = code;
+        AlphaOnly = alphaOnly;
+    }
+}
+
+[Component("Typhon.Test.ECS.MultiWhere.Beta", 1, StorageMode = StorageMode.SingleVersion)]
+[StructLayout(LayoutKind.Sequential)]
+struct MwfBeta
+{
+    [Index(AllowMultiple = true)] public int Code;
+    [Index(AllowMultiple = true)] public int BetaOnly;
+
+    public MwfBeta(int code, int betaOnly)
+    {
+        Code = code;
+        BetaOnly = betaOnly;
+    }
+}
+
+[Archetype]
+class MwfArch : Archetype<MwfArch>
+{
+    public static readonly Comp<MwfAlpha> Alpha = Register<MwfAlpha>();
+    public static readonly Comp<MwfBeta> Beta = Register<MwfBeta>();
+}
+
+/// <summary>
+/// Characterises what two <c>WhereField</c> calls on DIFFERENT components actually do - review item 29, design §9.6.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing in the suite chained two <c>WhereField</c> calls before this fixture: 293 call sites across the test project, none of them a second call on the
+/// same query. That is why the behaviour below was never observed.
+/// </para>
+/// <para>
+/// <c>Where</c> (the opaque, per-entity form) composes correctly across components and is used here as the oracle - it opens the entity and reads each
+/// component by its own type, so it cannot confuse two of them.
+/// </para>
+/// </remarks>
+[TestFixture]
+class MultiWhereFieldTests : TestBase<MultiWhereFieldTests>
+{
+    private const int Count = 40;
+
+    /// <summary>Alpha.Code = i, Beta.Code = 1000 + i, so a predicate meant for one is trivially distinguishable from the same predicate against the other.</summary>
+    private DatabaseEngine SetupEngine()
+    {
+        var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();
+        dbe.RegisterComponentFromAccessor<MwfAlpha>();
+        dbe.RegisterComponentFromAccessor<MwfBeta>();
+        dbe.InitializeArchetypes();
+
+        using var tx = dbe.CreateQuickTransaction();
+        for (var i = 0; i < Count; i++)
+        {
+            tx.Spawn<MwfArch>(
+                MwfArch.Alpha.Set(new MwfAlpha(i, i)),
+                MwfArch.Beta.Set(new MwfBeta(1000 + i, 1000 + i)));
+        }
+        tx.Commit();
+
+        return dbe;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // What ships today: the guard. A cross-component chain raises instead of answering.
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void MultiWhereField_DifferentComponent_Throws()
+    {
+        using var dbe = SetupEngine();
+        using var tx = dbe.CreateQuickTransaction();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            tx.Query<MwfArch>()
+                .WhereField<MwfAlpha>(a => a.Code >= 30)
+                .WhereField<MwfBeta>(b => b.Code >= 1000));
+
+        // The message must name BOTH components: the whole failure mode is that the second call silently captured the first's predicates, so a message
+        // naming only one of them would leave the reader guessing which call was the problem.
+        Assert.That(ex.Message, Does.Contain("Typhon.Test.ECS.MultiWhere.Alpha"));
+        Assert.That(ex.Message, Does.Contain("Typhon.Test.ECS.MultiWhere.Beta"));
+        Assert.That(ex.Message, Does.Contain("Where<T>"), "the message must point at the API that does compose across components");
+    }
+
+    [Test]
+    public void MultiWhereField_SameComponent_StillChains()
+    {
+        using var dbe = SetupEngine();
+        using var tx = dbe.CreateQuickTransaction();
+
+        // Two calls on ONE component are the case the cross-product was built for, and the guard must not touch it: last-wins on _whereComponentTable is
+        // harmless when both calls resolve to the same table.
+        var chained = tx.Query<MwfArch>()
+            .WhereField<MwfAlpha>(a => a.Code >= 10)
+            .WhereField<MwfAlpha>(a => a.AlphaOnly < 20)
+            .Execute();
+
+        var oracle = tx.Query<MwfArch>()
+            .Where<MwfAlpha>(a => a.Code >= 10 && a.AlphaOnly < 20)
+            .Execute();
+
+        Assert.That(oracle.Count, Is.EqualTo(10), "oracle sanity: i in 10..19");
+        Assert.That(chained.SetEquals(oracle), Is.True, "chained WhereField on the SAME component must keep ANDing correctly");
+    }
+
+    [Test]
+    public void MultiWhereField_MixedWithWhere_ComposesAcrossComponents()
+    {
+        using var dbe = SetupEngine();
+        using var tx = dbe.CreateQuickTransaction();
+
+        // The documented way to filter a second component today — and the one the guard's message recommends. It must actually work.
+        var mixed = tx.Query<MwfArch>()
+            .WhereField<MwfAlpha>(a => a.Code >= 30)
+            .Where<MwfBeta>(b => b.Code >= 1000)
+            .Execute();
+
+        var oracle = tx.Query<MwfArch>()
+            .Where<MwfAlpha>(a => a.Code >= 30)
+            .Where<MwfBeta>(b => b.Code >= 1000)
+            .Execute();
+
+        Assert.That(oracle.Count, Is.EqualTo(10), "oracle sanity");
+        Assert.That(mixed.SetEquals(oracle), Is.True, "WhereField on one component + Where on another must compose");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Acceptance tests for #693 — what correct cross-component WhereField looks like.
+    // Ignored, not deleted: they are the specification the fix has to satisfy.
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    [Ignore("#693 — cross-component WhereField is guarded, not implemented. Un-Ignore with the fix.")]
+    public void MultiWhereField_SharedFieldName_MatchesBroadScan()
+    {
+        using var dbe = SetupEngine();
+        using var tx = dbe.CreateQuickTransaction();
+
+        // Alpha.Code >= 30 selects i in 30..39 (10 entities). Beta.Code >= 1000 selects all 40. The AND is 10.
+        var actual = tx.Query<MwfArch>()
+            .WhereField<MwfAlpha>(a => a.Code >= 30)
+            .WhereField<MwfBeta>(b => b.Code >= 1000)
+            .Execute();
+
+        var oracle = tx.Query<MwfArch>()
+            .Where<MwfAlpha>(a => a.Code >= 30)
+            .Where<MwfBeta>(b => b.Code >= 1000)
+            .Execute();
+
+        Assert.That(oracle.Count, Is.EqualTo(10), "oracle sanity: the broad scan must see the two components separately");
+        Assert.That(actual.Count, Is.EqualTo(oracle.Count),
+            "two WhereField calls on different components must AND their predicates against their OWN components");
+        Assert.That(actual.SetEquals(oracle), Is.True, "and must select the same entities as the broad scan");
+    }
+
+    [Test]
+    [Ignore("#693 — cross-component WhereField is guarded, not implemented. Un-Ignore with the fix.")]
+    public void MultiWhereField_SharedFieldName_OrderIndependent()
+    {
+        using var dbe = SetupEngine();
+        using var tx = dbe.CreateQuickTransaction();
+
+        // AND is commutative, so swapping the two calls must not change the answer. It does if the last call decides whose fields both predicates read.
+        var alphaFirst = tx.Query<MwfArch>()
+            .WhereField<MwfAlpha>(a => a.Code >= 30)
+            .WhereField<MwfBeta>(b => b.Code >= 1000)
+            .Execute();
+
+        var betaFirst = tx.Query<MwfArch>()
+            .WhereField<MwfBeta>(b => b.Code >= 1000)
+            .WhereField<MwfAlpha>(a => a.Code >= 30)
+            .Execute();
+
+        Assert.That(alphaFirst.SetEquals(betaFirst), Is.True, "AND is commutative — call order must not change the result set");
+    }
+
+    [Test]
+    [Ignore("#693 — cross-component WhereField is guarded, not implemented. Un-Ignore with the fix.")]
+    public void MultiWhereField_DistinctFieldNames_MatchesBroadScan()
+    {
+        using var dbe = SetupEngine();
+        using var tx = dbe.CreateQuickTransaction();
+
+        var oracle = tx.Query<MwfArch>()
+            .Where<MwfAlpha>(a => a.AlphaOnly >= 30)
+            .Where<MwfBeta>(b => b.BetaOnly >= 1000)
+            .Execute();
+
+        Assert.That(oracle.Count, Is.EqualTo(10), "oracle sanity");
+
+        var actual = tx.Query<MwfArch>()
+            .WhereField<MwfAlpha>(a => a.AlphaOnly >= 30)
+            .WhereField<MwfBeta>(b => b.BetaOnly >= 1000)
+            .Execute();
+
+        Assert.That(actual.SetEquals(oracle), Is.True,
+            "AlphaOnly exists on neither the other component nor its field table — this must not silently drop or mis-resolve either predicate");
+    }
+}

--- a/test/Typhon.Engine.Tests/Data/OlcBTreeStressTests.cs
+++ b/test/Typhon.Engine.Tests/Data/OlcBTreeStressTests.cs
@@ -8,14 +8,33 @@ namespace Typhon.Engine.Tests;
 
 /// <summary>
 /// Stress tests for OLC (Optimistic Lock Coupling) B+Tree concurrency.
-/// These tests use 16-32 threads to exercise split/merge/restart/fallback paths
-/// that rarely trigger under light contention (2-8 threads in OlcBTreeTests).
+/// Thread counts are derived from <see cref="Environment.ProcessorCount"/> (see WideThreads / NarrowThreads) rather than fixed, so the fixture stays
+/// oversubscribed — and therefore meaningful — on both a 32-vCPU CI box and a 3-core hosted runner. Contrast OlcBTreeTests, which runs 2-8 threads.
 /// </summary>
+// NonParallelizable, NOT Explicit. The fixture oversubscribes the box with threads and was marked [Explicit] to keep it from saturating the thread pool
+// alongside the parallel fixtures — but [Explicit] does not merely deprioritise a test, it removes it from every unfiltered run, so this had not run in CI
+// since 2026-02. It is the B+Tree's only real concurrency guard, and #679 (a concurrent insert losing a key and leaving the tree inconsistent) went
+// unnoticed for that entire window. [NonParallelizable] buys the same isolation the [Explicit] reason was actually asking for: NUnit runs this fixture on
+// its own, never concurrently with another, so the thread pool is not contended. Measured: 0.94-1.12 s for all 8 tests, slowest single test 230-276 ms
+// against its [CancelAfter(5000)] budget — 18x headroom idle, and still 10.9x with 28 busy processes pinning a 32-CPU box.
 [TestFixture]
-[Explicit("Stress test — spawns 16-32 threads, run manually to avoid thread pool saturation in parallel CI")]
+[NonParallelizable]
 public class OlcBTreeStressTests
 {
     private IServiceProvider _serviceProvider;
+
+    // Thread counts scale with the box instead of being pinned at 16/32. What makes this fixture worth running is OVERSUBSCRIPTION — more runnable threads
+    // than cores, so the scheduler preempts a thread inside the OLC read/validate window and the optimistic-restart and pessimistic-fallback paths actually
+    // execute. A hard 32 delivers that on the 32-vCPU gate box and on a dev machine, but the macOS arm64 nightly runs this same shard plan on a 3-core
+    // hosted runner (bench/aws/shard.py:32-34). At 3 cores, 32 threads is no longer contention — it is ~10x oversubscription, which mostly buys scheduler
+    // thrash and wall time rather than any interleaving the 2x case does not already produce.
+    //
+    // 2x cores keeps the oversubscription the tests depend on. The floor of 8 protects the assertion that a mixed workload MUST produce optimistic restarts:
+    // below that there is too little concurrency to guarantee one, and the test would fail for lack of contention rather than for a defect. The ceiling of 32
+    // reproduces today's numbers EXACTLY everywhere the suite currently runs — at >= 16 logical CPUs this is Wide 32 / Narrow 16, unchanged.
+    private static readonly int WideThreads = Math.Clamp(Environment.ProcessorCount * 2, 8, 32);
+
+    private static readonly int NarrowThreads = Math.Max(4, WideThreads / 2);
 
     [SetUp]
     public void Setup()
@@ -72,21 +91,23 @@ public class OlcBTreeStressTests
     }
 
     // ========================================
-    // B4 — Mixed Read-Write (128 threads total)
+    // B4 — Mixed Read-Write (readers + inserters + removers, WideThreads total)
     // ========================================
 
     [Test]
     [CancelAfter(5000)]
-    public unsafe void Stress_MixedReadWrite_32Threads()
+    public unsafe void Stress_MixedReadWrite()
     {
         using var mpmmf = _serviceProvider.GetRequiredService<ManagedPagedMMF>();
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 200, sizeof(Index32Chunk));
 
-        const int readerCount = 20;
-        const int inserterCount = 6;
-        const int removerCount = 6;
-        const int totalThreads = readerCount + inserterCount + removerCount; // 32
+        // Same 20 : 6 : 6 split the fixed counts encoded, expressed as a ratio. Removers walk 501 + threadId * 10 for 10 keys each, so the removed span stays
+        // inside the 501..1000 half and never touches the 1..500 range the readers assert on, for any remover count up to 50.
+        var inserterCount = Math.Max(2, WideThreads / 5);
+        var removerCount = Math.Max(2, WideThreads / 5);
+        var readerCount = WideThreads - inserterCount - removerCount;
+        var totalThreads = WideThreads;
         const int initialKeys = 1000;
 
         var setupDepth = epochManager.EnterScope();
@@ -108,7 +129,7 @@ public class OlcBTreeStressTests
             var tasks = new Task[totalThreads];
             int taskIndex = 0;
 
-            // 80 readers: read from safe range 1..500 (never removed)
+            // Readers: sample the safe range 1..500, which no remover touches.
             for (int t = 0; t < readerCount; t++)
             {
                 var seed = t * 17;
@@ -139,7 +160,7 @@ public class OlcBTreeStressTests
                 }, TaskCreationOptions.LongRunning);
             }
 
-            // 24 inserters: insert from range 100_000+
+            // Inserters: disjoint blocks from 100_000+, 20 keys each.
             for (int t = 0; t < inserterCount; t++)
             {
                 var threadId = t;
@@ -165,7 +186,7 @@ public class OlcBTreeStressTests
                 }, TaskCreationOptions.LongRunning);
             }
 
-            // 24 removers: remove from range 501..1000 (disjoint per thread)
+            // Removers: disjoint 10-key blocks from 501 upward, all inside the half the readers never read.
             for (int t = 0; t < removerCount; t++)
             {
                 var threadId = t;
@@ -218,7 +239,7 @@ public class OlcBTreeStressTests
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 200, sizeof(Index32Chunk));
 
-        const int threadCount = 32;
+        var threadCount = WideThreads;
         const int keysPerThread = 150;
         int sharedCounter = 0;
 
@@ -302,8 +323,8 @@ public class OlcBTreeStressTests
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 200, sizeof(Index32Chunk));
 
-        const int writerCount = 16;
-        const int readerCount = 16;
+        var writerCount = WideThreads / 2;
+        var readerCount = WideThreads - writerCount;
         const int keysPerWriter = 200;
         int sharedCounter = 0;
 
@@ -423,13 +444,13 @@ public class OlcBTreeStressTests
 
     [Test]
     [CancelAfter(5000)]
-    public unsafe void Stress_MoveSameLeaf_16Threads()
+    public unsafe void Stress_MoveSameLeaf()
     {
         using var mpmmf = _serviceProvider.GetRequiredService<ManagedPagedMMF>();
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 200, sizeof(Index32Chunk));
 
-        const int threadCount = 16;
+        var threadCount = NarrowThreads;
         const int slotsPerThread = 800;   // exclusive range size per thread (wide gap avoids shared boundary leaves)
         const int keysPerThread = 200;    // only even slots populated
         const int movesPerThread = 200;   // move all keys: even→odd
@@ -512,13 +533,13 @@ public class OlcBTreeStressTests
     // Cross-leaf Move exercises the dual-lock path (lock two leaves in ChunkId order).
     [Test]
     [CancelAfter(5000)]
-    public unsafe void Stress_MoveCrossLeaf_16Threads()
+    public unsafe void Stress_MoveCrossLeaf()
     {
         using var mpmmf = _serviceProvider.GetRequiredService<ManagedPagedMMF>();
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 200, sizeof(Index32Chunk));
 
-        const int threadCount = 16;
+        var threadCount = NarrowThreads;
         const int keysPerThread = 200;
         const int movesPerThread = 50;
 
@@ -597,13 +618,13 @@ public class OlcBTreeStressTests
 
     [Test]
     [CancelAfter(5000)]
-    public unsafe void Stress_MoveValueTailConsistency_32Threads()
+    public unsafe void Stress_MoveValueTailConsistency()
     {
         using var mpmmf = _serviceProvider.GetRequiredService<ManagedPagedMMF>();
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 200, sizeof(Index32Chunk));
 
-        const int threadCount = 32;
+        var threadCount = WideThreads;
         const int sourceKeyCount = 200;
         const int valuesPerKey = 3;
 
@@ -696,14 +717,14 @@ public class OlcBTreeStressTests
 
     [Test]
     [CancelAfter(5000)]
-    public unsafe void Stress_EnumerationDuringMutation_16Threads()
+    public unsafe void Stress_EnumerationDuringMutation()
     {
         using var mpmmf = _serviceProvider.GetRequiredService<ManagedPagedMMF>();
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 200, sizeof(Index32Chunk));
 
-        const int writerCount = 8;
-        const int enumeratorCount = 8;
+        var writerCount = NarrowThreads / 2;
+        var enumeratorCount = NarrowThreads - writerCount;
         const int insertsPerWriter = 50;
         const int initialKeys = 500;
 
@@ -829,7 +850,7 @@ public class OlcBTreeStressTests
         using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
         var segment = mpmmf.AllocateChunkBasedSegment(PageBlockType.None, 100, sizeof(Index32Chunk));
 
-        const int writerCount = 8;
+        var writerCount = Math.Max(2, NarrowThreads / 2);
         const int batchSize = 10;
         const int batchCount = 5;
         const int initialKeys = 500;


### PR DESCRIPTION
The two code items from the post-#629 "cheap and worth doing" list. The third item on that list — board Status on issues that had none — needed no code and is already applied.

## #679 — the stress fixture had not run in CI since February

`OlcBTreeStressTests` was `[Explicit]`, which does not deprioritise a test, it removes it from every unfiltered run. It is the B+Tree's only real concurrency guard, so **#679 had no mechanism to be caught**. Now `[NonParallelizable]`, which buys the isolation the `[Explicit]` reason was actually asking for.

**Proven, not assumed:** an unfiltered suite goes 4361 → 4369 tests, exactly +8. Running the fixture with `--filter` proves nothing — an explicit filter *selects* `[Explicit]` tests and passes identically either way. That was my first check and it was worthless.

The gate reaches it through `shard.py`'s catch-all shard (the class is not in `shards.json`). Why `[Explicit]` survived there is documented at `shard.py:35` — NUnit runs such tests only when it reads the filter as naming them, and the gate's 305-term filter does not qualify.

### Thread counts now scale with the box

`Wide = clamp(ProcessorCount * 2, 8, 32)`, `Narrow = Wide / 2`, with each test's existing ratios preserved. **At ≥16 logical CPUs this reproduces today's 32/16 exactly**, so the gate box and a dev machine are unaffected. The case it fixes is the macOS arm64 nightly, which runs this same shard plan on a **3-core** hosted runner where 32 threads is ~10× oversubscription — scheduler thrash rather than useful interleaving.

The floor of 8 is load-bearing: below it there is too little concurrency to guarantee `OptimisticRestarts > 0`, and a stress test that stops stressing is worse than one that is skipped, because it reports green.

| CPUs | Wide / Narrow | result | total | slowest test |
|---|---|---|---|---|
| 32 (native) | 32 / 16 | 8/8 | 974 ms | 264 ms |
| 3 (simulated) | 8 / 4 | 8/8 | 287 ms | 68 ms |
| 2 (simulated) | 8 / 4 | 8/8 | 275 ms | 97 ms |

Five repeats at 3 cores all green. Under 28 busy processes pinning the box the slowest test degrades **1.7×** to 458 ms — still 10.9× inside its `CancelAfter(5000)` budget, so the thread-pool-saturation concern that motivated `[Explicit]` does not survive measurement.

Simulating with `DOTNET_PROCESSOR_COUNT` scales the threads down while leaving 32 real cores, so it is the **lowest**-contention case the floor can produce — the hard direction for the restart assertion, and it still passes. On real 3-core hardware those 8 threads are 2.7× oversubscribed, so contention is higher, not lower.

## #693 — multi-component `WhereField` returns wrong rows

Review item 29, listed as suspected and unverified. **It reproduces.**

| case | result |
|---|---|
| shared field name | **expected 10, got 40** — silent wrong answer |
| swap the two calls | result set **changes** — AND is not commutative |
| distinct names | throws from `QueryResolverHelper` |

The cause is an absence, not a mis-propagation: each call's branches are cross-producted into one flat `FieldPredicate[][]`, but a `FieldPredicate` carries only a field **name**, and `_whereComponentTable` is last-wins. Which component a predicate belonged to was never captured, so there is nothing to recover at execution time.

**This ships the guard, not the fix.** A second `WhereField` naming a different `ComponentTable` now raises, naming both components and pointing at `Where<T>`, which composes correctly across components. Nothing that worked is affected — the cross-component chain either threw or lied. Same principle as `IX-03`: the loud version of a failure that is otherwise silent and permanent.

The real fix is tracked as **#693**. Cross-component predicates already work elsewhere — `ExpressionParser.Parse<T1, T2>` splits by lambda *parameter* and `NavigationQueryBuilder` consumes it — so the work is giving `EcsQuery` that same per-predicate tracking.

**Nothing in the suite chained two `WhereField` calls before this**: 293 call sites, not one a second call on the same query. Six tests added — three for the guard and for the same-component and mixed `WhereField`/`Where` cases that must keep working, plus three acceptance tests for correct behaviour, `[Ignore]`d against #693 with `Where<T>` as the oracle.

## Verification

Full suite **4311 passed / 0 failed / 64 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaAaGuu1GgTpFKNnYVD5Bd
