### PR TITLE
#722 Repoint the quarantined view test at an open issue — fixes main

### DIFF
--- a/test/Typhon.Engine.Tests/Runtime/SystemInputViewLivenessTests.cs
+++ b/test/Typhon.Engine.Tests/Runtime/SystemInputViewLivenessTests.cs
@@ -95,9 +95,13 @@ class SystemInputViewLivenessTests : TestBase<SystemInputViewLivenessTests>
     /// publishes membership to it. Making this green needs direction 1 of #718 — a lifecycle-level notification channel views subscribe to by archetype —
     /// which is a design change to the view subsystem. Rewriting it to call Refresh() first would make it assert that RefreshPull works, which was never in
     /// doubt.
+    /// <para>
+    /// Tracked as #722 since #718 closed with the system-input half. The parent's title is about systems and that part is fixed; this is the residual, split
+    /// out rather than kept alive on a closed issue.
+    /// </para>
     /// </remarks>
     [Test]
-    [Ignore("#718 — a pull View nobody refreshes is still frozen; needs the lifecycle notification channel (direction 1), not the per-tick refresh.")]
+    [Ignore("#722 — a pull View nobody refreshes is still frozen; needs the lifecycle notification channel (direction 1), not the per-tick refresh.")]
     public void ViewCreatedBeforeTheSpawns_ConvergesWithOneCreatedAfter()
     {
         var dbe = ServiceProvider.GetRequiredService<DatabaseEngine>();


### PR DESCRIPTION
Fixes `main`, red since `4956f242` on `invariants`:

```
IGNORE_CLOSED_ISSUE - 1 violation(s)
  SystemInputViewLivenessTests.cs:100: [Ignore] references #718, which is CLOSED
```

Depends on **log2n-io/typhon-claude#72** (docs-first).

## What happened

PR #721 said `Closes #718` and left `ViewCreatedBeforeTheSpawns_ConvergesWithOneCreatedAfter` quarantined against #718 for direction 1, which it deliberately did not implement. My error — the quarantine reason literally says "needs direction 1" and I still let the message close the issue.

## Why the PR gate could not catch it

The lint passed on #721 (**#718 was open then**) and failed on `main` (**the merge closed it**). Any change that both closes an issue and leaves an `[Ignore]` pointing at it is green before merge and red after. Same shape as the cross-repo deadlock #70 fixed: a check evaluated against a world the merge changes.

Worth a companion to `closing-keywords` that asks whether anything in the tree still cites what the message closes. Not in this PR.

## The fix

The lint's own message prescribes it: *"that is a NEW defect and needs a new issue, not a stale reference."* And the two cases really are distinct:

| | |
|---|---|
| **fixed — #718's headline** | *a system's* input view is re-queried every tick; `SystemInputView_SeesEntitiesSpawnedWhileTheRuntimeIsRunning` green |
| **open — new #722** | a pull View held by *user* code that nobody refreshes is still a snapshot |

Reopening #718 would also have cleared the lint, and would have misrepresented merged work: the P0 it was filed for is fixed.

#722 carries the reason direction 1 is a design and not a repair — `ViewRegistry` is keyed per indexed **field**, every publisher iterates fields to find subscribers, and an unfiltered query has no field to register under. Typed Bug, P2, Area Query, Estimate L.

## Verified

```
lint-test-suppressions.py    clean
suite                        5055/0/13
```

One run also lost `ConcurrentAllocateAndFree_MaintainsConsistency` — a named victim of #720. It passes in isolation and the re-run was clean; recorded rather than ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FE5GUBSF5D1DhyPAuTBbYk