### PR TITLE
Reject a suppression that cites what the same change closes

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -375,7 +375,10 @@ jobs:
       pull-requests: read
       issues: read
     steps:
+      - uses: actions/checkout@v5
+
       - name: Reject closing keywords that target a pull request
+        id: keywords
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -414,6 +417,10 @@ jobs:
             | grep -oiE '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]+#[0-9]+' \
             | grep -oE '#[0-9]+' | tr -d '#' | sort -un || true)
 
+          # Published for the companion step below, and written BEFORE the early exit so the empty case is explicit
+          # rather than an absent output.
+          echo "closes=$(printf '%s' "$NUMS" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+
           if [ -z "$NUMS" ]; then
             echo "No closing keywords found — nothing to check."
             exit 0
@@ -451,6 +458,30 @@ jobs:
             exit 1
           fi
           echo "Closing keywords: all target issues. OK."
+
+      # ── The companion: nothing in the tree may still CITE what this PR closes ────────────────────────────
+      # `IGNORE_CLOSED_ISSUE` (in `invariants`) asks whether a suppression's issue is closed RIGHT NOW. On a PR that
+      # closes #N and leaves an `[Ignore("#N")]` behind, #N is still open while the PR is open — so that check passes,
+      # the merge closes #N, and the identical check reddens `main` minutes later. Green before merge, red after, with
+      # no run in between that could have caught it. Measured: PR #721 closed #718 with the suppression still in the
+      # tree; `invariants` passed on the PR and failed on main at 22:32.
+      #
+      # This step is the only place in CI that holds both facts at once — the closing set, and the tree as it will be
+      # after the merge (`pull_request` checks out the merge ref). Hence here rather than in `invariants`, which runs
+      # on push too and has no PR to read a closing set from.
+      #
+      # It runs the whole lint, so an unrelated violation would be reported here AND by `invariants`. That duplication
+      # is deliberate: this job is seconds and fails fast, and two identical messages are cheaper than a second flag to
+      # keep in sync.
+      - name: Nothing may still cite what this PR closes
+        if: steps.keywords.outputs.closes != ''
+        env:
+          CLOSES: ${{ steps.keywords.outputs.closes }}
+        run: |
+          set -uo pipefail
+          echo "This PR closes: $CLOSES"
+          # --no-github: IGNORE_CLOSED_ISSUE is `invariants`' job, and this runner has no reason to re-probe the API.
+          python3 scripts/lint-test-suppressions.py --no-github --closing "$CLOSES"
 
   # ---- The ONLY required check. Aggregates: skipped → pass, failure/cancelled → fail. ----
   gate:

--- a/scripts/lint-test-suppressions.py
+++ b/scripts/lint-test-suppressions.py
@@ -32,10 +32,18 @@ Checks (each maps to an issue #703 deliverable):
     SHARD_ZERO_TESTS      a class named in `shards.json` that resolves to zero runnable tests — either the
                           fixture is class-level `[Ignore]`d, or it is class-level tagged with a tier the gate
                           excludes (Quarantine / Nightly / Manual)
+    SUPPRESSION_CITES_CLOSING_ISSUE
+                          a suppression citing an issue THIS change closes  (needs --closing)
+
+`SUPPRESSION_CITES_CLOSING_ISSUE` exists because `IGNORE_CLOSED_ISSUE` has a blind spot it cannot see out of. On a PR
+that closes #N *and* leaves an `[Ignore("#N")]` behind, #N is still OPEN while the PR is open, so the lint passes —
+and the merge is what closes it, so the same lint reddens `main` minutes later. Green before merge, red after. The
+merge gate's `closing-keywords` job already extracts the set GitHub will act on; feed it here with `--closing`.
 
 Usage:
     python3 scripts/lint-test-suppressions.py                       # lint the repo, probe issue state
     python3 scripts/lint-test-suppressions.py --no-github           # offline: skip IGNORE_CLOSED_ISSUE
+    python3 scripts/lint-test-suppressions.py --closing "718 722"   # + reject suppressions citing what this closes
     python3 scripts/lint-test-suppressions.py --root DIR --shards F # point at a fixture tree (self-tests)
 
 Exit code: 0 when clean, 1 when any violation is found, 2 on a usage error.
@@ -275,6 +283,53 @@ def check_ignores(parsed, states):
     return violations
 
 
+def check_closing_keywords(parsed, closing):
+    """Flag suppressions that cite an issue THIS change closes.
+
+    The gap this fills is a timing one, and it is invisible from inside a PR. `IGNORE_CLOSED_ISSUE` asks whether the
+    cited issue is closed *right now*; on a PR that both closes #N and leaves an `[Ignore("#N")]` in the tree, #N is
+    still OPEN, so the lint passes — and the merge is what closes it, so the same lint fails on `main` minutes later.
+    Green before merge, red after, with nothing in between to catch it.
+
+    Measured: PR #721 closed #718 while `ViewCreatedBeforeTheSpawns_ConvergesWithOneCreatedAfter` stayed quarantined
+    against it. `invariants` passed on the PR and reddened `main` at 22:32.
+
+    `[Ignore]` ONLY, deliberately. Its `#N` comes from the reason string, a single field whose reference IS the
+    blocker by construction. `Quarantine` records its issue in free prose — the attribute block or the comment above
+    it — and that prose legitimately discusses more than one issue: `ChaosStressTests.CreateDeleteRecreate_RapidLifecycle`
+    is quarantined against #696 while its comment also names #695 (the livelock it was retargeted from) and #716 (a
+    suspected mechanism). Treating every nearby reference as the target flags that comment, which is well written and
+    exactly what a quarantine note should say. A checker that cries wolf on good prose gets switched off, so the
+    narrow, precise half is the one worth having.
+
+    The gap that leaves is real and worth its own issue: `Quarantine` has no machine-readable target field, which is
+    also why nothing today catches a quarantine whose issue has closed (`IGNORE_CLOSED_ISSUE` covers `[Ignore]` alone).
+    """
+    if not closing:
+        return []
+
+    violations = []
+    for path, (groups, _class_groups) in parsed.items():
+        for g in groups:
+            ignore_m = IGNORE_ATTR.search(g.attr_text)
+            if not ignore_m:
+                continue
+
+            refs = {int(n) for n in ISSUE_REF.findall(ignore_m.group(1))}
+            line = g.line_of(re.compile(r"\[Ignore"))
+
+            for ref in sorted(refs & closing):
+                violations.append(Violation(
+                    "SUPPRESSION_CITES_CLOSING_ISSUE", path, line,
+                    f"[Ignore] cites #{ref}, which this change CLOSES",
+                    "Pick one, because they contradict each other. If the suppression is obsolete, delete it and let "
+                    "the test run. If it describes work this change does NOT do, that work needs its own issue — "
+                    "split it out and repoint the marker there. Leaving both in one commit is green here and red on "
+                    "main, because the merge is what closes the issue: IGNORE_CLOSED_ISSUE cannot see it from inside "
+                    "the PR. If the closing keyword itself is the mistake, defuse it (`#N` in backticks, or 'PR #N')."))
+    return violations
+
+
 def check_quarantine(parsed):
     violations = []
     for path, (groups, class_groups) in parsed.items():
@@ -481,15 +536,22 @@ def main(argv):
                     help="owner/name used to resolve issue state")
     ap.add_argument("--no-github", action="store_true",
                     help="skip IGNORE_CLOSED_ISSUE (offline / no gh)")
+    ap.add_argument("--closing", default="",
+                    help="issue numbers this change will close (whitespace- or comma-separated, '#' optional). Any "
+                         "suppression citing one is rejected: the merge is what closes them, so IGNORE_CLOSED_ISSUE "
+                         "cannot see the conflict from inside the PR. Fed by the merge gate's closing-keywords job.")
     args = ap.parse_args(argv)
 
     if not os.path.isdir(args.root):
         print(f"ERROR: --root {args.root} is not a directory", file=sys.stderr)
         return 2
 
+    closing = {int(n) for n in re.findall(r"\d+", args.closing)}
+
     parsed = scan_tree(args.root)
 
     violations = []
+    violations += check_closing_keywords(parsed, closing)
     violations += check_quarantine(parsed)
     violations += check_explicit(parsed)
     violations += check_shards(parsed, args.shards)

--- a/scripts/tests/test_lint_suppressions.py
+++ b/scripts/tests/test_lint_suppressions.py
@@ -93,21 +93,24 @@ class LintFixtureCase(unittest.TestCase):
         with open(self.shards, "w", encoding="utf-8") as fh:
             json.dump([{"filter": "x", "classes": classes}], fh)
 
-    def run_lint(self):
+    def run_lint(self, closing=None):
         """(exit_code, stdout). --no-github keeps the self-tests offline and deterministic."""
+        argv = ["--root", self.root, "--shards", self.shards, "--no-github"]
+        if closing is not None:
+            argv += ["--closing", closing]
         buf = io.StringIO()
         with redirect_stdout(buf):
-            rc = lint.main(["--root", self.root, "--shards", self.shards, "--no-github"])
+            rc = lint.main(argv)
         return rc, buf.getvalue()
 
-    def assert_flags(self, check):
-        rc, out = self.run_lint()
+    def assert_flags(self, check, closing=None):
+        rc, out = self.run_lint(closing)
         self.assertEqual(rc, 1, f"expected {check} to fail the lint; output was:\n{out}")
         self.assertIn(check, out)
         return out
 
-    def assert_clean(self):
-        rc, out = self.run_lint()
+    def assert_clean(self, closing=None):
+        rc, out = self.run_lint(closing)
         self.assertEqual(rc, 0, f"expected a clean pass; output was:\n{out}")
 
 
@@ -360,3 +363,59 @@ class TestShardTierExclusion(LintFixtureCase):
         shard = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(shard)
         self.assertEqual(set(shard.GATE_EXCLUDED), lint.GATE_EXCLUDED_CATEGORIES)
+
+
+class TestClosingKeywordCompanion(LintFixtureCase):
+    """SUPPRESSION_CITES_CLOSING_ISSUE — the blind spot IGNORE_CLOSED_ISSUE cannot see out of.
+
+    On a PR that closes #N and leaves an [Ignore("#N")] behind, #N is still OPEN, so IGNORE_CLOSED_ISSUE passes; the
+    merge closes it and the same lint reddens main. Measured: PR #721 closed #718 with the suppression still in the
+    tree, and `invariants` went green on the PR and red on main minutes later. This check is fed the set the merge
+    gate's closing-keywords job already extracts, so the contradiction is visible while it is still cheap to fix.
+    """
+
+    IGNORED_AGAINST_718 = ('[TestFixture]\nclass A\n{\n    [Test]\n'
+                           '    [Ignore("#718 - needs the lifecycle notification channel")]\n'
+                           '    public void T() { }\n}\n')
+
+    def test_ignore_citing_an_issue_this_change_closes_is_rejected(self):
+        """The load-bearing case: PR #721's exact shape."""
+        self.write("A.cs", self.IGNORED_AGAINST_718)
+        out = self.assert_flags("SUPPRESSION_CITES_CLOSING_ISSUE", closing="718")
+        self.assertIn("#718", out)
+
+    def test_no_closing_set_is_a_no_op(self):
+        """Guards the guard: without --closing the check must stay silent, or every ordinary run breaks."""
+        self.write("A.cs", self.IGNORED_AGAINST_718)
+        self.assert_clean()
+
+    def test_suppression_citing_an_unrelated_issue_passes(self):
+        """The over-fire case. A tree full of [Ignore]s is normal; only the ones this change closes are wrong."""
+        self.write("A.cs", self.IGNORED_AGAINST_718)
+        self.assert_clean(closing="999 1000")
+
+    def test_quarantine_prose_is_deliberately_out_of_scope(self):
+        """The false positive that shaped the check, lifted from the real tree.
+
+        `ChaosStressTests.CreateDeleteRecreate_RapidLifecycle` is quarantined against #696, and its comment ALSO names
+        #695 (the livelock it was retargeted from) and #716 (a suspected mechanism). All three are a `#N` sitting next
+        to a `[Category("Quarantine")]`, and only one is the blocker — nothing distinguishes them without a convention
+        that does not exist. `[Ignore]`'s reason string carries no such ambiguity, so the check covers that alone.
+        Flagging this would punish the best-documented suppression in the suite, and a lint that cries wolf on good
+        prose gets switched off.
+        """
+        self.write("A.cs", '[TestFixture]\nclass A\n{\n    [Test]\n'
+                           '    // QUARANTINE (#696), retargeted from #695. Possibly #716 mechanism.\n'
+                           '    [Category("Quarantine")]\n'
+                           '    public void T() { }\n}\n')
+        self.assert_clean(closing="716")
+
+    def test_hash_prefixed_and_comma_separated_input_parses(self):
+        """The gate hands over whatever its grep produced; be liberal about the separator, not about the numbers."""
+        self.write("A.cs", self.IGNORED_AGAINST_718)
+        self.assert_flags("SUPPRESSION_CITES_CLOSING_ISSUE", closing="#717, #718")
+
+    def test_a_substring_number_is_not_a_match(self):
+        """#71 must not match a suppression citing #718 — the set is numeric, not textual."""
+        self.write("A.cs", self.IGNORED_AGAINST_718)
+        self.assert_clean(closing="71")


### PR DESCRIPTION
`IGNORE_CLOSED_ISSUE` has a blind spot it cannot see out of. It asks whether a suppression's issue is closed **right now**. On a PR that closes #N *and* leaves an `[Ignore("#N")]` in the tree, #N is still open while the PR is open — so the check passes, the merge closes it, and the identical check reddens `main` minutes later. Green before merge, red after, with no run in between that could have caught it.

Measured, not hypothetical: PR #721 shipped its #718 fix with `ViewCreatedBeforeTheSpawns_ConvergesWithOneCreatedAfter` still quarantined against it. `invariants` passed on the PR and failed on main at 22:32.

## The fix

`closing-keywords` already extracts the exact set GitHub will act on, from the two surfaces GitHub itself parses. It now hands that set to the lint via `--closing`, which rejects any `[Ignore]` citing one.

Replayed against the real case:

```
#721's actual tree, closing set "716 648 718"  ->  SystemInputViewLivenessTests.cs:104
                                                   [Ignore] cites #718, which this change CLOSES
today's tree, same closing set                 ->  clean
```

The job gains a checkout it did not need before. This is the only place in CI holding both facts at once — the closing set, and the tree as it will be *after* the merge (`pull_request` checks out the merge ref). `invariants` has neither: it runs on push too, and has no PR to read a set from.

## Why `[Ignore]` only

The first draft covered `Quarantine` as well, on the reasoning that the header contract is identical — both require an OPEN issue. It immediately flagged `ChaosStressTests.CreateDeleteRecreate_RapidLifecycle`:

```csharp
// QUARANTINE (#696), retargeted from #695. ... (and possibly
// #716's mechanism, a writer inserting into a merge-detached node). Roughly 1 run in 4.
```

**#696** is the target, #695 is history, #716 is a hypothesis. Nothing distinguishes them without a convention that does not exist, and that comment is the best-documented suppression in the suite — a lint that cries wolf on good prose gets switched off. `[Ignore]`'s reason string is a single field whose `#N` *is* the blocker by construction, so the check covers the half it can be precise about.

The gap that leaves is filed as **#724**: quarantine has no machine-readable target, which is also why nothing today catches a quarantine whose issue has closed.

## Tests

Seven cases. The load-bearing ones are not the positive:

- `test_no_closing_set_is_a_no_op` — without `--closing` the check must stay silent, or every ordinary run breaks
- `test_suppression_citing_an_unrelated_issue_passes` — a tree full of `[Ignore]`s is normal
- `test_a_substring_number_is_not_a_match` — `#71` must not match `#718`
- `test_quarantine_prose_is_deliberately_out_of_scope` — pins the narrowing above, using the real comment

Neutering the check turns three of them red. 39/39 green.

## Note

This PR's own title carries no `#N`, deliberately. `project-sync.yml`'s `update-on-merge` takes the first `#N` in the **PR title** and runs `gh issue close` on it unconditionally — a third closing path, independent of keywords, that neither `closing-keywords` nor this new check can see. It is what closed issue #722 an hour after I filed it (an intervening word, because the keyword itself was the mistake here — this PR narrates history, it does not resolve anything) (PR #723 was titled `#722 Repoint the quarantined view test…`, following the repo's `#issue`-prefixed convention). #722 has been reopened. Worth deciding separately whether the title should imply completion at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FE5GUBSF5D1DhyPAuTBbYk
