### PR TITLE
#729 Database integrity: check, report and repair

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,6 +29,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.label.name == 'run-benchmark'
     runs-on: ubuntu-latest
+    # ---- COST FAIL-SAFE (#729, 2026-08-09). ----
+    # `sky launch` holds a billed VM for exactly as long as this job runs, and an uncapped job inherits GitHub's
+    # 360-minute default — so a hang here strands a z1d.metal — the most expensive instance any workflow here launches for six hours. Opt-in-only triggers make that unlikely,
+    # not impossible, and the cost of being wrong is the whole point of capping it.
+    timeout-minutes: 120
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -48,6 +53,12 @@ jobs:
           sky launch bench/aws/benchmark.sky.yaml --down -y \
             --env PROFILE="$PROFILE" \
             --env RUN_ID=${{ github.run_id }}
+
+      # `--down` only fires on a normal exit. A step timeout or a cancelled run kills sky mid-flight and strands the VM,
+      # billing with nothing watching it. This runs on every path, including cancellation, and no-ops if it is already gone.
+      - name: Tear down the VM (always, including on timeout or cancel)
+        if: always()
+        run: sky down -y typhon-benchmark || true
 
       - name: Pull results from S3
         if: always()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.label.name == 'run-coverage'
     runs-on: ubuntu-latest
+    # ---- COST FAIL-SAFE (#729, 2026-08-09). ----
+    # `sky launch` holds a billed VM for exactly as long as this job runs, and an uncapped job inherits GitHub's
+    # 360-minute default — so a hang here strands a c6id.8xlarge for six hours. Opt-in-only triggers make that unlikely,
+    # not impossible, and the cost of being wrong is the whole point of capping it.
+    timeout-minutes: 45
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -32,7 +37,14 @@ jobs:
         run: python3 -m pip install --quiet "skypilot[aws]"
 
       - name: Run coverage on c6id
+        timeout-minutes: 40
         run: sky launch bench/aws/coverage.sky.yaml --down -y --env RUN_ID=${{ github.run_id }}
+
+      # `--down` only fires on a normal exit. A step timeout or a cancelled run kills sky mid-flight and strands the VM,
+      # billing with nothing watching it. This runs on every path, including cancellation, and no-ops if it is already gone.
+      - name: Tear down the VM (always, including on timeout or cancel)
+        if: always()
+        run: sky down -y typhon-coverage || true
 
       - name: Pull results from S3
         if: always()

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -81,6 +81,11 @@ jobs:
       && needs.changes.outputs.skip_ut != 'true'
       && vars.GATE_RUNNER != 'selfhosted'
     runs-on: ubuntu-latest
+    # ---- COST FAIL-SAFE (#729, 2026-08-09). ----
+    # Same exposure as the self-hosted job below, by a different route: `sky launch` holds a billed VM for as long as this
+    # step runs, so an uncapped step meant an uncapped VM. The step budget is larger than the self-hosted one because it
+    # also pays for cold provisioning (image pull + boot), which the warm persistent box does not.
+    timeout-minutes: 30
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -94,11 +99,19 @@ jobs:
       # Blocking launch: sky propagates the VM's run: exit code, so a test failure on the VM
       # fails this step → this job → the gate. --down tears the instance down either way.
       - name: Run correctness gate on c6id
+        timeout-minutes: 25
         run: |
           sky launch bench/aws/ci.sky.yaml --down -y \
             --env RUN_ENGINE=${{ needs.changes.outputs.engine }} \
             --env RUN_WORKBENCH=${{ needs.changes.outputs.workbench }} \
             --env RUN_ID=${{ github.run_id }}
+
+      # `--down` only tears the cluster down on a normal exit. A step timeout or a cancelled run kills sky mid-flight and
+      # strands the VM — billing with nothing watching it. This runs on every path, including cancellation, and is a no-op
+      # when the cluster is already gone.
+      - name: Tear down the VM (always, including on timeout or cancel)
+        if: always()
+        run: sky down -y typhon-ci-gate || true
 
       # if: always() — we want the report surfaced precisely when the gate FAILED.
       - name: Pull reports from S3
@@ -134,6 +147,16 @@ jobs:
       && needs.changes.outputs.skip_ut != 'true'
       && vars.GATE_RUNNER == 'selfhosted'
     runs-on: [self-hosted, linux, typhon-c6id]
+    # ---- COST FAIL-SAFE (#729, 2026-08-09). ----
+    # This job runs on a BILLED, always-on instance, and it had no timeout at all — so it inherited GitHub's 360-minute
+    # default. A gate that hung held the box for six hours; one that did so overnight would hold it for six hours before
+    # anyone saw it. This was the only workflow in the repo with no cap, and the only one that costs money per minute.
+    #
+    # The suite is 2-3 minutes healthy and 5 is already abnormal, so 10 on the step is a generous ceiling that still
+    # bounds the damage to roughly one suite's worth of compute. The job gets a slightly larger cap so the step timeout
+    # fires FIRST: that way the `if: always()` report and artifact steps still run and the .trx says where it hung,
+    # rather than the whole job being killed with no evidence of why.
+    timeout-minutes: 15
     steps:
       # clean:false keeps the warm bin/obj (untracked) for an incremental build; test DBs live on /nvme (TMPDIR),
       # not the worktree, so nothing accumulates there. git reset --hard reverts any tracked edits for isolation.
@@ -142,6 +165,7 @@ jobs:
         with:
           clean: false
       - name: Run correctness gate on the persistent c6id
+        timeout-minutes: 10
         env:
           RUN_ENGINE: ${{ needs.changes.outputs.engine }}
           RUN_WORKBENCH: ${{ needs.changes.outputs.workbench }}

--- a/src/Typhon.Engine/Foundation/Hashing/internals/Crc32CUtil.cs
+++ b/src/Typhon.Engine/Foundation/Hashing/internals/Crc32CUtil.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
@@ -16,8 +17,14 @@ namespace Typhon.Engine.Internals;
 /// Castagnoli polynomial required for database checksums is only available via the SSE4.2/ARM hardware intrinsics directly.
 /// </para>
 /// <para>
-/// Performance: ~1.3us per 8KB page (sequential) on SSE4.2 x64. The CRC32 instruction has 3-cycle latency but 1-cycle throughput,
-/// yielding ~8 bytes/3 cycles at ~4 GHz.
+/// Performance: ~670 ns per 8 KiB page as a single sequential chain on SSE4.2 x64 (measured, Zen 4 @ 4.5 GHz). The CRC32 instruction has
+/// 3-cycle latency but 1-cycle throughput, so a single chain is <b>latency-bound</b> at ~8 bytes / 3 cycles and leaves most of the unit idle.
+/// Splitting the same 8 KiB into independent regions breaks the dependency and is materially faster — 16 × 512 B measures ~500 ns — which is
+/// why <see cref="PageSectorFooter"/> costs less than the whole-page checksum it replaces rather than more.
+/// </para>
+/// <para>
+/// Detection strength is also better at smaller block sizes: CRC-32C holds HD=6 only up to 2045-byte datawords, so an 8 KiB dataword is HD=4
+/// (all &lt;= 3-bit errors caught) while a 512-byte one is HD=6 (all &lt;= 5-bit errors, plus every burst &lt;= 32 bits).
 /// </para>
 /// </remarks>
 internal static class Crc32CUtil
@@ -52,6 +59,49 @@ internal static class Crc32CUtil
         if (afterSkip < data.Length)
         {
             crc = ComputePartial(crc, data[afterSkip..]);
+        }
+
+        return crc ^ 0xFFFFFFFF;
+    }
+
+    /// <summary>
+    /// Compute CRC32C over a data span, skipping <b>two</b> disjoint regions that are treated as zeros.
+    /// </summary>
+    /// <remarks>
+    /// Needed by the per-sector page footer: sector 0 carries both the page's own checksum field and the sector array
+    /// itself, and each is written after the value that covers it — so both must be excluded from the sector's own CRC.
+    /// The two regions must not overlap and must be given in ascending offset order.
+    /// </remarks>
+    /// <param name="data">The complete data span including both skip regions.</param>
+    /// <param name="skip0Offset">Byte offset of the first region to skip.</param>
+    /// <param name="skip0Length">Length of the first skip region.</param>
+    /// <param name="skip1Offset">Byte offset of the second region to skip; must be at or after the end of the first.</param>
+    /// <param name="skip1Length">Length of the second skip region.</param>
+    public static uint ComputeSkippingPair(ReadOnlySpan<byte> data, int skip0Offset, int skip0Length, int skip1Offset, int skip1Length)
+    {
+        Debug.Assert(skip1Offset >= skip0Offset + skip0Length, "Skip regions must be disjoint and ascending.");
+
+        uint crc = 0xFFFFFFFF;
+
+        if (skip0Offset > 0)
+        {
+            crc = ComputePartial(crc, data[..skip0Offset]);
+        }
+
+        crc = ComputePartialZeros(crc, skip0Length);
+
+        var afterFirst = skip0Offset + skip0Length;
+        if (skip1Offset > afterFirst)
+        {
+            crc = ComputePartial(crc, data[afterFirst..skip1Offset]);
+        }
+
+        crc = ComputePartialZeros(crc, skip1Length);
+
+        var afterSecond = skip1Offset + skip1Length;
+        if (afterSecond < data.Length)
+        {
+            crc = ComputePartial(crc, data[afterSecond..]);
         }
 
         return crc ^ 0xFFFFFFFF;

--- a/src/Typhon.Engine/Integrity/internals/BootstrapReader.cs
+++ b/src/Typhon.Engine/Integrity/internals/BootstrapReader.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>Outcome of reading one slot of the page-0 A/B meta pair.</summary>
+internal sealed class MetaSlotView
+{
+    /// <summary>Physical page index of the slot (0 or 1).</summary>
+    public int SlotIndex { get; init; }
+
+    /// <summary>Whether the slot exists within the file at all.</summary>
+    public bool Present { get; init; }
+
+    /// <summary>Whether the slot's whole-page checksum matched.</summary>
+    public bool ChecksumValid { get; init; }
+
+    /// <summary>Stored checksum value.</summary>
+    public uint StoredChecksum { get; init; }
+
+    /// <summary>Recomputed checksum value.</summary>
+    public uint ComputedChecksum { get; init; }
+
+    /// <summary>The slot's pair generation. <c>0</c> means it was never written through the alternation path.</summary>
+    public ulong Generation { get; init; }
+
+    /// <summary>A slot is selectable when it is present, checksum-valid and carries a non-zero generation.</summary>
+    public bool IsValid => Present && ChecksumValid && Generation > 0;
+}
+
+/// <summary>
+/// Reads the database's identity and bootstrap dictionary from page 0 without booting the engine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bootstrap dictionary is the single point of failure for offline reading, and it lives on the page-0 A/B meta pair.
+/// This reader implements the same pair-selection rule the engine uses — newest valid generation wins — because reading a
+/// stale bootstrap would produce a flood of phantom findings. It is the first thing to get right and the first thing to
+/// test.
+/// </para>
+/// <para>
+/// Unlike <see cref="BootstrapDictionary.ReadFrom"/>, the stream parse here is <b>tolerant</b>: a truncated or malformed
+/// stream yields the entries recovered so far plus a diagnostic, never an exception. A checker must survive the input it
+/// exists to diagnose.
+/// </para>
+/// </remarks>
+internal sealed class BootstrapView
+{
+    /// <summary>Expected page-0 signature.</summary>
+    public const string ExpectedSignature = ManagedPagedMMF.HeaderSignature;
+
+    /// <summary>Bootstrap key holding the packed checkpoint-LSN + clean-shutdown pair.</summary>
+    public const string DurabilityWatermarksKey = "DurabilityWatermarks";
+
+    /// <summary>Bootstrap key holding the occupancy segment's root page index.</summary>
+    public const string OccupancyMapSpiKey = ManagedPagedMMF.BK_OccupancyMapSPI;
+
+    /// <summary>State of meta slot A (physical page 0).</summary>
+    public MetaSlotView SlotA { get; init; }
+
+    /// <summary>State of meta slot B (physical page 1).</summary>
+    public MetaSlotView SlotB { get; init; }
+
+    /// <summary>The selected slot, or <c>-1</c> when neither was valid.</summary>
+    public int SelectedSlot { get; init; } = -1;
+
+    /// <summary>Generation of the selected slot.</summary>
+    public ulong SelectedGeneration { get; init; }
+
+    /// <summary>Whether the 32-byte identity signature matched.</summary>
+    public bool SignatureValid { get; init; }
+
+    /// <summary>The raw signature string as decoded, for reporting a mismatch.</summary>
+    public string Signature { get; init; }
+
+    /// <summary>The on-disk format revision recorded on page 0.</summary>
+    public int FormatRevision { get; init; }
+
+    /// <summary>The database name recorded on page 0.</summary>
+    public string DatabaseName { get; init; }
+
+    /// <summary>Chunk size used when growing the data file.</summary>
+    public ulong FilesChunkSize { get; init; }
+
+    /// <summary>Parsed bootstrap entries, in stream order.</summary>
+    public IReadOnlyList<KeyValuePair<string, BootstrapDictionary.Value>> Entries { get; init; } = [];
+
+    /// <summary>Diagnostics produced while parsing the stream. Empty on a well-formed stream.</summary>
+    public IReadOnlyList<string> ParseDiagnostics { get; init; } = [];
+
+    /// <summary>Whether the stream terminated on its <c>0xFF</c> sentinel.</summary>
+    public bool SentinelReached { get; init; }
+
+    /// <summary>Declared stream length in bytes, as read from the 2-byte header.</summary>
+    public int DeclaredStreamLength { get; init; }
+
+    /// <summary>Whether a usable bootstrap was recovered.</summary>
+    public bool IsUsable => SelectedSlot >= 0 && SignatureValid;
+
+    /// <summary>Looks up an entry by key.</summary>
+    /// <param name="key">Bootstrap key.</param>
+    /// <param name="value">Receives the value when present.</param>
+    public bool TryGet(string key, out BootstrapDictionary.Value value)
+    {
+        for (var i = 0; i < Entries.Count; i++)
+        {
+            if (string.Equals(Entries[i].Key, key, StringComparison.Ordinal))
+            {
+                value = Entries[i].Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>Reads the packed checkpoint-LSN + clean-shutdown pair. A fresh database reads as <c>(0, false)</c>.</summary>
+    public (long CheckpointLsn, bool CleanShutdown) ReadWatermarks()
+    {
+        if (!TryGet(DurabilityWatermarksKey, out var v) || v.IntCount < 3)
+        {
+            return (0, false);
+        }
+
+        var lsn = (uint)v.GetInt(0) | ((long)v.GetInt(1) << 32);
+        return (lsn, v.GetInt(2) != 0);
+    }
+}
+
+/// <summary>
+/// Parses page 0 (the A/B meta pair) into a <see cref="BootstrapView"/> from raw bytes.
+/// </summary>
+internal static class BootstrapReader
+{
+    // RootFileHeader sits at PageBaseHeaderSize (64). Its fields, at their sequential-layout offsets within the struct:
+    //   [0,32)   HeaderSignature : fixed byte[32]
+    //   [32,36)  DatabaseFormatRevision : int
+    //   [40,48)  DatabaseFilesChunkSize : ulong   (8-aligned, so 4 bytes of padding precede it)
+    //   [48,112) DatabaseName : fixed byte[64]
+    private const int RootHeaderOffset = PagedMMF.PageBaseHeaderSize;
+    private const int SignatureLength = 32;
+    private const int FormatRevisionFieldOffset = 32;
+    private const int ChunkSizeFieldOffset = 40;
+    private const int NameFieldOffset = 48;
+    private const int NameLength = 64;
+
+    /// <summary>Reads and validates one meta slot without selecting it.</summary>
+    /// <param name="source">The page source.</param>
+    /// <param name="slotIndex">Physical page index of the slot (0 or 1).</param>
+    /// <param name="buffer">Scratch buffer of at least one page; receives the slot image on success.</param>
+    public static MetaSlotView ReadSlot(IPageSource source, int slotIndex, Span<byte> buffer)
+    {
+        if (!source.TryReadPage(slotIndex, buffer))
+        {
+            return new MetaSlotView { SlotIndex = slotIndex, Present = false };
+        }
+
+        var ok = PageImage.VerifyWholePageChecksum(buffer, out var computed);
+        return new MetaSlotView
+        {
+            SlotIndex = slotIndex,
+            Present = true,
+            ChecksumValid = ok,
+            StoredChecksum = PageImage.StoredChecksum(buffer),
+            ComputedChecksum = computed,
+            Generation = PageImage.PairGeneration(buffer)
+        };
+    }
+
+    /// <summary>
+    /// Reads both meta slots, selects the newest valid one, and parses its identity header and bootstrap stream.
+    /// </summary>
+    /// <param name="source">The page source.</param>
+    public static BootstrapView Read(IPageSource source)
+    {
+        Span<byte> slotABuf = new byte[IntegrityConstants.PageSize];
+        Span<byte> slotBBuf = new byte[IntegrityConstants.PageSize];
+
+        var a = ReadSlot(source, 0, slotABuf);
+        var b = ReadSlot(source, 1, slotBBuf);
+
+        int selected;
+        ReadOnlySpan<byte> image;
+        if (b.IsValid && (!a.IsValid || b.Generation > a.Generation))
+        {
+            selected = 1;
+            image = slotBBuf;
+        }
+        else if (a.IsValid)
+        {
+            selected = 0;
+            image = slotABuf;
+        }
+        else
+        {
+            return new BootstrapView { SlotA = a, SlotB = b, SelectedSlot = -1 };
+        }
+
+        var selectedGen = selected == 0 ? a.Generation : b.Generation;
+        var signature = ReadFixedString(image.Slice(RootHeaderOffset, SignatureLength));
+        var formatRevision = MemoryMarshal.Read<int>(image[(RootHeaderOffset + FormatRevisionFieldOffset)..]);
+        var chunkSize = MemoryMarshal.Read<ulong>(image[(RootHeaderOffset + ChunkSizeFieldOffset)..]);
+        var name = ReadFixedString(image.Slice(RootHeaderOffset + NameFieldOffset, NameLength));
+
+        var entries = ParseStream(image[ManagedPagedMMF.BootstrapStreamOffset..], out var diagnostics, out var sentinel, out var declaredLength);
+
+        return new BootstrapView
+        {
+            SlotA = a,
+            SlotB = b,
+            SelectedSlot = selected,
+            SelectedGeneration = selectedGen,
+            SignatureValid = string.Equals(signature, BootstrapView.ExpectedSignature, StringComparison.Ordinal),
+            Signature = signature,
+            FormatRevision = formatRevision,
+            DatabaseName = name,
+            FilesChunkSize = chunkSize,
+            Entries = entries,
+            ParseDiagnostics = diagnostics,
+            SentinelReached = sentinel,
+            DeclaredStreamLength = declaredLength
+        };
+    }
+
+    /// <summary>
+    /// Tolerant parse of the bootstrap key/value stream. Returns whatever it could recover and describes what it could not,
+    /// rather than throwing — the caller is diagnosing damage, so a partial dictionary plus an explanation beats an
+    /// exception.
+    /// </summary>
+    /// <param name="stream">The stream region of the meta page, starting at the 2-byte length header.</param>
+    /// <param name="diagnostics">Receives human-readable parse problems.</param>
+    /// <param name="sentinelReached">Receives whether the <c>0xFF</c> end sentinel was found.</param>
+    /// <param name="declaredLength">Receives the declared entry-bytes length.</param>
+    private static List<KeyValuePair<string, BootstrapDictionary.Value>> ParseStream(ReadOnlySpan<byte> stream, out List<string> diagnostics,
+        out bool sentinelReached, out int declaredLength)
+    {
+        diagnostics = [];
+        sentinelReached = false;
+        declaredLength = 0;
+
+        var entries = new List<KeyValuePair<string, BootstrapDictionary.Value>>();
+        if (stream.Length < 3)
+        {
+            diagnostics.Add("Bootstrap stream region is shorter than its 3-byte minimum.");
+            return entries;
+        }
+
+        declaredLength = MemoryMarshal.Read<ushort>(stream);
+        var end = 2 + declaredLength;
+        if (end > stream.Length)
+        {
+            diagnostics.Add($"Declared bootstrap stream length {declaredLength} runs {end - stream.Length} bytes past the page; truncating.");
+            end = stream.Length;
+        }
+
+        var pos = 2;
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        while (pos < end)
+        {
+            var tag = (BootstrapDictionary.ValueType)stream[pos++];
+            if (tag == BootstrapDictionary.ValueType.End)
+            {
+                sentinelReached = true;
+                break;
+            }
+
+            var keyStart = pos;
+            while (pos < end && stream[pos] != 0)
+            {
+                pos++;
+            }
+
+            if (pos >= end)
+            {
+                diagnostics.Add($"Bootstrap entry #{entries.Count} has an unterminated key; stream truncated.");
+                break;
+            }
+
+            var key = Encoding.UTF8.GetString(stream[keyStart..pos]);
+            pos++;   // skip NUL
+
+            if (!TryReadValue(stream, ref pos, end, tag, out var value))
+            {
+                diagnostics.Add($"Bootstrap key '{key}' has an unreadable value of type {tag}; stream truncated.");
+                break;
+            }
+
+            if (!seen.Add(key))
+            {
+                diagnostics.Add($"Bootstrap key '{key}' appears more than once; the last occurrence wins.");
+            }
+
+            entries.Add(new KeyValuePair<string, BootstrapDictionary.Value>(key, value));
+        }
+
+        if (!sentinelReached && pos < stream.Length && stream[pos] == (byte)BootstrapDictionary.ValueType.End)
+        {
+            sentinelReached = true;
+        }
+
+        if (!sentinelReached)
+        {
+            diagnostics.Add("Bootstrap stream did not terminate on its 0xFF sentinel.");
+        }
+
+        return entries;
+    }
+
+    private static bool TryReadValue(ReadOnlySpan<byte> stream, ref int pos, int end, BootstrapDictionary.ValueType type,
+        out BootstrapDictionary.Value value)
+    {
+        value = default;
+        switch (type)
+        {
+            case BootstrapDictionary.ValueType.Bool:
+                if (pos >= end)
+                {
+                    return false;
+                }
+
+                value = BootstrapDictionary.Value.FromBool(stream[pos++] != 0);
+                return true;
+
+            case >= BootstrapDictionary.ValueType.Int1 and <= BootstrapDictionary.ValueType.Int6:
+                var count = (byte)type - (byte)BootstrapDictionary.ValueType.Int1 + 1;
+                if (pos + (count * 4) > end)
+                {
+                    return false;
+                }
+
+                Span<int> ints = stackalloc int[6];
+                for (var i = 0; i < count; i++)
+                {
+                    ints[i] = MemoryMarshal.Read<int>(stream[(pos + (i * 4))..]);
+                }
+
+                pos += count * 4;
+                value = count switch
+                {
+                    1 => BootstrapDictionary.Value.FromInt(ints[0]),
+                    2 => BootstrapDictionary.Value.FromInt2(ints[0], ints[1]),
+                    3 => BootstrapDictionary.Value.FromInt3(ints[0], ints[1], ints[2]),
+                    4 => BootstrapDictionary.Value.FromInt4(ints[0], ints[1], ints[2], ints[3]),
+                    5 => BootstrapDictionary.Value.FromInt5(ints[0], ints[1], ints[2], ints[3], ints[4]),
+                    _ => BootstrapDictionary.Value.FromInt6(ints[0], ints[1], ints[2], ints[3], ints[4], ints[5])
+                };
+                return true;
+
+            case BootstrapDictionary.ValueType.Long:
+                if (pos + 8 > end)
+                {
+                    return false;
+                }
+
+                value = BootstrapDictionary.Value.FromLong(MemoryMarshal.Read<long>(stream[pos..]));
+                pos += 8;
+                return true;
+
+            case BootstrapDictionary.ValueType.DateTime:
+                if (pos + 8 > end)
+                {
+                    return false;
+                }
+
+                var ticks = MemoryMarshal.Read<long>(stream[pos..]);
+                pos += 8;
+                // A damaged stream can carry ticks outside DateTime's range; clamp rather than throw.
+                value = BootstrapDictionary.Value.FromDateTime(ticks >= DateTime.MinValue.Ticks && ticks <= DateTime.MaxValue.Ticks
+                    ? new DateTime(ticks)
+                    : DateTime.MinValue);
+                return true;
+
+            case BootstrapDictionary.ValueType.String:
+                var start = pos;
+                while (pos < end && stream[pos] != 0)
+                {
+                    pos++;
+                }
+
+                if (pos >= end)
+                {
+                    return false;
+                }
+
+                value = BootstrapDictionary.Value.FromString(Encoding.UTF8.GetString(stream[start..pos]));
+                pos++;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static string ReadFixedString(ReadOnlySpan<byte> field)
+    {
+        var len = field.IndexOf((byte)0);
+        if (len < 0)
+        {
+            len = field.Length;
+        }
+
+        return Encoding.UTF8.GetString(field[..len]);
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/Checks/BootstrapChecks.cs
+++ b/src/Typhon.Engine/Integrity/internals/Checks/BootstrapChecks.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// <c>BOO</c> — root and bootstrap checks. Runs first, because everything else depends on them: a <c>Fatal</c> here stops
+/// the scan rather than letting later checks report a flood of phantom findings derived from a bootstrap that was never
+/// valid.
+/// </summary>
+internal static class BootstrapChecks
+{
+    /// <summary>Check code: bundle shape.</summary>
+    public const string BundleShape = "CHK-BOO-01";
+
+    /// <summary>Check code: page-0 identity.</summary>
+    public const string Identity = "CHK-BOO-02";
+
+    /// <summary>Check code: A/B meta-pair selection.</summary>
+    public const string MetaPair = "CHK-BOO-03";
+
+    /// <summary>Check code: bootstrap stream well-formedness.</summary>
+    public const string Stream = "CHK-BOO-04";
+
+    /// <summary>Check code: every segment pointer resolves.</summary>
+    public const string SegmentPointers = "CHK-BOO-05";
+
+    /// <summary>Check code: checkpoint LSN versus the WAL window.</summary>
+    public const string CheckpointWindow = "CHK-BOO-06";
+
+    /// <summary>
+    /// Bootstrap keys whose <c>IntN</c> components are segment root-page indices, with the component positions that hold
+    /// them. Only these are cross-checked; an unrecognised key is reported as an advisory rather than guessed at, because
+    /// treating an arbitrary integer as a page index manufactures findings out of ordinary configuration values.
+    /// </summary>
+    private static readonly Dictionary<string, int[]> SpiKeys = new(StringComparer.Ordinal)
+    {
+        ["OccupancyMapSPI"] = [0],
+        ["UowRegistrySPI"] = [0],
+        ["sys.ComponentR1"] = [0, 1],
+        ["sys.SchemaHistory"] = [0, 1],
+        ["sys.AssemblyR1"] = [0, 1],
+        ["collection.FieldR1"] = [0]
+    };
+
+    /// <summary>
+    /// The checks that must run <b>before</b> the structural sweep, because the sweep is meaningless without them: if the
+    /// file is not a Typhon database, or neither meta slot is valid, every later finding would be an artefact of reading
+    /// garbage. A <see cref="IntegritySeverity.Fatal"/> here sets <see cref="ScanContext.StopScan"/>.
+    /// </summary>
+    /// <param name="ctx">The scan context; <see cref="ScanContext.Bootstrap"/> must already be populated.</param>
+    public static void RunEarly(ScanContext ctx)
+    {
+        CheckBundleShape(ctx);
+        CheckMetaPair(ctx);
+
+        if (ctx.StopScan)
+        {
+            return;
+        }
+
+        CheckIdentity(ctx);
+        CheckStream(ctx);
+    }
+
+    /// <summary>
+    /// The checks that need the structural sweep's results — every segment pointer is validated against what the sweep
+    /// actually found on disk, rather than against the dictionary's own claims.
+    /// </summary>
+    /// <param name="ctx">The scan context, with segments walked and roles assigned.</param>
+    public static void RunLate(ScanContext ctx)
+    {
+        CheckSegmentPointers(ctx);
+        CheckCheckpointWindow(ctx);
+    }
+
+    private static void CheckBundleShape(ScanContext ctx)
+    {
+        var bundle = ctx.Bundle;
+        if (bundle == null)
+        {
+            return;
+        }
+
+        if (bundle.TrailingBytes != 0)
+        {
+            ctx.Report(BundleShape, IntegritySeverity.Divergence, "STO-01", Locus.Database,
+                $"The data file is truncated {bundle.TrailingBytes} bytes into a page.",
+                $"File size {bundle.SizeBytes:N0} B is not a whole multiple of the {IntegrityConstants.PageSize} B page size. "
+                + "Every write the engine performs is whole-page, so a partial trailing page means the file was copied or "
+                + "truncated by something outside the engine.",
+                Repairability.Lossy,
+                new LossEstimate
+                {
+                    Kind = LossKind.Unknown,
+                    EntityCount = -1,
+                    BoundedMin = 0,
+                    BoundedMax = 1,
+                    Explanation = "At most the contents of one page; possibly nothing, if the page was never written."
+                });
+        }
+
+        if (bundle.LockHeld)
+        {
+            ctx.Report(BundleShape, IntegritySeverity.Advisory, "", Locus.Database,
+                "Another process holds this database open.",
+                "db.lock is held. Cross-structure findings from this scan describe a moving target and are reported as "
+                + "Suspected. Re-run with the database closed to confirm any of them.");
+        }
+
+        if (ctx.Source.PageCount < ManagedPagedMMF.MinimumPhysicalPageCount)
+        {
+            ctx.Report(BundleShape, IntegritySeverity.Fatal, "", Locus.Database,
+                $"The data file holds only {ctx.Source.PageCount} pages; a Typhon database has at least {ManagedPagedMMF.MinimumPhysicalPageCount}.",
+                "Genesis materialises the meta pair, the occupancy segment's directory root and its twin, and the first "
+                + "page of occupancy data. A file shorter than that was never a complete database, or has been truncated "
+                + "to nothing.");
+            ctx.StopScan = true;
+        }
+    }
+
+    private static void CheckMetaPair(ScanContext ctx)
+    {
+        var b = ctx.Bootstrap;
+
+        if (b.SelectedSlot < 0)
+        {
+            ctx.Report(MetaPair, IntegritySeverity.Fatal, "CK-05", new Locus(0),
+                "Both slots of the page-0 meta pair are invalid — the database cannot be opened.",
+                DescribeSlot(b.SlotA) + " " + DescribeSlot(b.SlotB)
+                + " The meta pair holds the root identity header and the bootstrap dictionary; with neither slot valid there "
+                + "is no way to locate any segment. This is recoverable only from a backup.");
+            ctx.StopScan = true;
+            return;
+        }
+
+        // One bad slot is survivable by design — that is what the pair is for — but it means the next write has no
+        // fallback, so it is worth saying out loud rather than leaving the operator on one copy without knowing.
+        var other = b.SelectedSlot == 0 ? b.SlotB : b.SlotA;
+        if (!other.IsValid)
+        {
+            ctx.Report(MetaPair, IntegritySeverity.Divergence, "CK-05", new Locus(other.SlotIndex),
+                $"Meta-pair slot {other.SlotIndex} is unusable; the database is running on a single copy of its root metadata.",
+                DescribeSlot(other) + $" Slot {b.SelectedSlot} is valid at generation {b.SelectedGeneration}. The pair heals "
+                + "on the next metadata write, which alternates back into the bad slot.",
+                Repairability.Lossless);
+        }
+    }
+
+    private static void CheckIdentity(ScanContext ctx)
+    {
+        var b = ctx.Bootstrap;
+
+        if (!b.SignatureValid)
+        {
+            ctx.Report(Identity, IntegritySeverity.Fatal, "", new Locus(b.SelectedSlot),
+                "Page 0 does not carry the Typhon signature — this is not a Typhon database.",
+                $"Expected '{BootstrapView.ExpectedSignature}', found '{b.Signature}'. The page's checksum is valid, so the "
+                + "bytes are intact; they are simply not a Typhon root header.");
+            ctx.StopScan = true;
+            return;
+        }
+
+        if (b.FormatRevision > PagedMMF.DatabaseFormatRevision)
+        {
+            ctx.Report(Identity, IntegritySeverity.Advisory, "", new Locus(b.SelectedSlot),
+                $"The database is format revision {b.FormatRevision}; this build understands up to {PagedMMF.DatabaseFormatRevision}.",
+                "Structures introduced after this build's revision are not decoded, so the scan's coverage is incomplete. "
+                + "Repair is refused outright on a newer format: repairing a layout the tool does not fully understand is how "
+                + "a tool corrupts a database it was asked to save.");
+            ctx.Findings.NoteCaveat(
+                $"The database is format revision {b.FormatRevision}, newer than this build's {PagedMMF.DatabaseFormatRevision}; "
+                + "structures added after this revision were not checked.");
+        }
+        else if (b.FormatRevision <= 0)
+        {
+            ctx.Report(Identity, IntegritySeverity.Fatal, "", new Locus(b.SelectedSlot),
+                $"Page 0 records an impossible format revision ({b.FormatRevision}).",
+                "The signature matched but the revision field did not, so the identity header is partially damaged.");
+            ctx.StopScan = true;
+        }
+    }
+
+    private static void CheckStream(ScanContext ctx)
+    {
+        var b = ctx.Bootstrap;
+
+        for (var i = 0; i < b.ParseDiagnostics.Count; i++)
+        {
+            ctx.Report(Stream, IntegritySeverity.Fatal, "", new Locus(b.SelectedSlot),
+                "The bootstrap dictionary is malformed.",
+                b.ParseDiagnostics[i]
+                + $" {b.Entries.Count} entries were recovered before the problem. The bootstrap names every system segment, "
+                + "so a truncated stream means some subsystems' data is unreachable even though its pages are intact.");
+        }
+
+        if (b.Entries.Count == 0 && b.ParseDiagnostics.Count == 0)
+        {
+            ctx.Report(Stream, IntegritySeverity.Fatal, "", new Locus(b.SelectedSlot),
+                "The bootstrap dictionary is empty.",
+                "A valid meta page always carries at least the occupancy segment pointer. An empty, well-formed stream means "
+                + "the page was written by something that did not populate it.");
+        }
+    }
+
+    private static void CheckSegmentPointers(ScanContext ctx)
+    {
+        var b = ctx.Bootstrap;
+
+        for (var i = 0; i < b.Entries.Count; i++)
+        {
+            var key = b.Entries[i].Key;
+            if (!SpiKeys.TryGetValue(key, out var positions))
+            {
+                continue;
+            }
+
+            var value = b.Entries[i].Value;
+            for (var p = 0; p < positions.Length; p++)
+            {
+                if (positions[p] >= value.IntCount)
+                {
+                    continue;
+                }
+
+                var spi = value.GetInt(positions[p]);
+                if (spi == 0)
+                {
+                    continue;   // a legitimately absent subsystem
+                }
+
+                ValidateSpi(ctx, key, spi);
+            }
+        }
+    }
+
+    private static void ValidateSpi(ScanContext ctx, string key, int spi)
+    {
+        if (!ctx.IsInRange(spi))
+        {
+            ctx.Report(SegmentPointers, IntegritySeverity.Fatal, "", new Locus(spi),
+                $"Bootstrap key '{key}' points at page {spi}, which is past the end of the file.",
+                $"The data file holds {ctx.Source.PageCount:N0} pages. An engine following this pointer would read outside the "
+                + "file. Every subsystem reachable only through this key is unreachable.");
+            return;
+        }
+
+        if (ctx.Roles.Length > spi && ctx.Roles[spi] != PageRole.SegmentRoot && ctx.Roles[spi] != PageRole.Reserved)
+        {
+            ctx.Report(SegmentPointers, IntegritySeverity.Fatal, "", new Locus(spi),
+                $"Bootstrap key '{key}' points at page {spi}, which is not a segment root.",
+                $"The page's role is {ctx.Roles[spi]}. Either the pointer is stale or the root page's header was overwritten; "
+                + "in both cases the segment behind this key cannot be loaded.");
+            return;
+        }
+
+        if (ctx.Occupancy is { IsComplete: true } && !ctx.Occupancy.IsAllocated(spi))
+        {
+            ctx.Report(SegmentPointers, IntegritySeverity.Divergence, "CK-09", new Locus(spi),
+                $"Bootstrap key '{key}' points at page {spi}, which the allocation bitmap marks as free.",
+                "The bitmap is derived state, so the page is treated as allocated and the bitmap as wrong. Left unrepaired, "
+                + "the allocator could hand this page out a second time and two owners would fight over it.",
+                Repairability.Lossless);
+        }
+    }
+
+    private static void CheckCheckpointWindow(ScanContext ctx)
+    {
+        var bundle = ctx.Bundle;
+        if (bundle == null)
+        {
+            return;
+        }
+
+        var (checkpointLsn, cleanShutdown) = ctx.Bootstrap.ReadWatermarks();
+
+        if (bundle.WalSegments.Count == 0)
+        {
+            if (checkpointLsn > 0 && !cleanShutdown)
+            {
+                ctx.Report(CheckpointWindow, IntegritySeverity.DataLoss, "WP-09", Locus.Database,
+                    "The database did not shut down cleanly and its write-ahead log is missing.",
+                    $"The last checkpoint reached LSN {checkpointLsn:N0} and the clean-shutdown flag is clear, so transactions "
+                    + "committed after that checkpoint lived only in the log. With no wal/ directory there is nothing to replay "
+                    + "them from.",
+                    Repairability.NotRepairable,
+                    new LossEstimate
+                    {
+                        Kind = LossKind.Unknown,
+                        EntityCount = -1,
+                        BoundedMin = 0,
+                        BoundedMax = long.MaxValue,
+                        Explanation = "Every transaction committed after the last checkpoint. The count cannot be bounded from "
+                            + "inside the database, because the only record of it was the log."
+                    });
+            }
+
+            return;
+        }
+
+        // Pre-allocated spares carry no records, so they say nothing about the window's reach.
+        var headers = new List<WalHeaderView>();
+        foreach (var h in WalChecks.ReadSegmentHeaders(bundle))
+        {
+            if (h.Valid && !h.Unused)
+            {
+                headers.Add(h);
+            }
+        }
+
+        if (headers.Count == 0)
+        {
+            return;
+        }
+
+        if (checkpointLsn > 0 && checkpointLsn < headers[0].FirstLsn)
+        {
+            ctx.Report(CheckpointWindow, IntegritySeverity.DataLoss, "LOG-03", Locus.Database,
+                "The write-ahead log does not reach back to the last checkpoint.",
+                $"The oldest surviving segment starts at LSN {headers[0].FirstLsn:N0}, but the last checkpoint recorded "
+                + $"{checkpointLsn:N0}. The records between the two were recycled before their contents were checkpointed, so "
+                + "the replay window has a hole at its start.",
+                Repairability.NotRepairable,
+                new LossEstimate
+                {
+                    Kind = LossKind.Unknown,
+                    EntityCount = -1,
+                    BoundedMin = 1,
+                    BoundedMax = long.MaxValue,
+                    Explanation = $"Every transaction between LSN {checkpointLsn:N0} and {headers[0].FirstLsn:N0}."
+                });
+        }
+    }
+
+    private static string DescribeSlot(MetaSlotView slot)
+    {
+        if (!slot.Present)
+        {
+            return $"Slot {slot.SlotIndex}: absent (the file is too short to contain it).";
+        }
+
+        if (!slot.ChecksumValid)
+        {
+            return $"Slot {slot.SlotIndex}: checksum mismatch (stored 0x{slot.StoredChecksum:X8}, computed 0x{slot.ComputedChecksum:X8}).";
+        }
+
+        return slot.Generation == 0
+            ? $"Slot {slot.SlotIndex}: checksum valid but never written through the alternation path (generation 0)."
+            : $"Slot {slot.SlotIndex}: valid at generation {slot.Generation}.";
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/Checks/PhysicalChecks.cs
+++ b/src/Typhon.Engine/Integrity/internals/Checks/PhysicalChecks.cs
@@ -1,0 +1,363 @@
+using System;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// <c>PHY</c> — per-page physical checks. Everything here is decidable from one page's own bytes, so it needs no
+/// cross-structure state and runs during the single sweep that reads the file.
+/// </summary>
+internal static class PhysicalChecks
+{
+    /// <summary>Check code: stored checksum matches page content.</summary>
+    public const string Checksum = "CHK-PHY-01";
+
+    /// <summary>Check code: the zero-checksum sentinel means "never written", not "live".</summary>
+    public const string ChecksumSentinel = "CHK-PHY-02";
+
+    /// <summary>Check code: flags and type hold defined values.</summary>
+    public const string HeaderFields = "CHK-PHY-03";
+
+    /// <summary>Check code: the seqlock modification counter is even on disk.</summary>
+    public const string SeqlockParity = "CHK-PHY-04";
+
+    /// <summary>Check code: flag combinations are legal.</summary>
+    public const string FlagCombination = "CHK-PHY-05";
+
+    /// <summary>Check code: the page's format revision is one this build knows.</summary>
+    public const string FormatRevision = "CHK-PHY-06";
+
+    /// <summary>Check code: the page's stamped index matches where it was found.</summary>
+    public const string MisdirectedWrite = "CHK-PHY-07";
+
+    /// <summary>
+    /// Runs every per-page check against one page image.
+    /// </summary>
+    /// <param name="ctx">The scan context.</param>
+    /// <param name="filePageIndex">Index the page was read from.</param>
+    /// <param name="page">The page image.</param>
+    /// <param name="allocated">Whether the allocation bitmap marks this page as in use.</param>
+    public static void RunForPage(ScanContext ctx, int filePageIndex, ReadOnlySpan<byte> page, bool allocated)
+    {
+        CheckHeaderFields(ctx, filePageIndex, page);
+        CheckSeqlockParity(ctx, filePageIndex, page);
+        CheckMisdirectedWrite(ctx, filePageIndex, page);
+
+        if (ctx.AtLeast(ScanDepth.Standard))
+        {
+            CheckChecksum(ctx, filePageIndex, page, allocated);
+        }
+    }
+
+    private static void CheckHeaderFields(ScanContext ctx, int filePageIndex, ReadOnlySpan<byte> page)
+    {
+        var flags = PageImage.Flags(page);
+        var type = PageImage.Type(page);
+
+        if (!PageImage.IsTypeDefined(type))
+        {
+            ctx.Report(HeaderFields, IntegritySeverity.Divergence, "", ctx.LocusForPage(filePageIndex),
+                $"Page {filePageIndex} carries an undefined block type ({(byte)type}).",
+                "The type byte is written once at page initialisation and never changes, so an undefined value means the "
+                + "header zone was overwritten by something that was not the page initialiser.");
+        }
+
+        if (!PageImage.AreFlagsWellFormed(flags))
+        {
+            ctx.Report(FlagCombination, IntegritySeverity.Divergence, "", ctx.LocusForPage(filePageIndex),
+                $"Page {filePageIndex} carries an illegal flag combination (0x{(byte)flags:X2}).",
+                "Legal combinations are: free; segment member; segment member and root. A root that is not a member, a page "
+                + "that is both free and a member, or any reserved bit set, cannot be produced by the page initialiser.");
+        }
+
+        var rev = PageImage.FormatRevision(page);
+        if (rev is < 0 or > 1)
+        {
+            ctx.Report(FormatRevision, IntegritySeverity.Advisory, "", ctx.LocusForPage(filePageIndex),
+                $"Page {filePageIndex} declares format revision {rev}, which this build does not know.",
+                "The page's internal layout may differ from what the decoders assume, so findings about its contents are less "
+                + "trustworthy than findings about its header.");
+        }
+    }
+
+    /// <summary>
+    /// The seqlock counter is even while a page is quiescent and odd while a write is in progress, and the checkpoint's
+    /// page snapshot only <i>begins</i> on an even counter. An odd counter on disk is therefore evidence that a page was
+    /// persisted by some path that did not honour the seqlock — the cheapest independent detector in the catalogue, one
+    /// byte-test per page at the shallowest depth.
+    /// </summary>
+    /// <remarks>
+    /// The meta pair is excluded and must be: it is written in place while latched by
+    /// <c>ManagedPagedMMF.PersistMetaNow</c>, so its counter is legitimately odd on disk. Encoding that exclusion is not
+    /// optional — without it the check fires on every healthy database.
+    /// </remarks>
+    private static void CheckSeqlockParity(ScanContext ctx, int filePageIndex, ReadOnlySpan<byte> page)
+    {
+        if (filePageIndex <= 1)
+        {
+            return;
+        }
+
+        var counter = PageImage.ModificationCounter(page);
+        if ((counter & 1) == 0)
+        {
+            return;
+        }
+
+        ctx.Report(SeqlockParity, IntegritySeverity.Divergence, "SL-01", ctx.LocusForPage(filePageIndex),
+            $"Page {filePageIndex} was captured mid-modification.",
+            $"Its seqlock counter is {counter}, which is odd. The counter is even when a page is quiescent and odd only while "
+            + "a writer holds it, and the checkpoint's snapshot refuses to start on an odd counter — so this image reached "
+            + "disk through a path that did not honour the seqlock. The page's contents may be internally inconsistent even "
+            + "though its checksum verifies.");
+    }
+
+    /// <summary>
+    /// A page carries its own logical index, so a page written to the wrong file offset is caught with certainty rather
+    /// than probabilistically. Without this a misdirected write is <i>completely</i> undetectable: the page's checksum is
+    /// perfectly valid, it is simply the wrong page.
+    /// </summary>
+    private static void CheckMisdirectedWrite(ScanContext ctx, int filePageIndex, ReadOnlySpan<byte> page)
+    {
+        var stamped = PageSectorFooter.ReadFilePageIndex(page);
+        if (stamped == 0 || stamped == filePageIndex)
+        {
+            return;   // 0 means the page predates the stamp
+        }
+
+        // A protected page legitimately lives in either of two physical slots, and the stamp records the LOGICAL index, so
+        // finding a primary's content at its twin offset is the mechanism working, not a misdirect. Test the twin SET
+        // rather than the page's role: a twin can also be one of the genesis-reserved pages (the occupancy root's twin is),
+        // and the role array keeps the stronger classification.
+        if (ctx.TwinSlots.Contains(filePageIndex))
+        {
+            return;
+        }
+
+        ctx.Report(MisdirectedWrite, IntegritySeverity.DataLoss, "", ctx.LocusForPage(filePageIndex),
+            $"Page {filePageIndex} holds the contents of page {stamped}.",
+            $"The page stamps its own logical index, and this image says {stamped}. A write landed at the wrong file offset, "
+            + $"which destroys whatever page {filePageIndex} held and leaves two offsets claiming to be page {stamped}. The "
+            + "checksum verifies, because the bytes themselves are intact — they are simply in the wrong place.",
+            Repairability.NotRepairable,
+            new LossEstimate
+            {
+                Kind = LossKind.Unknown,
+                EntityCount = -1,
+                BoundedMin = 1,
+                BoundedMax = 475,
+                Explanation = $"Everything page {filePageIndex} held before the misdirected write. Its contents are gone and "
+                    + "nothing in the database records what they were."
+            });
+    }
+
+    private static void CheckChecksum(ScanContext ctx, int filePageIndex, ReadOnlySpan<byte> page, bool allocated)
+    {
+        // The A/B protected pages are verified as PAIRS, not individually, and reporting them here would be wrong in both
+        // directions. The meta pair's first write goes to slot 1, so physical page 0 legitimately holds a never-CRC'd image
+        // on a fresh database — the engine's own load path skips page 0 for exactly this reason. A directory twin holds a
+        // complete image of an OLDER generation, which is not damage: it is the fallback working as designed.
+        if (filePageIndex <= 1)
+        {
+            return;   // owned by CHK-BOO-03
+        }
+
+        if (ctx.TwinSlots.Contains(filePageIndex))
+        {
+            CheckTwinSlot(ctx, filePageIndex, page);
+            return;
+        }
+
+        var sectorCount = PageSectorFooter.ReadSectorCount(page);
+        if (sectorCount > 0)
+        {
+            CheckSectoredPage(ctx, filePageIndex, page, sectorCount);
+            return;
+        }
+
+        var stored = PageImage.StoredChecksum(page);
+        if (stored == 0)
+        {
+            // The zero sentinel means "never checkpointed". A page that is allocated and carries content but no checksum is
+            // a different thing: either it was never flushed, or its header was zeroed by damage.
+            if (allocated && !IsBlank(page))
+            {
+                ctx.Report(ChecksumSentinel, IntegritySeverity.Divergence, "", ctx.LocusForPage(filePageIndex),
+                    $"Page {filePageIndex} is allocated and holds data but carries no checksum.",
+                    "A zero checksum is the sentinel for a page that was never written to disk. This page is marked allocated "
+                    + "and is not blank, so either the write never completed or the header was zeroed after the fact. Its "
+                    + "contents cannot be verified either way.");
+            }
+
+            return;
+        }
+
+        if (PageImage.VerifyWholePageChecksum(page, out var computed))
+        {
+            return;
+        }
+
+        ctx.ChecksumFailures++;
+        ReportChecksumFailure(ctx, filePageIndex, allocated, stored, computed);
+    }
+
+    /// <summary>
+    /// A twin slot holds the alternate copy of a protected directory page. It is <i>expected</i> to be an older generation,
+    /// so only an unreadable twin is a finding — and then only as a degradation, because the pair is still serving from its
+    /// good slot. What it costs is the fallback: the next write to that directory page has nothing to fall back to.
+    /// </summary>
+    private static void CheckTwinSlot(ScanContext ctx, int filePageIndex, ReadOnlySpan<byte> page)
+    {
+        if (PageImage.VerifyWholePageChecksum(page, out var computed))
+        {
+            return;
+        }
+
+        // A twin that was allocated but never written through the alternation path is blank, which is normal on a young
+        // database rather than damage.
+        if (PageImage.PairGeneration(page) == 0 && IsBlank(page))
+        {
+            return;
+        }
+
+        ctx.ChecksumFailures++;
+        ctx.Report(Checksum, IntegritySeverity.Divergence, "CK-05", ctx.LocusForPage(filePageIndex),
+            $"Directory twin slot on page {filePageIndex} is unreadable; its segment is running without a fallback copy.",
+            $"Stored 0x{PageImage.StoredChecksum(page):X8}, computed 0x{computed:X8}. The primary slot is serving correctly, "
+            + "so nothing is lost right now — but the pair exists so that a torn write to the directory can never destroy "
+            + "the segment, and that protection is currently absent. It restores itself on the next write to this directory "
+            + "page, which alternates back into the bad slot.",
+            Repairability.Lossless);
+    }
+
+    private static void CheckSectoredPage(ScanContext ctx, int filePageIndex, ReadOnlySpan<byte> page, int sectorCount)
+    {
+        ctx.PagesWithSectorFooters++;
+
+        Span<bool> sectorOk = stackalloc bool[PageSectorFooter.MaxSectorCount];
+        var footerIntact = PageSectorFooter.Verify(page, sectorCount, sectorOk, out var failed);
+
+        if (failed == 0)
+        {
+            return;
+        }
+
+        ctx.ChecksumFailures++;
+        ctx.SectorFailures += failed;
+
+        var locus = ctx.LocusForPage(filePageIndex);
+        var sectorBytes = IntegrityConstants.PageSize / sectorCount;
+
+        if (!footerIntact)
+        {
+            ctx.Report(Checksum, IntegritySeverity.DataLoss, "ADR-015", locus,
+                $"Page {filePageIndex} failed verification and its per-sector footer is unreadable.",
+                "The footer that records each sector's checksum did not itself verify, so no part of this page can be trusted "
+                + "and salvage falls back to whole-page granularity. Everything the page held is affected.",
+                Repairability.Lossy, DescribeWholePageLoss(ctx, filePageIndex));
+            return;
+        }
+
+        ctx.Report(Checksum, IntegritySeverity.DataLoss, "ADR-015", locus,
+            $"Page {filePageIndex} failed verification in {failed} of its {sectorCount} sectors.",
+            $"Each sector covers {sectorBytes} bytes and is verified independently, so the {sectorCount - failed} intact "
+            + $"sectors are provably current: {DescribeSectors(sectorOk, sectorCount)}. Only rows that touch a failed sector "
+            + "are affected — the rest of the page is salvageable.",
+            Repairability.Lossy,
+            new LossEstimate
+            {
+                Kind = LossKind.Unknown,
+                EntityCount = -1,
+                BoundedMin = 1,
+                BoundedMax = 475,
+                Explanation = $"Rows stored in the {failed} damaged sector(s) of page {filePageIndex}. Naming them exactly "
+                    + "requires the archetype layout, which an offline scan of this depth does not decode."
+            });
+    }
+
+    private static void ReportChecksumFailure(ScanContext ctx, int filePageIndex, bool allocated, uint stored, uint computed)
+    {
+        var locus = ctx.LocusForPage(filePageIndex);
+        var kind = locus.Kind;
+        var derived = IsDerivedKind(kind);
+
+        if (!allocated)
+        {
+            ctx.Report(Checksum, IntegritySeverity.Advisory, "ADR-015", locus,
+                $"Free page {filePageIndex} failed its checksum.",
+                $"Stored 0x{stored:X8}, computed 0x{computed:X8}. The page is not allocated, so nothing reads it and nothing "
+                + "is lost; the stale contents are simply not what its header claims.");
+            return;
+        }
+
+        if (derived)
+        {
+            ctx.Report(Checksum, IntegritySeverity.Divergence, "RB-01", locus,
+                $"Page {filePageIndex} of the {kind} segment failed its checksum.",
+                $"Stored 0x{stored:X8}, computed 0x{computed:X8}. {kind} is derived state, so this page is regenerated from "
+                + "primary data rather than repaired — nothing is lost.",
+                Repairability.Lossless);
+            return;
+        }
+
+        ctx.Report(Checksum, IntegritySeverity.DataLoss, "RB-04", locus,
+            $"Page {filePageIndex} failed its checksum and holds primary data.",
+            $"Stored 0x{stored:X8}, computed 0x{computed:X8}. This page carries {(kind == StorageSegmentKind.Other ? "unattributed" : kind.ToString())} "
+            + "content, which no other structure can regenerate. It carries no per-sector footer, so the whole page is "
+            + "condemned rather than the damaged part of it.",
+            Repairability.Lossy, DescribeWholePageLoss(ctx, filePageIndex));
+    }
+
+    private static LossEstimate DescribeWholePageLoss(ScanContext ctx, int filePageIndex)
+    {
+        var locus = ctx.LocusForPage(filePageIndex);
+        return new LossEstimate
+        {
+            Kind = LossKind.Unknown,
+            EntityCount = -1,
+            BoundedMin = 1,
+            BoundedMax = 475,
+            Archetype = locus.ArchetypeName,
+            Explanation = $"Everything stored on page {filePageIndex}. The upper bound is the most rows a page of any shape "
+                + "can hold; the exact figure needs the owning archetype's layout."
+        };
+    }
+
+    /// <summary>
+    /// Whether a segment kind holds state that is a pure function of primary data, and can therefore be discarded and
+    /// rebuilt with zero loss. Getting this partition right is the difference between a repair tool and a data-destroying
+    /// one.
+    /// </summary>
+    /// <param name="kind">The segment kind.</param>
+    public static bool IsDerivedKind(StorageSegmentKind kind) => kind switch
+    {
+        StorageSegmentKind.Index => true,
+        StorageSegmentKind.EntityMap => true,
+        StorageSegmentKind.Spatial => true,
+        StorageSegmentKind.Occupancy => true,
+        _ => false
+    };
+
+    private static string DescribeSectors(ReadOnlySpan<bool> sectorOk, int sectorCount)
+    {
+        Span<char> map = stackalloc char[sectorCount];
+        for (var i = 0; i < sectorCount; i++)
+        {
+            map[i] = sectorOk[i] ? '.' : 'X';
+        }
+
+        return new string(map);
+    }
+
+    private static bool IsBlank(ReadOnlySpan<byte> page)
+    {
+        for (var i = 0; i < page.Length; i++)
+        {
+            if (page[i] != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/Checks/SegmentChecks.cs
+++ b/src/Typhon.Engine/Integrity/internals/Checks/SegmentChecks.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// <c>SEG</c> — segment, directory and page-allocation checks. The family that decides whether the file's structural graph
+/// is a graph at all.
+/// </summary>
+internal static class SegmentChecks
+{
+    /// <summary>Check code: every page is claimed by at most one segment.</summary>
+    public const string SingleOwner = "CHK-SEG-01";
+
+    /// <summary>Check code: the allocation bitmap agrees with the reachability walk.</summary>
+    public const string OccupancyAgreement = "CHK-SEG-02";
+
+    /// <summary>Check code: the page directory and the forward chain agree.</summary>
+    public const string DirectoryChain = "CHK-SEG-05";
+
+    /// <summary>Check code: directory walks terminate.</summary>
+    public const string DirectoryTraversal = "CHK-SEG-06";
+
+    /// <summary>Check code: a segment root declares a defined kind.</summary>
+    public const string SegmentKind = "CHK-SEG-07";
+
+    /// <summary>Runs the segment family over the walked structure.</summary>
+    /// <param name="ctx">The scan context, with segments already walked.</param>
+    public static void Run(ScanContext ctx)
+    {
+        CheckWalkDiagnostics(ctx);
+        CheckSegmentKinds(ctx);
+        CheckDirectoryVersusChain(ctx);
+
+        if (ctx.AtLeast(ScanDepth.Deep))
+        {
+            CheckOccupancyAgreement(ctx);
+        }
+        else
+        {
+            ctx.Findings.NoteSkipped(OccupancyAgreement, "needs Deep depth");
+        }
+    }
+
+    private static void CheckWalkDiagnostics(ScanContext ctx)
+    {
+        foreach (var seg in ctx.Segments.Values)
+        {
+            for (var i = 0; i < seg.WalkDiagnostics.Count; i++)
+            {
+                var text = seg.WalkDiagnostics[i];
+                var fatal = text.Contains("cycle", StringComparison.OrdinalIgnoreCase)
+                    || text.Contains("cannot be read", StringComparison.OrdinalIgnoreCase);
+
+                ctx.Report(DirectoryTraversal, fatal ? IntegritySeverity.Fatal : IntegritySeverity.Divergence, "",
+                    new Locus(seg.RootPageIndex, seg.RootPageIndex, seg.Kind),
+                    $"The {seg.Kind} segment rooted at page {seg.RootPageIndex} could not be walked cleanly.",
+                    text + (fatal
+                        ? " An engine walking this structure would hang or read outside the file, so the segment is unusable "
+                          + "as it stands."
+                        : " The walk recovered what it could and stopped; pages past that point are unaccounted for."));
+            }
+        }
+    }
+
+    private static void CheckSegmentKinds(ScanContext ctx)
+    {
+        foreach (var seg in ctx.Segments.Values)
+        {
+            if (PageImage.IsKindDefined(seg.Kind))
+            {
+                continue;
+            }
+
+            ctx.Report(SegmentKind, IntegritySeverity.Divergence, "", new Locus(seg.RootPageIndex, seg.RootPageIndex),
+                $"The segment rooted at page {seg.RootPageIndex} declares an undefined kind ({(byte)seg.Kind}).",
+                "The kind is written once at segment creation and read back at load. An undefined value means the root "
+                + "page's header zone was overwritten, and the engine would not know how to interpret the segment's pages.");
+        }
+    }
+
+    /// <summary>
+    /// The page directory and the forward data-page chain are written by independent code paths, so a disagreement
+    /// localises a lost write precisely: one of the two writes did not reach disk before the previous close.
+    /// </summary>
+    private static void CheckDirectoryVersusChain(ScanContext ctx)
+    {
+        foreach (var seg in ctx.Segments.Values)
+        {
+            if (!seg.DirectoryComplete || !seg.ChainComplete)
+            {
+                continue;   // already reported as a traversal problem; the counts would be meaningless
+            }
+
+            if (seg.ForwardChainCount == seg.Pages.Count)
+            {
+                continue;
+            }
+
+            var diff = seg.ForwardChainCount - seg.Pages.Count;
+            ctx.Report(DirectoryChain, IntegritySeverity.Divergence, "",
+                new Locus(seg.RootPageIndex, seg.RootPageIndex, seg.Kind),
+                $"The {seg.Kind} segment rooted at page {seg.RootPageIndex} disagrees with itself about how many pages it owns.",
+                $"Its page directory enumerates {seg.Pages.Count:N0} pages; its forward page chain reaches "
+                + $"{seg.ForwardChainCount:N0} ({diff:+0;-#}). The two are written by separate code paths during a grow, so "
+                + (diff > 0
+                    ? "the directory append did not persist — the extra pages are allocated and linked but unaddressable."
+                    : "the chain pointer did not persist — the directory names pages the chain cannot reach."),
+                Repairability.Lossless);
+        }
+    }
+
+    /// <summary>
+    /// The allocation bitmap is derived state, so a disagreement with the reachability walk is reported as "the bitmap is
+    /// wrong", never as "these pages are wrong" — and the repair is a re-derive, not a page edit.
+    /// </summary>
+    private static void CheckOccupancyAgreement(ScanContext ctx)
+    {
+        var occ = ctx.Occupancy;
+        if (occ == null || !occ.IsComplete)
+        {
+            ctx.Findings.NoteSkipped(OccupancyAgreement, "the allocation bitmap could not be read in full");
+            return;
+        }
+
+        var leaked = new List<int>();
+        var phantom = new List<int>();
+        var pageCount = Math.Min(ctx.Source.PageCount, ctx.Roles.Length);
+
+        for (var p = 0; p < pageCount; p++)
+        {
+            var reachable = ctx.Roles[p] != PageRole.Unclaimed;
+            var allocated = occ.IsAllocated(p);
+
+            if (allocated && !reachable)
+            {
+                leaked.Add(p);
+            }
+            else if (!allocated && reachable)
+            {
+                phantom.Add(p);
+            }
+        }
+
+        if (leaked.Count > 0)
+        {
+            ctx.Report(OccupancyAgreement, IntegritySeverity.Leak, "CK-09",
+                new Locus(leaked[0]),
+                $"{leaked.Count:N0} pages are marked allocated but no segment claims them.",
+                $"{FormatPageList(leaked)} The bitmap survived a grow whose directory append did not, so the space is held "
+                + $"but unreachable — {(long)leaked.Count * IntegrityConstants.PageSize / 1024:N0} KiB. Nothing is lost; the "
+                + "space is reclaimed by re-deriving the bitmap from the reachability walk.",
+                Repairability.Lossless);
+        }
+
+        if (phantom.Count > 0)
+        {
+            ctx.Report(OccupancyAgreement, IntegritySeverity.Divergence, "CK-09",
+                new Locus(phantom[0]),
+                $"{phantom.Count:N0} pages are claimed by a segment but the allocation bitmap says they are free.",
+                $"{FormatPageList(phantom)} This is the dangerous direction: the allocator believes these pages are "
+                + "available and could hand one out to a second owner, at which point two structures would write over each "
+                + "other. Re-deriving the bitmap from the reachability walk fixes it, and doing so before any further "
+                + "allocation is what prevents the double-allocation.",
+                Repairability.Lossless);
+        }
+    }
+
+    private static string FormatPageList(List<int> pages)
+    {
+        const int show = 8;
+        var count = Math.Min(show, pages.Count);
+        var text = string.Join(", ", pages.GetRange(0, count));
+        return pages.Count > show ? $"Pages {text}, … (+{pages.Count - show:N0} more)." : $"Pages {text}.";
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/Checks/WalChecks.cs
+++ b/src/Typhon.Engine/Integrity/internals/Checks/WalChecks.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>One WAL segment file's header, as read without replaying anything.</summary>
+/// <param name="Name">File name of the segment.</param>
+/// <param name="FileBytes">Size of the file on disk.</param>
+/// <param name="Valid">Whether the header is well-formed and checksum-valid.</param>
+/// <param name="Unused">
+/// Whether the segment is pre-allocated but never written. The writer creates segments ahead of need so a commit never
+/// waits on file allocation, so an all-zero header is the normal state of a spare — not damage.
+/// </param>
+/// <param name="SegmentId">Monotonic segment identifier.</param>
+/// <param name="FirstLsn">LSN of the segment's first record.</param>
+/// <param name="PrevSegmentLsn">Last LSN of the previous segment.</param>
+/// <param name="DeclaredSize">Total size the header declares.</param>
+/// <param name="Problem">What is wrong with the header, when anything is.</param>
+internal readonly record struct WalHeaderView(string Name, long FileBytes, bool Valid, bool Unused, long SegmentId, long FirstLsn,
+    long PrevSegmentLsn, uint DeclaredSize, string Problem);
+
+/// <summary>
+/// <c>WAL</c> — write-ahead log window checks.
+/// </summary>
+/// <remarks>
+/// The log is read <b>as bytes and never replayed</b>: replay is a mutation, and mutation is what a checker must not do.
+/// This family reports that the window holds <i>n</i> committed transactions not yet in the data file; it does not apply
+/// them.
+/// </remarks>
+internal static class WalChecks
+{
+    /// <summary>Check code: segment headers are valid and sized as declared.</summary>
+    public const string SegmentHeaders = "CHK-WAL-01";
+
+    /// <summary>Check code: per-record CRC chain integrity.</summary>
+    public const string RecordChain = "CHK-WAL-02";
+
+    /// <summary>Check code: LSNs are strictly monotonic across segments.</summary>
+    public const string LsnOrder = "CHK-WAL-03";
+
+    /// <summary>Check code: the replayable window has no gap.</summary>
+    public const string WindowContiguity = "CHK-WAL-04";
+
+    /// <summary>Runs the WAL family.</summary>
+    /// <param name="ctx">The scan context.</param>
+    public static void Run(ScanContext ctx)
+    {
+        var bundle = ctx.Bundle;
+        if (bundle == null || bundle.WalSegments.Count == 0)
+        {
+            ctx.Findings.NoteSkipped(SegmentHeaders, "no WAL segments present");
+            return;
+        }
+
+        // Record-level walking needs the drain-block record layout, which this scan deliberately does not decode: a
+        // half-understood parse of a log it must not replay would produce findings nobody can act on. Saying so is the
+        // point of the limits block.
+        ctx.Findings.NoteSkipped(RecordChain, "per-record CRC chain walking is not implemented; only segment headers are verified");
+        ctx.Findings.NoteCaveat(
+            "WAL contents were not parsed. Segment headers, ordering and window contiguity are verified; the records inside "
+            + "each segment are not. A torn record tail inside an otherwise-valid segment would not be reported.");
+
+        var headers = ReadSegmentHeaders(bundle);
+        CheckHeaders(ctx, headers);
+        CheckOrdering(ctx, headers);
+    }
+
+    /// <summary>Reads every WAL segment file's 4 KiB header without touching its records.</summary>
+    /// <param name="bundle">The bundle whose <c>wal/</c> directory is read.</param>
+    public static IReadOnlyList<WalHeaderView> ReadSegmentHeaders(OfflineBundlePageSource bundle)
+    {
+        var result = new List<WalHeaderView>(bundle.WalSegments.Count);
+        var buffer = new byte[WalSegmentHeader.SizeInBytes];
+
+        for (var i = 0; i < bundle.WalSegments.Count; i++)
+        {
+            var seg = bundle.WalSegments[i];
+            if (seg.SizeBytes < WalSegmentHeader.SizeInBytes)
+            {
+                result.Add(new WalHeaderView(seg.Name, seg.SizeBytes, false, false, 0, 0, 0, 0,
+                    $"the file is {seg.SizeBytes:N0} bytes, shorter than the {WalSegmentHeader.SizeInBytes:N0}-byte header"));
+                continue;
+            }
+
+            try
+            {
+                using var handle = File.OpenHandle(seg.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                RandomAccess.Read(handle, buffer, 0);
+            }
+            catch (IOException ex)
+            {
+                result.Add(new WalHeaderView(seg.Name, seg.SizeBytes, false, false, 0, 0, 0, 0, $"the file could not be read: {ex.Message}"));
+                continue;
+            }
+
+            // A pre-allocated spare has an all-zero header. The writer creates segments ahead of need so a commit never
+            // blocks on file allocation, so this is the normal resting state of a spare rather than a damaged segment —
+            // and reporting it as damage would put a finding on every healthy database that pre-allocates.
+            if (IsAllZero(buffer))
+            {
+                result.Add(new WalHeaderView(seg.Name, seg.SizeBytes, false, true, long.MaxValue, 0, 0, 0, null));
+                continue;
+            }
+
+            var magic = MemoryMarshal.Read<uint>(buffer);
+            var version = MemoryMarshal.Read<uint>(buffer.AsSpan(4));
+            var segmentId = MemoryMarshal.Read<long>(buffer.AsSpan(8));
+            var firstLsn = MemoryMarshal.Read<long>(buffer.AsSpan(16));
+            var prevLsn = MemoryMarshal.Read<long>(buffer.AsSpan(24));
+            var declaredSize = MemoryMarshal.Read<uint>(buffer.AsSpan(32));
+            var storedCrc = MemoryMarshal.Read<uint>(buffer.AsSpan(WalSegmentHeader.HeaderCrcOffset));
+            var computedCrc = Crc32CUtil.ComputeSkipping(buffer, WalSegmentHeader.HeaderCrcOffset, sizeof(uint));
+
+            string problem = null;
+            if (magic != WalSegmentHeader.MagicValue)
+            {
+                problem = $"the magic number is 0x{magic:X8}, not the expected 0x{WalSegmentHeader.MagicValue:X8}";
+            }
+            else if (version != WalSegmentHeader.CurrentVersion)
+            {
+                problem = $"the format version is {version}, not {WalSegmentHeader.CurrentVersion}";
+            }
+            else if (storedCrc != computedCrc)
+            {
+                problem = $"the header checksum does not match (stored 0x{storedCrc:X8}, computed 0x{computedCrc:X8})";
+            }
+
+            result.Add(new WalHeaderView(seg.Name, seg.SizeBytes, problem == null, false, segmentId, firstLsn, prevLsn, declaredSize, problem));
+        }
+
+        // Unused spares sort last (their id is MaxValue), so the ordering checks below walk only real segments.
+        result.Sort(static (x, y) => x.SegmentId.CompareTo(y.SegmentId));
+        return result;
+    }
+
+    private static bool IsAllZero(ReadOnlySpan<byte> data)
+    {
+        for (var i = 0; i < data.Length; i++)
+        {
+            if (data[i] != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void CheckHeaders(ScanContext ctx, IReadOnlyList<WalHeaderView> headers)
+    {
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var h = headers[i];
+            if (h.Unused)
+            {
+                continue;   // a pre-allocated spare, waiting to be used
+            }
+
+            if (!h.Valid)
+            {
+                ctx.Report(SegmentHeaders, IntegritySeverity.Divergence, "N7", Locus.Database,
+                    $"WAL segment '{h.Name}' has an unusable header.",
+                    $"Specifically, {h.Problem}. Recovery cannot order this segment against the others, so any transactions "
+                    + "it holds are effectively outside the replayable window.");
+                continue;
+            }
+
+            if (h.DeclaredSize != 0 && h.FileBytes != h.DeclaredSize)
+            {
+                ctx.Report(SegmentHeaders, IntegritySeverity.Divergence, "N7", Locus.Database,
+                    $"WAL segment '{h.Name}' is not the size its header declares.",
+                    $"The header declares {h.DeclaredSize:N0} bytes; the file is {h.FileBytes:N0}. "
+                    + (h.FileBytes < h.DeclaredSize
+                        ? "A short file is the silent-truncation shape: records that were written are simply not there any more."
+                        : "A long file means something appended past the segment's declared end."));
+            }
+        }
+    }
+
+    private static void CheckOrdering(ScanContext ctx, IReadOnlyList<WalHeaderView> headers)
+    {
+        long previousId = long.MinValue;
+        long previousFirstLsn = long.MinValue;
+
+        for (var i = 0; i < headers.Count; i++)
+        {
+            var h = headers[i];
+            if (!h.Valid || h.Unused)
+            {
+                continue;
+            }
+
+            if (h.SegmentId == previousId)
+            {
+                ctx.Report(LsnOrder, IntegritySeverity.Fatal, "LOG-08", Locus.Database,
+                    $"Two WAL segments share id {h.SegmentId}.",
+                    $"'{h.Name}' duplicates an earlier segment's identifier. Recovery orders segments by id, so it cannot "
+                    + "decide which of the two to replay — and replaying the wrong one applies a different set of "
+                    + "transactions than the one that committed.");
+            }
+            else if (previousFirstLsn != long.MinValue && h.FirstLsn <= previousFirstLsn)
+            {
+                ctx.Report(LsnOrder, IntegritySeverity.Divergence, "LOG-08", Locus.Database,
+                    $"WAL segment '{h.Name}' does not start after the segment before it.",
+                    $"Its first LSN is {h.FirstLsn:N0}, but the previous segment already started at {previousFirstLsn:N0}. "
+                    + "LSNs are strictly monotonic across the log, so the sequence is either out of order or a segment "
+                    + "carries a stale header.");
+            }
+
+            if (previousId != long.MinValue && h.SegmentId > previousId + 1)
+            {
+                ctx.Report(WindowContiguity, IntegritySeverity.Fatal, "LOG-03", Locus.Database,
+                    $"The WAL is missing segment(s) between id {previousId} and {h.SegmentId}.",
+                    $"{h.SegmentId - previousId - 1} segment file(s) are absent from the middle of the log. Recovery replays "
+                    + "a contiguous window; a hole in the middle means it must stop at the hole, silently discarding every "
+                    + "transaction after it even though those segments are present and intact.",
+                    Repairability.NotRepairable,
+                    new LossEstimate
+                    {
+                        Kind = LossKind.Unknown,
+                        EntityCount = -1,
+                        BoundedMin = 1,
+                        BoundedMax = long.MaxValue,
+                        Explanation = $"Every transaction from segment {previousId + 1} onward — including the ones in the "
+                            + "segments that survived, because recovery cannot skip the gap."
+                    });
+            }
+
+            previousId = h.SegmentId;
+            previousFirstLsn = h.FirstLsn;
+        }
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/FindingCollector.cs
+++ b/src/Typhon.Engine/Integrity/internals/FindingCollector.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// Accumulates findings while keeping a report readable on a database where one systemic fault is individually true a
+/// million times.
+/// </summary>
+/// <remarks>
+/// Per check code, the first <see cref="PerCodeDetailLimit"/> occurrences are reported in full — each with its own
+/// <see cref="Locus"/>, which is what makes a finding actionable. Beyond that the collector stops enumerating and starts
+/// counting, and the surviving finding carries the true total in <see cref="IntegrityFinding.Occurrences"/>. A truncated
+/// enumeration is always disclosed in the report's <see cref="ScanLimits.Caveats"/> — silently dropping occurrences would
+/// make a catastrophic database look like a mildly damaged one.
+/// </remarks>
+internal sealed class FindingCollector
+{
+    /// <summary>Distinct loci reported per check code before the collector switches to counting.</summary>
+    public const int PerCodeDetailLimit = 50;
+
+    private readonly List<IntegrityFinding> _findings = [];
+    private readonly Dictionary<string, CodeState> _byCode = new(StringComparer.Ordinal);
+    private readonly IntegrityOptions _options;
+    private readonly HashSet<string> _skipped = new(StringComparer.Ordinal);
+    private readonly List<string> _caveats = [];
+
+    private sealed class CodeState
+    {
+        public int Detailed;
+        public long Total;
+        public IntegrityFinding Representative;
+    }
+
+    /// <summary>Creates a collector bound to a scan's options.</summary>
+    /// <param name="options">The scan options, which bound how much is recorded.</param>
+    public FindingCollector(IntegrityOptions options) => _options = options;
+
+    /// <summary>Whether the collector has reached the scan's global finding cap.</summary>
+    public bool IsSaturated => _findings.Count >= _options.MaxFindings;
+
+    /// <summary>Extra caveats to surface in the report's limits block.</summary>
+    public IReadOnlyList<string> Caveats => _caveats;
+
+    /// <summary>Check codes that were filtered out or not applicable at this depth.</summary>
+    public IReadOnlyList<string> Skipped
+    {
+        get
+        {
+            var list = new List<string>(_skipped);
+            list.Sort(StringComparer.Ordinal);
+            return list;
+        }
+    }
+
+    /// <summary>Records that a check did not run.</summary>
+    /// <param name="code">The check code.</param>
+    /// <param name="reason">Why it did not run — appended to the code for the report.</param>
+    public void NoteSkipped(string code, string reason) => _skipped.Add(reason == null ? code : $"{code} ({reason})");
+
+    /// <summary>Records a scan-specific caveat for the limits block.</summary>
+    /// <param name="caveat">The caveat text.</param>
+    public void NoteCaveat(string caveat)
+    {
+        if (!_caveats.Contains(caveat))
+        {
+            _caveats.Add(caveat);
+        }
+    }
+
+    /// <summary>
+    /// Adds a finding, collapsing repeats of the same code past the detail limit into an occurrence count.
+    /// </summary>
+    /// <param name="finding">The finding to record.</param>
+    public void Add(IntegrityFinding finding)
+    {
+        if (!_byCode.TryGetValue(finding.Code, out var state))
+        {
+            state = new CodeState();
+            _byCode[finding.Code] = state;
+        }
+
+        state.Total++;
+
+        if (state.Detailed < PerCodeDetailLimit && !IsSaturated)
+        {
+            state.Detailed++;
+            state.Representative ??= finding;
+            _findings.Add(finding);
+            return;
+        }
+
+        if (state.Detailed == PerCodeDetailLimit)
+        {
+            state.Detailed++;   // one-shot: only note the truncation once per code
+            NoteCaveat($"{finding.Code}: only the first {PerCodeDetailLimit} occurrences are enumerated; the rest are counted.");
+        }
+    }
+
+    /// <summary>
+    /// Produces the final severity-ranked list, stamping each code's representative finding with the true occurrence count.
+    /// </summary>
+    public IReadOnlyList<IntegrityFinding> Build()
+    {
+        var result = new List<IntegrityFinding>(_findings.Count);
+        var stamped = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var i = 0; i < _findings.Count; i++)
+        {
+            var f = _findings[i];
+            var total = _byCode[f.Code].Total;
+            if (total > 1 && stamped.Add(f.Code))
+            {
+                result.Add(new IntegrityFinding
+                {
+                    Code = f.Code,
+                    Severity = f.Severity,
+                    Confidence = f.Confidence,
+                    Locus = f.Locus,
+                    Summary = f.Summary,
+                    Detail = f.Detail,
+                    RuleId = f.RuleId,
+                    Repair = f.Repair,
+                    Loss = f.Loss,
+                    Occurrences = total
+                });
+                continue;
+            }
+
+            result.Add(f);
+        }
+
+        result.Sort(static (x, y) =>
+        {
+            var bySeverity = ((int)x.Severity).CompareTo((int)y.Severity);
+            if (bySeverity != 0)
+            {
+                return bySeverity;
+            }
+
+            var byCode = string.CompareOrdinal(x.Code, y.Code);
+            return byCode != 0 ? byCode : x.Locus.FilePageIndex.CompareTo(y.Locus.FilePageIndex);
+        });
+
+        return result;
+    }
+
+    /// <summary>Total occurrences recorded for a check code, including ones collapsed past the detail limit.</summary>
+    /// <param name="code">The check code.</param>
+    public long CountFor(string code) => _byCode.TryGetValue(code, out var s) ? s.Total : 0;
+
+    /// <summary>Counts findings by severity, for the report totals.</summary>
+    public IReadOnlyList<int> SeverityHistogram()
+    {
+        var counts = new int[5];
+        foreach (var state in _byCode.Values)
+        {
+            if (state.Representative != null)
+            {
+                counts[(int)state.Representative.Severity] += (int)Math.Min(state.Total, int.MaxValue);
+            }
+        }
+
+        return counts;
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/OccupancyRepair.cs
+++ b/src/Typhon.Engine/Integrity/internals/OccupancyRepair.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// Recomputes the page-allocation bitmap from the segments that actually exist.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The bitmap is <b>derived</b> state — the crash path already re-derives it — so it is never the authority on what is
+/// allocated. A disagreement with the reachability walk therefore means the bitmap is wrong, never that the pages are, and
+/// the repair is a recompute rather than a page edit. That asymmetry is the whole reason this repair is safe: it writes
+/// only to the structure that was already defined as reconstructible.
+/// </para>
+/// <para>
+/// Of the two directions of disagreement, the dangerous one is a <i>phantom</i> free bit — a page a segment owns that the
+/// bitmap says is available. Left alone, the allocator eventually hands that page to a second owner and the two structures
+/// write over each other. Leaked bits (marked but unreachable) merely waste space. Recomputing fixes both, and fixing the
+/// phantom direction before any further allocation is what prevents the double-allocation.
+/// </para>
+/// </remarks>
+internal static class OccupancyRepair
+{
+    /// <summary>
+    /// Rebuilds the bitmap in place from a fresh structural walk.
+    /// </summary>
+    /// <param name="bundlePath">The bundle directory.</param>
+    /// <returns>A description of what changed, for the repair receipt.</returns>
+    /// <exception cref="InvalidOperationException">The occupancy segment could not be located or is unusable.</exception>
+    public static string Rederive(string bundlePath)
+    {
+        using var source = new OfflineBundlePageSource(bundlePath);
+
+        var reachable = WalkReachablePages(source, out var occupancySegment);
+        if (occupancySegment == null)
+        {
+            throw new InvalidOperationException(
+                "No occupancy segment could be found, so the allocation bitmap cannot be rebuilt. The database's structural "
+                + "spine is damaged beyond what this repair can address.");
+        }
+
+        var dataPageCount = occupancySegment.Pages.Count - 1;
+        if (dataPageCount <= 0)
+        {
+            throw new InvalidOperationException("The occupancy segment has no data pages; there is no bitmap to rebuild.");
+        }
+
+        var wordCount = dataPageCount * OccupancyView.WordsPerPage;
+        var words = new ulong[wordCount];
+        var capacity = wordCount * 64;
+
+        var set = 0;
+        foreach (var page in reachable)
+        {
+            if (page < 0 || page >= capacity)
+            {
+                continue;
+            }
+
+            words[page >> 6] |= 1UL << (page & 63);
+            set++;
+        }
+
+        var before = 0;
+        var existing = OccupancyView.Read(source, occupancySegment);
+        if (existing.IsComplete)
+        {
+            before = existing.PopCount;
+        }
+
+        source.Dispose();
+        WriteBitmap(bundlePath, occupancySegment, words);
+
+        var delta = set - before;
+        return $"Rebuilt the allocation bitmap from {reachable.Count:N0} reachable pages "
+            + $"({before:N0} bits set before, {set:N0} after, {delta:+#;-#;0}). "
+            + (delta < 0
+                ? $"{-delta:N0} leaked page(s) reclaimed — {(long)(-delta) * IntegrityConstants.PageSize / 1024:N0} KiB."
+                : delta > 0
+                    ? $"{delta:N0} phantom free bit(s) cleared; those pages can no longer be handed to a second owner."
+                    : "The bitmap already agreed with the walk.");
+    }
+
+    /// <summary>
+    /// Enumerates every page any structure claims, plus the genesis-reserved ones. This is the authority the bitmap is
+    /// rebuilt against.
+    /// </summary>
+    private static HashSet<int> WalkReachablePages(OfflineBundlePageSource source, out SegmentView occupancySegment)
+    {
+        occupancySegment = null;
+        var reachable = new HashSet<int>();
+        Span<byte> page = new byte[IntegrityConstants.PageSize];
+
+        for (var p = 0; p < Math.Min(ManagedPagedMMF.InitialReservedPageCount, source.PageCount); p++)
+        {
+            reachable.Add(p);
+        }
+
+        var walker = new SegmentWalker(source);
+        for (var p = 0; p < source.PageCount; p++)
+        {
+            if (!source.TryReadPage(p, page))
+            {
+                continue;
+            }
+
+            if ((PageImage.Flags(page) & PageBlockFlags.IsLogicalSegmentRoot) == 0)
+            {
+                continue;
+            }
+
+            // Roots are identified by self-reference: a twin carries a byte copy of the primary's directory, which still
+            // names the primary. Without this test every paired segment is walked twice.
+            if (MemoryMarshal.Read<int>(PageImage.RawData(page)) != p)
+            {
+                continue;
+            }
+
+            var segment = walker.WalkSegment(p);
+            if (segment.Kind == StorageSegmentKind.Occupancy)
+            {
+                occupancySegment = segment;
+            }
+
+            for (var i = 0; i < segment.Pages.Count; i++)
+            {
+                reachable.Add(segment.Pages[i]);
+            }
+
+            for (var i = 0; i < segment.MapExtensionPages.Count; i++)
+            {
+                reachable.Add(segment.MapExtensionPages[i]);
+            }
+
+            for (var i = 0; i < segment.TwinPages.Count; i++)
+            {
+                reachable.Add(segment.TwinPages[i]);
+            }
+        }
+
+        return reachable;
+    }
+
+    /// <summary>Writes the recomputed words back into the occupancy segment's data pages, restamping each page.</summary>
+    private static void WriteBitmap(string bundlePath, SegmentView occupancySegment, ulong[] words)
+    {
+        var dataPath = Path.Combine(bundlePath, IntegrityConstants.DataFileName);
+        using var handle = File.OpenHandle(dataPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        var buffer = new byte[IntegrityConstants.PageSize];
+        var dataPageCount = occupancySegment.Pages.Count - 1;
+
+        for (var d = 0; d < dataPageCount; d++)
+        {
+            var filePage = occupancySegment.Pages[d + 1];
+            var offset = filePage * (long)IntegrityConstants.PageSize;
+            RandomAccess.Read(handle, buffer, offset);
+
+            var target = MemoryMarshal.Cast<byte, ulong>(buffer.AsSpan(PageImage.RawDataOffset))[..OccupancyView.WordsPerPage];
+            words.AsSpan(d * OccupancyView.WordsPerPage, OccupancyView.WordsPerPage).CopyTo(target);
+
+            // Advance the change revision before restamping: the per-sector currency stamp is derived from it, and leaving
+            // it unchanged would make the rewritten sectors indistinguishable from the ones they replaced.
+            var revision = MemoryMarshal.Read<int>(buffer.AsSpan(PageImage.ChangeRevisionOffset)) + 1;
+            MemoryMarshal.Write(buffer.AsSpan(PageImage.ChangeRevisionOffset), in revision);
+            PagedMMF.StampPageForWrite(buffer, filePage);
+
+            RandomAccess.Write(handle, buffer, offset);
+        }
+
+        RandomAccess.FlushToDisk(handle);
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/OccupancyView.cs
+++ b/src/Typhon.Engine/Integrity/internals/OccupancyView.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// The page-allocation bitmap, read from the occupancy segment's data pages.
+/// </summary>
+/// <remarks>
+/// The bitmap is <b>derived</b> state (<c>CK-09</c> re-derives it on the crash path), so it is never the authority on what
+/// is allocated. It is read so it can be <i>compared against</i> the reachability walk — a disagreement is reported as
+/// "occupancy is wrong", never as "these pages are wrong", and the repair is a re-derive rather than a page edit.
+/// </remarks>
+internal sealed class OccupancyView
+{
+    /// <summary>Number of L0 bitmap words one segment data page holds.</summary>
+    internal const int WordsPerPage = IntegrityConstants.PageRawDataSize / sizeof(long);
+
+    private readonly ulong[] _words;
+
+    private OccupancyView(ulong[] words, int capacity, bool complete, IReadOnlyList<string> diagnostics)
+    {
+        _words = words;
+        Capacity = capacity;
+        IsComplete = complete;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>Highest page index the bitmap can describe.</summary>
+    public int Capacity { get; }
+
+    /// <summary>Whether every word of the bitmap was read successfully.</summary>
+    public bool IsComplete { get; }
+
+    /// <summary>Problems encountered while reading the bitmap.</summary>
+    public IReadOnlyList<string> Diagnostics { get; }
+
+    /// <summary>Total set bits — the number of pages the bitmap claims are allocated.</summary>
+    public int PopCount
+    {
+        get
+        {
+            var total = 0;
+            for (var i = 0; i < _words.Length; i++)
+            {
+                total += BitOperations.PopCount(_words[i]);
+            }
+
+            return total;
+        }
+    }
+
+    /// <summary>Whether the bitmap marks a file page as allocated. Out-of-range indices read as <c>false</c>.</summary>
+    /// <param name="filePageIndex">The file page to test.</param>
+    public bool IsAllocated(int filePageIndex)
+    {
+        if (filePageIndex < 0 || filePageIndex >= Capacity)
+        {
+            return false;
+        }
+
+        var word = filePageIndex >> 6;
+        return word < _words.Length && (_words[word] & (1UL << (filePageIndex & 63))) != 0;
+    }
+
+    /// <summary>Reads the bitmap out of the occupancy segment's data pages.</summary>
+    /// <param name="source">The page source.</param>
+    /// <param name="occupancySegment">The walked occupancy segment.</param>
+    public static OccupancyView Read(IPageSource source, SegmentView occupancySegment)
+    {
+        var diagnostics = new List<string>();
+        if (occupancySegment == null || occupancySegment.Pages.Count < 2)
+        {
+            diagnostics.Add("The occupancy segment has no data pages; page-allocation state is unavailable.");
+            return new OccupancyView([], 0, false, diagnostics);
+        }
+
+        // Data pages are the segment's pages beyond the directory-only root. Word i lives on data page (i / WordsPerPage).
+        var dataPageCount = occupancySegment.Pages.Count - 1;
+        var wordCount = dataPageCount * WordsPerPage;
+        var words = new ulong[wordCount];
+        var complete = true;
+
+        Span<byte> buf = new byte[IntegrityConstants.PageSize];
+        for (var d = 0; d < dataPageCount; d++)
+        {
+            var filePage = occupancySegment.Pages[d + 1];
+            if (!source.TryReadPage(filePage, buf))
+            {
+                diagnostics.Add($"Occupancy data page {filePage} (segment page {d + 1}) could not be read; {WordsPerPage} bitmap words are unknown.");
+                complete = false;
+                continue;
+            }
+
+            var src = MemoryMarshal.Cast<byte, ulong>(PageImage.RawData(buf))[..WordsPerPage];
+            src.CopyTo(words.AsSpan(d * WordsPerPage, WordsPerPage));
+        }
+
+        return new OccupancyView(words, wordCount * 64, complete, diagnostics);
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/PageImage.cs
+++ b/src/Typhon.Engine/Integrity/internals/PageImage.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// Byte-level accessors over a raw 8 KiB page image, for a reader that must never trust what it is decoding.
+/// </summary>
+/// <remarks>
+/// Every accessor is a bounded read over a <see cref="ReadOnlySpan{T}"/> — no pointers, no <c>StructAt</c> reinterpretation
+/// of a possibly-garbage header, no dereferencing of a value that has not been range-checked by the caller. This is the
+/// traversal-safety requirement <c>MAP-04</c> makes explicit: a checker that crashes on the databases it was built to
+/// diagnose is worse than useless.
+/// </remarks>
+internal static class PageImage
+{
+    /// <summary>Byte offset of the page-block flags byte.</summary>
+    public const int FlagsOffset = 0;
+
+    /// <summary>Byte offset of the page-block type byte.</summary>
+    public const int TypeOffset = 1;
+
+    /// <summary>Byte offset of the type-scoped format revision.</summary>
+    public const int FormatRevisionOffset = 2;
+
+    /// <summary>Byte offset of the change revision, incremented on every write to disk.</summary>
+    public const int ChangeRevisionOffset = 4;
+
+    /// <summary>Byte offset of the seqlock-style modification counter.</summary>
+    public const int ModificationCounterOffset = 12;
+
+    /// <summary>Byte offset of the segment-header zone present on directory pages.</summary>
+    public const int LogicalSegmentHeaderOffset = 16;
+
+    /// <summary>Byte offset within the segment header of the next map-extension page index.</summary>
+    public const int NextMapPageOffset = LogicalSegmentHeaderOffset + 0;
+
+    /// <summary>Byte offset within the segment header of the next raw-data page index.</summary>
+    public const int NextRawDataPageOffset = LogicalSegmentHeaderOffset + 4;
+
+    /// <summary>Byte offset within the segment header of the segment kind.</summary>
+    public const int SegmentKindOffset = LogicalSegmentHeaderOffset + 8;
+
+    /// <summary>Byte offset within the segment header of the A/B twin page index.</summary>
+    public const int TwinPageOffset = LogicalSegmentHeaderOffset + 12;
+
+    /// <summary>Byte offset of the start of the page metadata region.</summary>
+    public const int MetadataOffset = 64;
+
+    /// <summary>Byte offset of the start of the page raw-data region.</summary>
+    public const int RawDataOffset = IntegrityConstants.PageHeaderSize;
+
+    /// <summary>Reads the page-block flags.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static PageBlockFlags Flags(ReadOnlySpan<byte> page) => (PageBlockFlags)page[FlagsOffset];
+
+    /// <summary>Reads the page-block type.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static PageBlockType Type(ReadOnlySpan<byte> page) => (PageBlockType)page[TypeOffset];
+
+    /// <summary>Reads the type-scoped format revision.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static short FormatRevision(ReadOnlySpan<byte> page) => MemoryMarshal.Read<short>(page[FormatRevisionOffset..]);
+
+    /// <summary>Reads the change revision — incremented on every write of this page to disk.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int ChangeRevision(ReadOnlySpan<byte> page) => MemoryMarshal.Read<int>(page[ChangeRevisionOffset..]);
+
+    /// <summary>Reads the stored page checksum.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint StoredChecksum(ReadOnlySpan<byte> page) => MemoryMarshal.Read<uint>(page[PageBaseHeader.PageChecksumOffset..]);
+
+    /// <summary>Reads the seqlock modification counter. Odd on disk is evidence of a write that bypassed the seqlock.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int ModificationCounter(ReadOnlySpan<byte> page) => MemoryMarshal.Read<int>(page[ModificationCounterOffset..]);
+
+    /// <summary>Reads the A/B pair generation stamped on a protected page. <c>0</c> means "not a pair slot".</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong PairGeneration(ReadOnlySpan<byte> page) => MemoryMarshal.Read<ulong>(page[PageBaseHeader.PairGenerationOffset..]);
+
+    /// <summary>Reads the next map-extension page index from a directory page's segment header.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int NextMapPage(ReadOnlySpan<byte> page) => MemoryMarshal.Read<int>(page[NextMapPageOffset..]);
+
+    /// <summary>Reads the next raw-data page index from a page's segment header (the forward chain).</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int NextRawDataPage(ReadOnlySpan<byte> page) => MemoryMarshal.Read<int>(page[NextRawDataPageOffset..]);
+
+    /// <summary>Reads the segment kind from a root page's segment header.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static StorageSegmentKind SegmentKind(ReadOnlySpan<byte> page) => (StorageSegmentKind)page[SegmentKindOffset];
+
+    /// <summary>Reads the A/B twin page index from a directory page's segment header. <c>0</c> means "no twin".</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int TwinPage(ReadOnlySpan<byte> page) => MemoryMarshal.Read<int>(page[TwinPageOffset..]);
+
+    /// <summary>The page's raw-data region.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<byte> RawData(ReadOnlySpan<byte> page) => page[RawDataOffset..];
+
+    /// <summary>The page's metadata region — the chunk-occupancy bitmap and the per-sector verification footer.</summary>
+    /// <param name="page">A full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ReadOnlySpan<byte> Metadata(ReadOnlySpan<byte> page) => page.Slice(MetadataOffset, IntegrityConstants.PageHeaderSize - MetadataOffset);
+
+    /// <summary>Whether the flags byte holds only defined bits.</summary>
+    /// <param name="flags">The flags value to validate.</param>
+    public static bool AreFlagsWellFormed(PageBlockFlags flags)
+    {
+        const PageBlockFlags all = PageBlockFlags.IsFree | PageBlockFlags.IsLogicalSegment | PageBlockFlags.IsLogicalSegmentRoot;
+        if ((flags & ~all) != 0)
+        {
+            return false;
+        }
+
+        // A root implies membership; free and allocated are mutually exclusive.
+        if ((flags & PageBlockFlags.IsLogicalSegmentRoot) != 0 && (flags & PageBlockFlags.IsLogicalSegment) == 0)
+        {
+            return false;
+        }
+
+        return (flags & PageBlockFlags.IsFree) == 0 || (flags & PageBlockFlags.IsLogicalSegment) == 0;
+    }
+
+    /// <summary>Whether the type byte is a defined <see cref="PageBlockType"/>.</summary>
+    /// <param name="type">The type value to validate.</param>
+    public static bool IsTypeDefined(PageBlockType type) => type is PageBlockType.None or PageBlockType.OccupancyMap;
+
+    /// <summary>Whether the kind byte is a defined <see cref="StorageSegmentKind"/>.</summary>
+    /// <param name="kind">The kind value to validate.</param>
+    public static bool IsKindDefined(StorageSegmentKind kind) => kind <= StorageSegmentKind.System;
+
+    /// <summary>
+    /// Verifies a page exactly the way the engine's load path does, honouring whichever checksum form the page declared —
+    /// per-sector footer or single whole-page CRC.
+    /// </summary>
+    /// <param name="page">A full page image.</param>
+    /// <param name="computed">Receives the computed whole-page value when the page uses that form; <c>0</c> otherwise.</param>
+    public static bool VerifyWholePageChecksum(ReadOnlySpan<byte> page, out uint computed) => PagedMMF.VerifyPageImage(page, out computed);
+}

--- a/src/Typhon.Engine/Integrity/internals/PairSlotRepair.cs
+++ b/src/Typhon.Engine/Integrity/internals/PairSlotRepair.cs
@@ -1,0 +1,133 @@
+using System;
+using System.IO;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// Restores the unusable half of an A/B protected page pair by copying its valid sibling over it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A protected page — the page-0 meta pair, and every segment-directory page — exists in two physical slots that writes
+/// alternate between, so a torn write can never destroy the only good copy. When one slot becomes unreadable the database
+/// keeps working from the other, which is the mechanism doing its job; but the redundancy is gone, and the <i>next</i>
+/// torn write to that page makes the database unopenable. That is the failure the pair exists to prevent, so restoring
+/// the missing half is worth doing explicitly rather than waiting for the next write to happen to land there.
+/// </para>
+/// <para>
+/// This is a <b>lossless</b> repair in the strictest sense: it reads only the slot that verifies, and writes only the
+/// slot that does not. No byte of damaged content is read, so nothing damaged can propagate. The copy is written with a
+/// generation one higher than the surviving slot's, which makes it the current one — consistent with what the next
+/// ordinary write would have produced.
+/// </para>
+/// </remarks>
+internal static class PairSlotRepair
+{
+    /// <summary>
+    /// Restores the pair that <paramref name="damagedPageIndex"/> belongs to.
+    /// </summary>
+    /// <param name="bundlePath">The bundle directory.</param>
+    /// <param name="damagedPageIndex">Physical index of the slot that failed verification.</param>
+    /// <returns>A description of what was done, for the repair receipt.</returns>
+    /// <exception cref="InvalidOperationException">Neither slot is usable, or the page is not part of a pair.</exception>
+    public static string Restore(string bundlePath, int damagedPageIndex)
+    {
+        var dataPath = Path.Combine(bundlePath, IntegrityConstants.DataFileName);
+        using var handle = File.OpenHandle(dataPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        var sibling = FindSibling(handle, damagedPageIndex, out var siblingImage);
+        if (sibling < 0)
+        {
+            throw new InvalidOperationException(
+                $"Page {damagedPageIndex} has no readable sibling slot, so there is nothing to restore it from. "
+                + "This is a restore-from-backup situation, not a repair.");
+        }
+
+        // Stamp the copy as the newer generation so pair selection picks it, exactly as an ordinary write would have.
+        var generation = PageImage.PairGeneration(siblingImage) + 1;
+        PageBaseHeader.WritePairGeneration(siblingImage, generation);
+        PagedMMF.StampPageForWrite(siblingImage, LogicalIndexOf(damagedPageIndex, sibling, siblingImage), allowSectorFooter: false);
+
+        RandomAccess.Write(handle, siblingImage, damagedPageIndex * (long)IntegrityConstants.PageSize);
+        RandomAccess.FlushToDisk(handle);
+
+        return $"Restored page {damagedPageIndex} from its sibling slot {sibling} at generation {generation}. "
+            + "The pair is redundant again; nothing was read from the damaged slot.";
+    }
+
+    /// <summary>
+    /// Finds the readable half of the pair <paramref name="damagedPageIndex"/> belongs to.
+    /// </summary>
+    /// <param name="handle">Open handle on the data file.</param>
+    /// <param name="damagedPageIndex">The slot that failed.</param>
+    /// <param name="image">Receives the sibling's page image.</param>
+    /// <returns>The sibling's physical index, or <c>-1</c> when there is none.</returns>
+    private static int FindSibling(Microsoft.Win32.SafeHandles.SafeFileHandle handle, int damagedPageIndex, out byte[] image)
+    {
+        image = new byte[IntegrityConstants.PageSize];
+
+        // The meta pair is at fixed physical slots 0 and 1.
+        if (damagedPageIndex is 0 or 1)
+        {
+            var sibling = 1 - damagedPageIndex;
+            if (TryRead(handle, sibling, image) && PagedMMF.VerifyPageImage(image, out _) && PageImage.PairGeneration(image) > 0)
+            {
+                return sibling;
+            }
+
+            return -1;
+        }
+
+        // A directory page names its twin in its own header — but the damaged slot's header may be exactly what is
+        // unreadable, so try the damaged page's own claim first and fall back to searching for a page that claims it.
+        var damaged = new byte[IntegrityConstants.PageSize];
+        if (TryRead(handle, damagedPageIndex, damaged))
+        {
+            var claimed = PageImage.TwinPage(damaged);
+            if (claimed > 0 && TryRead(handle, claimed, image) && PagedMMF.VerifyPageImage(image, out _) && PageImage.PairGeneration(image) > 0)
+            {
+                return claimed;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// The logical index the restored image should carry: the pair's <i>primary</i>, which is whichever of the two slots
+    /// the segment directory references.
+    /// </summary>
+    private static int LogicalIndexOf(int damagedPageIndex, int siblingIndex, ReadOnlySpan<byte> siblingImage)
+    {
+        if (damagedPageIndex is 0 or 1)
+        {
+            return 0;   // the meta pair's logical page is always 0
+        }
+
+        var stamped = PageSectorFooter.ReadFilePageIndex(siblingImage);
+        return stamped != 0 ? stamped : Math.Min(damagedPageIndex, siblingIndex);
+    }
+
+    private static bool TryRead(Microsoft.Win32.SafeHandles.SafeFileHandle handle, int pageIndex, byte[] destination)
+    {
+        var offset = pageIndex * (long)IntegrityConstants.PageSize;
+        if (offset + IntegrityConstants.PageSize > RandomAccess.GetLength(handle))
+        {
+            return false;
+        }
+
+        var total = 0;
+        while (total < destination.Length)
+        {
+            var read = RandomAccess.Read(handle, destination.AsSpan(total), offset + total);
+            if (read == 0)
+            {
+                return false;
+            }
+
+            total += read;
+        }
+
+        return true;
+    }
+}

--- a/src/Typhon.Engine/Integrity/internals/ScanContext.cs
+++ b/src/Typhon.Engine/Integrity/internals/ScanContext.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// Everything one scan discovered, shared by every check in the catalogue.
+/// </summary>
+/// <remarks>
+/// Built once by the structural pass so no check re-walks the file, and so every check sees the <i>same</i> view of a
+/// damaged database. Two checks that independently re-derive ownership can disagree, and on a corrupt file they will —
+/// which would make findings depend on evaluation order.
+/// </remarks>
+internal sealed class ScanContext
+{
+    /// <summary>The page source under inspection.</summary>
+    public IPageSource Source { get; init; }
+
+    /// <summary>Scan options, including depth and check filters.</summary>
+    public IntegrityOptions Options { get; init; }
+
+    /// <summary>How the pages were reached, which bounds the confidence of every cross-structure conclusion.</summary>
+    public ScanMode Mode { get; init; }
+
+    /// <summary>The bundle, when the source is one. <c>null</c> for non-bundle sources.</summary>
+    public OfflineBundlePageSource Bundle { get; init; }
+
+    /// <summary>Page-0 identity and bootstrap dictionary.</summary>
+    public BootstrapView Bootstrap { get; set; }
+
+    /// <summary>Every segment discovered by the physical sweep, keyed by root page.</summary>
+    public Dictionary<int, SegmentView> Segments { get; } = [];
+
+    /// <summary>Per-page role, indexed by file-page index.</summary>
+    public PageRole[] Roles { get; set; } = [];
+
+    /// <summary>Per-page owning segment root, or <c>-1</c> when unowned. Indexed by file-page index.</summary>
+    public int[] Owner { get; set; } = [];
+
+    /// <summary>Per-page flags byte as read, indexed by file-page index.</summary>
+    public byte[] FlagsByte { get; set; } = [];
+
+    /// <summary>
+    /// Physical slots that are the shadow half of an A/B protected directory page. Tracked separately from
+    /// <see cref="Roles"/> because a twin can also be one of the genesis-reserved pages, and the role array keeps the
+    /// stronger classification — so the role alone cannot answer "is this a twin?".
+    /// </summary>
+    public HashSet<int> TwinSlots { get; } = [];
+
+    /// <summary>The page-allocation bitmap, or <c>null</c> when it could not be read.</summary>
+    public OccupancyView Occupancy { get; set; }
+
+    /// <summary>Findings accumulated so far.</summary>
+    public FindingCollector Findings { get; init; }
+
+    /// <summary>Pages read and classified.</summary>
+    public int PagesScanned { get; set; }
+
+    /// <summary>Pages whose stored checksum did not match.</summary>
+    public int ChecksumFailures { get; set; }
+
+    /// <summary>Pages carrying a per-sector verification footer.</summary>
+    public int PagesWithSectorFooters { get; set; }
+
+    /// <summary>Sectors that failed verification across the whole file.</summary>
+    public int SectorFailures { get; set; }
+
+    /// <summary>Set when a <see cref="IntegritySeverity.Fatal"/> finding means later checks cannot be trusted.</summary>
+    public bool StopScan { get; set; }
+
+    /// <summary>Whether cross-structure conclusions from this source can be trusted as observed rather than inferred.</summary>
+    public IntegrityConfidence Confidence => Mode == ScanMode.OnlineSampled ? IntegrityConfidence.Suspected : IntegrityConfidence.Confirmed;
+
+    /// <summary>Whether a page index addresses a page that exists in the source.</summary>
+    /// <param name="filePageIndex">The page index to test.</param>
+    public bool IsInRange(int filePageIndex) => filePageIndex >= 0 && filePageIndex < Source.PageCount;
+
+    /// <summary>Whether the requested depth includes a given depth level.</summary>
+    /// <param name="depth">The depth level the check needs.</param>
+    public bool AtLeast(ScanDepth depth) => Options.Depth >= depth;
+
+    /// <summary>
+    /// Resolves the segment kind that owns a page, for the <see cref="Locus"/> of a page-scoped finding.
+    /// </summary>
+    /// <param name="filePageIndex">The page whose owner is wanted.</param>
+    public Locus LocusForPage(int filePageIndex)
+    {
+        if (filePageIndex < 0 || filePageIndex >= Owner.Length)
+        {
+            return new Locus(filePageIndex);
+        }
+
+        var root = Owner[filePageIndex];
+        if (root < 0 || !Segments.TryGetValue(root, out var seg))
+        {
+            return new Locus(filePageIndex);
+        }
+
+        return new Locus(filePageIndex, root, seg.Kind);
+    }
+
+    /// <summary>Reports a finding if its check code passes the option filters.</summary>
+    /// <param name="finding">The finding to record.</param>
+    public void Report(IntegrityFinding finding)
+    {
+        if (!Options.IsCheckEnabled(finding.Code))
+        {
+            return;
+        }
+
+        Findings.Add(finding);
+    }
+
+    /// <summary>
+    /// Reports a finding built from the common fields, stamping this scan's confidence automatically so no check can
+    /// accidentally claim a live observation was quiescent.
+    /// </summary>
+    /// <param name="code">Stable check code.</param>
+    /// <param name="severity">How bad it is.</param>
+    /// <param name="ruleId">The <c>rules/</c> invariant violated.</param>
+    /// <param name="locus">Where it is.</param>
+    /// <param name="summary">One sentence, no jargon.</param>
+    /// <param name="detail">The evidence.</param>
+    /// <param name="repair">What can be done about it.</param>
+    /// <param name="loss">What repairing it would cost.</param>
+    public void Report(string code, IntegritySeverity severity, string ruleId, Locus locus, string summary, string detail,
+        Repairability repair = Repairability.NotRepairable, LossEstimate loss = null)
+        => Report(new IntegrityFinding
+        {
+            Code = code,
+            Severity = severity,
+            RuleId = ruleId,
+            Locus = locus,
+            Summary = summary,
+            Detail = detail,
+            Repair = repair,
+            Loss = loss ?? LossEstimate.None,
+            Confidence = Confidence
+        });
+}

--- a/src/Typhon.Engine/Integrity/internals/SegmentWalker.cs
+++ b/src/Typhon.Engine/Integrity/internals/SegmentWalker.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>How a page came to be considered reachable.</summary>
+internal enum PageRole : byte
+{
+    /// <summary>No structure claims this page.</summary>
+    Unclaimed = 0,
+
+    /// <summary>One of the fixed pages reserved at genesis (meta pair, occupancy root/twin/reserves).</summary>
+    Reserved,
+
+    /// <summary>A segment's directory root page.</summary>
+    SegmentRoot,
+
+    /// <summary>A directory map-extension page.</summary>
+    MapExtension,
+
+    /// <summary>A data page listed in a segment's directory.</summary>
+    SegmentData,
+
+    /// <summary>The shadow slot of an A/B protected directory page. Occupancy-set, but in no segment's page list.</summary>
+    DirectoryTwin
+}
+
+/// <summary>One logical segment as recovered from raw bytes.</summary>
+internal sealed class SegmentView
+{
+    /// <summary>File-page index of the segment's directory root.</summary>
+    public int RootPageIndex { get; init; }
+
+    /// <summary>Kind recorded in the root page's header.</summary>
+    public StorageSegmentKind Kind { get; init; }
+
+    /// <summary>The file pages the directory enumerates, in directory order. <c>[0]</c> is the root.</summary>
+    public IReadOnlyList<int> Pages { get; init; } = [];
+
+    /// <summary>Directory map-extension pages walked to read the full directory (the root is excluded).</summary>
+    public IReadOnlyList<int> MapExtensionPages { get; init; } = [];
+
+    /// <summary>Twin (shadow) pages of this segment's directory pages.</summary>
+    public IReadOnlyList<int> TwinPages { get; init; } = [];
+
+    /// <summary>Pages counted by following the forward <c>NextRawDataPBID</c> chain, for the chain-vs-directory cross-check.</summary>
+    public int ForwardChainCount { get; init; }
+
+    /// <summary>Whether the directory walk terminated cleanly rather than hitting a cycle, a bad pointer or the page limit.</summary>
+    public bool DirectoryComplete { get; init; }
+
+    /// <summary>Whether the forward-chain walk terminated cleanly.</summary>
+    public bool ChainComplete { get; init; }
+
+    /// <summary>Problems encountered while walking this segment, for the check layer to turn into findings.</summary>
+    public IReadOnlyList<string> WalkDiagnostics { get; init; } = [];
+}
+
+/// <summary>
+/// Discovers and walks every logical segment in a data file from raw bytes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Segment discovery is <b>physical</b>, not bootstrap-driven: every segment root carries
+/// <see cref="PageBlockFlags.IsLogicalSegmentRoot"/> in its own header, so a full page sweep finds every segment without
+/// trusting a dictionary that may itself be damaged. The bootstrap's segment pointers are then treated as a <i>claim to
+/// verify</i> rather than the source of truth — which is the same primary-over-derived discipline the rest of the
+/// catalogue applies.
+/// </para>
+/// <para>
+/// Every pointer is range-checked against the file before it is followed, and every walk is bounded by a step limit. This
+/// is not defensive style, it is a hard requirement: a checker that dereferences a torn directory into a crash is worse
+/// than useless on exactly the databases it exists to diagnose.
+/// </para>
+/// </remarks>
+internal sealed class SegmentWalker
+{
+    private readonly IPageSource _source;
+    private readonly byte[] _scratchA = new byte[IntegrityConstants.PageSize];
+    private readonly byte[] _scratchB = new byte[IntegrityConstants.PageSize];
+
+    /// <summary>Number of int entries a directory page holds — the whole raw-data area.</summary>
+    internal const int DirectoryEntriesPerPage = IntegrityConstants.PageRawDataSize / sizeof(int);
+
+    /// <summary>Creates a walker over a page source.</summary>
+    /// <param name="source">The page source to read through.</param>
+    public SegmentWalker(IPageSource source) => _source = source;
+
+    /// <summary>
+    /// Resolves the current slot of an A/B protected directory page. Returns the physical page index whose content is
+    /// current, reading both slots and preferring the higher valid generation.
+    /// </summary>
+    /// <param name="primaryPage">The primary (directory-referenced) page index.</param>
+    /// <param name="image">Receives the selected slot's page image.</param>
+    /// <param name="resolution">Receives a description of what was found in each slot.</param>
+    /// <returns><c>true</c> when at least one slot was valid.</returns>
+    public bool TryResolveDirectoryPage(int primaryPage, Span<byte> image, out DirectoryPairResolution resolution)
+    {
+        resolution = default;
+        if (!_source.TryReadPage(primaryPage, _scratchA))
+        {
+            return false;
+        }
+
+        var flags = PageImage.Flags(_scratchA);
+        var twin = PageImage.TwinPage(_scratchA);
+        var primaryValid = IsPairSlotValid(_scratchA, out var genPrimary);
+
+        // No twin recorded: not a paired directory page. Its own image is all there is.
+        if ((flags & PageBlockFlags.IsLogicalSegment) == 0 || twin == 0)
+        {
+            _scratchA.CopyTo(image);
+            resolution = new DirectoryPairResolution(primaryPage, 0, primaryPage, genPrimary, primaryValid, false, false);
+            return true;
+        }
+
+        var twinValid = false;
+        ulong genTwin = 0;
+        var twinInRange = twin > 0 && twin < _source.PageCount;
+        if (twinInRange && _source.TryReadPage(twin, _scratchB))
+        {
+            twinValid = IsPairSlotValid(_scratchB, out genTwin);
+        }
+
+        if (!primaryValid && !twinValid)
+        {
+            resolution = new DirectoryPairResolution(primaryPage, twin, -1, 0, false, false, twinInRange);
+            return false;
+        }
+
+        if (twinValid && (!primaryValid || genTwin > genPrimary))
+        {
+            _scratchB.CopyTo(image);
+            resolution = new DirectoryPairResolution(primaryPage, twin, twin, genTwin, primaryValid, true, twinInRange);
+            return true;
+        }
+
+        _scratchA.CopyTo(image);
+        resolution = new DirectoryPairResolution(primaryPage, twin, primaryPage, genPrimary, true, twinValid, twinInRange);
+        return true;
+    }
+
+    /// <summary>
+    /// Walks one segment: resolves its directory pages through their A/B pairs, reads the page directory, and follows the
+    /// forward data-page chain for the cross-check.
+    /// </summary>
+    /// <param name="rootPageIndex">The segment's root page index.</param>
+    public SegmentView WalkSegment(int rootPageIndex)
+    {
+        var diagnostics = new List<string>();
+        var pages = new List<int>();
+        var mapExtensions = new List<int>();
+        var twins = new List<int>();
+        Span<byte> image = new byte[IntegrityConstants.PageSize];
+
+        if (!TryResolveDirectoryPage(rootPageIndex, image, out var rootRes))
+        {
+            diagnostics.Add(rootRes.TwinPage != 0
+                ? $"Both slots of root page {rootPageIndex} (twin {rootRes.TwinPage}) are invalid; the segment cannot be read."
+                : $"Root page {rootPageIndex} is invalid and has no twin; the segment cannot be read.");
+            return new SegmentView { RootPageIndex = rootPageIndex, WalkDiagnostics = diagnostics, DirectoryComplete = false, ChainComplete = false };
+        }
+
+        var kind = PageImage.SegmentKind(image);
+        if (rootRes.TwinPage != 0)
+        {
+            twins.Add(rootRes.TwinPage);
+        }
+
+        // Directory walk: root page's raw data holds int page indices, terminated by 0, continued on map-extension pages.
+        var currentDirectoryPage = rootPageIndex;
+        var complete = false;
+        var visitedDirectoryPages = new HashSet<int> { rootPageIndex };
+        var maxDirectoryPages = Math.Max(2, (_source.PageCount / DirectoryEntriesPerPage) + 2);
+
+        for (var step = 0; step < maxDirectoryPages; step++)
+        {
+            var entries = MemoryMarshal.Cast<byte, int>(PageImage.RawData(image))[..DirectoryEntriesPerPage];
+            var hitTerminator = false;
+            for (var i = 0; i < entries.Length; i++)
+            {
+                var p = entries[i];
+                if (p == 0)
+                {
+                    hitTerminator = true;
+                    break;
+                }
+
+                if (p < 0 || p >= _source.PageCount)
+                {
+                    diagnostics.Add($"Directory entry {pages.Count} on page {currentDirectoryPage} is out of range ({p}); the walk stopped there.");
+                    hitTerminator = true;
+                    break;
+                }
+
+                pages.Add(p);
+            }
+
+            if (hitTerminator)
+            {
+                complete = true;
+                break;
+            }
+
+            var nextMap = PageImage.NextMapPage(image);
+            if (nextMap == 0)
+            {
+                complete = true;
+                break;
+            }
+
+            if (nextMap < 0 || nextMap >= _source.PageCount)
+            {
+                diagnostics.Add($"Map-extension pointer on page {currentDirectoryPage} is out of range ({nextMap}).");
+                break;
+            }
+
+            if (!visitedDirectoryPages.Add(nextMap))
+            {
+                diagnostics.Add($"Directory map chain cycles back to page {nextMap}.");
+                break;
+            }
+
+            if (!TryResolveDirectoryPage(nextMap, image, out var mapRes))
+            {
+                diagnostics.Add($"Both slots of map-extension page {nextMap} (twin {mapRes.TwinPage}) are invalid; the directory is truncated.");
+                break;
+            }
+
+            mapExtensions.Add(nextMap);
+            if (mapRes.TwinPage != 0)
+            {
+                twins.Add(mapRes.TwinPage);
+            }
+
+            currentDirectoryPage = nextMap;
+        }
+
+        var chainCount = WalkForwardChain(rootPageIndex, pages.Count, out var chainComplete, diagnostics);
+
+        return new SegmentView
+        {
+            RootPageIndex = rootPageIndex,
+            Kind = kind,
+            Pages = pages,
+            MapExtensionPages = mapExtensions,
+            TwinPages = twins,
+            ForwardChainCount = chainCount,
+            DirectoryComplete = complete,
+            ChainComplete = chainComplete,
+            WalkDiagnostics = diagnostics
+        };
+    }
+
+    /// <summary>
+    /// Counts pages on the forward <c>NextRawDataPBID</c> chain. The directory and the chain are written by independent
+    /// code paths, so a mismatch localises a lost write precisely.
+    /// </summary>
+    private int WalkForwardChain(int rootPageIndex, int directoryCount, out bool complete, List<string> diagnostics)
+    {
+        complete = false;
+        Span<byte> buf = new byte[IntegrityConstants.PageSize];
+        if (!_source.TryReadPage(rootPageIndex, buf))
+        {
+            return 0;
+        }
+
+        var count = 1;
+        var maxWalk = (directoryCount * 2) + 16;
+        var visited = new HashSet<int> { rootPageIndex };
+
+        while (count < maxWalk)
+        {
+            var next = PageImage.NextRawDataPage(buf);
+            if (next == 0)
+            {
+                complete = true;
+                return count;
+            }
+
+            if (next < 0 || next >= _source.PageCount)
+            {
+                diagnostics.Add($"Forward-chain pointer out of range ({next}) after {count} pages.");
+                return count;
+            }
+
+            if (!visited.Add(next))
+            {
+                diagnostics.Add($"Forward data-page chain cycles back to page {next}.");
+                return count;
+            }
+
+            if (!_source.TryReadPage(next, buf))
+            {
+                diagnostics.Add($"Forward-chain page {next} could not be read.");
+                return count;
+            }
+
+            count++;
+        }
+
+        diagnostics.Add($"Forward data-page chain exceeded its {maxWalk}-page bound; it is cyclic or wildly longer than the directory.");
+        return count;
+    }
+
+    /// <summary>
+    /// A protected-pair slot is valid exactly when its whole-page checksum matches and its pair generation is non-zero,
+    /// mirroring the engine's own selection predicate.
+    /// </summary>
+    private static bool IsPairSlotValid(ReadOnlySpan<byte> slot, out ulong generation)
+    {
+        generation = 0;
+        if (!PageImage.VerifyWholePageChecksum(slot, out _))
+        {
+            return false;
+        }
+
+        generation = PageImage.PairGeneration(slot);
+        return generation > 0;
+    }
+}
+
+/// <summary>What the walker found when resolving an A/B protected directory page.</summary>
+/// <param name="PrimaryPage">The directory-referenced page index.</param>
+/// <param name="TwinPage">The shadow slot index, or <c>0</c> when the page is not paired.</param>
+/// <param name="SelectedPage">The slot whose content was used, or <c>-1</c> when neither was valid.</param>
+/// <param name="SelectedGeneration">Pair generation of the selected slot.</param>
+/// <param name="PrimaryValid">Whether the primary slot verified.</param>
+/// <param name="TwinValid">Whether the twin slot verified.</param>
+/// <param name="TwinInRange">Whether the recorded twin index addressed a page inside the file.</param>
+internal readonly record struct DirectoryPairResolution(int PrimaryPage, int TwinPage, int SelectedPage, ulong SelectedGeneration,
+    bool PrimaryValid, bool TwinValid, bool TwinInRange);

--- a/src/Typhon.Engine/Integrity/public/DatabaseRepair.cs
+++ b/src/Typhon.Engine/Integrity/public/DatabaseRepair.cs
@@ -1,0 +1,329 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Turns an <see cref="IntegrityReport"/> into a reviewable <see cref="RepairPlan"/>, and applies one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The expensive, subtle part of repair — regenerating derived state from primary data in the correct order without
+/// trusting anything stale — is already built and rule-governed inside the engine's recovery net. What was missing was
+/// <b>invocability, ordering control, and reporting</b>: the net runs only at open, only on the crash path, cannot be
+/// asked to run, and reports into log lines. This type gives it a front door, a plan, and a receipt.
+/// </para>
+/// <para>
+/// <b>What repair will never do.</b> Edit bytes inside a primary page (guessing at damaged content manufactures plausible
+/// data, which is strictly worse than a hole because it is undetectable afterwards). Splice a page from a backup into a
+/// live database (that produces a page consistent with an older generation of its neighbours, converting detectable
+/// corruption into undetectable corruption). Trust a derived structure to reconstruct primary data (an index is not a
+/// backup of the rows). Or delete user data to satisfy a derived constraint.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public static class DatabaseRepair
+{
+    /// <summary>
+    /// Derives a repair plan from a report. Read-only: produces a description, changes nothing.
+    /// </summary>
+    /// <param name="report">The report to plan against.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="report"/> is <c>null</c>.</exception>
+    public static RepairPlan Plan(IntegrityReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var steps = new List<RepairStep>();
+        var losses = new List<LossEstimate>();
+        var unaddressed = new List<string>();
+
+        var pairSlots = new List<Locus>();
+        var occupancyCodes = new List<string>();
+        var derivedCodes = new List<string>();
+        var lossyFindings = new List<IntegrityFinding>();
+
+        for (var i = 0; i < report.Findings.Count; i++)
+        {
+            var f = report.Findings[i];
+
+            // A live scan sees a consistent page but never a consistent database, so a cross-structure disagreement it
+            // observed may simply be a mutation in flight. Acting on that would repair a database that was healthy.
+            if (f.Confidence != IntegrityConfidence.Confirmed)
+            {
+                unaddressed.Add($"{f.Code}: observed on a live database (Suspected). Re-run the scan offline to confirm it before repairing.");
+                continue;
+            }
+
+            switch (f.Code)
+            {
+                case "CHK-BOO-03" when f.Severity == IntegritySeverity.Divergence:
+                case "CHK-PHY-01" when f.Repair == Repairability.Lossless && f.Locus.Kind == StorageSegmentKind.Other:
+                    pairSlots.Add(f.Locus);
+                    break;
+
+                case "CHK-SEG-02":
+                    occupancyCodes.Add(f.Code);
+                    break;
+
+                default:
+                    if (f.Repair == Repairability.Lossless)
+                    {
+                        derivedCodes.Add(f.Code);
+                    }
+                    else if (f.Repair == Repairability.Lossy)
+                    {
+                        lossyFindings.Add(f);
+                    }
+                    else if (f.Severity <= IntegritySeverity.Divergence)
+                    {
+                        unaddressed.Add($"{f.Code} at {f.Locus}: {f.Summary} — no repair primitive applies. {EscalationFor(f)}");
+                    }
+
+                    break;
+            }
+        }
+
+        var order = 0;
+
+        // Ordering is a correctness constraint. Pair slots go first: everything downstream reads directories, and a
+        // directory pair running on one copy is one torn write away from making the database unopenable.
+        for (var i = 0; i < pairSlots.Count; i++)
+        {
+            steps.Add(new RepairStep
+            {
+                Order = ++order,
+                Action = RepairAction.RestorePairSlot,
+                Class = RepairClass.Regenerate,
+                Addresses = ["CHK-BOO-03", "CHK-PHY-01"],
+                Locus = pairSlots[i],
+                Description = $"Rewrite page {pairSlots[i].FilePageIndex} from its valid sibling slot.",
+                Rationale = "The pair's other slot holds a complete, verified image. Copying it back restores the redundancy "
+                    + "that lets a torn write to this page be survived rather than being fatal. Nothing is read from the "
+                    + "damaged slot, so nothing damaged can propagate."
+            });
+        }
+
+        if (derivedCodes.Count > 0)
+        {
+            steps.Add(new RepairStep
+            {
+                Order = ++order,
+                Action = RepairAction.RegenerateDerivedStructures,
+                Class = RepairClass.Regenerate,
+                Addresses = derivedCodes,
+                Description = "Open the database so the engine regenerates every derived structure, then close it cleanly.",
+                Rationale = "Indexes, entity maps, revision chains, cluster heads and spatial state are pure functions of "
+                    + "primary data. The engine's own recovery net already rebuilds them in the order the rules require — "
+                    + "chains scrubbed before indexes are built over them, the entity map re-derived before anything reads "
+                    + "it. Reusing it is safer than reimplementing that ordering here."
+            });
+        }
+
+        // Occupancy last among the lossless steps: it is derived from the reachability walk, so it must be recomputed
+        // AFTER anything that changes what is reachable.
+        if (occupancyCodes.Count > 0)
+        {
+            steps.Add(new RepairStep
+            {
+                Order = ++order,
+                Action = RepairAction.RederiveOccupancy,
+                Class = RepairClass.Regenerate,
+                Addresses = occupancyCodes,
+                Description = "Recompute the page-allocation bitmap from the segments that actually exist.",
+                Rationale = "The bitmap is derived state and is never the authority on what is allocated, so a disagreement "
+                    + "means the bitmap is wrong rather than that the pages are. Recomputing it reclaims leaked space and — "
+                    + "more importantly — clears phantom free bits that would otherwise let the allocator hand a live page "
+                    + "to a second owner."
+            });
+        }
+
+        for (var i = 0; i < lossyFindings.Count; i++)
+        {
+            var f = lossyFindings[i];
+            unaddressed.Add(
+                $"{f.Code} at {f.Locus}: {f.Summary} — repairing this means excising data that is already unreadable, and "
+                + "this build will not guess at where an archetype's rows begin and end on a damaged page. "
+                + EscalationFor(f));
+            losses.Add(f.Loss);
+        }
+
+        return new RepairPlan
+        {
+            DatabaseFingerprint = Fingerprint(report),
+            Source = report.Source,
+            Verdict = report.Verdict,
+            Steps = steps,
+            Loss = new LossManifest { Entries = losses },
+            Unaddressed = unaddressed
+        };
+    }
+
+    /// <summary>
+    /// Applies a plan. The only mutating operation in the feature.
+    /// </summary>
+    /// <param name="bundlePath">Path to the bundle to repair. Must not be open in another process.</param>
+    /// <param name="plan">The plan to apply.</param>
+    /// <param name="allowLoss">Consent to lossy steps. Without it, every <see cref="RepairClass.Excise"/> step is skipped.</param>
+    /// <param name="backupFirst">Copy the bundle beside itself before the first mutation. Cheap insurance; on by default.</param>
+    /// <param name="dryRun">Log every step and execute none.</param>
+    /// <param name="regenerateDerived">
+    /// Callback that opens and cleanly closes the database so the engine's rebuild net runs. Supplied by the caller
+    /// because the repair module must not take a dependency on engine construction. <c>null</c> skips those steps.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="bundlePath"/> or <paramref name="plan"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">The database changed since the plan was produced.</exception>
+    public static RepairOutcome Apply(string bundlePath, RepairPlan plan, bool allowLoss = false, bool backupFirst = true,
+        bool dryRun = false, Action<string> regenerateDerived = null)
+    {
+        ArgumentNullException.ThrowIfNull(bundlePath);
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var resolved = OfflineBundlePageSource.ResolveBundleDirectory(bundlePath);
+
+        // Re-scan and refuse on drift. Repairing against a stale diagnosis is the failure mode this guard exists for.
+        using (var probe = new OfflineBundlePageSource(resolved))
+        {
+            if (probe.LockHeld)
+            {
+                throw new InvalidOperationException(
+                    $"'{resolved}' is open in another process. Repair requires exclusive access — close the database and retry.");
+            }
+
+            var current = IntegrityScanner.Scan(probe, new IntegrityOptions { Depth = plan.Verdict == IntegrityVerdict.Unopenable ? ScanDepth.Standard : ScanDepth.Deep });
+            var currentFingerprint = Fingerprint(current);
+            if (!string.Equals(currentFingerprint, plan.DatabaseFingerprint, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    "The database has changed since this plan was produced, so the plan's diagnosis no longer describes it. "
+                    + "Re-run the scan and produce a fresh plan.\n"
+                    + $"  plan was built for: {plan.DatabaseFingerprint}\n"
+                    + $"  database is now:    {currentFingerprint}");
+            }
+        }
+
+        var results = new List<RepairStepResult>(plan.Steps.Count);
+        string backupPath = null;
+
+        if (backupFirst && !dryRun && plan.Steps.Count > 0)
+        {
+            backupPath = CopyBundle(resolved);
+        }
+
+        for (var i = 0; i < plan.Steps.Count; i++)
+        {
+            var step = plan.Steps[i];
+
+            if (step.Class == RepairClass.Excise && !allowLoss)
+            {
+                results.Add(new RepairStepResult(step, StepOutcome.Skipped,
+                    "Skipped: this step destroys data and no consent was given.", LossEstimate.None));
+                continue;
+            }
+
+            if (dryRun)
+            {
+                results.Add(new RepairStepResult(step, StepOutcome.Skipped, "Dry run: not executed.", LossEstimate.None));
+                continue;
+            }
+
+            try
+            {
+                var detail = Execute(resolved, step, regenerateDerived);
+                results.Add(new RepairStepResult(step, StepOutcome.Succeeded, detail, LossEstimate.None));
+            }
+            catch (Exception ex) when (ex is IOException or InvalidOperationException or UnauthorizedAccessException)
+            {
+                results.Add(new RepairStepResult(step, StepOutcome.Failed, ex.Message, LossEstimate.None));
+                break;   // a failed step may leave later ones invalid; stop and let the operator look
+            }
+        }
+
+        IntegrityReport verification = null;
+        if (!dryRun && plan.Steps.Count > 0)
+        {
+            using var source = new OfflineBundlePageSource(resolved);
+            verification = IntegrityScanner.Scan(source, IntegrityOptions.Deep);
+        }
+
+        return new RepairOutcome { Plan = plan, Results = results, BackupPath = backupPath, VerificationReport = verification };
+    }
+
+    private static string Execute(string bundlePath, RepairStep step, Action<string> regenerateDerived) => step.Action switch
+    {
+        RepairAction.RestorePairSlot => PairSlotRepair.Restore(bundlePath, step.Locus.FilePageIndex),
+        RepairAction.RederiveOccupancy => OccupancyRepair.Rederive(bundlePath),
+        RepairAction.RegenerateDerivedStructures => RunRegeneration(bundlePath, regenerateDerived),
+        _ => throw new InvalidOperationException($"Repair action {step.Action} is not implemented in this build.")
+    };
+
+    private static string RunRegeneration(string bundlePath, Action<string> regenerateDerived)
+    {
+        if (regenerateDerived == null)
+        {
+            throw new InvalidOperationException(
+                "Regenerating derived structures needs a callback that opens and closes the database; none was supplied.");
+        }
+
+        regenerateDerived(bundlePath);
+        return "The engine opened the database, rebuilt its derived structures and closed cleanly.";
+    }
+
+    /// <summary>
+    /// A stable identity for "this database, in this state". Deliberately coarse: it must change when the database
+    /// changes, and must not change merely because a scan ran twice.
+    /// </summary>
+    /// <param name="report">The report to fingerprint.</param>
+    public static string Fingerprint(IntegrityReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        var id = report.Identity;
+        var sb = new StringBuilder(128);
+        sb.Append(id.Name).Append('|').Append(id.FormatRevision).Append('|').Append(id.PageCount).Append('|');
+        sb.Append(id.SizeBytes).Append('|').Append(id.CheckpointLsn).Append('|').Append(id.MetaGeneration).Append('|');
+
+        // Fold the findings in, so a plan built for one set of problems cannot be applied to a database with another set.
+        var hash = 17UL;
+        for (var i = 0; i < report.Findings.Count; i++)
+        {
+            var f = report.Findings[i];
+            hash = (hash * 1099511628211UL) ^ (ulong)f.Code.GetHashCode(StringComparison.Ordinal);
+            hash = (hash * 1099511628211UL) ^ (ulong)f.Locus.FilePageIndex;
+            hash = (hash * 1099511628211UL) ^ (ulong)f.Occurrences;
+        }
+
+        sb.Append(hash.ToString("x16", CultureInfo.InvariantCulture));
+        return sb.ToString();
+    }
+
+    private static string CopyBundle(string bundlePath)
+    {
+        var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+        var target = bundlePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + $".pre-repair-{stamp}";
+        Directory.CreateDirectory(target);
+
+        foreach (var file in Directory.GetFiles(bundlePath, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(bundlePath, file);
+            var destination = Path.Combine(target, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(destination));
+            File.Copy(file, destination, overwrite: true);
+        }
+
+        return target;
+    }
+
+    private static string EscalationFor(IntegrityFinding finding)
+    {
+        if (finding.Loss == null || finding.Loss.IsNone)
+        {
+            return "Nothing is lost by leaving it; the database continues to work.";
+        }
+
+        return $"What is affected: {finding.Loss.Explanation} Restoring from a backup taken before the damage is the only "
+            + "way to get it back — repair from within this database cannot recover data that is not there.";
+    }
+}

--- a/src/Typhon.Engine/Integrity/public/IPageSource.cs
+++ b/src/Typhon.Engine/Integrity/public/IPageSource.cs
@@ -1,0 +1,44 @@
+using JetBrains.Annotations;
+using System;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// A read-only, random-access source of 8 KiB storage pages. The seam every integrity check reads through, so the same
+/// catalogue can run against an offline bundle, a live engine, a backup file, or a synthetic in-memory image.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations <b>must be side-effect free</b>: no lock acquisition, no WAL replay, no clean-shutdown flag mutation, no
+/// page-cache residency change. This is principle <c>PR-2</c> (<i>scan never mutates</i>) expressed as a type constraint —
+/// it is what makes a scan always safe to run, including on a production database and on one that will not open.
+/// </para>
+/// <para>
+/// Deliberately <i>not</i> a page cache: no pinning, no eviction, no epochs, no latches. The scanner streams and does its
+/// own bounded buffering so it can walk a very large database in a process with a small heap without competing with a live
+/// engine's cache budget.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public interface IPageSource : IDisposable
+{
+    /// <summary>Number of pages addressable in this source. Indices <c>[0, PageCount)</c> are in range.</summary>
+    int PageCount { get; }
+
+    /// <summary>
+    /// Reads page <paramref name="index"/> into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="index">Zero-based file-page index.</param>
+    /// <param name="destination">Buffer of at least <see cref="IntegrityConstants.PageSize"/> bytes.</param>
+    /// <returns>
+    /// <c>true</c> when the page was read in full; <c>false</c> when it does not exist in this source (out of range, or a
+    /// hole in a sparse source such as an incremental backup). A <c>false</c> return is not an error — the caller decides
+    /// whether an absent page is a finding.
+    /// </returns>
+    bool TryReadPage(int index, Span<byte> destination);
+
+    /// <summary>
+    /// Human-readable identity of the source, used to anchor findings: a bundle path, a backup id, or <c>"live"</c>.
+    /// </summary>
+    string Describe();
+}

--- a/src/Typhon.Engine/Integrity/public/IntegrityConstants.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityConstants.cs
@@ -1,0 +1,33 @@
+using JetBrains.Annotations;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// The handful of on-disk layout constants an integrity consumer needs to size buffers and interpret a
+/// <see cref="Locus"/>. Mirrors the engine-internal storage constants so external callers (CLI, Workbench, tests) do not
+/// have to hard-code them.
+/// </summary>
+[PublicAPI]
+public static class IntegrityConstants
+{
+    /// <summary>Size in bytes of one storage page.</summary>
+    public const int PageSize = 8192;
+
+    /// <summary>Size in bytes of the page header zone (base header + metadata) that precedes the raw-data area.</summary>
+    public const int PageHeaderSize = 192;
+
+    /// <summary>Size in bytes of the raw-data area of a page — the part that holds chunks, directory entries or bitmap words.</summary>
+    public const int PageRawDataSize = PageSize - PageHeaderSize;
+
+    /// <summary>File name of the paged data file inside a <c>.typhon</c> bundle directory.</summary>
+    public const string DataFileName = "data";
+
+    /// <summary>File name of the single-writer lock inside a <c>.typhon</c> bundle directory.</summary>
+    public const string LockFileName = "db.lock";
+
+    /// <summary>Sub-directory holding the WAL segments inside a <c>.typhon</c> bundle directory.</summary>
+    public const string WalDirectoryName = "wal";
+
+    /// <summary>Canonical extension of a Typhon database bundle directory.</summary>
+    public const string BundleExtension = ".typhon";
+}

--- a/src/Typhon.Engine/Integrity/public/IntegrityFinding.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityFinding.cs
@@ -1,0 +1,314 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// How bad a finding is. Ordered most-severe first so a numeric comparison ranks findings.
+/// </summary>
+[PublicAPI]
+public enum IntegritySeverity
+{
+    /// <summary>The database cannot be safely opened or traversed. Scanning may have stopped early.</summary>
+    Fatal = 0,
+
+    /// <summary>Primary data is unreadable. Something the user stored is gone and cannot be regenerated from within the database.</summary>
+    DataLoss = 1,
+
+    /// <summary>A derived structure disagrees with primary data. Repairable by regeneration; no user data is lost.</summary>
+    Divergence = 2,
+
+    /// <summary>Space is allocated but unreachable. Wastes capacity; costs no correctness.</summary>
+    Leak = 3,
+
+    /// <summary>Informational — a condition worth surfacing that is not itself a defect.</summary>
+    Advisory = 4
+}
+
+/// <summary>
+/// Whether a finding was observed on a source that could not have been mutating underneath the scan.
+/// </summary>
+/// <remarks>
+/// A live scan sees a consistent <i>page</i>, never a consistent <i>database</i>, so a cross-structure disagreement observed
+/// online may simply be a mutation in flight. Repair acts only on <see cref="Confirmed"/> findings — collapsing these two
+/// into one boolean is how a tool ends up repairing a database that was healthy.
+/// </remarks>
+[PublicAPI]
+public enum IntegrityConfidence
+{
+    /// <summary>Observed on a quiescent source (offline, or online behind a tick fence and checkpoint barrier).</summary>
+    Confirmed = 0,
+
+    /// <summary>Observed on a live, mutating source. Never sufficient to justify a repair — re-run offline to confirm.</summary>
+    Suspected = 1
+}
+
+/// <summary>What, if anything, can be done about a finding from within the database.</summary>
+[PublicAPI]
+public enum Repairability
+{
+    /// <summary>Regenerable from primary data. Loss is zero by construction.</summary>
+    Lossless = 0,
+
+    /// <summary>Repairable only by excising a reference to data that is already unreadable. Requires explicit consent.</summary>
+    Lossy = 1,
+
+    /// <summary>No repair primitive applies. The report is the deliverable; escalation is a restore.</summary>
+    NotRepairable = 2
+}
+
+/// <summary>The unit in which a repair would lose something.</summary>
+[PublicAPI]
+public enum LossKind
+{
+    /// <summary>Nothing is lost.</summary>
+    None = 0,
+
+    /// <summary>Component values are lost; the owning entities survive with their other components.</summary>
+    Values = 1,
+
+    /// <summary>Whole entities are lost.</summary>
+    Entities = 2,
+
+    /// <summary>Elements of a component collection are lost.</summary>
+    Collection = 3,
+
+    /// <summary>Interned string payloads are lost.</summary>
+    Strings = 4,
+
+    /// <summary>Something is lost but the scan cannot characterise it. Always paired with a bound.</summary>
+    Unknown = 5
+}
+
+/// <summary>
+/// Where a finding is, in every addressing scheme that applies to it.
+/// </summary>
+/// <remarks>
+/// Deliberately over-specified. A page index is what a storage engineer needs; an archetype and entity id is what the
+/// application owner needs; the Workbench File Map addresses cells by physical page index. Reporting only one forces every
+/// consumer to re-derive the others — and re-derivation on a <i>damaged</i> database is exactly what cannot be trusted.
+/// </remarks>
+[PublicAPI]
+public readonly struct Locus : IEquatable<Locus>
+{
+    /// <summary>Sentinel for an addressing component that does not apply to a finding.</summary>
+    public const int None = -1;
+
+    /// <summary>
+    /// A locus that names the database as a whole. Use this rather than <c>default</c>: a default-initialised struct
+    /// reads every component as <c>0</c>, which renders as "page 0" and points a reader at the meta page.
+    /// </summary>
+    public static Locus Database => new(None, None, StorageSegmentKind.Other, null, null, 0, None);
+
+    /// <summary>Creates a locus. Pass <see cref="None"/> / <c>null</c> / <c>0</c> for components that do not apply.</summary>
+    /// <param name="filePageIndex">Physical file-page index, or <see cref="None"/>.</param>
+    /// <param name="segmentRootPage">Root page of the owning logical segment, or <see cref="None"/>.</param>
+    /// <param name="kind">Kind of the owning segment.</param>
+    /// <param name="archetypeName">Schema-level archetype name when resolvable.</param>
+    /// <param name="componentName">Schema-level component name when resolvable.</param>
+    /// <param name="chunkId">Chunk id within the owning chunk-based segment, or <c>0</c>.</param>
+    /// <param name="slot">Slot index within a cluster chunk, or <see cref="None"/>.</param>
+    /// <param name="entityId">Raw entity id when the finding is entity-scoped, or <c>0</c>.</param>
+    public Locus(int filePageIndex = None, int segmentRootPage = None, StorageSegmentKind kind = StorageSegmentKind.Other,
+        string archetypeName = null, string componentName = null, long chunkId = 0, int slot = None, ulong entityId = 0)
+    {
+        FilePageIndex = filePageIndex;
+        SegmentRootPage = segmentRootPage;
+        Kind = kind;
+        ArchetypeName = archetypeName;
+        ComponentName = componentName;
+        ChunkId = chunkId;
+        Slot = slot;
+        EntityId = entityId;
+    }
+
+    /// <summary>Physical file-page index, or <see cref="None"/> when the finding is not page-scoped.</summary>
+    public int FilePageIndex { get; }
+
+    /// <summary>Root page of the owning logical segment, or <see cref="None"/>.</summary>
+    public int SegmentRootPage { get; }
+
+    /// <summary>Kind of the owning logical segment.</summary>
+    public StorageSegmentKind Kind { get; }
+
+    /// <summary>Schema-level archetype name, when the scan could resolve one.</summary>
+    public string ArchetypeName { get; }
+
+    /// <summary>Schema-level component name, when the scan could resolve one.</summary>
+    public string ComponentName { get; }
+
+    /// <summary>Chunk id within the owning chunk-based segment, or <c>0</c>.</summary>
+    public long ChunkId { get; }
+
+    /// <summary>Slot index within a cluster chunk, or <see cref="None"/>.</summary>
+    public int Slot { get; }
+
+    /// <summary>Raw entity id when the finding is entity-scoped, or <c>0</c>.</summary>
+    public ulong EntityId { get; }
+
+    /// <summary>Renders the locus as a compact, human-readable path — only the components that apply.</summary>
+    public override string ToString()
+    {
+        var parts = new List<string>(6);
+        if (Kind != StorageSegmentKind.Other)
+        {
+            parts.Add(ArchetypeName != null ? $"{Kind}/{ArchetypeName}" : Kind.ToString());
+        }
+        else if (ArchetypeName != null)
+        {
+            parts.Add(ArchetypeName);
+        }
+
+        if (ComponentName != null)
+        {
+            parts.Add($".{ComponentName}");
+        }
+
+        if (FilePageIndex != None)
+        {
+            parts.Add($"page {FilePageIndex}");
+        }
+
+        if (ChunkId != 0)
+        {
+            parts.Add($"chunk {ChunkId}");
+        }
+
+        if (Slot != None)
+        {
+            parts.Add($"slot {Slot}");
+        }
+
+        if (EntityId != 0)
+        {
+            parts.Add($"entity {EntityId}");
+        }
+
+        return parts.Count == 0 ? "database" : string.Join(" ", parts);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(Locus other) =>
+        FilePageIndex == other.FilePageIndex && SegmentRootPage == other.SegmentRootPage && Kind == other.Kind
+        && ArchetypeName == other.ArchetypeName && ComponentName == other.ComponentName && ChunkId == other.ChunkId
+        && Slot == other.Slot && EntityId == other.EntityId;
+
+    /// <inheritdoc />
+    public override bool Equals(object obj) => obj is Locus other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(FilePageIndex, SegmentRootPage, (int)Kind, ArchetypeName, ComponentName, ChunkId, Slot);
+
+    /// <summary>Equality operator.</summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    public static bool operator ==(Locus left, Locus right) => left.Equals(right);
+
+    /// <summary>Inequality operator.</summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    public static bool operator !=(Locus left, Locus right) => !left.Equals(right);
+}
+
+/// <summary>
+/// What a repair would cost, in user terms.
+/// </summary>
+/// <remarks>
+/// <para>Three rules govern this type, and each exists because its violation is a specific way of lying:</para>
+/// <list type="number">
+/// <item><description>
+/// <b>Never report <c>0</c> when the answer is unknown.</b> <see cref="LossKind.Unknown"/> with a bound is honest; zero is
+/// a claim. Use <see cref="BoundedMin"/>/<see cref="BoundedMax"/> and leave <see cref="EntityCount"/> at <c>-1</c>.
+/// </description></item>
+/// <item><description>
+/// <b>Enumerate when enumeration is possible.</b> A count of zero and a count that was never taken must not be
+/// indistinguishable.
+/// </description></item>
+/// <item><description>
+/// <b>Loss is measured in user terms, not storage terms.</b> "Page 41,208 is unrecoverable" is not a loss report;
+/// "12 <c>Player</c> entities lose their <c>Inventory</c> values, the entities survive" is.
+/// </description></item>
+/// </list>
+/// </remarks>
+[PublicAPI]
+public sealed class LossEstimate
+{
+    /// <summary>A shared, allocation-free "nothing is lost" instance.</summary>
+    public static readonly LossEstimate None = new() { Kind = LossKind.None, EntityCount = 0, Explanation = "No data is lost." };
+
+    /// <summary>What unit the loss is measured in.</summary>
+    public LossKind Kind { get; init; }
+
+    /// <summary>Exact number of entities affected when enumerable; <c>-1</c> when only a bound is known.</summary>
+    public long EntityCount { get; init; } = -1;
+
+    /// <summary>Lower bound on affected entities when <see cref="EntityCount"/> is <c>-1</c>.</summary>
+    public long BoundedMin { get; init; }
+
+    /// <summary>Upper bound on affected entities when <see cref="EntityCount"/> is <c>-1</c>.</summary>
+    public long BoundedMax { get; init; }
+
+    /// <summary>
+    /// Affected entity ids, capped for report size. The complete set goes to the loss manifest file, never here.
+    /// </summary>
+    public IReadOnlyList<ulong> Sample { get; init; } = [];
+
+    /// <summary>Archetype the loss falls in, when resolvable.</summary>
+    public string Archetype { get; init; }
+
+    /// <summary>Component the loss falls in, when resolvable.</summary>
+    public string Component { get; init; }
+
+    /// <summary>Plain-English statement of what the user no longer has.</summary>
+    public string Explanation { get; init; } = "";
+
+    /// <summary>Whether this estimate represents any loss at all.</summary>
+    public bool IsNone => Kind == LossKind.None;
+
+    /// <summary>Renders the count as text: an exact number, or an honest range.</summary>
+    public string CountText => EntityCount >= 0 ? EntityCount.ToString("N0") : $"{BoundedMin:N0}–{BoundedMax:N0}";
+}
+
+/// <summary>
+/// One thing that is wrong with a database, with everything needed to judge it: what rule it violates, where it is, how
+/// confident the scan is, and what repairing it would cost.
+/// </summary>
+[PublicAPI]
+public sealed class IntegrityFinding
+{
+    /// <summary>
+    /// Stable check code, e.g. <c>"CHK-IDX-04"</c>. <b>A finding code is an API</b> — renaming one breaks somebody's alert.
+    /// </summary>
+    public required string Code { get; init; }
+
+    /// <summary>How bad this is.</summary>
+    public required IntegritySeverity Severity { get; init; }
+
+    /// <summary>Whether the source was quiescent when this was observed.</summary>
+    public IntegrityConfidence Confidence { get; init; } = IntegrityConfidence.Confirmed;
+
+    /// <summary>Where the problem is.</summary>
+    public Locus Locus { get; init; }
+
+    /// <summary>One sentence, no jargon — what is wrong.</summary>
+    public required string Summary { get; init; }
+
+    /// <summary>The evidence: expected versus found, with the numbers that support the conclusion.</summary>
+    public string Detail { get; init; } = "";
+
+    /// <summary>Identifier of the <c>rules/</c> invariant this violates, e.g. <c>"RB-03"</c>. Empty only for structural pre-checks.</summary>
+    public string RuleId { get; init; } = "";
+
+    /// <summary>What can be done about it.</summary>
+    public Repairability Repair { get; init; } = Repairability.NotRepairable;
+
+    /// <summary>What repairing it would cost. Never <c>null</c> — use <see cref="LossEstimate.None"/> for lossless findings.</summary>
+    public LossEstimate Loss { get; init; } = LossEstimate.None;
+
+    /// <summary>Number of occurrences this finding aggregates, when the scan collapsed a repeated condition. <c>1</c> otherwise.</summary>
+    public long Occurrences { get; init; } = 1;
+
+    /// <inheritdoc />
+    public override string ToString() => $"{Code} [{Severity}] {Locus}: {Summary}";
+}

--- a/src/Typhon.Engine/Integrity/public/IntegrityOptions.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityOptions.cs
@@ -1,0 +1,91 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Knobs for a scan. The defaults are the ones an operator should get by typing nothing.
+/// </summary>
+[PublicAPI]
+public sealed class IntegrityOptions
+{
+    /// <summary>Spine-only: what verify-on-open runs. Bounded by segment count, not database size.</summary>
+    public static IntegrityOptions Spine => new() { Depth = ScanDepth.Spine };
+
+    /// <summary>Page headers only. No checksum sweep, no cross-structure work.</summary>
+    public static IntegrityOptions Quick => new() { Depth = ScanDepth.Quick };
+
+    /// <summary>Headers plus a checksum sweep over every allocated page. The default for <c>typhon check</c>.</summary>
+    public static IntegrityOptions Standard => new() { Depth = ScanDepth.Standard };
+
+    /// <summary>Everything, including cross-structure checks. The depth the crash suite asserts at.</summary>
+    public static IntegrityOptions Deep => new() { Depth = ScanDepth.Deep };
+
+    /// <summary>How much work to do.</summary>
+    public ScanDepth Depth { get; init; } = ScanDepth.Standard;
+
+    /// <summary>
+    /// Check codes or family prefixes to run, e.g. <c>["CHK-IDX", "CHK-PHY-01"]</c>. Empty means every check applicable to
+    /// <see cref="Depth"/>. Anything excluded is named in <see cref="ScanLimits.ChecksSkipped"/>.
+    /// </summary>
+    public IReadOnlyList<string> IncludeChecks { get; init; } = [];
+
+    /// <summary>Check codes or family prefixes to skip. Applied after <see cref="IncludeChecks"/>.</summary>
+    public IReadOnlyList<string> ExcludeChecks { get; init; } = [];
+
+    /// <summary>
+    /// Maximum findings to record before the scan starts aggregating rather than enumerating. Protects a report against a
+    /// database where one systemic fault produces millions of individually-true findings.
+    /// </summary>
+    public int MaxFindings { get; init; } = 10_000;
+
+    /// <summary>Maximum entity ids carried inline in a <see cref="LossEstimate.Sample"/>. The full set goes to the manifest.</summary>
+    public int MaxLossSample { get; init; } = 32;
+
+    /// <summary>
+    /// Soft ceiling on scanner working-set bytes for cross-structure set comparison. The <see cref="ScanDepth.Deep"/>
+    /// checks degrade to counting rather than enumerating when a comparison would exceed it, and say so in
+    /// <see cref="ScanLimits.Caveats"/>.
+    /// </summary>
+    public long MemoryBudgetBytes { get; init; } = 256L * 1024 * 1024;
+
+    /// <summary>Cancellation for a long <see cref="ScanDepth.Deep"/> sweep. Cancelling produces a partial report, never an exception.</summary>
+    public System.Threading.CancellationToken Cancellation { get; init; }
+
+    /// <summary>Optional progress callback: <c>(phase, done, total)</c>. Invoked from the scanning thread; keep it cheap.</summary>
+    public Action<string, long, long> Progress { get; init; }
+
+    /// <summary>Whether a check code passes this option set's include/exclude filters.</summary>
+    /// <param name="code">Full check code, e.g. <c>"CHK-IDX-04"</c>.</param>
+    public bool IsCheckEnabled(string code)
+    {
+        if (IncludeChecks.Count > 0)
+        {
+            var matched = false;
+            for (var i = 0; i < IncludeChecks.Count; i++)
+            {
+                if (code.StartsWith(IncludeChecks[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    matched = true;
+                    break;
+                }
+            }
+
+            if (!matched)
+            {
+                return false;
+            }
+        }
+
+        for (var i = 0; i < ExcludeChecks.Count; i++)
+        {
+            if (code.StartsWith(ExcludeChecks[i], StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Typhon.Engine/Integrity/public/IntegrityReport.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityReport.cs
@@ -1,0 +1,286 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// The one-word answer to "is my database sound?". A single grep-able token, because an operator scanning a fleet needs
+/// exactly that.
+/// </summary>
+[PublicAPI]
+public enum IntegrityVerdict
+{
+    /// <summary>Every check passed.</summary>
+    Sound = 0,
+
+    /// <summary>
+    /// No correctness problem, but space is allocated and unreachable. Separate from <see cref="Sound"/> deliberately:
+    /// leaks must not scare anyone into a repair, but hiding them inside <see cref="Sound"/> makes space growth inexplicable.
+    /// </summary>
+    SoundWithLeaks = 1,
+
+    /// <summary>A derived structure disagrees with primary data. Schedule a repair; nothing is lost.</summary>
+    Divergent = 2,
+
+    /// <summary>Primary data is unreadable. Stop and think before repairing.</summary>
+    DataLoss = 3,
+
+    /// <summary>The database cannot be traversed. The scan stopped early.</summary>
+    Unopenable = 4
+}
+
+/// <summary>How the scan reached its pages, which bounds what its conclusions are worth.</summary>
+[PublicAPI]
+public enum ScanMode
+{
+    /// <summary>Read the bundle as bytes with no engine, no lock, no replay. Conclusions are <see cref="IntegrityConfidence.Confirmed"/>.</summary>
+    Offline = 0,
+
+    /// <summary>Read through a running engine without quiescing it. Per-page checks only; conclusions are <see cref="IntegrityConfidence.Suspected"/>.</summary>
+    OnlineSampled = 1,
+
+    /// <summary>Read through a running engine behind a tick fence and checkpoint barrier. Conclusions are <see cref="IntegrityConfidence.Confirmed"/>.</summary>
+    OnlineQuiesced = 2
+}
+
+/// <summary>How much work a scan does, and therefore what it can conclude.</summary>
+[PublicAPI]
+public enum ScanDepth
+{
+    /// <summary>
+    /// Page-0 pair selection, the bootstrap stream, and that every segment pointer resolves. Bounded by the number of
+    /// <i>segments</i>, not pages — kilobytes read, sub-millisecond. Cheap enough to run on every open.
+    /// </summary>
+    Spine = 0,
+
+    /// <summary>Adds every page header. O(pages), IOPS-bound; no page bodies are hashed.</summary>
+    Quick = 1,
+
+    /// <summary>Adds a checksum sweep over every allocated page. O(pages), bandwidth-bound.</summary>
+    Standard = 2,
+
+    /// <summary>Adds cross-structure checks — chains, clusters, indexes, entity maps, allocators. O(entities).</summary>
+    Deep = 3
+}
+
+/// <summary>Identity of the scanned database, as read from its own bytes.</summary>
+[PublicAPI]
+public sealed class DatabaseIdentity
+{
+    /// <summary>Database name recorded on page 0, or <c>null</c> when unreadable.</summary>
+    public string Name { get; init; }
+
+    /// <summary>On-disk format revision recorded on page 0.</summary>
+    public int FormatRevision { get; init; }
+
+    /// <summary>Total pages in the data file.</summary>
+    public int PageCount { get; init; }
+
+    /// <summary>Size of the data file in bytes.</summary>
+    public long SizeBytes { get; init; }
+
+    /// <summary>Last checkpoint LSN recorded in the bootstrap dictionary, or <c>0</c>.</summary>
+    public long CheckpointLsn { get; init; }
+
+    /// <summary>Whether the previous process recorded a clean shutdown. <c>false</c> means recovery would run on open.</summary>
+    public bool CleanShutdown { get; init; }
+
+    /// <summary>Which physical slot of the page-0 A/B meta pair held the selected content, or <c>-1</c> when neither was valid.</summary>
+    public int MetaSlot { get; init; } = -1;
+
+    /// <summary>Generation of the selected meta slot.</summary>
+    public ulong MetaGeneration { get; init; }
+
+    /// <summary>Number of WAL segment files present beside the data file.</summary>
+    public int WalSegmentCount { get; init; }
+
+    /// <summary>Total bytes across the WAL segment files.</summary>
+    public long WalBytes { get; init; }
+}
+
+/// <summary>Aggregate counters describing what the scan actually looked at.</summary>
+[PublicAPI]
+public sealed class ScanTotals
+{
+    /// <summary>Pages read and classified.</summary>
+    public int PagesScanned { get; init; }
+
+    /// <summary>Pages whose occupancy bit is set.</summary>
+    public int PagesAllocated { get; init; }
+
+    /// <summary>Pages whose stored checksum did not match their content.</summary>
+    public int ChecksumFailures { get; init; }
+
+    /// <summary>Pages carrying a per-sector verification footer.</summary>
+    public int PagesWithSectorFooters { get; init; }
+
+    /// <summary>Sectors that failed verification across all pages.</summary>
+    public int SectorFailures { get; init; }
+
+    /// <summary>Logical segments discovered and walked.</summary>
+    public int SegmentsWalked { get; init; }
+
+    /// <summary>Chunks found allocated across every chunk-based segment.</summary>
+    public long ChunksAllocated { get; init; }
+
+    /// <summary>Bytes held by allocated-but-unreachable structures.</summary>
+    public long BytesLeaked { get; init; }
+
+    /// <summary>Finding counts by severity, indexed by <see cref="IntegritySeverity"/>.</summary>
+    public IReadOnlyList<int> BySeverity { get; init; } = [];
+}
+
+/// <summary>
+/// The statement of what a scan could <b>not</b> have detected. Present on every report, including a fully green one, and
+/// deliberately not suppressible.
+/// </summary>
+/// <remarks>
+/// When a recovery gap discards a committed update, the database passes <b>every</b> check in the catalogue — because it
+/// <i>is</i> self-consistent, merely stale. A report that says <c>Sound</c> without this block is telling the operator
+/// something materially untrue, and the whole feature is a claim to honesty.
+/// </remarks>
+[PublicAPI]
+public sealed class ScanLimits
+{
+    /// <summary>The always-true statement of the instrument's structural blind spot.</summary>
+    public const string StructuralLimit =
+        "This scan verifies that the database is INTERNALLY CONSISTENT. It cannot verify that the database matches what "
+        + "was committed. Specifically it cannot detect: committed updates lost during a prior recovery; entities "
+        + "resurrected by a prior recovery; or any damage that left every structure in mutual agreement. Detecting those "
+        + "requires a reference copy, which this build cannot take.";
+
+    /// <summary>Check codes that were not run at the requested depth or were explicitly excluded.</summary>
+    public IReadOnlyList<string> ChecksSkipped { get; init; } = [];
+
+    /// <summary>Additional, scan-specific caveats — a truncated walk, an unresolvable schema, an unstamped page range.</summary>
+    public IReadOnlyList<string> Caveats { get; init; } = [];
+}
+
+/// <summary>
+/// The product of a scan: what was looked at, what is wrong, what a repair would cost, and what could not be seen.
+/// </summary>
+/// <remarks>
+/// This is also the interface the crash suite consumes. It needs no shadow model, so it can be asserted after any chaos
+/// cell — including ones whose correct final state the harness cannot compute.
+/// </remarks>
+[PublicAPI]
+public sealed class IntegrityReport
+{
+    /// <summary>Schema version of this report's JSON form. Bumped on any breaking shape change.</summary>
+    public const int ReportVersion = 1;
+
+    /// <summary>Identity of the source that was scanned, from <see cref="IPageSource.Describe"/>.</summary>
+    public required string Source { get; init; }
+
+    /// <summary>How the pages were reached.</summary>
+    public required ScanMode Mode { get; init; }
+
+    /// <summary>How much work was done.</summary>
+    public required ScanDepth Depth { get; init; }
+
+    /// <summary>Identity of the scanned database.</summary>
+    public required DatabaseIdentity Identity { get; init; }
+
+    /// <summary>Every finding, severity-ranked.</summary>
+    public required IReadOnlyList<IntegrityFinding> Findings { get; init; }
+
+    /// <summary>What the scan looked at.</summary>
+    public required ScanTotals Totals { get; init; }
+
+    /// <summary>What the scan could not have detected. Never <c>null</c>.</summary>
+    public required ScanLimits Limits { get; init; }
+
+    /// <summary>Wall-clock duration of the scan.</summary>
+    public TimeSpan Duration { get; init; }
+
+    /// <summary>UTC instant the scan completed.</summary>
+    public DateTime CompletedUtc { get; init; } = DateTime.UtcNow;
+
+    /// <summary>The one-word answer, derived from the most severe finding.</summary>
+    public IntegrityVerdict Verdict
+    {
+        get
+        {
+            var worst = IntegritySeverity.Advisory;
+            var any = false;
+            for (var i = 0; i < Findings.Count; i++)
+            {
+                var s = Findings[i].Severity;
+                if (!any || s < worst)
+                {
+                    worst = s;
+                    any = true;
+                }
+            }
+
+            if (!any)
+            {
+                return IntegrityVerdict.Sound;
+            }
+
+            return worst switch
+            {
+                IntegritySeverity.Fatal => IntegrityVerdict.Unopenable,
+                IntegritySeverity.DataLoss => IntegrityVerdict.DataLoss,
+                IntegritySeverity.Divergence => IntegrityVerdict.Divergent,
+                IntegritySeverity.Leak => IntegrityVerdict.SoundWithLeaks,
+                _ => IntegrityVerdict.Sound
+            };
+        }
+    }
+
+    /// <summary>
+    /// Process exit code carrying the verdict, so <c>typhon check</c> drops into a cron job or a CI gate without anyone
+    /// parsing anything. Distinct codes for <see cref="IntegrityVerdict.Divergent"/> and
+    /// <see cref="IntegrityVerdict.DataLoss"/> matter: the first is "schedule a repair", the second is "stop and think".
+    /// </summary>
+    public int ExitCode => (int)Verdict;
+
+    /// <summary>Aggregate loss across every finding, grouped by archetype and component.</summary>
+    public IReadOnlyList<LossEstimate> LossSummary
+    {
+        get
+        {
+            var byKey = new Dictionary<string, LossEstimate>(StringComparer.Ordinal);
+            for (var i = 0; i < Findings.Count; i++)
+            {
+                var loss = Findings[i].Loss;
+                if (loss == null || loss.IsNone)
+                {
+                    continue;
+                }
+
+                var key = $"{loss.Archetype} {loss.Component} {loss.Kind}";
+                if (!byKey.TryGetValue(key, out var acc))
+                {
+                    byKey[key] = loss;
+                    continue;
+                }
+
+                byKey[key] = new LossEstimate
+                {
+                    Kind = acc.Kind,
+                    EntityCount = acc.EntityCount >= 0 && loss.EntityCount >= 0 ? acc.EntityCount + loss.EntityCount : -1,
+                    BoundedMin = acc.BoundedMin + loss.BoundedMin,
+                    BoundedMax = acc.BoundedMax + loss.BoundedMax,
+                    Archetype = acc.Archetype,
+                    Component = acc.Component,
+                    Explanation = acc.Explanation,
+                    Sample = acc.Sample
+                };
+            }
+
+            var result = new List<LossEstimate>(byKey.Count);
+            foreach (var v in byKey.Values)
+            {
+                result.Add(v);
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>Whether the database is free of correctness problems (leaks and advisories do not count).</summary>
+    public bool IsSound => Verdict is IntegrityVerdict.Sound or IntegrityVerdict.SoundWithLeaks;
+}

--- a/src/Typhon.Engine/Integrity/public/IntegrityReportJson.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityReportJson.cs
@@ -1,0 +1,317 @@
+using JetBrains.Annotations;
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Renders an <see cref="IntegrityReport"/> as JSON for CI gates, scripts and the Workbench.
+/// </summary>
+/// <remarks>
+/// The schema is versioned (<see cref="IntegrityReport.ReportVersion"/>) and finding codes are stable, because
+/// <b>a finding code is an API</b> — renaming one breaks somebody's alert. Written by hand rather than through a
+/// serializer so the shape is visible in one place and cannot drift when a property is added to a model type.
+/// </remarks>
+[PublicAPI]
+public static class IntegrityReportJson
+{
+    /// <summary>Renders the report as JSON.</summary>
+    /// <param name="report">The report to render.</param>
+    /// <param name="indent">Whether to pretty-print.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="report"/> is <c>null</c>.</exception>
+    public static string Render(IntegrityReport report, bool indent = true)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var sb = new StringBuilder(8192);
+        var w = new Writer(sb, indent);
+
+        w.BeginObject();
+        w.Prop("reportVersion", IntegrityReport.ReportVersion);
+        w.Prop("verdict", report.Verdict.ToString());
+        w.Prop("exitCode", report.ExitCode);
+        w.Prop("source", report.Source);
+        w.Prop("mode", report.Mode.ToString());
+        w.Prop("depth", report.Depth.ToString());
+        w.Prop("completedUtc", report.CompletedUtc.ToString("O", CultureInfo.InvariantCulture));
+        w.Prop("durationMs", report.Duration.TotalMilliseconds);
+
+        w.Key("identity");
+        w.BeginObject();
+        var id = report.Identity;
+        w.Prop("name", id.Name);
+        w.Prop("formatRevision", id.FormatRevision);
+        w.Prop("pageCount", id.PageCount);
+        w.Prop("sizeBytes", id.SizeBytes);
+        w.Prop("checkpointLsn", id.CheckpointLsn);
+        w.Prop("cleanShutdown", id.CleanShutdown);
+        w.Prop("metaSlot", id.MetaSlot);
+        w.Prop("metaGeneration", (long)id.MetaGeneration);
+        w.Prop("walSegmentCount", id.WalSegmentCount);
+        w.Prop("walBytes", id.WalBytes);
+        w.EndObject();
+
+        w.Key("totals");
+        w.BeginObject();
+        var t = report.Totals;
+        w.Prop("pagesScanned", t.PagesScanned);
+        w.Prop("pagesAllocated", t.PagesAllocated);
+        w.Prop("checksumFailures", t.ChecksumFailures);
+        w.Prop("pagesWithSectorFooters", t.PagesWithSectorFooters);
+        w.Prop("sectorFailures", t.SectorFailures);
+        w.Prop("segmentsWalked", t.SegmentsWalked);
+        w.Prop("bytesLeaked", t.BytesLeaked);
+        w.EndObject();
+
+        w.Key("findings");
+        w.BeginArray();
+        for (var i = 0; i < report.Findings.Count; i++)
+        {
+            var f = report.Findings[i];
+            w.BeginObject();
+            w.Prop("code", f.Code);
+            w.Prop("severity", f.Severity.ToString());
+            w.Prop("confidence", f.Confidence.ToString());
+            w.Prop("summary", f.Summary);
+            w.Prop("detail", f.Detail);
+            w.Prop("ruleId", f.RuleId);
+            w.Prop("repair", f.Repair.ToString());
+            w.Prop("occurrences", f.Occurrences);
+
+            w.Key("locus");
+            w.BeginObject();
+            w.Prop("filePageIndex", f.Locus.FilePageIndex);
+            w.Prop("segmentRootPage", f.Locus.SegmentRootPage);
+            w.Prop("kind", f.Locus.Kind.ToString());
+            w.Prop("archetype", f.Locus.ArchetypeName);
+            w.Prop("component", f.Locus.ComponentName);
+            w.Prop("chunkId", f.Locus.ChunkId);
+            w.Prop("slot", f.Locus.Slot);
+            w.Prop("entityId", (long)f.Locus.EntityId);
+            w.Prop("text", f.Locus.ToString());
+            w.EndObject();
+
+            w.Key("loss");
+            WriteLoss(w, f.Loss);
+            w.EndObject();
+        }
+
+        w.EndArray();
+
+        w.Key("lossSummary");
+        w.BeginArray();
+        var losses = report.LossSummary;
+        for (var i = 0; i < losses.Count; i++)
+        {
+            WriteLoss(w, losses[i]);
+        }
+
+        w.EndArray();
+
+        w.Key("limits");
+        w.BeginObject();
+        w.Prop("structural", ScanLimits.StructuralLimit);
+        w.Key("checksSkipped");
+        w.BeginArray();
+        for (var i = 0; i < report.Limits.ChecksSkipped.Count; i++)
+        {
+            w.Value(report.Limits.ChecksSkipped[i]);
+        }
+
+        w.EndArray();
+        w.Key("caveats");
+        w.BeginArray();
+        for (var i = 0; i < report.Limits.Caveats.Count; i++)
+        {
+            w.Value(report.Limits.Caveats[i]);
+        }
+
+        w.EndArray();
+        w.EndObject();
+
+        w.EndObject();
+        return sb.ToString();
+    }
+
+    private static void WriteLoss(Writer w, LossEstimate loss)
+    {
+        w.BeginObject();
+        w.Prop("kind", loss.Kind.ToString());
+        w.Prop("entityCount", loss.EntityCount);
+        w.Prop("boundedMin", loss.BoundedMin);
+        w.Prop("boundedMax", loss.BoundedMax);
+        w.Prop("archetype", loss.Archetype);
+        w.Prop("component", loss.Component);
+        w.Prop("explanation", loss.Explanation);
+        w.Key("sample");
+        w.BeginArray();
+        for (var i = 0; i < loss.Sample.Count; i++)
+        {
+            w.Value((long)loss.Sample[i]);
+        }
+
+        w.EndArray();
+        w.EndObject();
+    }
+
+    /// <summary>
+    /// A minimal JSON writer. Deliberately hand-rolled: the report shape is a published contract, and keeping it in one
+    /// readable block is worth more than the convenience of reflection-driven serialization that changes shape whenever a
+    /// model property is added.
+    /// </summary>
+    private sealed class Writer
+    {
+        private readonly StringBuilder _sb;
+        private readonly bool _indent;
+        private int _depth;
+        private bool _needComma;
+
+        public Writer(StringBuilder sb, bool indent)
+        {
+            _sb = sb;
+            _indent = indent;
+        }
+
+        public void BeginObject()
+        {
+            Separate();
+            _sb.Append('{');
+            _depth++;
+            _needComma = false;
+        }
+
+        public void EndObject()
+        {
+            _depth--;
+            NewLine();
+            _sb.Append('}');
+            _needComma = true;
+        }
+
+        public void BeginArray()
+        {
+            Separate();
+            _sb.Append('[');
+            _depth++;
+            _needComma = false;
+        }
+
+        public void EndArray()
+        {
+            _depth--;
+            NewLine();
+            _sb.Append(']');
+            _needComma = true;
+        }
+
+        public void Key(string name)
+        {
+            Separate();
+            AppendString(name);
+            _sb.Append(_indent ? ": " : ":");
+            _needComma = false;
+        }
+
+        public void Prop(string name, string value)
+        {
+            Key(name);
+            if (value == null)
+            {
+                _sb.Append("null");
+            }
+            else
+            {
+                AppendString(value);
+            }
+
+            _needComma = true;
+        }
+
+        public void Prop(string name, long value)
+        {
+            Key(name);
+            _sb.Append(value.ToString(CultureInfo.InvariantCulture));
+            _needComma = true;
+        }
+
+        public void Prop(string name, double value)
+        {
+            Key(name);
+            _sb.Append(value.ToString("0.###", CultureInfo.InvariantCulture));
+            _needComma = true;
+        }
+
+        public void Prop(string name, bool value)
+        {
+            Key(name);
+            _sb.Append(value ? "true" : "false");
+            _needComma = true;
+        }
+
+        public void Value(string value)
+        {
+            Separate();
+            AppendString(value);
+            _needComma = true;
+        }
+
+        public void Value(long value)
+        {
+            Separate();
+            _sb.Append(value.ToString(CultureInfo.InvariantCulture));
+            _needComma = true;
+        }
+
+        private void Separate()
+        {
+            if (_needComma)
+            {
+                _sb.Append(',');
+            }
+
+            NewLine();
+        }
+
+        private void NewLine()
+        {
+            if (!_indent)
+            {
+                return;
+            }
+
+            _sb.Append('\n');
+            _sb.Append(' ', _depth * 2);
+        }
+
+        private void AppendString(string value)
+        {
+            _sb.Append('"');
+            for (var i = 0; i < value.Length; i++)
+            {
+                var c = value[i];
+                switch (c)
+                {
+                    case '"': _sb.Append("\\\""); break;
+                    case '\\': _sb.Append("\\\\"); break;
+                    case '\n': _sb.Append("\\n"); break;
+                    case '\r': _sb.Append("\\r"); break;
+                    case '\t': _sb.Append("\\t"); break;
+                    default:
+                        if (c < 0x20)
+                        {
+                            _sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            _sb.Append(c);
+                        }
+
+                        break;
+                }
+            }
+
+            _sb.Append('"');
+        }
+    }
+}

--- a/src/Typhon.Engine/Integrity/public/IntegrityReportText.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityReportText.cs
@@ -1,0 +1,271 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Renders an <see cref="IntegrityReport"/> as human-readable text.
+/// </summary>
+/// <remarks>
+/// Findings are ranked by severity and the loss summary comes <b>last</b>, so it is the parting message rather than
+/// something scrolled past. The limits block prints on a green report too — that is the whole point of it.
+/// </remarks>
+[PublicAPI]
+public static class IntegrityReportText
+{
+    /// <summary>Renders the full report.</summary>
+    /// <param name="report">The report to render.</param>
+    /// <param name="colour">Whether to emit ANSI colour escapes.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="report"/> is <c>null</c>.</exception>
+    public static string Render(IntegrityReport report, bool colour = false)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var sb = new StringBuilder(4096);
+        var p = new Palette(colour);
+
+        RenderHeader(sb, report, p);
+        RenderVerdict(sb, report, p);
+        RenderFindings(sb, report, p);
+        RenderLoss(sb, report, p);
+        RenderLimits(sb, report, p);
+        RenderFooter(sb, report, p);
+
+        return sb.ToString();
+    }
+
+    private static void RenderHeader(StringBuilder sb, IntegrityReport report, Palette p)
+    {
+        var id = report.Identity;
+        sb.Append("\n  ").Append(p.Bold).Append(id.Name ?? "(unnamed)").Append(p.Reset);
+        sb.Append(" · format v").Append(id.FormatRevision);
+        sb.Append(" · ").Append(id.PageCount.ToString("N0")).Append(" pages (").Append(FormatBytes(id.SizeBytes)).Append(')');
+        if (id.CheckpointLsn > 0)
+        {
+            sb.Append(" · checkpoint LSN ").Append(id.CheckpointLsn.ToString("N0"));
+        }
+
+        sb.Append('\n');
+        sb.Append("  source: ").Append(report.Source).Append('\n');
+        sb.Append("  clean shutdown: ").Append(id.CleanShutdown ? "yes" : p.Warn + "NO  (the last close did not set the clean flag)" + p.Reset).Append('\n');
+        if (id.WalSegmentCount > 0)
+        {
+            sb.Append("  write-ahead log: ").Append(id.WalSegmentCount).Append(" segment(s), ").Append(FormatBytes(id.WalBytes)).Append('\n');
+        }
+
+        sb.Append('\n');
+    }
+
+    private static void RenderVerdict(StringBuilder sb, IntegrityReport report, Palette p)
+    {
+        var colour = report.Verdict switch
+        {
+            IntegrityVerdict.Sound => p.Ok,
+            IntegrityVerdict.SoundWithLeaks => p.Ok,
+            IntegrityVerdict.Divergent => p.Warn,
+            _ => p.Bad
+        };
+
+        sb.Append("  ").Append(p.Bold).Append("VERDICT: ").Append(colour).Append(report.Verdict.ToString().ToUpperInvariant()).Append(p.Reset);
+
+        var count = report.Findings.Count;
+        sb.Append(count == 0 ? "                     no findings" : $"{new string(' ', Math.Max(1, 34 - report.Verdict.ToString().Length))}{count} finding{(count == 1 ? "" : "s")}");
+        sb.Append("\n\n");
+    }
+
+    private static void RenderFindings(StringBuilder sb, IntegrityReport report, Palette p)
+    {
+        if (report.Findings.Count == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < report.Findings.Count; i++)
+        {
+            var f = report.Findings[i];
+            sb.Append("  ").Append(Glyph(f.Severity, p)).Append(' ');
+            sb.Append(f.Severity.ToString().PadRight(11));
+            sb.Append(f.Code.PadRight(13));
+            sb.Append(f.Summary);
+            if (f.Occurrences > 1)
+            {
+                sb.Append(p.Dim).Append("  (×").Append(f.Occurrences.ToString("N0")).Append(')').Append(p.Reset);
+            }
+
+            sb.Append('\n');
+
+            if (f.Confidence == IntegrityConfidence.Suspected)
+            {
+                sb.Append("                              ").Append(p.Dim).Append("SUSPECTED — observed on a live database; re-run offline to confirm.").Append(p.Reset).Append('\n');
+            }
+
+            AppendWrapped(sb, f.Detail, "                              ", p.Dim, p.Reset);
+
+            var trailer = new List<string>(3);
+            if (f.RuleId.Length > 0)
+            {
+                trailer.Add(f.RuleId);
+            }
+
+            trailer.Add(f.Repair switch
+            {
+                Repairability.Lossless => "rebuildable, no loss",
+                Repairability.Lossy => "repairable with loss",
+                _ => "not repairable from within this database"
+            });
+
+            sb.Append("                              → ").Append(string.Join("  ·  ", trailer)).Append('\n').Append('\n');
+        }
+    }
+
+    private static void RenderLoss(StringBuilder sb, IntegrityReport report, Palette p)
+    {
+        var losses = report.LossSummary;
+        if (losses.Count == 0)
+        {
+            return;
+        }
+
+        sb.Append("  ").Append(p.Bold).Append("LOSS IF REPAIRED").Append(p.Reset).Append('\n');
+        for (var i = 0; i < losses.Count; i++)
+        {
+            var l = losses[i];
+            sb.Append("    ").Append(l.CountText).Append(' ');
+            sb.Append(l.Kind switch
+            {
+                LossKind.Values => "component value(s)",
+                LossKind.Entities => "entities",
+                LossKind.Collection => "collection element(s)",
+                LossKind.Strings => "interned string(s)",
+                _ => "row(s), unit undetermined"
+            });
+
+            if (l.Archetype != null)
+            {
+                sb.Append(" in ").Append(l.Archetype);
+                if (l.Component != null)
+                {
+                    sb.Append('.').Append(l.Component);
+                }
+            }
+
+            sb.Append('\n');
+            AppendWrapped(sb, l.Explanation, "      ", p.Dim, p.Reset);
+        }
+
+        sb.Append('\n');
+    }
+
+    private static void RenderLimits(StringBuilder sb, IntegrityReport report, Palette p)
+    {
+        sb.Append("  ").Append(p.Bold).Append("LIMITS OF THIS SCAN").Append(p.Reset).Append('\n');
+        AppendWrapped(sb, ScanLimits.StructuralLimit, "    ", p.Dim, p.Reset);
+
+        var limits = report.Limits;
+        for (var i = 0; i < limits.Caveats.Count; i++)
+        {
+            AppendWrapped(sb, "· " + limits.Caveats[i], "    ", p.Dim, p.Reset);
+        }
+
+        if (limits.ChecksSkipped.Count > 0)
+        {
+            AppendWrapped(sb, "· Not run at this depth: " + string.Join("; ", limits.ChecksSkipped), "    ", p.Dim, p.Reset);
+        }
+
+        sb.Append('\n');
+    }
+
+    private static void RenderFooter(StringBuilder sb, IntegrityReport report, Palette p)
+    {
+        var t = report.Totals;
+        sb.Append("  ").Append(p.Dim);
+        sb.Append(t.PagesScanned.ToString("N0")).Append(" pages scanned · ");
+        sb.Append(t.PagesAllocated.ToString("N0")).Append(" allocated · ");
+        sb.Append(t.SegmentsWalked.ToString("N0")).Append(" segments");
+        if (t.PagesWithSectorFooters > 0)
+        {
+            sb.Append(" · ").Append(t.PagesWithSectorFooters.ToString("N0")).Append(" pages with per-sector verification");
+        }
+
+        sb.Append(" · ").Append(report.Duration.TotalMilliseconds.ToString("N0")).Append(" ms").Append(p.Reset).Append('\n');
+
+        if (!report.IsSound)
+        {
+            sb.Append('\n').Append("  Next: typhon repair ").Append(report.Source).Append(" --plan\n");
+        }
+
+        sb.Append('\n');
+    }
+
+    private static string Glyph(IntegritySeverity severity, Palette p) => severity switch
+    {
+        IntegritySeverity.Fatal => p.Bad + "✖" + p.Reset,
+        IntegritySeverity.DataLoss => p.Bad + "✖" + p.Reset,
+        IntegritySeverity.Divergence => p.Warn + "▲" + p.Reset,
+        IntegritySeverity.Leak => p.Dim + "·" + p.Reset,
+        _ => p.Dim + "i" + p.Reset
+    };
+
+    private static void AppendWrapped(StringBuilder sb, string text, string indent, string open, string close)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        const int width = 100;
+        var words = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var line = new StringBuilder(width);
+
+        for (var i = 0; i < words.Length; i++)
+        {
+            if (line.Length > 0 && line.Length + 1 + words[i].Length > width)
+            {
+                sb.Append(indent).Append(open).Append(line).Append(close).Append('\n');
+                line.Clear();
+            }
+
+            if (line.Length > 0)
+            {
+                line.Append(' ');
+            }
+
+            line.Append(words[i]);
+        }
+
+        if (line.Length > 0)
+        {
+            sb.Append(indent).Append(open).Append(line).Append(close).Append('\n');
+        }
+    }
+
+    private static string FormatBytes(long bytes) => bytes switch
+    {
+        >= 1L << 30 => $"{bytes / (double)(1L << 30):N1} GiB",
+        >= 1L << 20 => $"{bytes / (double)(1L << 20):N1} MiB",
+        >= 1L << 10 => $"{bytes / (double)(1L << 10):N1} KiB",
+        _ => $"{bytes} B"
+    };
+
+    private readonly struct Palette
+    {
+        public Palette(bool enabled)
+        {
+            Bold = enabled ? "\u001b[1m" : "";
+            Dim = enabled ? "\u001b[2m" : "";
+            Ok = enabled ? "\u001b[32m" : "";
+            Warn = enabled ? "\u001b[33m" : "";
+            Bad = enabled ? "\u001b[31m" : "";
+            Reset = enabled ? "\u001b[0m" : "";
+        }
+
+        public string Bold { get; }
+        public string Dim { get; }
+        public string Ok { get; }
+        public string Warn { get; }
+        public string Bad { get; }
+        public string Reset { get; }
+    }
+}

--- a/src/Typhon.Engine/Integrity/public/IntegrityScanner.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityScanner.cs
@@ -68,12 +68,25 @@ public static class IntegrityScanner
 
         if (!ctx.StopScan)
         {
-            DiscoverStructure(ctx);
-            ReadOccupancy(ctx);
-            BootstrapChecks.RunLate(ctx);
-            SegmentChecks.Run(ctx);
-            SweepPages(ctx);
-            WalChecks.Run(ctx);
+            // Spine is the tier that runs on every open, so it must stay bounded by the number of SEGMENTS rather than
+            // the size of the database — it reaches structures through the bootstrap's own pointers and never sweeps.
+            // Deeper tiers can afford the physical sweep, which is strictly better at finding things the bootstrap does
+            // not mention, but paying for it at every open is the tax this design explicitly refused.
+            if (ctx.Options.Depth == ScanDepth.Spine)
+            {
+                DiscoverSpine(ctx);
+                BootstrapChecks.RunLate(ctx);
+                SegmentChecks.Run(ctx);
+            }
+            else
+            {
+                DiscoverStructure(ctx);
+                ReadOccupancy(ctx);
+                BootstrapChecks.RunLate(ctx);
+                SegmentChecks.Run(ctx);
+                SweepPages(ctx);
+                WalChecks.Run(ctx);
+            }
         }
 
         stopwatch.Stop();
@@ -94,6 +107,72 @@ public static class IntegrityScanner
     /// </remarks>
     /// <param name="source">The source to verify.</param>
     public static IntegrityReport VerifySpine(IPageSource source) => Scan(source, IntegrityOptions.Spine);
+
+    /// <summary>
+    /// Segment discovery for the <see cref="ScanDepth.Spine"/> tier: follow the bootstrap's own segment pointers and walk
+    /// only those segments' directories. Reads on the order of a few pages per segment, never the whole file.
+    /// </summary>
+    /// <remarks>
+    /// This deliberately gives up what the physical sweep buys — a segment the bootstrap has forgotten about is invisible
+    /// here — and that trade is the whole point of the tier. Spine answers "can this database be traversed at all", which
+    /// is the question worth asking on every open; "is every page accounted for" is a question worth asking when someone
+    /// asks it.
+    /// </remarks>
+    private static void DiscoverSpine(ScanContext ctx)
+    {
+        var walker = new SegmentWalker(ctx.Source);
+        var seen = new HashSet<int>();
+
+        // The genesis pages exist before any segment does, so they are reachable by definition.
+        for (var p = 0; p < Math.Min(ManagedPagedMMF.InitialReservedPageCount, ctx.Source.PageCount); p++)
+        {
+            ctx.Roles[p] = PageRole.Reserved;
+        }
+
+        for (var i = 0; i < ctx.Bootstrap.Entries.Count; i++)
+        {
+            var value = ctx.Bootstrap.Entries[i].Value;
+            for (var c = 0; c < value.IntCount; c++)
+            {
+                var spi = value.GetInt(c);
+
+                // A bootstrap value is an arbitrary integer until proven otherwise, so only follow one that addresses a
+                // real page AND says on that page that it is a segment root. Anything else is configuration, not a
+                // pointer, and chasing it would manufacture findings out of ordinary values.
+                if (spi <= 0 || !ctx.IsInRange(spi) || !seen.Add(spi))
+                {
+                    continue;
+                }
+
+                if (!LooksLikeSegmentRoot(ctx, spi))
+                {
+                    continue;
+                }
+
+                var segment = walker.WalkSegment(spi);
+                ctx.Segments[spi] = segment;
+                AttributePages(ctx, segment);
+            }
+        }
+    }
+
+    /// <summary>Whether a page declares itself the root of the segment its own directory names.</summary>
+    private static bool LooksLikeSegmentRoot(ScanContext ctx, int pageIndex)
+    {
+        Span<byte> page = new byte[IntegrityConstants.PageSize];
+        if (!ctx.Source.TryReadPage(pageIndex, page))
+        {
+            return false;
+        }
+
+        ctx.FlagsByte[pageIndex] = (byte)PageImage.Flags(page);
+        if ((PageImage.Flags(page) & PageBlockFlags.IsLogicalSegmentRoot) == 0)
+        {
+            return false;
+        }
+
+        return System.Runtime.InteropServices.MemoryMarshal.Read<int>(PageImage.RawData(page)) == pageIndex;
+    }
 
     private static void DiscoverStructure(ScanContext ctx)
     {

--- a/src/Typhon.Engine/Integrity/public/IntegrityScanner.cs
+++ b/src/Typhon.Engine/Integrity/public/IntegrityScanner.cs
@@ -1,0 +1,402 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// Answers three questions about a database without changing a byte of it: <i>is it sound</i>, <i>what exactly is wrong</i>,
+/// and <i>what would a repair cost</i>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The scan is provably read-only — it reaches pages through an <see cref="IPageSource"/>, which is contractually
+/// side-effect free — so it is always safe to run: on a production database, on a corrupt one, on one that will not open.
+/// That last case is the point. The engine already repairs on the crash path, but it does so silently, only at open, only
+/// when it feels like it, and reports into log lines. A database can therefore be silently repaired with the operator
+/// learning nothing, or refuse to open with the operator learning nothing useful.
+/// </para>
+/// <para>
+/// The scanner is also a test oracle. Because it needs no model of what the database <i>should</i> contain, it can be
+/// asserted after any crash-injection cell — including ones whose correct final state the harness cannot compute.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// using var source = new OfflineBundlePageSource("game.typhon");
+/// var report = IntegrityScanner.Scan(source, IntegrityOptions.Deep);
+/// Console.WriteLine(IntegrityReportText.Render(report));
+/// return report.ExitCode;
+/// </code>
+/// </example>
+[PublicAPI]
+public static class IntegrityScanner
+{
+    /// <summary>
+    /// Scans a page source and produces a report.
+    /// </summary>
+    /// <param name="source">The source to read through. Not disposed by this method.</param>
+    /// <param name="options">Depth, filters and budgets. Defaults to <see cref="IntegrityOptions.Standard"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
+    public static IntegrityReport Scan(IPageSource source, IntegrityOptions options = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        options ??= IntegrityOptions.Standard;
+
+        var bundle = source as OfflineBundlePageSource;
+        var mode = bundle is { LockHeld: true } ? ScanMode.OnlineSampled : ScanMode.Offline;
+
+        var stopwatch = Stopwatch.StartNew();
+        var ctx = new ScanContext
+        {
+            Source = source,
+            Options = options,
+            Mode = mode,
+            Bundle = bundle,
+            Findings = new FindingCollector(options)
+        };
+
+        var pageCount = source.PageCount;
+        ctx.Roles = new PageRole[pageCount];
+        ctx.Owner = new int[pageCount];
+        ctx.FlagsByte = new byte[pageCount];
+        Array.Fill(ctx.Owner, -1);
+
+        ctx.Bootstrap = BootstrapReader.Read(source);
+        BootstrapChecks.RunEarly(ctx);
+
+        if (!ctx.StopScan)
+        {
+            DiscoverStructure(ctx);
+            ReadOccupancy(ctx);
+            BootstrapChecks.RunLate(ctx);
+            SegmentChecks.Run(ctx);
+            SweepPages(ctx);
+            WalChecks.Run(ctx);
+        }
+
+        stopwatch.Stop();
+        return Build(ctx, stopwatch.Elapsed);
+    }
+
+    /// <summary>
+    /// The always-on open-time tier: page-0 pair selection, the bootstrap stream, and that every segment pointer resolves
+    /// to a real segment root. Bounded by the number of <i>segments</i> rather than the size of the database — kilobytes
+    /// read, sub-millisecond — which is what makes it affordable on every open.
+    /// </summary>
+    /// <remarks>
+    /// The clean-shutdown flag records that the last process closed properly. It does <b>not</b> record that the bytes are
+    /// still correct. Damage that happens while a database is closed — bit rot, a truncated copy, a restore from the wrong
+    /// place, a file-level backup tool writing through — is invisible to a clean open, which then proceeds to serve it.
+    /// This tier is the cheapest thing that catches the whole structurally-broken class, which is exactly the damage where
+    /// opening anyway does the most harm.
+    /// </remarks>
+    /// <param name="source">The source to verify.</param>
+    public static IntegrityReport VerifySpine(IPageSource source) => Scan(source, IntegrityOptions.Spine);
+
+    private static void DiscoverStructure(ScanContext ctx)
+    {
+        var source = ctx.Source;
+        var pageCount = source.PageCount;
+        Span<byte> page = new byte[IntegrityConstants.PageSize];
+
+        // Pass 1 — read every page's flags byte. Segment discovery is PHYSICAL: a root page says so in its own header, so
+        // the sweep finds every segment without trusting a dictionary that may itself be damaged.
+        //
+        // The one trap is A/B protection: a directory page's twin is a BYTE COPY of its primary, root flag included, so a
+        // naive "flagged as root" test reports every paired segment twice and then declares every one of its pages
+        // double-claimed. The discriminator is self-reference — a segment's page directory names its own root as entry 0,
+        // and a twin's copy of that directory still names the PRIMARY. So a page is a root exactly when its own directory
+        // points back at it. That test needs no cross-page state, which matters: it stays correct on a file where the
+        // pointers themselves are what is damaged.
+        var roots = new List<int>();
+        for (var p = 0; p < pageCount; p++)
+        {
+            if (ctx.Options.Cancellation.IsCancellationRequested)
+            {
+                ctx.Findings.NoteCaveat($"The scan was cancelled after {p:N0} of {pageCount:N0} pages; coverage is partial.");
+                return;
+            }
+
+            if (!source.TryReadPage(p, page))
+            {
+                continue;
+            }
+
+            var flags = PageImage.Flags(page);
+            ctx.FlagsByte[p] = (byte)flags;
+            if ((flags & PageBlockFlags.IsLogicalSegmentRoot) == 0)
+            {
+                continue;
+            }
+
+            var firstDirectoryEntry = System.Runtime.InteropServices.MemoryMarshal.Read<int>(PageImage.RawData(page));
+            if (firstDirectoryEntry == p)
+            {
+                roots.Add(p);
+            }
+            else if (PageImage.TwinPage(page) != 0)
+            {
+                ctx.Roles[p] = PageRole.DirectoryTwin;   // provisional; the owning segment's walk confirms it
+            }
+        }
+
+        // The genesis pages exist before any segment does, so they are reachable by definition rather than by walking.
+        for (var p = 0; p < Math.Min(ManagedPagedMMF.InitialReservedPageCount, pageCount); p++)
+        {
+            ctx.Roles[p] = PageRole.Reserved;
+        }
+
+        // Pass 2 — walk each discovered segment and attribute its pages.
+        var walker = new SegmentWalker(source);
+        for (var i = 0; i < roots.Count; i++)
+        {
+            var seg = walker.WalkSegment(roots[i]);
+            ctx.Segments[roots[i]] = seg;
+            AttributePages(ctx, seg);
+            ctx.Options.Progress?.Invoke("segments", i + 1, roots.Count);
+        }
+    }
+
+    private static void AttributePages(ScanContext ctx, SegmentView seg)
+    {
+        Claim(ctx, seg.RootPageIndex, seg, PageRole.SegmentRoot);
+
+        for (var i = 0; i < seg.MapExtensionPages.Count; i++)
+        {
+            Claim(ctx, seg.MapExtensionPages[i], seg, PageRole.MapExtension);
+        }
+
+        for (var i = 0; i < seg.TwinPages.Count; i++)
+        {
+            ctx.TwinSlots.Add(seg.TwinPages[i]);
+            Claim(ctx, seg.TwinPages[i], seg, PageRole.DirectoryTwin);
+        }
+
+        for (var i = 0; i < seg.Pages.Count; i++)
+        {
+            var p = seg.Pages[i];
+            if (p == seg.RootPageIndex)
+            {
+                continue;
+            }
+
+            Claim(ctx, p, seg, PageRole.SegmentData);
+        }
+    }
+
+    private static void Claim(ScanContext ctx, int page, SegmentView seg, PageRole role)
+    {
+        if (!ctx.IsInRange(page))
+        {
+            return;
+        }
+
+        var existing = ctx.Owner[page];
+        if (existing >= 0 && existing != seg.RootPageIndex)
+        {
+            // Two owners will eventually write over each other. Report it once per page, at the moment the conflict is
+            // provable, with both claimants named.
+            ctx.Segments.TryGetValue(existing, out var other);
+            ctx.Report(SegmentChecks.SingleOwner, IntegritySeverity.DataLoss, "", new Locus(page, seg.RootPageIndex, seg.Kind),
+                $"Page {page} is claimed by two segments.",
+                $"The {other?.Kind.ToString() ?? "unknown"} segment rooted at page {existing} and the {seg.Kind} segment "
+                + $"rooted at page {seg.RootPageIndex} both list it. Whichever writes second destroys the other's data, and "
+                + "neither can be regenerated from the other.",
+                Repairability.NotRepairable,
+                new LossEstimate
+                {
+                    Kind = LossKind.Unknown,
+                    EntityCount = -1,
+                    BoundedMin = 1,
+                    BoundedMax = 475,
+                    Explanation = $"Whatever one of the two segments stored on page {page}; which one has already lost is not "
+                        + "determinable from the file."
+                });
+            return;
+        }
+
+        ctx.Owner[page] = seg.RootPageIndex;
+
+        // Do not let a data-page claim downgrade a structural role: a page that is both a root and listed in its own
+        // directory (which every root is) must stay classified as a root.
+        if (ctx.Roles[page] == PageRole.Unclaimed || role < ctx.Roles[page])
+        {
+            ctx.Roles[page] = role;
+        }
+    }
+
+    private static void ReadOccupancy(ScanContext ctx)
+    {
+        // The occupancy segment is found the same way as any other: physically. The bootstrap's pointer to it is checked
+        // against this, not used to find it.
+        foreach (var seg in ctx.Segments.Values)
+        {
+            if (seg.Kind != StorageSegmentKind.Occupancy)
+            {
+                continue;
+            }
+
+            ctx.Occupancy = OccupancyView.Read(ctx.Source, seg);
+            for (var i = 0; i < ctx.Occupancy.Diagnostics.Count; i++)
+            {
+                ctx.Findings.NoteCaveat(ctx.Occupancy.Diagnostics[i]);
+            }
+
+            return;
+        }
+
+        ctx.Findings.NoteCaveat("No occupancy segment was found, so page-allocation state could not be compared against the "
+            + "reachability walk. Leak and phantom detection are unavailable.");
+    }
+
+    private static void SweepPages(ScanContext ctx)
+    {
+        if (!ctx.AtLeast(ScanDepth.Quick))
+        {
+            ctx.Findings.NoteSkipped("CHK-PHY-*", "needs Quick depth or deeper");
+            return;
+        }
+
+        var source = ctx.Source;
+        var pageCount = source.PageCount;
+        Span<byte> page = new byte[IntegrityConstants.PageSize];
+
+        for (var p = 0; p < pageCount; p++)
+        {
+            if (ctx.Options.Cancellation.IsCancellationRequested)
+            {
+                ctx.Findings.NoteCaveat($"The page sweep was cancelled after {p:N0} of {pageCount:N0} pages; coverage is partial.");
+                break;
+            }
+
+            if (!source.TryReadPage(p, page))
+            {
+                continue;
+            }
+
+            ctx.PagesScanned++;
+            var allocated = ctx.Occupancy?.IsAllocated(p) ?? ctx.Roles[p] != PageRole.Unclaimed;
+            PhysicalChecks.RunForPage(ctx, p, page, allocated);
+
+            if ((p & 0xFFF) == 0)
+            {
+                ctx.Options.Progress?.Invoke("pages", p, pageCount);
+            }
+        }
+
+        if (!ctx.AtLeast(ScanDepth.Standard))
+        {
+            ctx.Findings.NoteSkipped(PhysicalChecks.Checksum, "needs Standard depth or deeper");
+        }
+    }
+
+    private static IntegrityReport Build(ScanContext ctx, TimeSpan duration)
+    {
+        var b = ctx.Bootstrap;
+        var (checkpointLsn, cleanShutdown) = b.ReadWatermarks();
+
+        var allocated = 0;
+        if (ctx.Occupancy != null)
+        {
+            allocated = ctx.Occupancy.PopCount;
+        }
+        else
+        {
+            for (var i = 0; i < ctx.Roles.Length; i++)
+            {
+                if (ctx.Roles[i] != PageRole.Unclaimed)
+                {
+                    allocated++;
+                }
+            }
+        }
+
+        long leakedBytes = 0;
+        var leakCount = ctx.Findings.CountFor(SegmentChecks.OccupancyAgreement);
+        if (leakCount > 0 && ctx.Occupancy != null)
+        {
+            leakedBytes = Math.Max(0, allocated - CountReachable(ctx)) * (long)IntegrityConstants.PageSize;
+        }
+
+        // Every scan states what it could not have detected, including a fully green one. Suppressing it when everything
+        // passes is precisely when suppressing it does harm.
+        var caveats = new List<string>(ctx.Findings.Caveats);
+        if (!ctx.AtLeast(ScanDepth.Deep))
+        {
+            caveats.Add($"Depth was {ctx.Options.Depth}; cross-structure checks (chains, clusters, indexes, entity maps, "
+                + "allocator watermarks) were not run. Run at Deep depth for those.");
+        }
+
+        if (ctx.Mode == ScanMode.OnlineSampled)
+        {
+            caveats.Add("The database was open in another process, so every cross-structure conclusion is reported as "
+                + "Suspected rather than Confirmed. Re-run with the database closed before acting on any of them.");
+        }
+
+        return new IntegrityReport
+        {
+            Source = ctx.Source.Describe(),
+            Mode = ctx.Mode,
+            Depth = ctx.Options.Depth,
+            Identity = new DatabaseIdentity
+            {
+                Name = b.DatabaseName,
+                FormatRevision = b.FormatRevision,
+                PageCount = ctx.Source.PageCount,
+                SizeBytes = ctx.Bundle?.SizeBytes ?? ((long)ctx.Source.PageCount * IntegrityConstants.PageSize),
+                CheckpointLsn = checkpointLsn,
+                CleanShutdown = cleanShutdown,
+                MetaSlot = b.SelectedSlot,
+                MetaGeneration = b.SelectedGeneration,
+                WalSegmentCount = ctx.Bundle?.WalSegments.Count ?? 0,
+                WalBytes = SumWal(ctx)
+            },
+            Findings = ctx.Findings.Build(),
+            Totals = new ScanTotals
+            {
+                PagesScanned = ctx.PagesScanned,
+                PagesAllocated = allocated,
+                ChecksumFailures = ctx.ChecksumFailures,
+                PagesWithSectorFooters = ctx.PagesWithSectorFooters,
+                SectorFailures = ctx.SectorFailures,
+                SegmentsWalked = ctx.Segments.Count,
+                BytesLeaked = leakedBytes,
+                BySeverity = ctx.Findings.SeverityHistogram()
+            },
+            Limits = new ScanLimits { ChecksSkipped = ctx.Findings.Skipped, Caveats = caveats },
+            Duration = duration
+        };
+    }
+
+    private static int CountReachable(ScanContext ctx)
+    {
+        var n = 0;
+        for (var i = 0; i < ctx.Roles.Length; i++)
+        {
+            if (ctx.Roles[i] != PageRole.Unclaimed)
+            {
+                n++;
+            }
+        }
+
+        return n;
+    }
+
+    private static long SumWal(ScanContext ctx)
+    {
+        if (ctx.Bundle == null)
+        {
+            return 0;
+        }
+
+        long total = 0;
+        for (var i = 0; i < ctx.Bundle.WalSegments.Count; i++)
+        {
+            total += ctx.Bundle.WalSegments[i].SizeBytes;
+        }
+
+        return total;
+    }
+}

--- a/src/Typhon.Engine/Integrity/public/OfflineBundlePageSource.cs
+++ b/src/Typhon.Engine/Integrity/public/OfflineBundlePageSource.cs
@@ -1,0 +1,223 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Typhon.Engine;
+
+/// <summary>One WAL segment file found beside the data file, described without being parsed.</summary>
+/// <param name="Path">Absolute path to the segment file.</param>
+/// <param name="SizeBytes">Size of the file in bytes.</param>
+/// <param name="Name">File name only.</param>
+[PublicAPI]
+public readonly record struct WalSegmentRef(string Path, long SizeBytes, string Name);
+
+/// <summary>
+/// Reads a <c>.typhon</c> bundle directly as bytes: no <c>DatabaseEngine</c>, no page cache, no lock acquisition, no WAL
+/// replay. The page source the checker uses when it matters most — when the database will not open.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Booting the engine to inspect a database is self-defeating three ways. It <b>destroys the evidence</b> (on the crash
+/// path the rebuild net clears and re-derives indexes, chains, entity maps and occupancy before a caller gets a handle, so
+/// a post-open check can only ever verify that <i>rebuild worked</i>). It <b>cannot reach the cases that matter most</b>
+/// (an open that fails loudly by design leaves no handle to ask questions through). And it <b>mutates</b> — acquiring the
+/// lock, clearing the clean-shutdown flag, replaying the log, checkpointing on close.
+/// </para>
+/// <para>
+/// Opened <c>FileAccess.Read</c> with <c>FileShare.ReadWrite</c> so a live database can still be scanned; a scan of a
+/// live database yields <see cref="IntegrityConfidence.Suspected"/> cross-structure findings, never
+/// <see cref="IntegrityConfidence.Confirmed"/> ones.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public sealed class OfflineBundlePageSource : IPageSource
+{
+    private readonly SafeFileHandleWrapper _data;
+    private readonly string _describe;
+
+    /// <summary>Opens a bundle for reading.</summary>
+    /// <param name="bundlePath">
+    /// Path to the <c>{name}.typhon</c> bundle directory, or to the <c>data</c> file inside one. A path whose extension is
+    /// missing gets <c>.typhon</c> appended when that directory exists.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="bundlePath"/> is <c>null</c>.</exception>
+    /// <exception cref="DirectoryNotFoundException">No bundle directory could be resolved from <paramref name="bundlePath"/>.</exception>
+    /// <exception cref="FileNotFoundException">The bundle has no <c>data</c> file.</exception>
+    public OfflineBundlePageSource(string bundlePath)
+    {
+        ArgumentNullException.ThrowIfNull(bundlePath);
+
+        BundlePath = ResolveBundleDirectory(bundlePath);
+        var dataPath = Path.Combine(BundlePath, IntegrityConstants.DataFileName);
+        if (!File.Exists(dataPath))
+        {
+            throw new FileNotFoundException(
+                $"'{BundlePath}' has no '{IntegrityConstants.DataFileName}' file — it is not a Typhon database bundle.", dataPath);
+        }
+
+        _data = new SafeFileHandleWrapper(dataPath);
+        SizeBytes = _data.Length;
+        PageCount = (int)(SizeBytes / IntegrityConstants.PageSize);
+        TrailingBytes = (int)(SizeBytes % IntegrityConstants.PageSize);
+        _describe = BundlePath;
+
+        var lockPath = Path.Combine(BundlePath, IntegrityConstants.LockFileName);
+        LockFilePresent = File.Exists(lockPath);
+        LockHeld = LockFilePresent && IsLocked(lockPath);
+
+        WalSegments = EnumerateWal(Path.Combine(BundlePath, IntegrityConstants.WalDirectoryName));
+    }
+
+    /// <summary>Absolute path to the bundle directory.</summary>
+    public string BundlePath { get; }
+
+    /// <summary>Size of the <c>data</c> file in bytes.</summary>
+    public long SizeBytes { get; }
+
+    /// <summary>
+    /// Bytes past the last whole page. Non-zero means the data file is truncated mid-page — itself a finding, because
+    /// every write the engine performs is whole-page.
+    /// </summary>
+    public int TrailingBytes { get; }
+
+    /// <summary>Whether a <c>db.lock</c> file exists in the bundle.</summary>
+    public bool LockFilePresent { get; }
+
+    /// <summary>Whether <c>db.lock</c> is held by another process — i.e. a live engine has this database open.</summary>
+    public bool LockHeld { get; }
+
+    /// <summary>WAL segment files found in the bundle's <c>wal/</c> directory, unparsed, ordered by name.</summary>
+    public IReadOnlyList<WalSegmentRef> WalSegments { get; }
+
+    /// <inheritdoc />
+    public int PageCount { get; }
+
+    /// <inheritdoc />
+    public bool TryReadPage(int index, Span<byte> destination)
+    {
+        if (index < 0 || index >= PageCount)
+        {
+            return false;
+        }
+
+        if (destination.Length < IntegrityConstants.PageSize)
+        {
+            throw new ArgumentException($"Destination must be at least {IntegrityConstants.PageSize} bytes.", nameof(destination));
+        }
+
+        return _data.ReadExactly(destination[..IntegrityConstants.PageSize], index * (long)IntegrityConstants.PageSize);
+    }
+
+    /// <inheritdoc />
+    public string Describe() => _describe;
+
+    /// <inheritdoc />
+    public void Dispose() => _data.Dispose();
+
+    /// <summary>
+    /// Resolves a user-supplied path to a bundle directory. Accepts the directory itself, the <c>data</c> file inside it,
+    /// or a stem with no extension.
+    /// </summary>
+    /// <param name="path">The user-supplied path.</param>
+    /// <exception cref="DirectoryNotFoundException">Nothing resolvable was found.</exception>
+    public static string ResolveBundleDirectory(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        var full = Path.GetFullPath(path);
+
+        if (Directory.Exists(full))
+        {
+            return full;
+        }
+
+        // Pointed at the data file inside a bundle.
+        if (File.Exists(full) && string.Equals(Path.GetFileName(full), IntegrityConstants.DataFileName, StringComparison.Ordinal))
+        {
+            return Path.GetDirectoryName(full);
+        }
+
+        // A stem without the canonical extension.
+        var withExt = full + IntegrityConstants.BundleExtension;
+        if (Directory.Exists(withExt))
+        {
+            return withExt;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"No Typhon bundle at '{path}'. Expected a '{IntegrityConstants.BundleExtension}' directory containing "
+            + $"'{IntegrityConstants.DataFileName}'.");
+    }
+
+    private static bool IsLocked(string lockPath)
+    {
+        try
+        {
+            using var probe = new FileStream(lockPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            return false;
+        }
+        catch (IOException)
+        {
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    private static IReadOnlyList<WalSegmentRef> EnumerateWal(string walDir)
+    {
+        if (!Directory.Exists(walDir))
+        {
+            return [];
+        }
+
+        var files = Directory.GetFiles(walDir);
+        Array.Sort(files, StringComparer.Ordinal);
+        var refs = new List<WalSegmentRef>(files.Length);
+        for (var i = 0; i < files.Length; i++)
+        {
+            var fi = new FileInfo(files[i]);
+            refs.Add(new WalSegmentRef(files[i], fi.Length, fi.Name));
+        }
+
+        return refs;
+    }
+
+    /// <summary>
+    /// Minimal read-only file handle wrapper. Separate so the read path stays a single positional read with no stream
+    /// state, which is what lets a scan run against a file another process is actively writing.
+    /// </summary>
+    private sealed class SafeFileHandleWrapper : IDisposable
+    {
+        private readonly Microsoft.Win32.SafeHandles.SafeFileHandle _handle;
+
+        public SafeFileHandleWrapper(string path)
+        {
+            _handle = File.OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            Length = RandomAccess.GetLength(_handle);
+        }
+
+        public long Length { get; }
+
+        public bool ReadExactly(Span<byte> destination, long offset)
+        {
+            var total = 0;
+            while (total < destination.Length)
+            {
+                var read = RandomAccess.Read(_handle, destination[total..], offset + total);
+                if (read == 0)
+                {
+                    return false;
+                }
+
+                total += read;
+            }
+
+            return true;
+        }
+
+        public void Dispose() => _handle.Dispose();
+    }
+}

--- a/src/Typhon.Engine/Integrity/public/OfflineBundlePageSource.cs
+++ b/src/Typhon.Engine/Integrity/public/OfflineBundlePageSource.cs
@@ -93,6 +93,19 @@ public sealed class OfflineBundlePageSource : IPageSource
     /// <inheritdoc />
     public int PageCount { get; }
 
+    /// <summary>
+    /// Pages actually read from disk since this source was opened.
+    /// </summary>
+    /// <remarks>
+    /// Exists so a test can assert what a scan <b>costs</b> rather than what it claims to cost. The open-time
+    /// <see cref="ScanDepth.Spine"/> tier is only affordable as a default because it is bounded by the number of segments
+    /// rather than the size of the database; that is a property of the I/O it performs, so it has to be measured at the
+    /// I/O boundary. Asserting it any further up measures the wrong thing.
+    /// </remarks>
+    public long PagesRead => System.Threading.Volatile.Read(ref _pagesRead);
+
+    private long _pagesRead;
+
     /// <inheritdoc />
     public bool TryReadPage(int index, Span<byte> destination)
     {
@@ -106,6 +119,7 @@ public sealed class OfflineBundlePageSource : IPageSource
             throw new ArgumentException($"Destination must be at least {IntegrityConstants.PageSize} bytes.", nameof(destination));
         }
 
+        System.Threading.Interlocked.Increment(ref _pagesRead);
         return _data.ReadExactly(destination[..IntegrityConstants.PageSize], index * (long)IntegrityConstants.PageSize);
     }
 

--- a/src/Typhon.Engine/Integrity/public/OpenVerification.cs
+++ b/src/Typhon.Engine/Integrity/public/OpenVerification.cs
@@ -1,0 +1,78 @@
+using JetBrains.Annotations;
+using System;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// How much of a database to verify while opening it.
+/// </summary>
+/// <remarks>
+/// Three moments could carry verification and only one of them was empty. A crash-path open already runs the full rebuild
+/// net. An offline <c>typhon check</c> is explicit. A <b>clean</b> open verified nothing at all — it skipped the rebuild
+/// on the strength of a flag that only records that the last process closed properly, never that the bytes survived.
+/// </remarks>
+[PublicAPI]
+public enum OpenVerification
+{
+    /// <summary>
+    /// Verify nothing. Exists for benchmarks and in-memory fixtures, and emits a warning at open naming the risk — an
+    /// escape hatch that is silent is just a default with extra steps.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Page-0 pair selection, the bootstrap stream, and that every segment pointer resolves to a real, allocated segment
+    /// root. <b>O(segments)</b> rather than O(pages): kilobytes read, sub-millisecond. The default.
+    /// </summary>
+    Spine = 1,
+
+    /// <summary>Adds every page's header. O(pages) and IOPS-bound; no page bodies are hashed.</summary>
+    Quick = 2,
+
+    /// <summary>Adds a checksum sweep over every allocated page. O(pages) and bandwidth-bound.</summary>
+    Standard = 3
+}
+
+/// <summary>
+/// Thrown when opening a database whose structural spine does not verify.
+/// </summary>
+/// <remarks>
+/// There is no <c>--force</c> and no degraded mode. This is not new behaviour in kind — the recovery net already fails an
+/// open loudly rather than opening over suspect primary data; verify-on-open extends the same judgement to the clean path.
+/// A database integrity problem is not a detail worth hiding to make an open succeed.
+/// </remarks>
+[PublicAPI]
+public sealed class DatabaseIntegrityException : Exception
+{
+    /// <summary>Creates the exception from the report that refused the open.</summary>
+    /// <param name="report">The verification report. Attached so the caller can see exactly what failed.</param>
+    public DatabaseIntegrityException(IntegrityReport report)
+        : base(BuildMessage(report)) => Report = report;
+
+    /// <summary>The report that refused the open, with every finding and the scan's stated limits.</summary>
+    public IntegrityReport Report { get; }
+
+    private static string BuildMessage(IntegrityReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var sb = new System.Text.StringBuilder(512);
+        sb.Append("The database failed integrity verification and was not opened (verdict: ").Append(report.Verdict).Append(").\n");
+
+        for (var i = 0; i < report.Findings.Count; i++)
+        {
+            var f = report.Findings[i];
+            if (f.Severity != IntegritySeverity.Fatal)
+            {
+                continue;
+            }
+
+            sb.Append("  ").Append(f.Code).Append(": ").Append(f.Summary).Append('\n');
+            sb.Append("    ").Append(f.Detail).Append('\n');
+        }
+
+        sb.Append("\nRun `typhon check <bundle> --depth deep` for the full report, and `typhon repair <bundle> --plan` to see "
+            + "what can be done about it.");
+        return sb.ToString();
+    }
+}

--- a/src/Typhon.Engine/Integrity/public/RepairPlan.cs
+++ b/src/Typhon.Engine/Integrity/public/RepairPlan.cs
@@ -1,0 +1,229 @@
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace Typhon.Engine;
+
+/// <summary>
+/// What a repair step is allowed to do, which is the safety boundary of the whole feature.
+/// </summary>
+[PublicAPI]
+public enum RepairClass
+{
+    /// <summary>
+    /// Discard a derived structure and rebuild it from primary data. Loss is definitionally zero: the output is a pure
+    /// function of data that was not touched.
+    /// </summary>
+    Regenerate = 0,
+
+    /// <summary>
+    /// Remove a reference to primary data that cannot be read, so the rest of the database becomes usable. The datum is
+    /// <b>already</b> gone — excision does not destroy it, it stops the database pretending it is there. Always requires
+    /// explicit consent, because the operator may prefer a restore over a database that has silently narrowed.
+    /// </summary>
+    Excise = 1
+}
+
+/// <summary>The kinds of repair this build can actually perform.</summary>
+[PublicAPI]
+public enum RepairAction
+{
+    /// <summary>Rewrite the unusable half of an A/B protected page pair from its valid sibling, restoring the redundancy.</summary>
+    RestorePairSlot = 0,
+
+    /// <summary>Recompute the page-allocation bitmap from the reachability walk, reclaiming leaks and clearing phantoms.</summary>
+    RederiveOccupancy = 1,
+
+    /// <summary>
+    /// Open the database so the engine's rebuild net regenerates every derived structure — indexes, entity maps, chains,
+    /// cluster heads, spatial state — in the order those rules require, then close it cleanly.
+    /// </summary>
+    RegenerateDerivedStructures = 2,
+
+    /// <summary>Excise references to primary data that cannot be read. Lossy; requires consent.</summary>
+    ExciseUnreadablePrimary = 3
+}
+
+/// <summary>One ordered step of a repair.</summary>
+[PublicAPI]
+public sealed class RepairStep
+{
+    /// <summary>Position in the plan. Steps execute in this order and the order is a correctness constraint, not a preference.</summary>
+    public required int Order { get; init; }
+
+    /// <summary>What this step does.</summary>
+    public required RepairAction Action { get; init; }
+
+    /// <summary>Whether it regenerates or excises.</summary>
+    public required RepairClass Class { get; init; }
+
+    /// <summary>Check codes this step answers.</summary>
+    public required IReadOnlyList<string> Addresses { get; init; }
+
+    /// <summary>Where it acts.</summary>
+    public Locus Locus { get; init; }
+
+    /// <summary>Plain-English description of the action, for the operator reviewing the plan.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Why this step is safe, or what it costs. The sentence an operator needs before consenting.</summary>
+    public required string Rationale { get; init; }
+
+    /// <summary>What executing it would lose. <see cref="LossEstimate.None"/> for every <see cref="RepairClass.Regenerate"/> step.</summary>
+    public LossEstimate Loss { get; init; } = LossEstimate.None;
+
+    /// <inheritdoc />
+    public override string ToString() => $"{Order}. [{Class}] {Action} — {Description}";
+}
+
+/// <summary>
+/// The complete enumeration of what a repair would destroy, kept separate from the plan because it can be enormous.
+/// </summary>
+/// <remarks>
+/// A modal that says <i>"47 entities will be affected — OK?"</i> is not consent. The list is the consent.
+/// </remarks>
+[PublicAPI]
+public sealed class LossManifest
+{
+    /// <summary>Per-step loss estimates, in plan order.</summary>
+    public IReadOnlyList<LossEstimate> Entries { get; init; } = [];
+
+    /// <summary>Whether anything at all would be lost.</summary>
+    public bool IsEmpty
+    {
+        get
+        {
+            for (var i = 0; i < Entries.Count; i++)
+            {
+                if (!Entries[i].IsNone)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}
+
+/// <summary>
+/// A reviewable, ordered description of what a repair will do — produced by a read-only pass and consumed by the only
+/// mutating one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The plan is a file, not a flag.</b> It records the report it was derived from and the identity of the database it
+/// was derived for, and applying it re-scans first and <b>refuses if the database changed</b>. Repairing against a stale
+/// diagnosis is how a repair tool damages a healthy database, and a plan that cannot detect staleness is a plan that
+/// invites it.
+/// </para>
+/// <para>
+/// The natural product instinct is one command that does the right thing. That is rejected here: the cost of a wrong
+/// automatic repair is unbounded and unrecoverable, while the cost of one extra command is thirty seconds.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public sealed class RepairPlan
+{
+    /// <summary>Schema version of the plan's serialized form.</summary>
+    public const int PlanVersion = 1;
+
+    /// <summary>Fingerprint of the report this plan was derived from, and of the database state it described.</summary>
+    public required string DatabaseFingerprint { get; init; }
+
+    /// <summary>Human-readable identity of the target database.</summary>
+    public required string Source { get; init; }
+
+    /// <summary>When the plan was produced.</summary>
+    public DateTime CreatedUtc { get; init; } = DateTime.UtcNow;
+
+    /// <summary>The verdict the plan was built to address.</summary>
+    public required IntegrityVerdict Verdict { get; init; }
+
+    /// <summary>The ordered steps.</summary>
+    public required IReadOnlyList<RepairStep> Steps { get; init; }
+
+    /// <summary>The full loss enumeration.</summary>
+    public required LossManifest Loss { get; init; }
+
+    /// <summary>Findings this plan cannot address at all, with the reason. The honest remainder.</summary>
+    public required IReadOnlyList<string> Unaddressed { get; init; }
+
+    /// <summary>Whether any step would destroy something, and therefore whether consent is required.</summary>
+    public bool RequiresLossyConsent
+    {
+        get
+        {
+            for (var i = 0; i < Steps.Count; i++)
+            {
+                if (Steps[i].Class == RepairClass.Excise)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>Whether the plan would do anything.</summary>
+    public bool IsEmpty => Steps.Count == 0;
+}
+
+/// <summary>What happened to one step when the plan was applied.</summary>
+[PublicAPI]
+public enum StepOutcome
+{
+    /// <summary>The step ran and did what it said.</summary>
+    Succeeded = 0,
+
+    /// <summary>The step was not attempted — no consent, or a prior step made it unnecessary.</summary>
+    Skipped = 1,
+
+    /// <summary>The step was attempted and failed. Later steps did not run.</summary>
+    Failed = 2
+}
+
+/// <summary>The receipt for one applied step.</summary>
+/// <param name="Step">The step that was attempted.</param>
+/// <param name="Outcome">What happened.</param>
+/// <param name="Detail">What the step actually did, or why it did not.</param>
+/// <param name="ActualLoss">
+/// What was really lost, which may be <b>less</b> than estimated — a suspect page can turn out to be orphaned and heal.
+/// </param>
+[PublicAPI]
+public readonly record struct RepairStepResult(RepairStep Step, StepOutcome Outcome, string Detail, LossEstimate ActualLoss);
+
+/// <summary>The result of applying a plan: what was attempted, what worked, and what it really cost.</summary>
+[PublicAPI]
+public sealed class RepairOutcome
+{
+    /// <summary>The plan that was applied.</summary>
+    public required RepairPlan Plan { get; init; }
+
+    /// <summary>Per-step receipts, in execution order.</summary>
+    public required IReadOnlyList<RepairStepResult> Results { get; init; }
+
+    /// <summary>Path of the pre-repair copy, when one was taken.</summary>
+    public string BackupPath { get; init; }
+
+    /// <summary>The verification scan run after the repair. <c>null</c> when the repair aborted before it.</summary>
+    public IntegrityReport VerificationReport { get; init; }
+
+    /// <summary>Whether every attempted step succeeded.</summary>
+    public bool Succeeded
+    {
+        get
+        {
+            for (var i = 0; i < Results.Count; i++)
+            {
+                if (Results[i].Outcome == StepOutcome.Failed)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Typhon.Engine/Storage/internals/ChunkBasedSegment.cs
+++ b/src/Typhon.Engine/Storage/internals/ChunkBasedSegment.cs
@@ -143,14 +143,16 @@ public class ChunkBasedSegment<TStore> : LogicalSegment<TStore> where TStore : s
     /// <summary>Byte offset within a non-root page of this segment where chunk 0 begins.</summary>
     public int OtherDataOffset => PagedMMF.PageHeaderSize + _otherAlignmentPadding;
 
-    /// <summary>
-    /// Records how many per-sector verification slots fit on a page of this segment, given how much of the metadata region
-    /// its chunk-occupancy bitmap claims.
-    /// </summary>
-    /// <param name="page">The page to stamp.</param>
-    /// <param name="bitmapLongs">Number of 64-bit bitmap words this page's chunk count needs.</param>
-    private static unsafe void DeclareSectorGeometry(PageAccessor page, int bitmapLongs)
-        => PageSectorFooter.DeclareGeometry(new Span<byte>(page.Address, PagedMMF.PageSize), bitmapLongs * sizeof(long));
+    /// <inheritdoc />
+    /// <remarks>
+    /// The chunk-occupancy bitmap grows up from the start of the metadata region; the per-sector verification footer grows
+    /// down from its end. This is what keeps them apart, and it is consulted at page <i>initialisation</i> so a page never
+    /// — not even transiently, in the window where it is unlatched and dirty and a checkpoint could persist it — declares
+    /// a finer geometry than its bitmap leaves room for. A page that did would have its footer stamped over its own chunk
+    /// bitmap, which silently corrupts chunk allocation rather than failing loudly.
+    /// </remarks>
+    protected override int MetadataReservedBytes(bool isRootPage) => (isRootPage ? _bitmapLongsRoot : _bitmapLongsOther) * sizeof(long);
+
 
     // ═══════════════════════════════════════════════════════════════════════
     // Segment lifecycle: Create, Load, Grow
@@ -171,13 +173,6 @@ public class ChunkBasedSegment<TStore> : LogicalSegment<TStore> where TStore : s
             var page = GetPageExclusive(i, epoch, out var memPageIdx);
             int longSize = i == 0 ? _bitmapLongsRoot : _bitmapLongsOther;
             page.Metadata<long>(0, longSize).Clear();
-
-            // The chunk bitmap and the per-sector verification footer share the page metadata region: the bitmap grows up
-            // from its start, the footer down from its end. Only the segment knows how many bitmap words its stride needs,
-            // so it is the segment that declares how many sector slots are left over. A small enough stride leaves none,
-            // and the page falls back to a whole-page checksum — correct, and reported by the checker as reduced salvage
-            // granularity rather than silently assumed.
-            DeclareSectorGeometry(page, longSize);
 
             // Clear chunk 0's raw data on the root page so the BTree directory starts clean.
             // We do this inline because ReserveChunk(index, clearContent:true) needs a ChunkAccessor which requires an epoch scope — unavailable during segment
@@ -307,7 +302,6 @@ public class ChunkBasedSegment<TStore> : LogicalSegment<TStore> where TStore : s
                 {
                     var page = GetPageExclusiveUnchecked(i, epoch, out var memPageIdx);
                     page.Metadata<long>(0, _bitmapLongsOther).Clear();
-                    DeclareSectorGeometry(page, _bitmapLongsOther);
                     effectiveChangeSet?.AddByMemPageIndex(memPageIdx);
 
                     // Protect new pages against the checkpoint race during Grow→first-access window.

--- a/src/Typhon.Engine/Storage/internals/ChunkBasedSegment.cs
+++ b/src/Typhon.Engine/Storage/internals/ChunkBasedSegment.cs
@@ -143,6 +143,15 @@ public class ChunkBasedSegment<TStore> : LogicalSegment<TStore> where TStore : s
     /// <summary>Byte offset within a non-root page of this segment where chunk 0 begins.</summary>
     public int OtherDataOffset => PagedMMF.PageHeaderSize + _otherAlignmentPadding;
 
+    /// <summary>
+    /// Records how many per-sector verification slots fit on a page of this segment, given how much of the metadata region
+    /// its chunk-occupancy bitmap claims.
+    /// </summary>
+    /// <param name="page">The page to stamp.</param>
+    /// <param name="bitmapLongs">Number of 64-bit bitmap words this page's chunk count needs.</param>
+    private static unsafe void DeclareSectorGeometry(PageAccessor page, int bitmapLongs)
+        => PageSectorFooter.DeclareGeometry(new Span<byte>(page.Address, PagedMMF.PageSize), bitmapLongs * sizeof(long));
+
     // ═══════════════════════════════════════════════════════════════════════
     // Segment lifecycle: Create, Load, Grow
     // ═══════════════════════════════════════════════════════════════════════
@@ -162,6 +171,13 @@ public class ChunkBasedSegment<TStore> : LogicalSegment<TStore> where TStore : s
             var page = GetPageExclusive(i, epoch, out var memPageIdx);
             int longSize = i == 0 ? _bitmapLongsRoot : _bitmapLongsOther;
             page.Metadata<long>(0, longSize).Clear();
+
+            // The chunk bitmap and the per-sector verification footer share the page metadata region: the bitmap grows up
+            // from its start, the footer down from its end. Only the segment knows how many bitmap words its stride needs,
+            // so it is the segment that declares how many sector slots are left over. A small enough stride leaves none,
+            // and the page falls back to a whole-page checksum — correct, and reported by the checker as reduced salvage
+            // granularity rather than silently assumed.
+            DeclareSectorGeometry(page, longSize);
 
             // Clear chunk 0's raw data on the root page so the BTree directory starts clean.
             // We do this inline because ReserveChunk(index, clearContent:true) needs a ChunkAccessor which requires an epoch scope — unavailable during segment
@@ -291,6 +307,7 @@ public class ChunkBasedSegment<TStore> : LogicalSegment<TStore> where TStore : s
                 {
                     var page = GetPageExclusiveUnchecked(i, epoch, out var memPageIdx);
                     page.Metadata<long>(0, _bitmapLongsOther).Clear();
+                    DeclareSectorGeometry(page, _bitmapLongsOther);
                     effectiveChangeSet?.AddByMemPageIndex(memPageIdx);
 
                     // Protect new pages against the checkpoint race during Grow→first-access window.

--- a/src/Typhon.Engine/Storage/internals/LogicalSegment.cs
+++ b/src/Typhon.Engine/Storage/internals/LogicalSegment.cs
@@ -106,6 +106,20 @@ public class LogicalSegment<TStore> : IDisposable where TStore : struct, IPageSt
     public ref TStore Store => ref _store;
 
     /// <summary>
+    /// How many bytes of a page's metadata region this segment claims for its own use, and therefore how much is left
+    /// for the per-sector verification footer (which grows down from the end of the region).
+    /// </summary>
+    /// <param name="isRootPage">Whether the page is the segment's directory root, which can have a different chunk count.</param>
+    /// <remarks>
+    /// <b>This must be answered before the page is first written, not after.</b> A page is unlatched and dirty between
+    /// <c>CreateOrGrow</c> initialising it and its owner finishing with it, so a checkpoint can persist it in that window.
+    /// If the page declared a finer geometry than its bitmap allows — even transiently — the footer stamp would land on
+    /// top of the chunk-occupancy bitmap and corrupt chunk allocation. A plain logical segment keeps no bitmap, so the
+    /// base answer is zero and its pages get the finest granularity.
+    /// </remarks>
+    protected virtual int MetadataReservedBytes(bool isRootPage) => 0;
+
+    /// <summary>
     /// Get a typed <see cref="PageAccessor"/> for a segment page via epoch-based protection.
     /// Caller must be inside an <see cref="EpochGuard"/> scope.
     /// </summary>
@@ -450,7 +464,7 @@ public class LogicalSegment<TStore> : IDisposable where TStore : struct, IPageSt
 
                     InitHeader(page.Address, PageClearMode.Header,
                         PageBlockFlags.IsLogicalSegment | (isFirstPage ? PageBlockFlags.IsLogicalSegmentRoot : PageBlockFlags.None),
-                        type, 1);
+                        type, 1, MetadataReservedBytes(isFirstPage));
                     isPageDirty = true;
                 }
 
@@ -506,7 +520,7 @@ public class LogicalSegment<TStore> : IDisposable where TStore : struct, IPageSt
                         {
                             var endMemIdx = RequestExclusiveForGrow(mapIndices[curIndexMapIndex + 1], epoch, verifyCrc: false);
                             var endPage = _store.GetPage(endMemIdx);
-                            InitHeader(endPage.Address, PageClearMode.Header, PageBlockFlags.IsLogicalSegment, type, 1);
+                            InitHeader(endPage.Address, PageClearMode.Header, PageBlockFlags.IsLogicalSegment, type, 1, MetadataReservedBytes(isRootPage: false));
                             changeSet?.AddByMemPageIndex(endMemIdx);
                             endPage.RawData<int>(0, 1)[0] = 0;
                             // Durability: AddByMemPageIndex already bumps DC to 1 via tracked IncrementDirty. Without a
@@ -606,7 +620,8 @@ public class LogicalSegment<TStore> : IDisposable where TStore : struct, IPageSt
                 page.RawData<byte>(offset, PagedMMF.PageRawDataSize - offset).Clear();
             }
 
-            InitHeader(page.Address, PageClearMode.None, PageBlockFlags.IsLogicalSegment | (i == 0 ? PageBlockFlags.IsLogicalSegmentRoot : PageBlockFlags.None), type, 1);
+            InitHeader(page.Address, PageClearMode.None, PageBlockFlags.IsLogicalSegment | (i == 0 ? PageBlockFlags.IsLogicalSegmentRoot : PageBlockFlags.None), type, 1,
+                MetadataReservedBytes(i == 0));
 
             // Update link list of the pages that make the segment
             ref var lsh = ref page.StructAt<LogicalSegmentHeader>(LogicalSegmentHeader.Offset);

--- a/src/Typhon.Engine/Storage/internals/LogicalSegment.cs
+++ b/src/Typhon.Engine/Storage/internals/LogicalSegment.cs
@@ -728,7 +728,18 @@ public class LogicalSegment<TStore> : IDisposable where TStore : struct, IPageSt
     /// <summary>
     /// Initialize page header directly from a raw pointer (epoch-based path).
     /// </summary>
-    internal static unsafe void InitHeader(byte* pageAddr, PageClearMode clearMode, PageBlockFlags flags, PageBlockType type, short formatRevision)
+    /// <param name="pageAddr">Address of the page image.</param>
+    /// <param name="clearMode">How much of the page to zero before stamping.</param>
+    /// <param name="flags">Role flags for the page.</param>
+    /// <param name="type">Block type for the page.</param>
+    /// <param name="formatRevision">Type-scoped format revision.</param>
+    /// <param name="reservedMetadataBytes">
+    /// Bytes of the page metadata region the owning segment will claim for its chunk-occupancy bitmap. Decides how many
+    /// per-sector verification slots fit in what is left (<see cref="PageSectorFooter"/>). Zero for segments with no chunk
+    /// bitmap, which is the common case and yields the finest granularity.
+    /// </param>
+    internal static unsafe void InitHeader(byte* pageAddr, PageClearMode clearMode, PageBlockFlags flags, PageBlockType type, short formatRevision,
+        int reservedMetadataBytes = 0)
     {
         ref var header = ref Unsafe.AsRef<PageBaseHeader>(pageAddr + PageBaseHeader.Offset);
 
@@ -750,6 +761,11 @@ public class LogicalSegment<TStore> : IDisposable where TStore : struct, IPageSt
         header.Flags = flags;
         header.Type = type;
         header.FormatRevision = formatRevision;
+
+        // Declare the page's per-sector verification geometry AFTER any clear, since the clear would wipe it. A chunk-based
+        // segment re-declares with its real bitmap size once it knows the stride; everything else keeps the finest
+        // granularity, which is correct because a page with no chunk bitmap has the whole metadata region free.
+        PageSectorFooter.DeclareGeometry(new Span<byte>(pageAddr, PagedMMF.PageSize), reservedMetadataBytes);
     }
 
     internal virtual bool Load(int filePageIndex)

--- a/src/Typhon.Engine/Storage/internals/ManagedPagedMMF.cs
+++ b/src/Typhon.Engine/Storage/internals/ManagedPagedMMF.cs
@@ -106,6 +106,18 @@ public partial class ManagedPagedMMF : PagedMMF, IMetricSource, IDebugProperties
     // (directory only) · 3 occ-root-twin · 4 occ-first-data (L0 bits) · 5 occ-data-reserve · 6 occ-mapext-reserve ·
     // 7 occ-mapext-twin-reserve.
     internal const int InitialReservedPageCount = 8;
+
+    /// <summary>
+    /// The fewest pages a Typhon data file can physically contain: the meta pair (0, 1), the occupancy segment's
+    /// directory root (2) and its twin (3), and the first page of occupancy data (4).
+    /// </summary>
+    /// <remarks>
+    /// Deliberately <b>not</b> <see cref="InitialReservedPageCount"/>. That constant counts occupancy <i>bits</i> set
+    /// aside at genesis — pages 5, 6 and 7 are reserved so the occupancy map can grow later without needing to allocate
+    /// through itself — but nothing writes them, so the file is five pages long until real data arrives. Confusing the
+    /// reserved count with the physical count makes a freshly-created database look truncated.
+    /// </remarks>
+    internal const int MinimumPhysicalPageCount = OccupancyFirstDataPageIndex + 1;
     private const int OccupancySegmentRootPageIndex = 2;
     private const int OccupancyRootTwinPageIndex = 3;
     // The occupancy bitmap's first data page. The directory-only root (v4) carries no bitmap words, so the first L0 page must
@@ -414,6 +426,13 @@ public partial class ManagedPagedMMF : PagedMMF, IMetricSource, IDebugProperties
         cs.SaveChanges();
         PersistMetaNow();
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// This is the layer that owns the meta pair, the bootstrap dictionary and the occupancy segment, so it is the layer
+    /// where verifying them means anything.
+    /// </remarks>
+    protected override void VerifyOnOpen() => VerifyBundleSpineOnOpen();
 
     protected override void OnFileLoading()
     {
@@ -863,7 +882,13 @@ public partial class ManagedPagedMMF : PagedMMF, IMetricSource, IDebugProperties
 
             var nextGen = _metaGeneration + 1;
             PageBaseHeader.WritePairGeneration(pageSpan, nextGen);
-            ((PageBaseHeader*)pageAddr)->PageChecksum = Crc32CUtil.ComputeSkipping(pageSpan, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+
+            // The meta page is the one page that CANNOT carry a per-sector footer: its metadata region holds the root
+            // identity header, and the bootstrap stream starts immediately after and runs to the end of the page, so the
+            // footer's bytes are occupied by real content. Clear the declaration explicitly rather than relying on it
+            // never having been set — a stray value there would make a reader verify this page the wrong way.
+            PageSectorFooter.ClearGeometry(pageSpan);
+            StampPageForWrite(pageSpan, MetaSlotA);
 
             // Write the full image to the alternate slot and fsync BEFORE flipping the current pointer.
             var targetSlot = MetaSlotA + MetaSlotB - _metaCurrentSlot;   // the other slot
@@ -944,9 +969,9 @@ public partial class ManagedPagedMMF : PagedMMF, IMetricSource, IDebugProperties
     private static bool IsPairSlotValid(ReadOnlySpan<byte> slot, out ulong generation)
     {
         generation = 0;
-        var storedCrc = MemoryMarshal.Read<uint>(slot.Slice(PageBaseHeader.PageChecksumOffset));
-        var computedCrc = Crc32CUtil.ComputeSkipping(slot, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
-        if (storedCrc != computedCrc)
+        // Geometry-aware: a directory page carries a per-sector footer (declared at page init), the meta page does not.
+        // Verifying either one the wrong way would reject a perfectly good slot and could fail an open on a healthy database.
+        if (!VerifyPageImage(slot, out _))
         {
             return false;
         }
@@ -1038,7 +1063,11 @@ public partial class ManagedPagedMMF : PagedMMF, IMetricSource, IDebugProperties
 
             var span = new Span<byte>(image, PageSize);
             PageBaseHeader.WritePairGeneration(span, newGen);
-            ((PageBaseHeader*)image)->PageChecksum = Crc32CUtil.ComputeSkipping(span, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+
+            // Stamp the PRIMARY index, not the alternate slot this image is about to land in: a protected page alternates
+            // between two physical slots by design, so the logical index is what identifies it. Stamping the slot would
+            // make every legitimate flip look like a misdirected write.
+            StampPageForWrite(span, primaryPageIndex);
 
             WritePageDirect(alternate, span);
             FlushToDisk();

--- a/src/Typhon.Engine/Storage/internals/PageSectorFooter.cs
+++ b/src/Typhon.Engine/Storage/internals/PageSectorFooter.cs
@@ -83,6 +83,10 @@ internal static class PageSectorFooter
     /// <param name="reservedMetadataBytes">Bytes of the metadata region already claimed, counted from <see cref="MetadataOffset"/>.</param>
     public static int ChooseSectorCount(int reservedMetadataBytes)
     {
+        if (BisectDisableSectorFooters)
+        {
+            return 0;
+        }
         var floor = MetadataOffset + reservedMetadataBytes;
         for (var n = MaxSectorCount; n >= 2; n >>= 1)
         {
@@ -268,4 +272,7 @@ internal static class PageSectorFooter
 
     /// <summary>Byte offset of the change revision within the page base header, mirrored here to avoid a layout lookup.</summary>
     private const int PageImageChangeRevisionOffset = 4;
+
+    /// <summary>TEMPORARY BISECT PROBE — forces every page onto the legacy whole-page checksum.</summary>
+    internal static readonly bool BisectDisableSectorFooters = true;
 }

--- a/src/Typhon.Engine/Storage/internals/PageSectorFooter.cs
+++ b/src/Typhon.Engine/Storage/internals/PageSectorFooter.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Typhon.Engine.Internals;
+
+/// <summary>
+/// Per-sector page verification: an array of <c>{CRC32C, generation}</c> pairs covering equal slices of a page, so damage
+/// can be localised to a sector instead of condemning all 8192 bytes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The problem.</b> A page carries one CRC32C over all 8192 bytes, so a single flipped bit condemns every entity on it —
+/// up to 475. The detector's resolution is 8192 bytes; the decision anyone actually wants to make is per-entity, roughly 24
+/// bytes. Splitting the checksum into 16 independent 512-byte sectors takes provable salvage from <b>0 % to 40–91 %</b> of
+/// entities depending on archetype shape, and it does so at <b>zero added bytes</b> (the space is already inside the page
+/// and already covered) and <b>negative CPU cost</b> (independent chains break the <c>crc32</c> instruction's 3-cycle
+/// latency dependency — see <see cref="Crc32CUtil"/>).
+/// </para>
+/// <para>
+/// <b>Why the generation field is required.</b> A torn write leaves one region from the <i>previous</i> write. Those bytes
+/// are not corrupt — they are a valid image of generation <i>G-1</i>, and their CRC validates. Without a currency stamp,
+/// whole clusters can be silently stale with every checksum passing. The CRC proves <i>integrity</i>; only the generation
+/// proves <i>currency</i>.
+/// </para>
+/// <para>
+/// <b>The validity rule, and why the obvious one is unsafe.</b> Comparing each sector's generation to the page header's is
+/// backwards-unsafe: the header lives in sector 0, so if sector 0 did not persist but sector 5 did, the header reads
+/// <i>G-1</i> — and the rule then condemns the newest, correct sector while accepting every stale one, because the stale
+/// sectors all agree with the stale header. The rule used here takes the <b>maximum</b> over the header and every sector
+/// stamp, which cannot invert that way. It is sound because every page write rewrites every sector's stamp (writes are
+/// always whole-page), so after a clean write all stamps agree and the maximum never over-condemns.
+/// </para>
+/// <para>
+/// <b>Geometry is declared by the page, not inferred.</b> The footer shares the page metadata region with the
+/// chunk-occupancy bitmap, whose size depends on the owning segment's stride — which the page writer does not know. So the
+/// segment stamps <see cref="SectorCountOffset"/> once at page initialisation and the writer honours it. Pages whose
+/// bitmap leaves no room (a stride-8 segment fills the whole region) declare <c>0</c> and keep the legacy whole-page
+/// checksum. A reader therefore never has to consult a directory to know how to verify a page — which is exactly the
+/// property a damage-tolerant reader needs.
+/// </para>
+/// </remarks>
+internal static class PageSectorFooter
+{
+    /// <summary>
+    /// Byte offset of the page's own logical index. Detects a <b>misdirected write</b> — a page landing at the wrong file
+    /// offset, which is otherwise completely undetectable because its checksum is perfectly valid. <c>0</c> means unstamped.
+    /// </summary>
+    /// <remarks>
+    /// This is the page's <b>logical</b> index, not the physical slot it happens to occupy: A/B protected pages alternate
+    /// between two physical slots by design, so stamping the physical slot would make every legitimate flip look like a
+    /// misdirect. The reader compares against the index it asked for.
+    /// </remarks>
+    public const int FilePageIndexOffset = 48;
+
+    /// <summary>Byte offset of the declared sector count. Legal values are <c>0</c>, 2, 4, 8 and 16.</summary>
+    public const int SectorCountOffset = 52;
+
+    /// <summary>Byte offset of the declared sector size, as a base-2 logarithm of the byte count.</summary>
+    public const int SectorLogSizeOffset = 53;
+
+    /// <summary>The footer's high-water mark: it grows <i>down</i> from the end of the page header zone.</summary>
+    public const int FooterEndOffset = PagedMMF.PageHeaderSize;
+
+    /// <summary>Bytes each sector costs in the footer: a 4-byte CRC32C plus a 2-byte generation.</summary>
+    public const int BytesPerSector = 6;
+
+    /// <summary>The most sectors a page can carry, which is also the granularity that maximises salvage.</summary>
+    public const int MaxSectorCount = 16;
+
+    /// <summary>Start of the page metadata region, which the footer shares with the chunk-occupancy bitmap.</summary>
+    public const int MetadataOffset = PagedMMF.PageBaseHeaderSize;
+
+    /// <summary>Byte offset at which the footer for <paramref name="sectorCount"/> sectors begins.</summary>
+    /// <param name="sectorCount">Number of sectors.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int FooterBase(int sectorCount) => FooterEndOffset - (sectorCount * BytesPerSector);
+
+    /// <summary>
+    /// The largest legal sector count whose footer fits above a bitmap of <paramref name="reservedMetadataBytes"/> bytes,
+    /// or <c>0</c> when none does.
+    /// </summary>
+    /// <param name="reservedMetadataBytes">Bytes of the metadata region already claimed, counted from <see cref="MetadataOffset"/>.</param>
+    public static int ChooseSectorCount(int reservedMetadataBytes)
+    {
+        var floor = MetadataOffset + reservedMetadataBytes;
+        for (var n = MaxSectorCount; n >= 2; n >>= 1)
+        {
+            if (FooterBase(n) >= floor)
+            {
+                return n;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Declares a page's footer geometry. Called once when a segment initialises the page — the segment is the only layer
+    /// that knows how much of the metadata region its chunk bitmap needs — and the write path reads the declaration back
+    /// rather than trying to infer it.
+    /// </summary>
+    /// <param name="page">The full page image.</param>
+    /// <param name="reservedMetadataBytes">Bytes of the metadata region the owning segment claims for its chunk bitmap.</param>
+    public static void DeclareGeometry(Span<byte> page, int reservedMetadataBytes)
+    {
+        var n = ChooseSectorCount(reservedMetadataBytes);
+        page[SectorCountOffset] = (byte)n;
+        page[SectorLogSizeOffset] = n == 0 ? (byte)0 : (byte)System.Numerics.BitOperations.TrailingZeroCount(PagedMMF.PageSize / n);
+    }
+
+    /// <summary>Clears any footer declaration, returning the page to whole-page checksumming.</summary>
+    /// <param name="page">The full page image.</param>
+    public static void ClearGeometry(Span<byte> page)
+    {
+        page[SectorCountOffset] = 0;
+        page[SectorLogSizeOffset] = 0;
+    }
+
+    /// <summary>Stamps the page's own logical index, so a write that lands at the wrong offset is detectable.</summary>
+    /// <param name="page">The full page image.</param>
+    /// <param name="filePageIndex">The page's logical file-page index.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void StampFilePageIndex(Span<byte> page, int filePageIndex) => MemoryMarshal.Write(page[FilePageIndexOffset..], in filePageIndex);
+
+    /// <summary>
+    /// Reads the declared sector count, returning <c>0</c> for any value that is not a legal, self-consistent declaration.
+    /// A reader must never trust a count it has not validated — the byte may itself be damage.
+    /// </summary>
+    /// <param name="page">The full page image.</param>
+    public static int ReadSectorCount(ReadOnlySpan<byte> page)
+    {
+        int n = page[SectorCountOffset];
+        if (n is not (2 or 4 or 8 or 16))
+        {
+            return 0;
+        }
+
+        int logSize = page[SectorLogSizeOffset];
+        if (logSize is < 1 or > 30 || (1 << logSize) != PagedMMF.PageSize / n)
+        {
+            return 0;
+        }
+
+        return n;
+    }
+
+    /// <summary>Reads the page's stamped logical index. <c>0</c> means the page predates the stamp.</summary>
+    /// <param name="page">The full page image.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int ReadFilePageIndex(ReadOnlySpan<byte> page) => MemoryMarshal.Read<int>(page[FilePageIndexOffset..]);
+
+    /// <summary>Reads sector <paramref name="sector"/>'s stored CRC.</summary>
+    /// <param name="page">The full page image.</param>
+    /// <param name="sectorCount">Validated sector count.</param>
+    /// <param name="sector">Sector index.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint ReadSectorCrc(ReadOnlySpan<byte> page, int sectorCount, int sector)
+        => MemoryMarshal.Read<uint>(page[(FooterBase(sectorCount) + (sector * 4))..]);
+
+    /// <summary>Reads sector <paramref name="sector"/>'s stored generation stamp.</summary>
+    /// <param name="page">The full page image.</param>
+    /// <param name="sectorCount">Validated sector count.</param>
+    /// <param name="sector">Sector index.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ushort ReadSectorGeneration(ReadOnlySpan<byte> page, int sectorCount, int sector)
+        => MemoryMarshal.Read<ushort>(page[(FooterBase(sectorCount) + (sectorCount * 4) + (sector * 2))..]);
+
+    /// <summary>
+    /// Computes sector <paramref name="sector"/>'s CRC over the page image, excluding the two self-referencing regions that
+    /// are written after it: the page checksum field and the footer array itself. Both live in sector 0.
+    /// </summary>
+    /// <param name="page">The full page image.</param>
+    /// <param name="sectorCount">Validated sector count.</param>
+    /// <param name="sector">Sector index.</param>
+    public static uint ComputeSectorCrc(ReadOnlySpan<byte> page, int sectorCount, int sector)
+    {
+        var size = PagedMMF.PageSize / sectorCount;
+        var slice = page.Slice(sector * size, size);
+        if (sector != 0)
+        {
+            return Crc32CUtil.Compute(slice);
+        }
+
+        var footerBase = FooterBase(sectorCount);
+        return Crc32CUtil.ComputeSkippingPair(slice, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize,
+            footerBase, FooterEndOffset - footerBase);
+    }
+
+    /// <summary>
+    /// Stamps every sector's CRC and generation, then sets <see cref="PageBaseHeader.PageChecksum"/> to a CRC over the
+    /// footer array — so the array that protects the sectors is itself protected, and a single pass over the page produces
+    /// both the fine-grained and the whole-page verdicts.
+    /// </summary>
+    /// <param name="page">The full page image, with its <c>ChangeRevision</c> already advanced for this write.</param>
+    /// <param name="sectorCount">Validated sector count; must be non-zero.</param>
+    public static void Stamp(Span<byte> page, int sectorCount)
+    {
+        var generation = (ushort)(MemoryMarshal.Read<int>(page[PageImageChangeRevisionOffset..]) & 0xFFFF);
+        var footerBase = FooterBase(sectorCount);
+
+        for (var s = 0; s < sectorCount; s++)
+        {
+            var crc = ComputeSectorCrc(page, sectorCount, s);
+            MemoryMarshal.Write(page[(footerBase + (s * 4))..], in crc);
+            MemoryMarshal.Write(page[(footerBase + (sectorCount * 4) + (s * 2))..], in generation);
+        }
+
+        var footerCrc = Crc32CUtil.Compute(page[footerBase..FooterEndOffset]);
+        MemoryMarshal.Write(page[PageBaseHeader.PageChecksumOffset..], in footerCrc);
+    }
+
+    /// <summary>
+    /// Verifies a stamped page. Fills <paramref name="sectorOk"/> with each sector's verdict and reports whether the footer
+    /// array itself verified.
+    /// </summary>
+    /// <param name="page">The full page image.</param>
+    /// <param name="sectorCount">Validated sector count; must be non-zero.</param>
+    /// <param name="sectorOk">Receives one verdict per sector; must be at least <paramref name="sectorCount"/> long.</param>
+    /// <param name="failedSectors">Receives the number of sectors that did not verify.</param>
+    /// <returns><c>true</c> when the footer array verified — i.e. when the per-sector verdicts can be trusted at all.</returns>
+    public static bool Verify(ReadOnlySpan<byte> page, int sectorCount, Span<bool> sectorOk, out int failedSectors)
+    {
+        failedSectors = 0;
+        var footerBase = FooterBase(sectorCount);
+        var storedFooterCrc = MemoryMarshal.Read<uint>(page[PageBaseHeader.PageChecksumOffset..]);
+        var footerIntact = Crc32CUtil.Compute(page[footerBase..FooterEndOffset]) == storedFooterCrc;
+
+        // The currency floor: the newest generation any part of this page claims. Taking the maximum (rather than trusting
+        // the header, which lives in sector 0) is what stops a torn sector 0 from condemning the sectors that DID persist.
+        var pageGeneration = (ushort)(MemoryMarshal.Read<int>(page[PageImageChangeRevisionOffset..]) & 0xFFFF);
+        if (footerIntact)
+        {
+            for (var s = 0; s < sectorCount; s++)
+            {
+                var gen = ReadSectorGeneration(page, sectorCount, s);
+                if (GenerationIsNewer(gen, pageGeneration))
+                {
+                    pageGeneration = gen;
+                }
+            }
+        }
+
+        for (var s = 0; s < sectorCount; s++)
+        {
+            var ok = footerIntact
+                && ComputeSectorCrc(page, sectorCount, s) == ReadSectorCrc(page, sectorCount, s)
+                && ReadSectorGeneration(page, sectorCount, s) == pageGeneration;
+            sectorOk[s] = ok;
+            if (!ok)
+            {
+                failedSectors++;
+            }
+        }
+
+        return footerIntact;
+    }
+
+    /// <summary>
+    /// Wrapping-aware "is <paramref name="candidate"/> newer than <paramref name="current"/>" over a 16-bit counter. Half
+    /// the range is treated as the future, which is correct because a page's sector stamps can never be more than a handful
+    /// of generations apart.
+    /// </summary>
+    /// <param name="candidate">The generation being considered.</param>
+    /// <param name="current">The generation to compare against.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool GenerationIsNewer(ushort candidate, ushort current) => (ushort)(candidate - current) is > 0 and < 0x8000;
+
+    /// <summary>Byte offset of the change revision within the page base header, mirrored here to avoid a layout lookup.</summary>
+    private const int PageImageChangeRevisionOffset = 4;
+}

--- a/src/Typhon.Engine/Storage/internals/PageSectorFooter.cs
+++ b/src/Typhon.Engine/Storage/internals/PageSectorFooter.cs
@@ -83,10 +83,6 @@ internal static class PageSectorFooter
     /// <param name="reservedMetadataBytes">Bytes of the metadata region already claimed, counted from <see cref="MetadataOffset"/>.</param>
     public static int ChooseSectorCount(int reservedMetadataBytes)
     {
-        if (BisectDisableSectorFooters)
-        {
-            return 0;
-        }
         var floor = MetadataOffset + reservedMetadataBytes;
         for (var n = MaxSectorCount; n >= 2; n >>= 1)
         {
@@ -273,6 +269,4 @@ internal static class PageSectorFooter
     /// <summary>Byte offset of the change revision within the page base header, mirrored here to avoid a layout lookup.</summary>
     private const int PageImageChangeRevisionOffset = 4;
 
-    /// <summary>TEMPORARY BISECT PROBE — forces every page onto the legacy whole-page checksum.</summary>
-    internal static readonly bool BisectDisableSectorFooters = true;
 }

--- a/src/Typhon.Engine/Storage/internals/PagedMMF.Logging.cs
+++ b/src/Typhon.Engine/Storage/internals/PagedMMF.Logging.cs
@@ -21,4 +21,21 @@ public partial class PagedMMF
         Level = LogLevel.Warning,
         Message = "CopyPageWithSeqlock: skipping page after {ElapsedMs}ms — writer holding odd ModificationCounter={Counter}")]
     private static partial void LogSeqlockWriterHeldSkip(ILogger logger, int elapsedMs, int counter);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Open-time integrity verification is disabled (VerifyOnOpen = None). Damage that occurred while this "
+                + "database was closed — bit rot, a truncated copy, a restore from the wrong place — will be served "
+                + "silently rather than reported. Intended for benchmarks and in-memory fixtures only.")]
+    private static partial void LogOpenVerificationDisabledCore(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Open-time integrity verification found {Count} non-fatal finding(s) (verdict {Verdict}). The database "
+                + "opened. Run `typhon check <bundle> --depth deep` for the full report.")]
+    private static partial void LogOpenVerificationFindingsCore(ILogger logger, int count, string verdict);
+
+    private void LogOpenVerificationDisabled() => LogOpenVerificationDisabledCore(Logger);
+
+    private void LogOpenVerificationFindings(int count, string verdict) => LogOpenVerificationFindingsCore(Logger, count, verdict);
 }

--- a/src/Typhon.Engine/Storage/internals/PagedMMF.cs
+++ b/src/Typhon.Engine/Storage/internals/PagedMMF.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text.Json;
 using System.Threading;
@@ -71,7 +72,11 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
     // cluster record finds ClusterChunkId where Location[0] lived, and a v4 index leaf read as a ClusterLocation
     // resolves to a plausible-looking but wrong cluster slot. Both silently serve corrupt data rather than failing.
     // Pre-alpha means no migration is owed — it does NOT mean a stale file may open and answer wrongly.
-    internal const int DatabaseFormatRevision   = 5;
+    // 6: per-sector page verification (PageSectorFooter). A page that declares sector geometry stores a CRC32C + currency
+    //    stamp per 512 B sector in the free tail of its metadata region, and its PageChecksum field becomes a CRC over that
+    //    footer rather than over the whole page. A revision-5 reader would compute a whole-page checksum and report every
+    //    such page as corrupt, so the bump is what turns a confusing false alarm into a clean "incompatible format" refusal.
+    internal const int DatabaseFormatRevision   = 6;
     internal const ulong MinimumCacheSize       = MinimumMemPageCount * PageSize;      // 8 MiB — the hard floor (see Validate)
     internal const ulong DefaultDatabaseCacheSize   = 256UL * 1024 * 1024;             // 256 MiB — the shipped production default
     internal const ulong RecommendedMinimumCacheSize = 64UL * 1024 * 1024;             // 64 MiB — warn below this (unless TestMode)
@@ -649,6 +654,11 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
 
     private void LoadFile()
     {
+        // Verify BEFORE taking a handle, so a structurally-broken database is never touched at all. The clean-shutdown
+        // flag says the last process closed properly; it says nothing about whether the bytes are still correct, and
+        // damage that happens while a database is closed is otherwise served silently.
+        VerifyOnOpen();
+
         // Create the Files
         var filePathName = Options.BuildDatabasePathFileName();
         _fileHandle = File.OpenHandle(filePathName, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, FileOptions.Asynchronous | FileOptions.RandomAccess);
@@ -667,6 +677,86 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
     {
         var handler = LoadingEvent;
         handler?.Invoke(this, null!);
+    }
+
+    /// <summary>
+    /// Runs the configured open-time verification, if this store has a structural spine to verify.
+    /// </summary>
+    /// <remarks>
+    /// A no-op on the base paged file, which is a bare page container: it has no meta pair, no bootstrap dictionary and no
+    /// occupancy segment, so every spine check would be asking about structures that were never supposed to exist. Only
+    /// <see cref="ManagedPagedMMF"/> — the layer that owns those structures — overrides this. Getting that split wrong
+    /// makes verification report a healthy raw file as unopenable, which is the worst possible failure mode for a feature
+    /// whose entire value is that its findings can be trusted.
+    /// </remarks>
+    protected virtual void VerifyOnOpen()
+    {
+    }
+
+    /// <summary>
+    /// Verifies a bundle's structural spine before it is opened and refuses the open on a
+    /// <see cref="IntegritySeverity.Fatal"/> finding.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <c>Fatal</c> finding means the spine is broken — both meta slots invalid, an unparseable bootstrap, a segment
+    /// pointer that does not resolve. Opening anyway is the most harmful possible response: the engine follows those
+    /// pointers into garbage. Lesser findings do <b>not</b> block the open, because a database with a divergent index is
+    /// still a working database and refusing it would be the cure being worse than the disease; they are logged so the
+    /// operator learns about them.
+    /// </para>
+    /// <para>
+    /// The scan is skipped when the bundle cannot be read, since there is then nothing to verify — verification must never
+    /// be the thing that breaks an open it was meant to protect.
+    /// </para>
+    /// </remarks>
+    protected void VerifyBundleSpineOnOpen()
+    {
+        var mode = Options.VerifyOnOpen;
+        if (mode == OpenVerification.None)
+        {
+            LogOpenVerificationDisabled();
+            return;
+        }
+
+        var depth = mode switch
+        {
+            OpenVerification.Quick => ScanDepth.Quick,
+            OpenVerification.Standard => ScanDepth.Standard,
+            _ => ScanDepth.Spine
+        };
+
+        IntegrityReport report;
+        try
+        {
+            using var source = new OfflineBundlePageSource(Options.BundleDirectory);
+            report = IntegrityScanner.Scan(source, new IntegrityOptions { Depth = depth });
+        }
+        catch (Exception ex) when (ex is IOException or DirectoryNotFoundException or FileNotFoundException or UnauthorizedAccessException)
+        {
+            // Nothing to verify (a fresh or non-bundle store, or a file another process is exclusively holding). The
+            // ordinary open path reports those far better than a checker would.
+            return;
+        }
+
+        var fatal = 0;
+        for (var i = 0; i < report.Findings.Count; i++)
+        {
+            if (report.Findings[i].Severity == IntegritySeverity.Fatal)
+            {
+                fatal++;
+            }
+        }
+
+        if (fatal > 0)
+        {
+            throw new DatabaseIntegrityException(report);
+        }
+
+        if (report.Findings.Count > 0)
+        {
+            LogOpenVerificationFindings(report.Findings.Count, report.Verdict.ToString());
+        }
     }
     
     public bool IsDatabaseFileCreating { get; }
@@ -1499,19 +1589,19 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
             // Read stored CRC from the page header
             var pageAddr = (PageBaseHeader*)(_memPagesAddr + (memPageIndex * (long)PageSize));
             var storedCrc = pageAddr->PageChecksum;
+            var pageSpan = new ReadOnlySpan<byte>((byte*)pageAddr, PageSize);
 
-            // CRC == 0 means the page has never been checkpointed (pre-FPI pages) — skip
-            if (storedCrc == 0)
+            // CRC == 0 means the page has never been checkpointed — skip. The sentinel only applies to whole-page
+            // checksumming: a page carrying a per-sector footer was definitionally written by the stamping path, so its
+            // checksum field is a footer CRC that may legitimately be any value including zero.
+            var sectorCount = PageSectorFooter.ReadSectorCount(pageSpan);
+            if (storedCrc == 0 && sectorCount == 0)
             {
                 pi.CrcVerified = true;
                 return;
             }
 
-            // Compute CRC over the page, skipping the checksum field itself
-            var pageSpan = new ReadOnlySpan<byte>((byte*)pageAddr, PageSize);
-            var computedCrc = Crc32CUtil.ComputeSkipping(pageSpan, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
-
-            if (computedCrc == storedCrc)
+            if (VerifyPageImage(pageSpan, out var computedCrc))
             {
                 pi.CrcVerified = true;
                 return;
@@ -1535,6 +1625,71 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
         {
             pi.StateSyncRoot.ExitExclusiveAccess();
         }
+    }
+
+    /// <summary>
+    /// Stamps a page image's identity and integrity fields immediately before it is written to disk.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two things are stamped. The page's own <b>logical index</b>, which makes a misdirected write — a page landing at the
+    /// wrong file offset — detectable with certainty; without it such a write is invisible, because the page's checksum is
+    /// perfectly valid and it is simply the wrong page.
+    /// </para>
+    /// <para>
+    /// And the <b>checksum</b>, in whichever form the page declared at initialisation. A page that declared per-sector
+    /// geometry gets one CRC32C per sector plus a currency stamp, and its <c>PageChecksum</c> field becomes a CRC over that
+    /// footer — so the array protecting the sectors is itself protected. A page that declared none keeps the single
+    /// whole-page checksum. The per-sector form is not merely finer, it is also <i>cheaper</i>: independent CRC chains
+    /// break the <c>crc32</c> instruction's 3-cycle latency dependency that makes one 8 KiB chain leave the execution unit
+    /// mostly idle.
+    /// </para>
+    /// <para>
+    /// Callers must have advanced <see cref="PageBaseHeader.ChangeRevision"/> first — the per-sector currency stamp is
+    /// derived from it.
+    /// </para>
+    /// </remarks>
+    /// <param name="page">The page image about to be written.</param>
+    /// <param name="logicalPageIndex">The page's logical file-page index.</param>
+    /// <param name="allowSectorFooter">
+    /// <c>false</c> for A/B protected pages. They are already covered against a torn write by their twin, so the finer
+    /// granularity buys nothing, and keeping them on the whole-page checksum leaves the pair-selection predicate untouched.
+    /// </param>
+    internal static void StampPageForWrite(Span<byte> page, int logicalPageIndex, bool allowSectorFooter = true)
+    {
+        PageSectorFooter.StampFilePageIndex(page, logicalPageIndex);
+
+        var sectors = allowSectorFooter ? PageSectorFooter.ReadSectorCount(page) : 0;
+        if (sectors > 0)
+        {
+            PageSectorFooter.Stamp(page, sectors);
+            return;
+        }
+
+        var crc = Crc32CUtil.ComputeSkipping(page, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+        MemoryMarshal.Write(page[PageBaseHeader.PageChecksumOffset..], in crc);
+    }
+
+    /// <summary>
+    /// Verifies a page image the same way <see cref="StampPageForWrite"/> stamped it, honouring the page's own declared
+    /// geometry so a reader never has to consult a directory to know how to check a page.
+    /// </summary>
+    /// <param name="page">The page image.</param>
+    /// <param name="computed">Receives the computed whole-page checksum when the page uses that form; <c>0</c> otherwise.</param>
+    /// <returns><c>true</c> when the page verifies.</returns>
+    internal static bool VerifyPageImage(ReadOnlySpan<byte> page, out uint computed)
+    {
+        var sectors = PageSectorFooter.ReadSectorCount(page);
+        if (sectors == 0)
+        {
+            computed = Crc32CUtil.ComputeSkipping(page, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+            return computed == MemoryMarshal.Read<uint>(page[PageBaseHeader.PageChecksumOffset..]);
+        }
+
+        computed = 0;
+        Span<bool> sectorOk = stackalloc bool[PageSectorFooter.MaxSectorCount];
+        PageSectorFooter.Verify(page, sectors, sectorOk, out var failed);
+        return failed == 0;
     }
 
     /// <summary>
@@ -1965,7 +2120,7 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
                 }
                 else
                 {
-                    stagingHeader->PageChecksum = Crc32CUtil.ComputeSkipping(staging.Span, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+                    StampPageForWrite(staging.Span, filePageIndex);
                 }
             }
 
@@ -2023,24 +2178,38 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
         // The common structural flush touches ZERO protected pages (pure data), so scan first — a cheap dictionary probe per
         // page, no allocation — and only build the partitioned `normalPages` list when a protected page is actually present.
         // (The previous version allocated a full-length List<int> on EVERY flush and discarded it whenever protectedCount==0.)
+        // The same partition must ALSO exclude externally-persisted pages (the CK-05 meta pair). They are written only by
+        // PersistMetaNow, which alternates slots and stamps a fresh CRC; the in-place path below skips the CRC stamp for
+        // file page 0 (its `FilePageIndex > 0` guard) but did NOT skip the WRITE, so a structural flush that happened to
+        // carry logical page 0 overwrote meta slot 0 with an image whose stored checksum no longer matched its content.
+        // The pair then silently ran on one copy: the surviving slot still opened the database, so nothing complained —
+        // until that slot tore too, at which point BOTH slots read invalid and the database became permanently unopenable.
+        // That is precisely the failure CK-05 exists to make impossible, so the exclusion belongs here and not only in
+        // CollectDirtyMemPageIndices (which had it all along — this path is fed by a ChangeSet, not by that scan).
         int[] normalPages = memPageIndices;
-        var hasProtected = false;
+        var needsPartition = false;
         for (int i = 0; i < memPageIndices.Length; i++)
         {
             var filePageIdx = _memPagesInfo[memPageIndices[i]].FilePageIndex;
-            if (filePageIdx > 0 && IsProtectedPage(filePageIdx))
+            if (IsExternallyPersisted(filePageIdx) || (filePageIdx > 0 && IsProtectedPage(filePageIdx)))
             {
-                hasProtected = true;
+                needsPartition = true;
                 break;
             }
         }
 
-        if (hasProtected)
+        if (needsPartition)
         {
             var normal = new List<int>(memPageIndices.Length);
             for (int i = 0; i < memPageIndices.Length; i++)
             {
                 var pi = _memPagesInfo[memPageIndices[i]];
+                if (IsExternallyPersisted(pi.FilePageIndex))
+                {
+                    // Owned by PersistMetaNow. Not written here at all — the continuation still releases its DirtyCounter.
+                    continue;
+                }
+
                 if (pi.FilePageIndex > 0 && IsProtectedPage(pi.FilePageIndex))
                 {
                     // Wait for any pending IO read so the live page is complete, bump ChangeRevision, then redirect the write.
@@ -2100,9 +2269,8 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
                 var headerAddr = (PageBaseHeader*)(memPageBaseAddr + (curPageInfo.MemPageIndex * PageSize));
                 ++headerAddr->ChangeRevision;
 
-                // Compute CRC over the updated page so the on-disk copy is self-consistent (CP-07 equivalent for SavePages)
-                var pageSpan = new ReadOnlySpan<byte>((byte*)headerAddr, PageSize);
-                headerAddr->PageChecksum = Crc32CUtil.ComputeSkipping(pageSpan, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+                // Stamp identity + checksum over the updated page so the on-disk copy is self-consistent (CP-07 equivalent for SavePages)
+                StampPageForWrite(new Span<byte>((byte*)headerAddr, PageSize), curPageInfo.FilePageIndex);
             }
 
             var nextMemPageIndex = normalPages[i];
@@ -2134,8 +2302,7 @@ public partial class PagedMMF : ResourceNode, IMemoryResource
             var headerAddr = (PageBaseHeader*)(memPageBaseAddr + (curPageInfo.MemPageIndex * PageSize));
             ++headerAddr->ChangeRevision;
 
-            var pageSpan = new ReadOnlySpan<byte>((byte*)headerAddr, PageSize);
-            headerAddr->PageChecksum = Crc32CUtil.ComputeSkipping(pageSpan, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+            StampPageForWrite(new Span<byte>((byte*)headerAddr, PageSize), curPageInfo.FilePageIndex);
         }
 
         // Don't forget to add the last operation

--- a/src/Typhon.Engine/Storage/public/PagedMMFOptions.cs
+++ b/src/Typhon.Engine/Storage/public/PagedMMFOptions.cs
@@ -58,6 +58,24 @@ public class PagedMMFOptions
     public bool PagesDebugPattern { get; set; }
 
     /// <summary>
+    /// How much of the database to verify when opening it. Defaults to <see cref="OpenVerification.Spine"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The clean-shutdown flag records that the last process <i>closed properly</i>. It does not record that the bytes are
+    /// still correct. Damage that happens while a database is closed — bit rot, a truncated copy, a restore from the wrong
+    /// place, a file-level backup tool writing through — is invisible to a clean open, which then proceeds to serve it.
+    /// </para>
+    /// <para>
+    /// <see cref="OpenVerification.Spine"/> is the tier that earns being always on: it is bounded by the number of
+    /// segments rather than the size of the database, so it reads kilobytes and costs well under a millisecond, and it
+    /// catches the entire structurally-broken class — which is precisely the damage where opening anyway does the most
+    /// harm, because the engine then follows directory pointers into garbage.
+    /// </para>
+    /// </remarks>
+    public OpenVerification VerifyOnOpen { get; set; } = OpenVerification.Spine;
+
+    /// <summary>
     /// Factory that creates the backpressure strategy for page cache allocation.
     /// Defaults to <see cref="WaitForIOStrategy"/> (signal-driven passive wait).
     /// </summary>

--- a/src/Typhon.Shell/Commands/CheckCommand.cs
+++ b/src/Typhon.Shell/Commands/CheckCommand.cs
@@ -1,0 +1,137 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using Typhon.Engine;
+
+namespace Typhon.Shell.Commands;
+
+/// <summary>
+/// <c>typhon check &lt;bundle&gt;</c> — reports what is wrong with a database without changing a byte of it.
+/// </summary>
+/// <remarks>
+/// Reads the bundle as bytes with no engine, no lock and no log replay, so it is always safe to run — including on the
+/// database that will not open, which is the case that most justifies having it. The verdict is carried in the exit code
+/// so the command drops into a cron job or a CI gate without anyone parsing anything.
+/// </remarks>
+// ReSharper disable once ClassNeverInstantiated.Global
+internal sealed class CheckCommand : Command<CheckCommand.Settings>
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public sealed class Settings : CommandSettings
+    {
+        // ReSharper disable UnusedAutoPropertyAccessor.Global
+        [CommandArgument(0, "<bundle>")]
+        [Description("Path to the .typhon bundle directory.")]
+        public string Bundle { get; set; }
+
+        [CommandOption("-d|--depth")]
+        [Description("spine | quick | standard | deep. Default: standard.")]
+        public string Depth { get; set; }
+
+        [CommandOption("-f|--format")]
+        [Description("text | json. Default: text on a terminal, json when piped.")]
+        public string Format { get; set; }
+
+        [CommandOption("-o|--out")]
+        [Description("Write the report to a file instead of standard output.")]
+        public string Out { get; set; }
+
+        [CommandOption("--checks")]
+        [Description("Only run checks whose code starts with one of these prefixes, e.g. CHK-IDX.")]
+        public string[] Checks { get; set; }
+
+        [CommandOption("--skip")]
+        [Description("Skip checks whose code starts with one of these prefixes.")]
+        public string[] Skip { get; set; }
+        // ReSharper restore UnusedAutoPropertyAccessor.Global
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        if (!TryParseDepth(settings.Depth, out var depth, out var depthError))
+        {
+            AnsiConsole.MarkupLine($"[red]{Markup.Escape(depthError)}[/]");
+            return ScanFailedExitCode;
+        }
+
+        IntegrityReport report;
+        try
+        {
+            using var source = new OfflineBundlePageSource(settings.Bundle);
+            report = IntegrityScanner.Scan(source, new IntegrityOptions
+            {
+                Depth = depth,
+                IncludeChecks = settings.Checks ?? [],
+                ExcludeChecks = settings.Skip ?? [],
+                Cancellation = cancellationToken
+            });
+        }
+        catch (Exception ex) when (ex is IOException or DirectoryNotFoundException or FileNotFoundException or UnauthorizedAccessException)
+        {
+            AnsiConsole.MarkupLine($"[red]Could not read the bundle: {Markup.Escape(ex.Message)}[/]");
+            return ScanFailedExitCode;
+        }
+
+        var asJson = ResolveFormat(settings.Format, settings.Out);
+        var text = asJson ? IntegrityReportJson.Render(report) : IntegrityReportText.Render(report, colour: settings.Out == null && !Console.IsOutputRedirected);
+
+        if (settings.Out != null)
+        {
+            File.WriteAllText(settings.Out, text);
+            AnsiConsole.MarkupLine($"[grey]Report written to {Markup.Escape(settings.Out)} — verdict {report.Verdict}.[/]");
+        }
+        else
+        {
+            Console.Out.Write(text);
+        }
+
+        return report.ExitCode;
+    }
+
+    /// <summary>Exit code for "the scan itself could not run", kept clear of every verdict code.</summary>
+    internal const int ScanFailedExitCode = 64;
+
+    /// <summary>Parses the depth option.</summary>
+    /// <param name="value">The raw option value, or <c>null</c> for the default.</param>
+    /// <param name="depth">Receives the parsed depth.</param>
+    /// <param name="error">Receives a message when the value is not recognised.</param>
+    internal static bool TryParseDepth(string value, out ScanDepth depth, out string error)
+    {
+        error = null;
+        depth = ScanDepth.Standard;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "spine": depth = ScanDepth.Spine; return true;
+            case "quick": depth = ScanDepth.Quick; return true;
+            case "standard": depth = ScanDepth.Standard; return true;
+            case "deep": depth = ScanDepth.Deep; return true;
+            default:
+                error = $"Unknown depth '{value}'. Expected spine, quick, standard or deep.";
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Chooses the output format: what was asked for, else JSON when the output is going anywhere but a terminal, because
+    /// the consumer of a redirected report is a program.
+    /// </summary>
+    /// <param name="format">The raw format option, or <c>null</c>.</param>
+    /// <param name="outPath">The <c>--out</c> path, or <c>null</c>.</param>
+    internal static bool ResolveFormat(string format, string outPath)
+    {
+        if (!string.IsNullOrWhiteSpace(format))
+        {
+            return format.Trim().Equals("json", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return outPath != null || Console.IsOutputRedirected;
+    }
+}

--- a/src/Typhon.Shell/Commands/RepairCommand.cs
+++ b/src/Typhon.Shell/Commands/RepairCommand.cs
@@ -1,0 +1,203 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Typhon.Engine;
+
+namespace Typhon.Shell.Commands;
+
+/// <summary>
+/// <c>typhon repair &lt;bundle&gt;</c> — produces a reviewable repair plan, and applies one.
+/// </summary>
+/// <remarks>
+/// Two steps, deliberately. The natural product instinct is one command that does the right thing; that is rejected here
+/// because the cost of a wrong automatic repair is unbounded and unrecoverable while the cost of one extra command is
+/// thirty seconds. <c>--plan</c> writes a file and mutates nothing; <c>--apply</c> re-scans first and refuses if the
+/// database changed, because repairing against a stale diagnosis is how a repair tool damages a healthy database.
+/// </remarks>
+// ReSharper disable once ClassNeverInstantiated.Global
+internal sealed class RepairCommand : Command<RepairCommand.Settings>
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public sealed class Settings : CommandSettings
+    {
+        // ReSharper disable UnusedAutoPropertyAccessor.Global
+        [CommandArgument(0, "<bundle>")]
+        [Description("Path to the .typhon bundle directory.")]
+        public string Bundle { get; set; }
+
+        [CommandOption("--plan")]
+        [Description("Produce a plan and a loss manifest. Mutates nothing. This is the default.")]
+        public bool PlanOnly { get; set; }
+
+        [CommandOption("--apply")]
+        [Description("Execute the plan. The only mutating mode.")]
+        public bool Apply { get; set; }
+
+        [CommandOption("--allow-loss")]
+        [Description("Consent to steps that destroy data that is already unreadable.")]
+        public bool AllowLoss { get; set; }
+
+        [CommandOption("--no-backup-first")]
+        [Description("Do not copy the bundle before the first mutation. A copy is taken by default.")]
+        public bool NoBackupFirst { get; set; }
+
+        [CommandOption("--dry-run")]
+        [Description("With --apply: describe every step and execute none.")]
+        public bool DryRun { get; set; }
+
+        [CommandOption("-o|--out")]
+        [Description("Write the plan to this file instead of standard output.")]
+        public string Out { get; set; }
+        // ReSharper restore UnusedAutoPropertyAccessor.Global
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        IntegrityReport report;
+        try
+        {
+            using var source = new OfflineBundlePageSource(settings.Bundle);
+            if (source.LockHeld)
+            {
+                AnsiConsole.MarkupLine(
+                    "[red]This database is open in another process.[/] Repair needs exclusive access — close it and retry.");
+                return CheckCommand.ScanFailedExitCode;
+            }
+
+            report = IntegrityScanner.Scan(source, new IntegrityOptions { Depth = ScanDepth.Deep, Cancellation = cancellationToken });
+        }
+        catch (Exception ex) when (ex is IOException or DirectoryNotFoundException or FileNotFoundException or UnauthorizedAccessException)
+        {
+            AnsiConsole.MarkupLine($"[red]Could not read the bundle: {Markup.Escape(ex.Message)}[/]");
+            return CheckCommand.ScanFailedExitCode;
+        }
+
+        var plan = DatabaseRepair.Plan(report);
+
+        if (!settings.Apply)
+        {
+            var rendered = RenderPlan(plan, report);
+            if (settings.Out != null)
+            {
+                File.WriteAllText(settings.Out, rendered);
+                AnsiConsole.MarkupLine($"[grey]Plan written to {Markup.Escape(settings.Out)}.[/]");
+            }
+            else
+            {
+                Console.Out.Write(rendered);
+            }
+
+            return report.ExitCode;
+        }
+
+        if (plan.IsEmpty)
+        {
+            AnsiConsole.MarkupLine("[green]Nothing to repair.[/]");
+            return report.ExitCode;
+        }
+
+        RepairOutcome outcome;
+        try
+        {
+            outcome = DatabaseRepair.Apply(settings.Bundle, plan, settings.AllowLoss, !settings.NoBackupFirst, settings.DryRun);
+        }
+        catch (InvalidOperationException ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Refused: {Markup.Escape(ex.Message)}[/]");
+            return CheckCommand.ScanFailedExitCode;
+        }
+
+        Console.Out.Write(RenderOutcome(outcome));
+        return outcome.VerificationReport?.ExitCode ?? (outcome.Succeeded ? 0 : CheckCommand.ScanFailedExitCode);
+    }
+
+    /// <summary>Renders a plan for an operator to read before consenting.</summary>
+    /// <param name="plan">The plan.</param>
+    /// <param name="report">The report it was derived from.</param>
+    internal static string RenderPlan(RepairPlan plan, IntegrityReport report)
+    {
+        var sb = new StringBuilder(2048);
+        sb.Append("\n  REPAIR PLAN for ").Append(plan.Source).Append('\n');
+        sb.Append("  diagnosis: ").Append(plan.Verdict).Append(", ").Append(report.Findings.Count).Append(" finding(s)\n");
+        sb.Append("  fingerprint: ").Append(plan.DatabaseFingerprint).Append('\n').Append('\n');
+
+        if (plan.IsEmpty)
+        {
+            sb.Append("  No repairable problems were found.\n");
+        }
+
+        for (var i = 0; i < plan.Steps.Count; i++)
+        {
+            var step = plan.Steps[i];
+            sb.Append("  ").Append(step.Order).Append(". [").Append(step.Class).Append("] ").Append(step.Description).Append('\n');
+            sb.Append("     ").Append(step.Rationale).Append('\n');
+            sb.Append("     addresses: ").Append(string.Join(", ", step.Addresses)).Append('\n').Append('\n');
+        }
+
+        if (plan.Unaddressed.Count > 0)
+        {
+            sb.Append("  NOT ADDRESSED BY THIS PLAN\n");
+            for (var i = 0; i < plan.Unaddressed.Count; i++)
+            {
+                sb.Append("    · ").Append(plan.Unaddressed[i]).Append('\n');
+            }
+
+            sb.Append('\n');
+        }
+
+        if (!plan.Loss.IsEmpty)
+        {
+            sb.Append("  LOSS IF APPLIED\n");
+            for (var i = 0; i < plan.Loss.Entries.Count; i++)
+            {
+                var loss = plan.Loss.Entries[i];
+                sb.Append("    ").Append(loss.CountText).Append(' ').Append(loss.Kind).Append(" — ").Append(loss.Explanation).Append('\n');
+            }
+
+            sb.Append('\n');
+        }
+
+        if (!plan.IsEmpty)
+        {
+            sb.Append("  Next: typhon repair ").Append(plan.Source).Append(" --apply");
+            sb.Append(plan.RequiresLossyConsent ? " --allow-loss\n" : "\n");
+        }
+
+        sb.Append('\n');
+        return sb.ToString();
+    }
+
+    /// <summary>Renders the receipt for an applied plan.</summary>
+    /// <param name="outcome">The outcome.</param>
+    internal static string RenderOutcome(RepairOutcome outcome)
+    {
+        var sb = new StringBuilder(2048);
+        sb.Append("\n  REPAIR ").Append(outcome.Succeeded ? "COMPLETE" : "FAILED").Append('\n');
+
+        if (outcome.BackupPath != null)
+        {
+            sb.Append("  pre-repair copy: ").Append(outcome.BackupPath).Append('\n');
+        }
+
+        sb.Append('\n');
+        for (var i = 0; i < outcome.Results.Count; i++)
+        {
+            var r = outcome.Results[i];
+            sb.Append("  ").Append(r.Step.Order).Append(". ").Append(r.Outcome.ToString().ToUpperInvariant()).Append(" — ").Append(r.Step.Description).Append('\n');
+            sb.Append("     ").Append(r.Detail).Append('\n');
+        }
+
+        if (outcome.VerificationReport != null)
+        {
+            sb.Append('\n').Append("  VERIFICATION: ").Append(outcome.VerificationReport.Verdict);
+            sb.Append(" (").Append(outcome.VerificationReport.Findings.Count).Append(" finding(s) remaining)\n");
+        }
+
+        sb.Append('\n');
+        return sb.ToString();
+    }
+}

--- a/src/Typhon.Shell/Program.cs
+++ b/src/Typhon.Shell/Program.cs
@@ -66,6 +66,23 @@ internal static class Program
                     .WithExample(["docs"])
                     .WithExample(["docs", "guide/getting-started"]);
 
+                // `typhon check <bundle>` reports what is wrong with a database without changing a byte of it, and carries
+                // the verdict in its exit code (0 sound · 1 leaks · 2 divergent · 3 data loss · 4 unopenable · 64 scan
+                // failed) so it drops straight into cron or a CI gate. It reads the bundle as bytes with no engine, which
+                // is what lets it diagnose the database that will not open — the case that most justifies having it.
+                config.AddCommand<CheckCommand>("check")
+                    .WithDescription("Check a database's integrity and report what is wrong. Read-only.")
+                    .WithExample(["check", "game.typhon"])
+                    .WithExample(["check", "game.typhon", "--depth", "deep"])
+                    .WithExample(["check", "game.typhon", "--format", "json", "--out", "report.json"]);
+
+                // `typhon repair <bundle>` is two steps on purpose: --plan writes a reviewable description and mutates
+                // nothing, --apply re-scans and refuses if the database moved since the plan was made.
+                config.AddCommand<RepairCommand>("repair")
+                    .WithDescription("Plan and apply a repair, with an explicit account of anything it would cost.")
+                    .WithExample(["repair", "game.typhon", "--plan"])
+                    .WithExample(["repair", "game.typhon", "--apply"]);
+
                 // `typhon telemetry …` authors typhon.telemetry.json in the working directory (#522). Scriptable
                 // verbs over the source-generated flag catalog; the interactive tree lives under `edit`.
                 config.AddBranch("telemetry", tel =>

--- a/test/Typhon.Engine.Tests/Durability/CrashRecovery/MetaPairTests.cs
+++ b/test/Typhon.Engine.Tests/Durability/CrashRecovery/MetaPairTests.cs
@@ -133,11 +133,16 @@ public class MetaPairTests : AllocatorTestBase
         _mmf.Dispose();
         _mmf = null;
 
-        // Both slots invalid → open must fail loudly, never silently fall back. (The MMF wraps the LoadMeta failure in a
+        // Both slots invalid → open must fail loudly, never silently fall back. (The MMF wraps the failure in a
         // "Virtual Disk Manager initialization error" — assert the loud meta-pair diagnostic on the inner exception.)
+        //
+        // Open-time spine verification now catches this BEFORE the file handle is taken, so the inner exception is a
+        // DatabaseIntegrityException carrying the full report rather than LoadMeta's bare InvalidOperationException. The
+        // rule this test verifies — a corrupt pair fails the open loudly instead of silently falling back — is unchanged;
+        // the diagnostic is simply better. LoadMeta's own throw remains as defence in depth for VerifyOnOpen = None.
         Assert.That(() => _mmf = Open(fresh: false),
-            Throws.Exception.With.InnerException.TypeOf<InvalidOperationException>()
-                .And.InnerException.Message.Contains("Both meta-pair slots"));
+            Throws.Exception.With.InnerException.TypeOf<DatabaseIntegrityException>()
+                .And.InnerException.Message.Contains("meta pair"));
     }
 
     [Test]

--- a/test/Typhon.Engine.Tests/Integrity/DatabaseRepairTests.cs
+++ b/test/Typhon.Engine.Tests/Integrity/DatabaseRepairTests.cs
@@ -1,0 +1,382 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// Tests for plan → consent → apply.
+/// </summary>
+/// <remarks>
+/// The properties under test are mostly <i>refusals</i>, and deliberately so: a repair tool that acts on a wrong
+/// conclusion is worse than no repair tool, so most of what makes this safe is what it declines to do. Planning must
+/// change nothing, applying must refuse a stale diagnosis, and a lossy step must never run without explicit consent.
+/// </remarks>
+[TestFixture]
+internal sealed class DatabaseRepairTests
+{
+    private string _root;
+    private ServiceProvider _serviceProvider;
+
+    private static string CurrentDatabaseName
+    {
+        get
+        {
+            var name = TestContext.CurrentContext.Test.Name;
+            foreach (var c in new[] { '(', ')', ',', ' ', '"' })
+            {
+                name = name.Replace(c, '_');
+            }
+
+            const int max = 63;
+            const string prefix = "Trep_";
+            return prefix.Length + name.Length > max ? prefix + name[^(max - prefix.Length)..] : prefix + name;
+        }
+    }
+
+    private string DbDir => Path.Combine(_root, "db");
+
+    private string BundlePath => Path.Combine(DbDir, $"{CurrentDatabaseName}.typhon");
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "Typhon.Tests", nameof(DatabaseRepairTests), CurrentDatabaseName);
+        Directory.CreateDirectory(DbDir);
+        Directory.CreateDirectory(Path.Combine(_root, "wal"));
+
+        var services = new ServiceCollection();
+        services
+            .AddLogging(b => b.SetMinimumLevel(LogLevel.Error))
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddHighResolutionSharedTimer()
+            .AddDeadlineWatchdog()
+            .AddScopedManagedPagedMemoryMappedFile(opts =>
+            {
+                opts.DatabaseName = CurrentDatabaseName;
+                opts.DatabaseDirectory = DbDir;
+                opts.DatabaseCacheSize = (ulong)PagedMMF.MinimumCacheSize * 4;
+            })
+            .AddScopedDatabaseEngine(opts =>
+            {
+                opts.Wal = new WalWriterOptions
+                {
+                    WalDirectory = Path.Combine(_root, "wal"),
+                    GroupCommitIntervalMs = 5,
+                    UseFUA = false,
+                    SegmentSize = 4 * 1024 * 1024,
+                    PreAllocateSegments = 1
+                };
+            });
+
+        _serviceProvider = services.BuildServiceProvider();
+        _serviceProvider.EnsureFileDeleted<ManagedPagedMMFOptions>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _serviceProvider?.Dispose();
+        _serviceProvider = null;
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, true);
+            }
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private void BuildAndClose(int entityCount = 64)
+    {
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var dbe = scope.ServiceProvider.GetRequiredService<DatabaseEngine>();
+            dbe.RegisterComponentFromAccessor<CompA>();
+            dbe.InitializeArchetypes();
+
+            using (var uow = dbe.CreateUnitOfWork(DurabilityMode.Immediate))
+            {
+                for (var i = 0; i < entityCount; i++)
+                {
+                    using var tx = uow.CreateTransaction();
+                    var comp = new CompA(i + 1, i, i);
+                    tx.Spawn<CompAArch>(CompAArch.A.Set(in comp));
+                    tx.Commit();
+                }
+
+                uow.Flush();
+            }
+
+            dbe.ForceCheckpoint();
+        }
+
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+    }
+
+    private IntegrityReport Scan(ScanDepth depth = ScanDepth.Deep)
+    {
+        using var source = new OfflineBundlePageSource(BundlePath);
+        return IntegrityScanner.Scan(source, new IntegrityOptions { Depth = depth });
+    }
+
+    private static void DamagePage(string bundlePath, int filePageIndex, Action<byte[]> mutate)
+    {
+        var dataPath = Path.Combine(bundlePath, IntegrityConstants.DataFileName);
+        var page = new byte[IntegrityConstants.PageSize];
+        using var fs = new FileStream(dataPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        fs.Seek(filePageIndex * (long)IntegrityConstants.PageSize, SeekOrigin.Begin);
+        fs.ReadExactly(page);
+        mutate(page);
+        fs.Seek(filePageIndex * (long)IntegrityConstants.PageSize, SeekOrigin.Begin);
+        fs.Write(page);
+    }
+
+    // ── Planning changes nothing ─────────────────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void HealthyDatabase_PlansNothing()
+    {
+        BuildAndClose();
+
+        var plan = DatabaseRepair.Plan(Scan());
+
+        Assert.That(plan.IsEmpty, Is.True, "a sound database must produce an empty plan");
+        Assert.That(plan.RequiresLossyConsent, Is.False);
+        Assert.That(plan.Unaddressed, Is.Empty);
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void Planning_DoesNotTouchTheDatabase()
+    {
+        BuildAndClose();
+        DamagePage(BundlePath, 0, page => page.AsSpan(200, 64).Fill(0xAB));
+
+        var dataPath = Path.Combine(BundlePath, IntegrityConstants.DataFileName);
+        var before = File.ReadAllBytes(dataPath);
+
+        var plan = DatabaseRepair.Plan(Scan());
+        Assert.That(plan.Steps, Is.Not.Empty, "precondition: there is something to plan");
+
+        var after = File.ReadAllBytes(dataPath);
+        Assert.That(after.SequenceEqual(before), Is.True, "producing a plan must be provably read-only");
+    }
+
+    // ── The lossless repair that matters: restoring a degraded A/B pair ──────────────────────────────────────────────
+
+    /// <summary>
+    /// One damaged meta slot leaves the database working but without a fallback: the next torn write to the surviving
+    /// slot makes it permanently unopenable. Restoring the pair is therefore a real repair, not housekeeping.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void DamagedMetaSlot_IsRestoredFromItsSibling()
+    {
+        BuildAndClose();
+
+        var healthy = Scan();
+        Assert.That(healthy.Verdict, Is.EqualTo(IntegrityVerdict.Sound), "precondition: starts sound");
+
+        var goodSlot = healthy.Identity.MetaSlot;
+        var badSlot = 1 - goodSlot;
+        DamagePage(BundlePath, badSlot, page => page.AsSpan(300, 128).Fill(0xAB));
+
+        var damaged = Scan();
+        Assert.That(damaged.Findings.Any(f => f.Code == "CHK-BOO-03"), Is.True,
+            "precondition: the degraded pair is detected.\n" + IntegrityReportText.Render(damaged));
+
+        var plan = DatabaseRepair.Plan(damaged);
+        Assert.That(plan.Steps.Any(s => s.Action == RepairAction.RestorePairSlot), Is.True, "the planner must offer to restore it");
+        Assert.That(plan.RequiresLossyConsent, Is.False, "restoring a pair loses nothing");
+
+        var outcome = DatabaseRepair.Apply(BundlePath, plan, backupFirst: false);
+
+        Assert.That(outcome.Succeeded, Is.True, DescribeOutcome(outcome));
+        Assert.That(outcome.VerificationReport, Is.Not.Null, "apply must re-scan and attach the receipt");
+        Assert.That(outcome.VerificationReport.Verdict, Is.EqualTo(IntegrityVerdict.Sound),
+            "after the repair the database must scan clean.\n" + IntegrityReportText.Render(outcome.VerificationReport));
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void RestoringAPair_LeavesTheDatabaseOpenable()
+    {
+        BuildAndClose();
+
+        var healthy = Scan();
+        var badSlot = 1 - healthy.Identity.MetaSlot;
+        DamagePage(BundlePath, badSlot, page => page.AsSpan(300, 128).Fill(0xAB));
+
+        var plan = DatabaseRepair.Plan(Scan());
+        DatabaseRepair.Apply(BundlePath, plan, backupFirst: false);
+
+        // The real proof is not that the scan is green — it is that the engine still opens it and the data is there.
+        Setup();
+        using var scope = _serviceProvider.CreateScope();
+        var dbe = scope.ServiceProvider.GetRequiredService<DatabaseEngine>();
+        dbe.RegisterComponentFromAccessor<CompA>();
+        Assert.DoesNotThrow(() => dbe.InitializeArchetypes(), "the repaired database must still open through the normal path");
+    }
+
+    // ── Refusals ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applying a plan built against a different state of the database is how a repair tool damages a healthy one. The
+    /// fingerprint check is the guard, and it must fire rather than "do its best".
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void StalePlan_IsRefused()
+    {
+        BuildAndClose();
+
+        var healthy = Scan();
+        var badSlot = 1 - healthy.Identity.MetaSlot;
+        DamagePage(BundlePath, badSlot, page => page.AsSpan(300, 128).Fill(0xAB));
+
+        var plan = DatabaseRepair.Plan(Scan());
+
+        // The database moves on after the plan was made.
+        DamagePage(BundlePath, healthy.Identity.PageCount - 1, page => page[IntegrityConstants.PageHeaderSize + 8] ^= 0xFF);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => DatabaseRepair.Apply(BundlePath, plan, backupFirst: false));
+        Assert.That(ex.Message, Does.Contain("changed since this plan was produced"));
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void DryRun_ExecutesNothing()
+    {
+        BuildAndClose();
+
+        var healthy = Scan();
+        var badSlot = 1 - healthy.Identity.MetaSlot;
+        DamagePage(BundlePath, badSlot, page => page.AsSpan(300, 128).Fill(0xAB));
+
+        var plan = DatabaseRepair.Plan(Scan());
+        var dataPath = Path.Combine(BundlePath, IntegrityConstants.DataFileName);
+        var before = File.ReadAllBytes(dataPath);
+
+        var outcome = DatabaseRepair.Apply(BundlePath, plan, backupFirst: false, dryRun: true);
+
+        Assert.That(outcome.Results.All(r => r.Outcome == StepOutcome.Skipped), Is.True, "a dry run executes nothing");
+        Assert.That(File.ReadAllBytes(dataPath).SequenceEqual(before), Is.True, "and therefore changes nothing");
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void BackupFirst_CopiesTheBundleBeforeMutating()
+    {
+        BuildAndClose();
+
+        var healthy = Scan();
+        var badSlot = 1 - healthy.Identity.MetaSlot;
+        DamagePage(BundlePath, badSlot, page => page.AsSpan(300, 128).Fill(0xAB));
+
+        var plan = DatabaseRepair.Plan(Scan());
+        var outcome = DatabaseRepair.Apply(BundlePath, plan, backupFirst: true);
+
+        Assert.That(outcome.BackupPath, Is.Not.Null);
+        Assert.That(Directory.Exists(outcome.BackupPath), Is.True, "the pre-repair copy must exist");
+        Assert.That(File.Exists(Path.Combine(outcome.BackupPath, IntegrityConstants.DataFileName)), Is.True,
+            "and must contain the data file");
+    }
+
+    /// <summary>
+    /// A finding whose data is genuinely gone must be reported as unaddressed with an honest explanation, not quietly
+    /// dropped from the plan. Silence here would read as "nothing to do".
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void UnrepairableDamage_IsReportedRatherThanSilentlyDropped()
+    {
+        BuildAndClose();
+
+        // Damage a data page of a PRIMARY segment. Which segment owns a page decides whether damage is repairable at all:
+        // an index or entity-map page is derived and simply regenerated, so it would prove nothing here.
+        var target = FindPrimaryDataPage();
+        Assert.That(target, Is.GreaterThan(0), "precondition: the database has a primary data page to damage");
+        DamagePage(BundlePath, target, page => page.AsSpan(IntegrityConstants.PageHeaderSize, 512).Fill(0x00));
+
+        var report = Scan();
+        var plan = DatabaseRepair.Plan(report);
+
+        Assert.That(report.Verdict, Is.Not.EqualTo(IntegrityVerdict.Sound), "precondition: the damage is detected");
+        Assert.That(plan.Unaddressed, Is.Not.Empty,
+            "damage this build cannot repair must be named, with a reason.\n" + IntegrityReportText.Render(report));
+        Assert.That(string.Join(" ", plan.Unaddressed), Does.Contain("backup").IgnoreCase,
+            "and the escalation path must be stated");
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void Fingerprint_ChangesWhenTheDatabaseChanges()
+    {
+        BuildAndClose();
+
+        var before = DatabaseRepair.Fingerprint(Scan());
+        Assert.That(DatabaseRepair.Fingerprint(Scan()), Is.EqualTo(before), "scanning twice must not change the fingerprint");
+
+        DamagePage(BundlePath, 2, page => page[IntegrityConstants.PageHeaderSize + 8] ^= 0xFF);
+        Assert.That(DatabaseRepair.Fingerprint(Scan()), Is.Not.EqualTo(before), "but damaging the database must");
+    }
+
+    /// <summary>
+    /// Finds a non-root data page belonging to a segment that holds primary data, so damage to it is genuinely
+    /// unrecoverable rather than merely a rebuild away.
+    /// </summary>
+    private int FindPrimaryDataPage()
+    {
+        using var source = new OfflineBundlePageSource(BundlePath);
+        var walker = new SegmentWalker(source);
+        Span<byte> page = new byte[IntegrityConstants.PageSize];
+
+        for (var p = ManagedPagedMMF.InitialReservedPageCount; p < source.PageCount; p++)
+        {
+            if (!source.TryReadPage(p, page) || (PageImage.Flags(page) & PageBlockFlags.IsLogicalSegmentRoot) == 0)
+            {
+                continue;
+            }
+
+            // Roots identify themselves by self-reference; a twin's copy of the directory still names the primary.
+            if (System.Runtime.InteropServices.MemoryMarshal.Read<int>(PageImage.RawData(page)) != p)
+            {
+                continue;
+            }
+
+            var segment = walker.WalkSegment(p);
+            if (PhysicalChecks.IsDerivedKind(segment.Kind) || segment.Kind == StorageSegmentKind.Other)
+            {
+                continue;
+            }
+
+            for (var i = 1; i < segment.Pages.Count; i++)
+            {
+                if (segment.Pages[i] != segment.RootPageIndex)
+                {
+                    return segment.Pages[i];
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private static string DescribeOutcome(RepairOutcome outcome)
+    {
+        var lines = outcome.Results.Select(r => $"  {r.Step.Action}: {r.Outcome} — {r.Detail}");
+        return "repair outcome:\n" + string.Join("\n", lines);
+    }
+}

--- a/test/Typhon.Engine.Tests/Integrity/IntegrityScannerTests.cs
+++ b/test/Typhon.Engine.Tests/Integrity/IntegrityScannerTests.cs
@@ -1,0 +1,534 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// End-to-end tests for the offline integrity scanner: it must call a healthy database sound, and it must find damage that
+/// the engine's own load path either cannot see or can only respond to by refusing to open.
+/// </summary>
+/// <remarks>
+/// Every test here builds a <b>real</b> database through the normal engine path, closes it, and then reads the bytes back
+/// with no engine at all. That separation is the point of the feature and therefore the point of the fixture: a test that
+/// scanned through a live engine would be testing something else.
+/// </remarks>
+[TestFixture]
+internal sealed class IntegrityScannerTests
+{
+    private string _root;
+    private ServiceProvider _serviceProvider;
+
+    private static string CurrentDatabaseName
+    {
+        get
+        {
+            var name = TestContext.CurrentContext.Test.Name;
+            foreach (var c in new[] { '(', ')', ',', ' ', '"' })
+            {
+                name = name.Replace(c, '_');
+            }
+
+            const int max = 63;
+            const string prefix = "Tint_";
+            if (prefix.Length + name.Length > max)
+            {
+                name = name[^(max - prefix.Length)..];
+            }
+
+            return prefix + name;
+        }
+    }
+
+    private string DbDir => Path.Combine(_root, "db");
+
+    private string BundlePath => Path.Combine(DbDir, $"{CurrentDatabaseName}.typhon");
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "Typhon.Tests", nameof(IntegrityScannerTests), CurrentDatabaseName);
+        Directory.CreateDirectory(DbDir);
+        Directory.CreateDirectory(Path.Combine(_root, "wal"));
+
+        var services = new ServiceCollection();
+        services
+            .AddLogging(b => b.SetMinimumLevel(LogLevel.Error))
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddHighResolutionSharedTimer()
+            .AddDeadlineWatchdog()
+            .AddScopedManagedPagedMemoryMappedFile(opts =>
+            {
+                opts.DatabaseName = CurrentDatabaseName;
+                opts.DatabaseDirectory = DbDir;
+                opts.DatabaseCacheSize = (ulong)PagedMMF.MinimumCacheSize * 4;
+            })
+            .AddScopedDatabaseEngine(opts =>
+            {
+                opts.Wal = new WalWriterOptions
+                {
+                    WalDirectory = Path.Combine(_root, "wal"),
+                    GroupCommitIntervalMs = 5,
+                    UseFUA = false,
+                    SegmentSize = 4 * 1024 * 1024,
+                    PreAllocateSegments = 1
+                };
+            });
+
+        _serviceProvider = services.BuildServiceProvider();
+        _serviceProvider.EnsureFileDeleted<ManagedPagedMMFOptions>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _serviceProvider?.Dispose();
+        _serviceProvider = null;
+
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, true);
+            }
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+    }
+
+    /// <summary>Builds a small, fully-committed database and closes it cleanly.</summary>
+    private void BuildHealthyDatabase(int entityCount = 64)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var dbe = scope.ServiceProvider.GetRequiredService<DatabaseEngine>();
+        dbe.RegisterComponentFromAccessor<CompA>();
+        dbe.InitializeArchetypes();
+
+        using (var uow = dbe.CreateUnitOfWork(DurabilityMode.Immediate))
+        {
+            for (var i = 0; i < entityCount; i++)
+            {
+                using var tx = uow.CreateTransaction();
+                var comp = new CompA(i + 1, i, i);
+                tx.Spawn<CompAArch>(CompAArch.A.Set(in comp));
+                tx.Commit();
+            }
+
+            uow.Flush();
+        }
+
+        dbe.ForceCheckpoint();
+    }
+
+    private IntegrityReport Scan(ScanDepth depth = ScanDepth.Standard)
+    {
+        using var source = new OfflineBundlePageSource(BundlePath);
+        return IntegrityScanner.Scan(source, new IntegrityOptions { Depth = depth });
+    }
+
+    private static void DamagePage(string bundlePath, int filePageIndex, Action<byte[]> mutate)
+    {
+        var dataPath = Path.Combine(bundlePath, IntegrityConstants.DataFileName);
+        var page = new byte[IntegrityConstants.PageSize];
+        using var fs = new FileStream(dataPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        fs.Seek(filePageIndex * (long)IntegrityConstants.PageSize, SeekOrigin.Begin);
+        fs.ReadExactly(page);
+        mutate(page);
+        fs.Seek(filePageIndex * (long)IntegrityConstants.PageSize, SeekOrigin.Begin);
+        fs.Write(page);
+    }
+
+    // ── The baseline: a healthy database must be called sound ────────────────────────────────────────────────────────
+    // This is the test that matters most. A checker that reports findings on a healthy database is worse than no checker,
+    // because every real finding then arrives inside a haystack of noise nobody trusts.
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void HealthyDatabase_ScansSound()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var report = Scan();
+
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Sound),
+            "A cleanly-closed database must scan clean.\n" + IntegrityReportText.Render(report));
+        Assert.That(report.Identity.Name, Is.EqualTo(CurrentDatabaseName), "the scanner must read the database name from page 0");
+        Assert.That(report.Identity.MetaSlot, Is.AnyOf(0, 1), "one of the two meta slots must have been selected");
+        Assert.That(report.Totals.SegmentsWalked, Is.GreaterThan(0), "a real database has segments; walking none means discovery failed");
+        Assert.That(report.Totals.PagesScanned, Is.GreaterThan(0));
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void HealthyDatabase_DeepScanIsAlsoSound()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var report = Scan(ScanDepth.Deep);
+
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Sound),
+            "Deep depth adds the occupancy cross-check, which must agree on a healthy database.\n" + IntegrityReportText.Render(report));
+    }
+
+    /// <summary>
+    /// The limits block is not optional and not suppressible, including on a green report. A report that says "Sound"
+    /// without stating what it could not have seen is telling the operator something materially untrue.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void GreenReport_StillCarriesTheLimitsBlock()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var report = Scan();
+        var text = IntegrityReportText.Render(report);
+
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Sound));
+        Assert.That(text, Does.Contain("LIMITS OF THIS SCAN"));
+        Assert.That(text, Does.Contain("INTERNALLY CONSISTENT"), "the structural blind spot must be stated verbatim");
+    }
+
+    // ── Damage the scanner must find ─────────────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void TornDataPage_IsReportedWithItsChecksums()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        // Pick an allocated, non-reserved page from the healthy scan so the damage lands somewhere that matters.
+        var baseline = Scan();
+        Assert.That(baseline.Verdict, Is.EqualTo(IntegrityVerdict.Sound), "precondition: the database starts healthy");
+
+        var target = baseline.Identity.PageCount - 1;
+        DamagePage(BundlePath, target, page => page[IntegrityConstants.PageHeaderSize + 16] ^= 0xFF);
+
+        var report = Scan();
+
+        Assert.That(report.Verdict, Is.Not.EqualTo(IntegrityVerdict.Sound), "a flipped byte inside a page must not scan clean");
+        Assert.That(report.Findings.Any(f => f.Code == "CHK-PHY-01"), Is.True,
+            "the checksum check must fire.\n" + IntegrityReportText.Render(report));
+    }
+
+    /// <summary>
+    /// The scenario that most justifies offline-first: both meta slots damaged. The engine refuses to open at all, so an
+    /// engine-hosted checker is unavailable in exactly the case where someone most wants one. The offline scanner turns a
+    /// total loss into a diagnosis.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void BothMetaSlotsCorrupt_IsDiagnosedRatherThanUnopenable()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        DamagePage(BundlePath, 0, page => page.AsSpan(200, 64).Fill(0xAB));
+        DamagePage(BundlePath, 1, page => page.AsSpan(200, 64).Fill(0xCD));
+
+        var report = Scan();
+
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Unopenable));
+        var finding = report.Findings.FirstOrDefault(f => f.Code == "CHK-BOO-03");
+        Assert.That(finding, Is.Not.Null, "the meta-pair check must fire.\n" + IntegrityReportText.Render(report));
+        Assert.That(finding.Detail, Does.Contain("Slot 0"), "the report must say what was wrong with EACH slot, not just that it failed");
+        Assert.That(finding.Detail, Does.Contain("Slot 1"));
+    }
+
+    /// <summary>
+    /// One damaged meta slot is survivable by design — that is what the A/B pair is for — so the scan must still succeed
+    /// and pick the good slot, while saying out loud that the database is now running without a fallback.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void OneMetaSlotCorrupt_StillReadsTheOther()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var baseline = Scan();
+        var goodSlot = baseline.Identity.MetaSlot;
+        var badSlot = 1 - goodSlot;
+
+        DamagePage(BundlePath, badSlot, page => page.AsSpan(200, 64).Fill(0xAB));
+
+        var report = Scan();
+
+        Assert.That(report.Identity.MetaSlot, Is.EqualTo(goodSlot), "the surviving slot must still be selected");
+        Assert.That(report.Identity.Name, Is.EqualTo(CurrentDatabaseName), "identity must still be readable from the good slot");
+        Assert.That(report.Verdict, Is.Not.EqualTo(IntegrityVerdict.Unopenable), "one bad slot is not fatal");
+        Assert.That(report.Findings.Any(f => f.Code == "CHK-BOO-03"), Is.True, "but it must be reported");
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void NotATyphonDatabase_IsRejectedWithoutCrashing()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        // Overwrite the signature in both slots but keep each page's checksum valid, so the scanner reaches the identity
+        // check rather than stopping at the pair check.
+        for (var slot = 0; slot <= 1; slot++)
+        {
+            DamagePage(BundlePath, slot, page =>
+            {
+                page.AsSpan(PagedMMF.PageBaseHeaderSize, 32).Clear();
+                System.Text.Encoding.UTF8.GetBytes("NotTyphon").CopyTo(page.AsSpan(PagedMMF.PageBaseHeaderSize));
+                var crc = Crc32CUtil.ComputeSkipping(page, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+                BitConverter.GetBytes(crc).CopyTo(page.AsSpan(PageBaseHeader.PageChecksumOffset));
+            });
+        }
+
+        var report = Scan();
+
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Unopenable));
+        Assert.That(report.Findings.Any(f => f.Code == "CHK-BOO-02"), Is.True,
+            "the identity check must fire.\n" + IntegrityReportText.Render(report));
+    }
+
+    /// <summary>
+    /// A checker that crashes on the input it exists to diagnose is worse than useless, so garbage must produce a
+    /// <i>report</i>, never an exception. This is the traversal-safety requirement stated as a test.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void TotalGarbage_ProducesAReportRatherThanAnException()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var dataPath = Path.Combine(BundlePath, IntegrityConstants.DataFileName);
+        var length = new FileInfo(dataPath).Length;
+        var random = new Random(20260809);
+        var noise = new byte[length];
+        random.NextBytes(noise);
+        File.WriteAllBytes(dataPath, noise);
+
+        IntegrityReport report = null;
+        Assert.DoesNotThrow(() => report = Scan(ScanDepth.Deep), "a scan of pure noise must not throw");
+        Assert.That(report, Is.Not.Null);
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Unopenable));
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void TruncatedFile_IsReported()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var dataPath = Path.Combine(BundlePath, IntegrityConstants.DataFileName);
+        using (var fs = new FileStream(dataPath, FileMode.Open, FileAccess.Write))
+        {
+            fs.SetLength(fs.Length - 1024);
+        }
+
+        var report = Scan();
+
+        Assert.That(report.Findings.Any(f => f.Code == "CHK-BOO-01"), Is.True,
+            "a file truncated mid-page must be reported.\n" + IntegrityReportText.Render(report));
+    }
+
+    // ── Report shape ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void Report_RendersAsValidJson()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var report = Scan();
+        var json = IntegrityReportJson.Render(report);
+
+        Assert.DoesNotThrow(() => System.Text.Json.JsonDocument.Parse(json), "the report's JSON form must parse:\n" + json);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        Assert.That(doc.RootElement.GetProperty("verdict").GetString(), Is.EqualTo("Sound"));
+        Assert.That(doc.RootElement.GetProperty("reportVersion").GetInt32(), Is.EqualTo(IntegrityReport.ReportVersion));
+        Assert.That(doc.RootElement.GetProperty("limits").GetProperty("structural").GetString(), Is.Not.Empty,
+            "the limits block must survive into the machine-readable form too");
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void ExitCodes_DistinguishDivergenceFromDataLoss()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var sound = Scan();
+        Assert.That(sound.ExitCode, Is.EqualTo(0), "sound must be 0 so a CI gate passes");
+
+        DamagePage(BundlePath, 0, page => page.AsSpan(200, 64).Fill(0xAB));
+        DamagePage(BundlePath, 1, page => page.AsSpan(200, 64).Fill(0xCD));
+
+        Assert.That(Scan().ExitCode, Is.EqualTo(4), "unopenable must be distinguishable from every lesser verdict");
+    }
+
+    // ── Verify on open ───────────────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The clean-shutdown flag records that the last process closed properly, not that the bytes survived. A database
+    /// damaged while it was closed must be refused rather than served — that is the whole decision behind verify-on-open.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void DatabaseDamagedWhileClosed_IsRefusedOnOpen()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        DamagePage(BundlePath, 0, page => page.AsSpan(200, 64).Fill(0xAB));
+        DamagePage(BundlePath, 1, page => page.AsSpan(200, 64).Fill(0xCD));
+
+        using var reopened = BuildProviderWithoutDeleting();
+        var ex = Assert.Catch<Exception>(() =>
+        {
+            using var scope = reopened.CreateScope();
+            scope.ServiceProvider.GetRequiredService<ManagedPagedMMF>();
+        });
+
+        var integrity = FindIntegrityException(ex);
+        Assert.That(integrity, Is.Not.Null, "the open must fail with the integrity report attached, not a bare error");
+        Assert.That(integrity.Report.Verdict, Is.EqualTo(IntegrityVerdict.Unopenable));
+        Assert.That(integrity.Message, Does.Contain("typhon check"), "and must tell the operator what to run next");
+    }
+
+    /// <summary>
+    /// A database with a merely degraded structure still opens. Refusing it would be the cure being worse than the
+    /// disease — the point of the tier is to catch what makes opening actively harmful, not to be maximally strict.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void NonFatalFindings_DoNotBlockTheOpen()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        var baseline = Scan();
+        DamagePage(BundlePath, 1 - baseline.Identity.MetaSlot, page => page.AsSpan(300, 128).Fill(0xAB));
+
+        Assert.That(Scan().Findings.Any(f => f.Severity == IntegritySeverity.Divergence), Is.True, "precondition: a non-fatal finding exists");
+
+        using var reopened = BuildProviderWithoutDeleting();
+        Assert.DoesNotThrow(() =>
+        {
+            using var scope = reopened.CreateScope();
+            scope.ServiceProvider.GetRequiredService<ManagedPagedMMF>();
+        }, "one degraded meta slot must not stop the database opening from the other");
+    }
+
+    [Test]
+    [CancelAfter(30_000)]
+    public void VerificationCanBeTurnedOff()
+    {
+        BuildHealthyDatabase();
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        DamagePage(BundlePath, 0, page => page.AsSpan(200, 64).Fill(0xAB));
+        DamagePage(BundlePath, 1, page => page.AsSpan(200, 64).Fill(0xCD));
+
+        var services = new ServiceCollection();
+        services
+            .AddLogging(b => b.SetMinimumLevel(LogLevel.Critical))
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddScopedManagedPagedMemoryMappedFile(opts =>
+            {
+                opts.DatabaseName = CurrentDatabaseName;
+                opts.DatabaseDirectory = DbDir;
+                opts.VerifyOnOpen = OpenVerification.None;
+            });
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        // With verification off the open still fails — but through the engine's own meta-pair selection, not the checker.
+        // The escape hatch removes the instrument, not the underlying protection.
+        var ex = Assert.Catch<Exception>(() => scope.ServiceProvider.GetRequiredService<ManagedPagedMMF>());
+        Assert.That(FindIntegrityException(ex), Is.Null, "with verification off, the checker must not be what refuses the open");
+    }
+
+    /// <summary>
+    /// Builds a provider over the SAME on-disk database without deleting it first. <see cref="Setup"/> deliberately wipes
+    /// the file so each test starts clean; a reopen test must not, or it would be opening a database it just recreated.
+    /// </summary>
+    private ServiceProvider BuildProviderWithoutDeleting()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddLogging(b => b.SetMinimumLevel(LogLevel.Critical))
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddScopedManagedPagedMemoryMappedFile(opts =>
+            {
+                opts.DatabaseName = CurrentDatabaseName;
+                opts.DatabaseDirectory = DbDir;
+                opts.DatabaseCacheSize = (ulong)PagedMMF.MinimumCacheSize * 4;
+            });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static DatabaseIntegrityException FindIntegrityException(Exception ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is DatabaseIntegrityException integrity)
+            {
+                return integrity;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The spine tier is what runs on every open, so it must be bounded by segment count rather than database size. This
+    /// asserts the shape (it does not read page bodies) rather than a wall-clock number, which would be flaky.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void SpineTier_DoesNotSweepPages()
+    {
+        BuildHealthyDatabase(256);
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        using var source = new OfflineBundlePageSource(BundlePath);
+        var report = IntegrityScanner.VerifySpine(source);
+
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Sound));
+        Assert.That(report.Totals.PagesScanned, Is.Zero, "the spine tier must not sweep page bodies");
+        Assert.That(report.Totals.SegmentsWalked, Is.GreaterThan(0), "but it must still resolve every segment");
+        Assert.That(report.Limits.ChecksSkipped, Is.Not.Empty, "and it must say which checks it skipped");
+    }
+}

--- a/test/Typhon.Engine.Tests/Integrity/IntegrityScannerTests.cs
+++ b/test/Typhon.Engine.Tests/Integrity/IntegrityScannerTests.cs
@@ -512,23 +512,78 @@ internal sealed class IntegrityScannerTests
     }
 
     /// <summary>
-    /// The spine tier is what runs on every open, so it must be bounded by segment count rather than database size. This
-    /// asserts the shape (it does not read page bodies) rather than a wall-clock number, which would be flaky.
+    /// The spine tier runs on <b>every open</b>, so its cost must be bounded by the number of segments, not by the size
+    /// of the database. This asserts the I/O it actually performs.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The first version of this test asserted <c>Totals.PagesScanned == 0</c> and passed — while the implementation was
+    /// reading every page in the file on every open. That counter is only incremented by the <i>later</i> checksum sweep,
+    /// so it measured a different thing than the one that mattered and turned a serious performance defect into a green
+    /// test. The lesson is specific: when the claim is about cost, assert at the boundary where the cost is incurred.
+    /// </para>
+    /// <para>
+    /// The bound is expressed against page count rather than as a wall-clock number so it cannot be flaky, and it is
+    /// deliberately generous — the point is to catch O(database), not to police a constant.
+    /// </para>
+    /// </remarks>
     [Test]
     [CancelAfter(30_000)]
-    public void SpineTier_DoesNotSweepPages()
+    public void SpineTier_ReadsSegmentsNotTheWholeFile()
     {
-        BuildHealthyDatabase(256);
+        BuildHealthyDatabase(512);
         _serviceProvider.Dispose();
         _serviceProvider = null;
 
         using var source = new OfflineBundlePageSource(BundlePath);
         var report = IntegrityScanner.VerifySpine(source);
 
-        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Sound));
-        Assert.That(report.Totals.PagesScanned, Is.Zero, "the spine tier must not sweep page bodies");
-        Assert.That(report.Totals.SegmentsWalked, Is.GreaterThan(0), "but it must still resolve every segment");
-        Assert.That(report.Limits.ChecksSkipped, Is.Not.Empty, "and it must say which checks it skipped");
+        Assert.That(report.Verdict, Is.EqualTo(IntegrityVerdict.Sound), IntegrityReportText.Render(report));
+        Assert.That(report.Totals.SegmentsWalked, Is.GreaterThan(0), "it must still resolve the segments the bootstrap names");
+        Assert.That(report.Limits.ChecksSkipped, Is.Not.Empty, "and say which checks it skipped");
+
+        Assert.That(source.PagesRead, Is.LessThan(source.PageCount),
+            $"the spine tier read {source.PagesRead} pages of a {source.PageCount}-page database — it must not sweep the file. "
+            + "This tier is on by default at every open, so O(database) here is a tax on every open of every database.");
+
+        // A few pages per segment plus the meta pair. Generous, but O(segments) rather than O(pages) is the property.
+        var budget = (report.Totals.SegmentsWalked * 8L) + 16;
+        Assert.That(source.PagesRead, Is.LessThanOrEqualTo(budget),
+            $"read {source.PagesRead} pages for {report.Totals.SegmentsWalked} segments; the tier is meant to cost a few "
+            + "pages per segment.");
+    }
+
+    /// <summary>
+    /// The same bound, restated where it bites: growing the database must not grow what an open costs.
+    /// </summary>
+    [Test]
+    [CancelAfter(60_000)]
+    public void SpineTierCost_DoesNotGrowWithTheDatabase()
+    {
+        BuildHealthyDatabase(64);
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        long smallReads;
+        int smallPages;
+        using (var small = new OfflineBundlePageSource(BundlePath))
+        {
+            IntegrityScanner.VerifySpine(small);
+            smallReads = small.PagesRead;
+            smallPages = small.PageCount;
+        }
+
+        Setup();
+        BuildHealthyDatabase(30_000);
+        _serviceProvider.Dispose();
+        _serviceProvider = null;
+
+        using var big = new OfflineBundlePageSource(BundlePath);
+        IntegrityScanner.VerifySpine(big);
+
+        Assert.That(big.PageCount, Is.GreaterThan(smallPages * 4), "precondition: the second database is materially larger");
+        Assert.That(big.PagesRead, Is.LessThan(smallReads * 4),
+            $"spine read {smallReads} pages on a {smallPages}-page database and {big.PagesRead} on a {big.PageCount}-page one. "
+            + "The cost must track segment count, not file size.");
     }
 }

--- a/test/Typhon.Engine.Tests/Integrity/MetaPairStructuralFlushTests.cs
+++ b/test/Typhon.Engine.Tests/Integrity/MetaPairStructuralFlushTests.cs
@@ -1,0 +1,192 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// CK-05 regression: the structural flush path must never write the meta pair.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The page-0 meta pair exists so a torn write can never destroy the only copy of the root metadata: writes alternate
+/// between two physical slots, and the current slot is never overwritten in place. That guarantee holds only while
+/// <c>PersistMetaNow</c> is the <b>sole</b> writer of those two slots.
+/// </para>
+/// <para>
+/// It was not. <c>SavePages</c> — the structural ChangeSet flush — writes whatever pages the ChangeSet carries, and its
+/// checksum-stamping step is guarded by <c>FilePageIndex &gt; 0</c> while the <i>write</i> was not. A flush that happened
+/// to carry logical page 0 therefore overwrote meta slot 0 with an image whose stored checksum no longer matched its
+/// content. Nothing complained, because the other slot still opened the database — the pair had silently degraded to a
+/// single copy. The failure only surfaces later, when that surviving slot tears too and both slots read invalid, at which
+/// point the database is permanently unopenable. <c>CollectDirtyMemPageIndices</c> had the exclusion all along; this path
+/// is fed by a ChangeSet rather than by that scan, so it never applied.
+/// </para>
+/// <para>
+/// Found by the offline integrity scanner on its first run against a healthy database, which is the argument for having an
+/// independent detector: nothing inside the engine could notice, because every individual structure was well-formed.
+/// </para>
+/// </remarks>
+[TestFixture]
+internal sealed class MetaPairStructuralFlushTests
+{
+    private string _root;
+
+    private static string DbName => "Tmps_" + TestSeed.StableHash(TestContext.CurrentContext.Test.Name).ToString("X8");
+
+    private string DbDir => Path.Combine(_root, "db");
+
+    private string BundlePath => Path.Combine(DbDir, $"{DbName}.typhon");
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "Typhon.Tests", nameof(MetaPairStructuralFlushTests), DbName);
+        Directory.CreateDirectory(DbDir);
+        Directory.CreateDirectory(Path.Combine(_root, "wal"));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, true);
+            }
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+    }
+
+    /// <summary>
+    /// After a full engine lifecycle both meta slots must be individually checksum-valid. "At least one is valid" is the
+    /// weaker property that lets the database open; it is not the property the pair exists to provide.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void FullEngineLifecycle_LeavesBothMetaSlotsValid()
+    {
+        var writes = RunLifecycle();
+
+        var dataPath = Path.Combine(BundlePath, IntegrityConstants.DataFileName);
+        var slot0 = ReadPage(dataPath, 0);
+        var slot1 = ReadPage(dataPath, 1);
+
+        var report = Describe(slot0, 0) + "\n" + Describe(slot1, 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(IsValid(slot0), Is.True, "meta slot 0 must be checksum-valid:\n" + report);
+            Assert.That(IsValid(slot1), Is.True, "meta slot 1 must be checksum-valid:\n" + report);
+        });
+
+        // The generations must differ by exactly one: strict alternation is what makes the pair a pair. Two writes landing
+        // on the same slot in a row is the signature of a second writer, which is the bug this test guards.
+        var gen0 = PageBaseHeader.ReadPairGeneration(slot0);
+        var gen1 = PageBaseHeader.ReadPairGeneration(slot1);
+        Assert.That(Math.Abs((long)gen0 - (long)gen1), Is.EqualTo(1), "meta generations must be consecutive:\n" + report);
+
+        // And no slot may be written twice in a row during shutdown.
+        for (var i = 1; i < writes.Count; i++)
+        {
+            Assert.That(writes[i], Is.Not.EqualTo(writes[i - 1]),
+                $"meta-pair writes must strictly alternate; observed [{string.Join(", ", writes)}]");
+        }
+    }
+
+    /// <summary>Runs a representative lifecycle and returns the physical meta-pair page indices written during shutdown.</summary>
+    private List<int> RunLifecycle()
+    {
+        var writes = new List<int>();
+        var services = new ServiceCollection();
+        services
+            .AddLogging(b => b.SetMinimumLevel(LogLevel.Error))
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddHighResolutionSharedTimer()
+            .AddDeadlineWatchdog()
+            .AddScopedManagedPagedMemoryMappedFile(opts =>
+            {
+                opts.DatabaseName = DbName;
+                opts.DatabaseDirectory = DbDir;
+                opts.DatabaseCacheSize = (ulong)PagedMMF.MinimumCacheSize * 4;
+            })
+            .AddScopedDatabaseEngine(opts =>
+            {
+                opts.Wal = new WalWriterOptions
+                {
+                    WalDirectory = Path.Combine(_root, "wal"),
+                    GroupCommitIntervalMs = 5,
+                    UseFUA = false,
+                    SegmentSize = 4 * 1024 * 1024,
+                    PreAllocateSegments = 1
+                };
+            });
+
+        using var provider = services.BuildServiceProvider();
+        provider.EnsureFileDeleted<ManagedPagedMMFOptions>();
+
+        using var scope = provider.CreateScope();
+        var dbe = scope.ServiceProvider.GetRequiredService<DatabaseEngine>();
+        dbe.RegisterComponentFromAccessor<CompA>();
+        dbe.InitializeArchetypes();
+
+        using (var uow = dbe.CreateUnitOfWork(DurabilityMode.Immediate))
+        {
+            for (var i = 0; i < 64; i++)
+            {
+                using var tx = uow.CreateTransaction();
+                var comp = new CompA(i + 1, i, i);
+                tx.Spawn<CompAArch>(CompAArch.A.Set(in comp));
+                tx.Commit();
+            }
+
+            uow.Flush();
+        }
+
+        dbe.ForceCheckpoint();
+
+        // Record shutdown-time writes: this is where the structural flush and the clean-shutdown metadata write interleave.
+        var mmf = scope.ServiceProvider.GetRequiredService<ManagedPagedMMF>();
+        mmf.PageWriteInterceptor = idx =>
+        {
+            if (idx <= 1)
+            {
+                lock (writes)
+                {
+                    writes.Add(idx);
+                }
+            }
+        };
+
+        scope.Dispose();
+        return writes;
+    }
+
+    private static string Describe(byte[] page, int slot) =>
+        $"  slot {slot}: generation={PageBaseHeader.ReadPairGeneration(page)} stored=0x{StoredCrc(page):X8} "
+        + $"computed=0x{ComputedCrc(page):X8} valid={IsValid(page)} modificationCounter={BitConverter.ToInt32(page, 12)}";
+
+    private static bool IsValid(byte[] page) => StoredCrc(page) == ComputedCrc(page);
+
+    private static byte[] ReadPage(string path, int index)
+    {
+        var page = new byte[IntegrityConstants.PageSize];
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        fs.Seek(index * (long)IntegrityConstants.PageSize, SeekOrigin.Begin);
+        fs.ReadExactly(page);
+        return page;
+    }
+
+    private static uint StoredCrc(byte[] page) => BitConverter.ToUInt32(page, PageBaseHeader.PageChecksumOffset);
+
+    private static uint ComputedCrc(byte[] page) => Crc32CUtil.ComputeSkipping(page, PageBaseHeader.PageChecksumOffset, PageBaseHeader.PageChecksumSize);
+}

--- a/test/Typhon.Engine.Tests/Integrity/PageSectorFooterTests.cs
+++ b/test/Typhon.Engine.Tests/Integrity/PageSectorFooterTests.cs
@@ -1,0 +1,270 @@
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// Unit tests for the per-sector page verification footer — the format change that takes provable salvage after a torn
+/// write from 0 % of a page's rows to most of them.
+/// </summary>
+/// <remarks>
+/// The tests that matter most here are the two that pin down <i>currency</i> rather than integrity. A torn write leaves
+/// one region holding a valid image of the previous generation: its checksum passes, and only the generation stamp can
+/// tell that it is stale. And the rule for reading those stamps has to be the maximum over all of them, because comparing
+/// each against the page header is unsafe in the one direction that matters.
+/// </remarks>
+[TestFixture]
+internal sealed class PageSectorFooterTests
+{
+    private static byte[] MakePage(int reservedMetadataBytes, int changeRevision, byte fill = 0x5A)
+    {
+        var page = new byte[PagedMMF.PageSize];
+        new Random(1234).NextBytes(page);
+        page.AsSpan(PagedMMF.PageHeaderSize).Fill(fill);
+        PageSectorFooter.DeclareGeometry(page, reservedMetadataBytes);
+        BitConverter.GetBytes(changeRevision).CopyTo(page.AsSpan(4));
+        return page;
+    }
+
+    private static int Verify(byte[] page, out bool footerIntact)
+    {
+        var n = PageSectorFooter.ReadSectorCount(page);
+        Span<bool> ok = stackalloc bool[PageSectorFooter.MaxSectorCount];
+        footerIntact = PageSectorFooter.Verify(page, n, ok, out var failed);
+        return failed;
+    }
+
+    // ── Geometry ─────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void Geometry_ShrinksAsTheChunkBitmapGrows()
+    {
+        // The footer and the chunk-occupancy bitmap share the metadata region, so the achievable granularity falls as the
+        // segment's stride shrinks (a smaller stride means more chunks per page, means more bitmap words).
+        Assert.Multiple(() =>
+        {
+            Assert.That(PageSectorFooter.ChooseSectorCount(0), Is.EqualTo(16), "a page with no chunk bitmap gets the finest granularity");
+            Assert.That(PageSectorFooter.ChooseSectorCount(8), Is.EqualTo(16), "a cluster page (1 bitmap word) still gets 16");
+            Assert.That(PageSectorFooter.ChooseSectorCount(32), Is.EqualTo(16));
+            Assert.That(PageSectorFooter.ChooseSectorCount(40), Is.EqualTo(8), "5 bitmap words leaves room for 8");
+            Assert.That(PageSectorFooter.ChooseSectorCount(112), Is.EqualTo(2));
+            Assert.That(PageSectorFooter.ChooseSectorCount(128), Is.Zero, "a stride-8 segment fills the region; no footer fits");
+        });
+    }
+
+    [Test]
+    public void Geometry_NeverOverlapsTheChunkBitmap()
+    {
+        for (var reserved = 0; reserved <= 128; reserved += 8)
+        {
+            var n = PageSectorFooter.ChooseSectorCount(reserved);
+            if (n == 0)
+            {
+                continue;
+            }
+
+            Assert.That(PageSectorFooter.FooterBase(n), Is.GreaterThanOrEqualTo(PageSectorFooter.MetadataOffset + reserved),
+                $"footer for {n} sectors must start after {reserved} reserved bitmap bytes");
+        }
+    }
+
+    [Test]
+    public void ReadSectorCount_RejectsAnInconsistentDeclaration()
+    {
+        var page = MakePage(0, 1);
+        Assert.That(PageSectorFooter.ReadSectorCount(page), Is.EqualTo(16), "precondition");
+
+        page[PageSectorFooter.SectorLogSizeOffset] = 7;   // inconsistent with a count of 16
+        Assert.That(PageSectorFooter.ReadSectorCount(page), Is.Zero, "a self-inconsistent declaration must be treated as unstamped");
+
+        page = MakePage(0, 1);
+        page[PageSectorFooter.SectorCountOffset] = 7;     // not a legal count
+        Assert.That(PageSectorFooter.ReadSectorCount(page), Is.Zero);
+    }
+
+    // ── Integrity ────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void FreshlyStampedPage_VerifiesCompletely()
+    {
+        var page = MakePage(0, 42);
+        PageSectorFooter.Stamp(page, 16);
+
+        var failed = Verify(page, out var footerIntact);
+
+        Assert.That(footerIntact, Is.True);
+        Assert.That(failed, Is.Zero);
+    }
+
+    [Test]
+    public void ByteFlipInOneSector_CondemnsOnlyThatSector()
+    {
+        var page = MakePage(0, 42);
+        PageSectorFooter.Stamp(page, 16);
+
+        const int sectorSize = PagedMMF.PageSize / 16;
+        page[(7 * sectorSize) + 100] ^= 0xFF;
+
+        var n = PageSectorFooter.ReadSectorCount(page);
+        Span<bool> ok = stackalloc bool[PageSectorFooter.MaxSectorCount];
+        PageSectorFooter.Verify(page, n, ok, out var failed);
+
+        Assert.That(failed, Is.EqualTo(1), "exactly one sector must be condemned");
+        Assert.That(ok[7], Is.False, "and it must be the one that was damaged");
+        for (var s = 0; s < 16; s++)
+        {
+            if (s != 7)
+            {
+                Assert.That(ok[s], Is.True, $"sector {s} was untouched and must still verify — this is the salvage the format exists for");
+            }
+        }
+    }
+
+    // ── Currency: the part a checksum alone cannot do ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A torn write leaves part of the page holding a valid image of the previous generation. Every byte of it is
+    /// intact and its checksum passes — it is simply <i>old</i>. Without a currency stamp the page would verify clean
+    /// while silently serving stale rows, which is strictly worse than reporting damage.
+    /// </summary>
+    [Test]
+    public void StaleSectorFromAPreviousGeneration_IsCaughtEvenThoughItsChecksumPasses()
+    {
+        var generationOld = MakePage(0, 100);
+        PageSectorFooter.Stamp(generationOld, 16);
+
+        // Generation 101 rewrites the page's contents...
+        var generationNew = (byte[])generationOld.Clone();
+        generationNew.AsSpan(PagedMMF.PageHeaderSize).Fill(0xC3);
+        BitConverter.GetBytes(101).CopyTo(generationNew.AsSpan(4));
+        PageSectorFooter.Stamp(generationNew, 16);
+
+        // ...but sectors 9-15 never landed, so they still hold generation 100's bytes AND generation 100's footer entries.
+        const int sectorSize = PagedMMF.PageSize / 16;
+        var torn = (byte[])generationNew.Clone();
+        for (var s = 9; s < 16; s++)
+        {
+            generationOld.AsSpan(s * sectorSize, sectorSize).CopyTo(torn.AsSpan(s * sectorSize));
+            // The footer entries for those sectors are in sector 0, which DID land — so restore them individually to model
+            // a tear that also missed the footer bytes for the affected sectors.
+            var crcOffset = PageSectorFooter.FooterBase(16) + (s * 4);
+            var genOffset = PageSectorFooter.FooterBase(16) + (16 * 4) + (s * 2);
+            generationOld.AsSpan(crcOffset, 4).CopyTo(torn.AsSpan(crcOffset));
+            generationOld.AsSpan(genOffset, 2).CopyTo(torn.AsSpan(genOffset));
+        }
+
+        // Re-seal the footer array so the footer's own CRC matches, which is what a real torn write would leave if the
+        // tear boundary fell after sector 0.
+        var footerBase = PageSectorFooter.FooterBase(16);
+        var footerCrc = Crc32CUtil.Compute(torn.AsSpan(footerBase, PageSectorFooter.FooterEndOffset - footerBase));
+        BitConverter.GetBytes(footerCrc).CopyTo(torn.AsSpan(PageBaseHeader.PageChecksumOffset));
+
+        Span<bool> ok = stackalloc bool[PageSectorFooter.MaxSectorCount];
+        var footerIntact = PageSectorFooter.Verify(torn, 16, ok, out var failed);
+
+        Assert.That(footerIntact, Is.True, "the footer itself survived; the sectors are what is stale");
+        Assert.That(failed, Is.EqualTo(7), "all seven stale sectors must be condemned despite their checksums passing");
+        for (var s = 0; s < 9; s++)
+        {
+            Assert.That(ok[s], Is.True, $"sector {s} is current and must survive");
+        }
+    }
+
+    /// <summary>
+    /// The validity rule must take the <b>maximum</b> generation across the header and every sector stamp. The obvious
+    /// alternative — compare each sector against the page header — inverts when it is sector 0 that failed to persist:
+    /// the header then reads the OLD generation, so every stale sector agrees with it and the one sector that actually
+    /// landed is the one condemned. That is the worst possible answer, because it selects for stale data.
+    /// </summary>
+    [Test]
+    public void WhenSectorZeroIsTheStaleOne_TheRuleDoesNotInvert()
+    {
+        var page = MakePage(0, 100);
+        PageSectorFooter.Stamp(page, 16);
+
+        // Sector 5 persisted at generation 101; everything else, including the header in sector 0, is still at 100.
+        const int sectorSize = PagedMMF.PageSize / 16;
+        page.AsSpan(5 * sectorSize, sectorSize).Fill(0xE1);
+        var newCrc = PageSectorFooter.ComputeSectorCrc(page, 16, 5);
+        BitConverter.GetBytes(newCrc).CopyTo(page.AsSpan(PageSectorFooter.FooterBase(16) + (5 * 4)));
+        BitConverter.GetBytes((ushort)101).CopyTo(page.AsSpan(PageSectorFooter.FooterBase(16) + (16 * 4) + (5 * 2)));
+
+        var footerBase = PageSectorFooter.FooterBase(16);
+        var footerCrc = Crc32CUtil.Compute(page.AsSpan(footerBase, PageSectorFooter.FooterEndOffset - footerBase));
+        BitConverter.GetBytes(footerCrc).CopyTo(page.AsSpan(PageBaseHeader.PageChecksumOffset));
+
+        Span<bool> ok = stackalloc bool[PageSectorFooter.MaxSectorCount];
+        PageSectorFooter.Verify(page, 16, ok, out var failed);
+
+        Assert.That(ok[5], Is.True, "the sector that DID persist at the newest generation must be kept");
+        Assert.That(failed, Is.EqualTo(15), "and every sector still at the older generation must be condemned");
+    }
+
+    [Test]
+    public void GenerationComparison_HandlesWraparound()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(PageSectorFooter.GenerationIsNewer(5, 4), Is.True);
+            Assert.That(PageSectorFooter.GenerationIsNewer(4, 5), Is.False);
+            Assert.That(PageSectorFooter.GenerationIsNewer(0, ushort.MaxValue), Is.True, "0 follows 65535");
+            Assert.That(PageSectorFooter.GenerationIsNewer(ushort.MaxValue, 0), Is.False);
+            Assert.That(PageSectorFooter.GenerationIsNewer(7, 7), Is.False, "equal is not newer");
+        });
+    }
+
+    // ── Round-trip through the engine's own stamp/verify pair ────────────────────────────────────────────────────────
+
+    [Test]
+    public void StampPageForWrite_AndVerifyPageImage_AgreeForBothForms()
+    {
+        var sectored = MakePage(0, 7);
+        PagedMMF.StampPageForWrite(sectored, 41208);
+        Assert.That(PagedMMF.VerifyPageImage(sectored, out _), Is.True, "a page declaring sectors must verify through the sector path");
+        Assert.That(PageSectorFooter.ReadFilePageIndex(sectored), Is.EqualTo(41208), "and must carry its own index");
+
+        var wholePage = MakePage(128, 7);   // no room for a footer
+        Assert.That(PageSectorFooter.ReadSectorCount(wholePage), Is.Zero, "precondition: this page declares no footer");
+        PagedMMF.StampPageForWrite(wholePage, 99);
+        Assert.That(PagedMMF.VerifyPageImage(wholePage, out _), Is.True, "a page with no footer must verify through the whole-page path");
+    }
+
+    [Test]
+    public void StampPageForWrite_DetectsATamperedPageInBothForms()
+    {
+        foreach (var reserved in new[] { 0, 128 })
+        {
+            var page = MakePage(reserved, 7);
+            PagedMMF.StampPageForWrite(page, 12);
+            page[PagedMMF.PageHeaderSize + 500] ^= 0x01;
+            Assert.That(PagedMMF.VerifyPageImage(page, out _), Is.False, $"a flipped bit must be caught (reserved={reserved})");
+        }
+    }
+
+    /// <summary>
+    /// Every legal geometry must round-trip, not just the 16-sector one — a small-stride segment gets fewer sectors and
+    /// its pages still have to verify.
+    /// </summary>
+    [Test]
+    public void EveryLegalGeometry_RoundTrips()
+    {
+        foreach (var reserved in new[] { 0, 8, 40, 80, 112 })
+        {
+            var n = PageSectorFooter.ChooseSectorCount(reserved);
+            var page = MakePage(reserved, 3);
+            Assert.That(PageSectorFooter.ReadSectorCount(page), Is.EqualTo(n), $"declared geometry must read back (reserved={reserved})");
+
+            PageSectorFooter.Stamp(page, n);
+            var failed = Verify(page, out var footerIntact);
+            Assert.That(footerIntact, Is.True, $"footer must verify for {n} sectors");
+            Assert.That(failed, Is.Zero, $"all {n} sectors must verify");
+
+            // And the bitmap region must be untouched by stamping.
+            var bitmap = page.AsSpan(PageSectorFooter.MetadataOffset, reserved).ToArray();
+            PageSectorFooter.Stamp(page, n);
+            Assert.That(page.AsSpan(PageSectorFooter.MetadataOffset, reserved).ToArray().SequenceEqual(bitmap), Is.True,
+                $"stamping must never write into the chunk bitmap (reserved={reserved})");
+        }
+    }
+}

--- a/test/Typhon.Engine.Tests/Integrity/SectorGeometryDeclarationTests.cs
+++ b/test/Typhon.Engine.Tests/Integrity/SectorGeometryDeclarationTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace Typhon.Engine.Tests;
+
+/// <summary>
+/// The per-sector footer and the chunk-occupancy bitmap share a page's 128-byte metadata region — the bitmap growing up
+/// from its start, the footer down from its end. This fixture pins the invariant that keeps them apart.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The subtle part is <b>when</b> the geometry is decided. Page initialisation happens in the base logical segment,
+/// which knows nothing about strides; the chunk bitmap's size is known only to the chunk-based subclass. An
+/// implementation that let the base declare a default and had the subclass narrow it afterwards would be wrong in a way
+/// that no single-threaded test detects: <c>CreateOrGrow</c> unlatches each page while it is still dirty, so a
+/// checkpoint can persist it in the window between the two declarations. A page persisted while transiently declaring 16
+/// sectors puts its footer at <c>[96,192)</c> — straight through the bitmap of any segment whose stride needs more than
+/// 24 bytes of it.
+/// </para>
+/// <para>
+/// The symptom of getting this wrong is not a checksum failure. It is silently corrupted chunk allocation: bits flipped
+/// under the allocator, chunks handed out twice or lost, and — downstream — a B+Tree descent reaching a leaf it can
+/// neither validate nor modify. So the invariant is asserted directly, on real pages, rather than trusted.
+/// </para>
+/// </remarks>
+[TestFixture]
+internal sealed class SectorGeometryDeclarationTests
+{
+    private string _root;
+    private ServiceProvider _serviceProvider;
+
+    private static string DbName => "Tsgd_" + TestSeed.StableHash(TestContext.CurrentContext.Test.Name).ToString("X8");
+
+    [SetUp]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "Typhon.Tests", nameof(SectorGeometryDeclarationTests), DbName);
+        Directory.CreateDirectory(_root);
+
+        var services = new ServiceCollection();
+        services
+            .AddLogging(b => b.SetMinimumLevel(LogLevel.Error))
+            .AddResourceRegistry()
+            .AddMemoryAllocator()
+            .AddEpochManager()
+            .AddScopedManagedPagedMemoryMappedFile(opts =>
+            {
+                opts.DatabaseName = DbName;
+                opts.DatabaseDirectory = _root;
+                opts.DatabaseCacheSize = (ulong)PagedMMF.MinimumCacheSize * 4;
+            });
+
+        _serviceProvider = services.BuildServiceProvider();
+        _serviceProvider.EnsureFileDeleted<ManagedPagedMMFOptions>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _serviceProvider?.Dispose();
+        _serviceProvider = null;
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, true);
+            }
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+    }
+
+    /// <summary>
+    /// Every page of a chunk-based segment, at every stride, must declare a footer that starts at or after the end of its
+    /// own chunk bitmap — immediately after creation and again after a grow.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    [TestCase(8, TestName = "SectorGeometry_NeverOverlapsBitmap(stride 8 — bitmap fills the region)")]
+    [TestCase(16, TestName = "SectorGeometry_NeverOverlapsBitmap(stride 16)")]
+    [TestCase(24, TestName = "SectorGeometry_NeverOverlapsBitmap(stride 24)")]
+    [TestCase(32, TestName = "SectorGeometry_NeverOverlapsBitmap(stride 32)")]
+    [TestCase(64, TestName = "SectorGeometry_NeverOverlapsBitmap(stride 64)")]
+    [TestCase(320, TestName = "SectorGeometry_NeverOverlapsBitmap(stride 320 — cluster-like)")]
+    public void SectorGeometry_NeverOverlapsBitmap(int stride)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var mmf = scope.ServiceProvider.GetRequiredService<ManagedPagedMMF>();
+
+        var changeSet = mmf.CreateChangeSet();
+        var segment = mmf.AllocateChunkBasedSegment(PageBlockType.None, 4, stride, changeSet, StorageSegmentKind.Component);
+        changeSet.SaveChanges();
+
+        AssertEveryPageIsSafe(mmf, segment, stride, "after Create");
+
+        // Force a grow through the real path — allocating past capacity — since that is where the base initialises pages
+        // the subclass then finishes, and therefore where a transient over-declaration would land.
+        var growSet = mmf.CreateChangeSet();
+        var target = (segment.ChunkCountPerPage * 5) + 16;
+        for (var i = 0; i < target; i++)
+        {
+            segment.AllocateChunk(clearContent: false, growSet);
+        }
+
+        growSet.SaveChanges();
+        Assert.That(segment.Length, Is.GreaterThan(4), "precondition: the segment actually grew");
+
+        AssertEveryPageIsSafe(mmf, segment, stride, "after Grow");
+    }
+
+    private static void AssertEveryPageIsSafe(ManagedPagedMMF mmf, ChunkBasedSegment<PersistentStore> segment, int stride, string phase)
+    {
+        var buffer = new byte[PagedMMF.PageSize];
+
+        for (var i = 0; i < segment.Length; i++)
+        {
+            var filePage = segment.Pages[i];
+            mmf.ReadPageDirect(filePage, buffer);
+
+            var declared = PageSectorFooter.ReadSectorCount(buffer);
+            if (declared == 0)
+            {
+                continue;   // whole-page checksum: no footer, nothing to overlap
+            }
+
+            var chunkCount = i == 0 ? segment.ChunkCountRootPage : segment.ChunkCountPerPage;
+            var bitmapBytes = ((chunkCount + 63) >> 6) * sizeof(long);
+            var footerBase = PageSectorFooter.FooterBase(declared);
+
+            Assert.That(footerBase, Is.GreaterThanOrEqualTo(PageSectorFooter.MetadataOffset + bitmapBytes),
+                $"{phase}: page {filePage} (segment page {i}, stride {stride}) declares {declared} sectors, putting its "
+                + $"footer at [{footerBase},192) — but its chunk bitmap occupies "
+                + $"[{PageSectorFooter.MetadataOffset},{PageSectorFooter.MetadataOffset + bitmapBytes}). Stamping that "
+                + "footer would write over the bitmap and silently corrupt chunk allocation.");
+        }
+    }
+
+    /// <summary>
+    /// The bitmap must survive a page being stamped, which is the property the overlap invariant exists to protect. This
+    /// checks it by construction rather than by inference: fill a page's bitmap, stamp it, and compare.
+    /// </summary>
+    [Test]
+    [CancelAfter(30_000)]
+    public void StampingAPage_LeavesItsChunkBitmapByteIdentical()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var mmf = scope.ServiceProvider.GetRequiredService<ManagedPagedMMF>();
+
+        var changeSet = mmf.CreateChangeSet();
+        var segment = mmf.AllocateChunkBasedSegment(PageBlockType.None, 4, 16, changeSet, StorageSegmentKind.Component);
+        changeSet.SaveChanges();
+
+        // Allocate a spread of chunks so the bitmap holds a distinctive pattern rather than zeros.
+        for (var i = 0; i < 64; i++)
+        {
+            segment.AllocateChunk(clearContent: false);
+        }
+
+        var buffer = new byte[PagedMMF.PageSize];
+        mmf.ReadPageDirect(segment.Pages[1], buffer);
+
+        var bitmapBytes = ((segment.ChunkCountPerPage + 63) >> 6) * sizeof(long);
+        var before = buffer.AsSpan(PageSectorFooter.MetadataOffset, bitmapBytes).ToArray();
+
+        PagedMMF.StampPageForWrite(buffer, segment.Pages[1]);
+
+        var after = buffer.AsSpan(PageSectorFooter.MetadataOffset, bitmapBytes).ToArray();
+        Assert.That(after, Is.EqualTo(before), "stamping a page must never touch its chunk-occupancy bitmap");
+        Assert.That(PagedMMF.VerifyPageImage(buffer, out _), Is.True, "and the stamped page must verify");
+    }
+}

--- a/tools/Typhon.Workbench/ClientApp/e2e/integrity.spec.ts
+++ b/tools/Typhon.Workbench/ClientApp/e2e/integrity.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+// #729 — the Database Integrity view, driven end to end against a *deliberately damaged* database.
+//
+// The damage is the point. A canary over a healthy fixture can only ever assert the green path, which is the
+// one outcome whose regression matters least: the verdict banner's non-green states, the findings table, the
+// repair plan, the consent gate and the receipt are all unreachable without real damage. So each spec seeds a
+// database, corrupts it through the DEBUG-only fixture endpoint, and drives the UI over the result.
+
+const BASE = 'http://localhost:5173';
+// Kestrel resolves a bare filePath against its own working directory (tools/Typhon.Workbench), not DemoData.
+const SERVER_CWD = path.resolve('..');
+
+function bundlePath(name: string): string {
+  return path.join(SERVER_CWD, name);
+}
+
+/**
+ * Creates a fresh, initialised, closed `.typhon` bundle and returns its absolute path.
+ *
+ * Deletes any previous one first, which is not mere tidiness: these specs deliberately leave damaged
+ * databases behind, and the `unopenable` variant leaves one that by construction *cannot* be opened. Reusing
+ * it would fail the seed itself on the second run — the spec would pass once and then fail forever, which is
+ * worse than failing outright because it looks like a regression in the feature rather than in the fixture.
+ */
+async function seedBundle(request: APIRequestContext, name: string): Promise<string> {
+  const bundle = bundlePath(name);
+  // Leftover pre-repair backups accumulate one directory per run otherwise.
+  for (const entry of fs.existsSync(SERVER_CWD) ? fs.readdirSync(SERVER_CWD) : []) {
+    if (entry === name || entry.startsWith(`${name}.pre-repair-`)) {
+      fs.rmSync(path.join(SERVER_CWD, entry), { recursive: true, force: true });
+    }
+  }
+
+  const open = await request.post(`${BASE}/api/sessions/file`, { data: { filePath: name } });
+  expect(open.ok(), 'seeding the fixture database must succeed').toBeTruthy();
+  const { sessionId } = await open.json();
+  // Closed immediately: repair needs exclusive access, and a scan of a live database can only ever report
+  // `Suspected` confidence.
+  await request.delete(`${BASE}/api/sessions/${sessionId}`, { headers: { 'X-Session-Token': sessionId } });
+  return bundle;
+}
+
+async function damage(request: APIRequestContext, bundle: string, variant: string): Promise<string> {
+  const res = await request.post(`${BASE}/api/fixtures/damaged`, { data: { path: bundle, variant } });
+  expect(res.ok(), `damaging the fixture (${variant}) must succeed`).toBeTruthy();
+  const body = await res.json();
+  return body.verdict as string;
+}
+
+function dataHash(bundle: string): string {
+  return crypto.createHash('sha256').update(fs.readFileSync(path.join(bundle, 'data'))).digest('hex');
+}
+
+/** Opens the view from the Welcome screen — the no-session entry, and the one that matters most. */
+async function openIntegrityFromWelcome(page: import('@playwright/test').Page, bundle: string) {
+  await page.goto('/');
+  await page.getByTestId('welcome-check-integrity').click();
+  await expect(page.getByTestId('integrity-standalone')).toBeVisible();
+  await page.getByTestId('integrity-path').fill(bundle);
+}
+
+test.describe('#729 Database Integrity', () => {
+  test('reachable with no session, and reports damage on a database that is not open', async ({ page, request }) => {
+    const bundle = await seedBundle(request, 'e2e-integrity-damage.typhon');
+    expect(await damage(request, bundle, 'meta-slot')).toBe('Divergent');
+
+    await openIntegrityFromWelcome(page, bundle);
+    await page.getByTestId('integrity-scan').click();
+
+    await expect(page.getByTestId('integrity-verdict-badge')).toContainText('Divergent');
+    // The findings table must actually have rows — a verdict with an empty table would mean the report
+    // rendered its headline and dropped its evidence.
+    await expect(page.getByTestId('integrity-finding-row')).not.toHaveCount(0);
+    await expect(page.getByTestId('integrity-totals')).toBeVisible();
+  });
+
+  test('the Limits block renders on a GREEN report and cannot be collapsed', async ({ page, request }) => {
+    // The single most suppressible piece of the report, and the one the design forbids suppressing: a scan
+    // verifies internal consistency only, and the moment that gap is most likely to mislead is exactly when
+    // everything passed and the reader stops reading.
+    const bundle = await seedBundle(request, 'e2e-integrity-green.typhon');
+
+    await openIntegrityFromWelcome(page, bundle);
+    await page.getByTestId('integrity-scan').click();
+
+    await expect(page.getByTestId('integrity-verdict-badge')).toContainText('Sound');
+    const limits = page.getByTestId('integrity-limits');
+    await expect(limits).toBeVisible();
+    await expect(limits).toContainText(/limits of this scan/i);
+    // No disclosure control of any kind inside the block — no <details>, no toggle button.
+    await expect(limits.locator('details, button, [role="button"]')).toHaveCount(0);
+  });
+
+  test('plan → dry run → apply → verified green, with the dry run mutating nothing', async ({ page, request }) => {
+    const bundle = await seedBundle(request, 'e2e-integrity-repair.typhon');
+    await damage(request, bundle, 'meta-slot');
+
+    await openIntegrityFromWelcome(page, bundle);
+    await page.getByTestId('integrity-scan').click();
+    await expect(page.getByTestId('integrity-verdict-badge')).toContainText('Divergent');
+
+    // Plan — read-only, and it must produce steps or there is nothing to review.
+    await page.getByTestId('integrity-plan').click();
+    await expect(page.getByTestId('integrity-repair')).toBeVisible();
+    await expect(page.getByTestId('integrity-step-row')).not.toHaveCount(0);
+
+    // Dry run — the file must come back byte-identical. This is the assertion that makes "rehearsal" mean
+    // something; without it "dry run" is a label on a button.
+    const before = dataHash(bundle);
+    await page.getByTestId('integrity-dry-run').click();
+    await expect(page.getByTestId('integrity-rehearsal')).toBeVisible();
+    expect(dataHash(bundle), 'a dry run must not write a single byte').toBe(before);
+
+    // Apply — and the receipt must carry the post-repair verification, not just a success flag.
+    await page.getByTestId('integrity-apply').click();
+    await expect(page.getByTestId('integrity-receipt')).toBeVisible();
+    await expect(page.getByTestId('integrity-result-row')).not.toHaveCount(0);
+    await expect(page.getByTestId('integrity-verification')).toContainText('Sound');
+    expect(dataHash(bundle), 'a real repair must write').not.toBe(before);
+  });
+
+  test('an unopenable database still produces a report', async ({ page, request }) => {
+    // The case that most justifies the whole feature: no engine can open this, so no session-scoped view
+    // could ever have shown it.
+    const bundle = await seedBundle(request, 'e2e-integrity-unopenable.typhon');
+    expect(await damage(request, bundle, 'unopenable')).toBe('Unopenable');
+
+    await openIntegrityFromWelcome(page, bundle);
+    await page.getByTestId('integrity-scan').click();
+
+    await expect(page.getByTestId('integrity-verdict-badge')).toContainText('Unopenable');
+    await expect(page.getByTestId('integrity-limits')).toBeVisible();
+  });
+
+  test('a stale plan is refused with the server’s own words, not a status code', async ({ page, request }) => {
+    const bundle = await seedBundle(request, 'e2e-integrity-stale.typhon');
+    await damage(request, bundle, 'meta-slot');
+
+    await openIntegrityFromWelcome(page, bundle);
+    await page.getByTestId('integrity-scan').click();
+    await page.getByTestId('integrity-plan').click();
+    await expect(page.getByTestId('integrity-repair')).toBeVisible();
+
+    // Move the database underneath the reviewed plan, then apply it.
+    await damage(request, bundle, 'checksum');
+    await page.getByTestId('integrity-apply').click();
+
+    // The point is the sentence, not the 409: the server explains what to do about it, and that explanation
+    // must survive the client's error handling.
+    await expect(page.getByTestId('integrity-apply-error')).toContainText(/database has changed since the plan was reviewed/i);
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/schema/openapi.json
+++ b/tools/Typhon.Workbench/ClientApp/schema/openapi.json
@@ -1031,6 +1031,138 @@
         ]
       }
     },
+    "/api/integrity/scan": {
+      "post": {
+        "tags": [
+          "Integrity"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrityScanRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrityScanRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrityScanRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrityReportDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
+    "/api/integrity/plan": {
+      "post": {
+        "tags": [
+          "Integrity"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrityScanRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrityScanRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrityScanRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepairPlanDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
+    "/api/integrity/apply": {
+      "post": {
+        "tags": [
+          "Integrity"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepairApplyRequestDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepairApplyRequestDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepairApplyRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepairOutcomeDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": [ ]
+          }
+        ]
+      }
+    },
     "/api/options": {
       "get": {
         "tags": [
@@ -3445,7 +3577,8 @@
   "components": {
     "schemas": {
       "AdaptiveWaiterTransitionKind": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Variant of an TraceEventKind.ConcurrencyAdaptiveWaiterYieldOrSleep event."
       },
       "AggregationQueryDto": {
         "required": [
@@ -5315,10 +5448,12 @@
         }
       },
       "GcReason": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Reason the CLR triggered a garbage collection. Values match `GCStart_V2.Reason` from the\r\n`Microsoft-Windows-DotNETRuntime` EventSource — do not renumber."
       },
       "GcSuspendReason": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Reason the CLR suspended the execution engine. Values match `GCSuspendEEBegin_V1.Reason` from the\r\n`Microsoft-Windows-DotNETRuntime` EventSource — do not renumber."
       },
       "GcSuspensionDto": {
         "required": [
@@ -5355,7 +5490,8 @@
         }
       },
       "GcType": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Type classification of a garbage collection. Values match `GCStart_V2.Type` from the\r\n`Microsoft-Windows-DotNETRuntime` EventSource — do not renumber."
       },
       "GlobalMetricsDto": {
         "required": [
@@ -5514,8 +5650,449 @@
           }
         }
       },
+      "IntegrityFindingDto": {
+        "required": [
+          "code",
+          "severity",
+          "confidence",
+          "summary",
+          "detail",
+          "ruleId",
+          "repair",
+          "occurrences",
+          "locus",
+          "loss"
+        ],
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "severity": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "confidence": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "summary": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ruleId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "repair": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "occurrences": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int64"
+          },
+          "locus": {
+            "$ref": "#/components/schemas/IntegrityLocusDto"
+          },
+          "loss": {
+            "$ref": "#/components/schemas/IntegrityLossDto"
+          }
+        }
+      },
+      "IntegrityIdentityDto": {
+        "required": [
+          "name",
+          "formatRevision",
+          "pageCount",
+          "sizeBytes",
+          "checkpointLsn",
+          "cleanShutdown",
+          "walSegmentCount",
+          "walBytes"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "formatRevision": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "pageCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "sizeBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int64"
+          },
+          "checkpointLsn": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int64"
+          },
+          "cleanShutdown": {
+            "type": "boolean"
+          },
+          "walSegmentCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "walBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int64"
+          }
+        }
+      },
+      "IntegrityLimitsDto": {
+        "required": [
+          "structural",
+          "checksSkipped",
+          "caveats"
+        ],
+        "type": "object",
+        "properties": {
+          "structural": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "checksSkipped": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "caveats": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "IntegrityLocusDto": {
+        "required": [
+          "filePageIndex",
+          "segmentRootPage",
+          "kind",
+          "archetype",
+          "component",
+          "text"
+        ],
+        "type": "object",
+        "properties": {
+          "filePageIndex": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "segmentRootPage": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "kind": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "archetype": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "component": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "text": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "IntegrityLossDto": {
+        "required": [
+          "kind",
+          "count",
+          "archetype",
+          "component",
+          "explanation"
+        ],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "count": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "archetype": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "component": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "explanation": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "IntegrityReportDto": {
+        "required": [
+          "verdict",
+          "exitCode",
+          "source",
+          "mode",
+          "depth",
+          "durationMs",
+          "identity",
+          "totals",
+          "findings",
+          "limits"
+        ],
+        "type": "object",
+        "properties": {
+          "verdict": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "exitCode": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "source": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "mode": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "depth": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "durationMs": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "identity": {
+            "$ref": "#/components/schemas/IntegrityIdentityDto"
+          },
+          "totals": {
+            "$ref": "#/components/schemas/IntegrityTotalsDto"
+          },
+          "findings": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IntegrityFindingDto"
+            }
+          },
+          "limits": {
+            "$ref": "#/components/schemas/IntegrityLimitsDto"
+          }
+        }
+      },
+      "IntegrityScanRequestDto": {
+        "required": [
+          "path"
+        ],
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "depth": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": "standard"
+          }
+        }
+      },
+      "IntegrityTotalsDto": {
+        "required": [
+          "pagesScanned",
+          "pagesAllocated",
+          "checksumFailures",
+          "pagesWithSectorFooters",
+          "sectorFailures",
+          "segmentsWalked",
+          "bytesLeaked"
+        ],
+        "type": "object",
+        "properties": {
+          "pagesScanned": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "pagesAllocated": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "checksumFailures": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "pagesWithSectorFooters": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "sectorFailures": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "segmentsWalked": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "bytesLeaked": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int64"
+          }
+        }
+      },
       "MemoryAllocDirection": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Direction of a TraceEventKind.MemoryAllocEvent: allocation or free."
       },
       "NavigateClauseDto": {
         "required": [
@@ -5675,7 +6252,8 @@
         "type": "integer"
       },
       "PostTickSummary": {
-        "type": "object"
+        "type": "object",
+        "description": "Per-tick post-tick serial markers in CacheSectionId.PostTickSummaries. One row per tick, capturing the duration of each TickPhase\r\nregion that runs after the system DAG completes — wraps the existing `InspectorPhase` blocks in `TyphonRuntime.OnTickEndInternal`. Zero µs means\r\nthe phase ran with no measurable work (e.g. no subscriptions active for float PostTickSummary.SubscriptionOutputUs)."
       },
       "PredicateNodeDto": {
         "required": [
@@ -6411,7 +6989,8 @@
             ],
             "format": "uint8"
           }
-        }
+        },
+        "description": "Structural evaluator shape carried by QueryDefinitionDescribeEventDto. Excludes threshold (per-execution data)."
       },
       "QueryInstanceIdDto": {
         "required": [
@@ -6802,7 +7381,226 @@
         }
       },
       "QueueTickSummary": {
-        "type": "object"
+        "type": "object",
+        "description": "Per-(tick, queue) rollup row in CacheSectionId.QueueTickSummaries. One row per queue per tick. Folded from the new `QueueTickEnd` wire\r\nevent the engine emits at end-of-tick per active event queue."
+      },
+      "RepairApplyRequestDto": {
+        "required": [
+          "path",
+          "fingerprint"
+        ],
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "fingerprint": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "allowLoss": {
+            "type": "boolean",
+            "default": false
+          },
+          "backupFirst": {
+            "type": "boolean",
+            "default": true
+          },
+          "dryRun": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "RepairOutcomeDto": {
+        "required": [
+          "succeeded",
+          "backupPath",
+          "results",
+          "verification"
+        ],
+        "type": "object",
+        "properties": {
+          "succeeded": {
+            "type": "boolean"
+          },
+          "backupPath": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "results": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RepairStepResultDto"
+            }
+          },
+          "verification": {
+            "$ref": "#/components/schemas/IntegrityReportDto"
+          }
+        }
+      },
+      "RepairPlanDto": {
+        "required": [
+          "source",
+          "fingerprint",
+          "verdict",
+          "requiresLossyConsent",
+          "steps",
+          "loss",
+          "unaddressed"
+        ],
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "fingerprint": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "verdict": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "requiresLossyConsent": {
+            "type": "boolean"
+          },
+          "steps": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RepairStepDto"
+            }
+          },
+          "loss": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/IntegrityLossDto"
+            }
+          },
+          "unaddressed": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RepairStepDto": {
+        "required": [
+          "order",
+          "action",
+          "class",
+          "description",
+          "rationale",
+          "addresses"
+        ],
+        "type": "object",
+        "properties": {
+          "order": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "action": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "class": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "rationale": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "addresses": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RepairStepResultDto": {
+        "required": [
+          "order",
+          "action",
+          "outcome",
+          "detail"
+        ],
+        "type": "object",
+        "properties": {
+          "order": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "action": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "outcome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
       },
       "ResourceGraphDto": {
         "required": [
@@ -8773,7 +9571,8 @@
         }
       },
       "SystemArchetypeTouchSummary": {
-        "type": "object"
+        "type": "object",
+        "description": "Per-(tick, system, archetype) entity-touch rollup row in CacheSectionId.SystemArchetypeTouches. One row per active\r\n(system, archetype) pair per tick — sparse by definition (most systems target one archetype, callbacks emit no rows). Folded from\r\nthe new `SchedulerSystemArchetype` wire event the engine emits at parallel-query completion. Sorted by (TickNumber, SystemIndex,\r\nArchetypeId) for binary-search range scans. Wire size 16 bytes — packs tightly so a 100k-tick / 200-system trace at one row per\r\n(system, tick) lands at ~320 MB worst case (typical: ~30-50 MB after sparsity)."
       },
       "SystemDefinitionDto": {
         "required": [
@@ -9093,10 +9892,12 @@
         }
       },
       "SystemTickSummary": {
-        "type": "object"
+        "type": "object",
+        "description": "Per-(tick, system) rollup row in CacheSectionId.SystemTickSummaries. One row per system per tick — dense across systems so binary-search by\r\ntick yields a contiguous slice of all systems for that tick. Skipped systems are present with byte SystemTickSummary.SkipReasonCode != 0; consumers filter on that."
       },
       "ThreadWaitReason": {
-        "type": "integer"
+        "type": "integer",
+        "description": "Reason a thread left the CPU at a context-switch point. Hand-rolled mirror of Windows' `KWAIT_REASON` kernel enum (a.k.a. `KTHREAD::WaitReason`),\r\ncaptured by the ETW scheduling pump from `CSwitchTraceData.OldThreadWaitReason` and carried on TraceEventKind.ThreadContextSwitch records."
       },
       "TickSummaryDto": {
         "required": [
@@ -9479,9 +10280,6 @@
           },
           {
             "$ref": "#/components/schemas/TraceEventDtoDurabilityRecoveryDiscoverEventDto"
-          },
-          {
-            "$ref": "#/components/schemas/TraceEventDtoDurabilityRecoveryFpiEventDto"
           },
           {
             "$ref": "#/components/schemas/TraceEventDtoDurabilityRecoveryRecordEventDto"
@@ -9928,6 +10726,7 @@
             "$ref": "#/components/schemas/TraceEventDtoWriteTickFenceTableEventDto"
           }
         ],
+        "description": "Base type for the typed-DTO trace event hierarchy. Each kind gets its own derived sealed record carrying\r\nexactly its payload fields, dispatched at the wire boundary via System.Text.Json's polymorphic\r\nserialization with the camelCase `kind` property as discriminator.",
         "discriminator": {
           "propertyName": "kind",
           "mapping": {
@@ -9990,7 +10789,6 @@
             "durabilityCheckpointSleep": "#/components/schemas/TraceEventDtoDurabilityCheckpointSleepEventDto",
             "durabilityCheckpointWriteBatch": "#/components/schemas/TraceEventDtoDurabilityCheckpointWriteBatchEventDto",
             "durabilityRecoveryDiscover": "#/components/schemas/TraceEventDtoDurabilityRecoveryDiscoverEventDto",
-            "durabilityRecoveryFpi": "#/components/schemas/TraceEventDtoDurabilityRecoveryFpiEventDto",
             "durabilityRecoveryRecord": "#/components/schemas/TraceEventDtoDurabilityRecoveryRecordEventDto",
             "durabilityRecoveryRedo": "#/components/schemas/TraceEventDtoDurabilityRecoveryRedoEventDto",
             "durabilityRecoverySegment": "#/components/schemas/TraceEventDtoDurabilityRecoverySegmentEventDto",
@@ -10164,31 +10962,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10196,6 +10999,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10204,6 +11008,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10212,6 +11017,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10220,9 +11026,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `BTreeDelete` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoBTreeInsertEventDto": {
         "properties": {
@@ -10246,31 +11054,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10278,6 +11091,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10286,6 +11100,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10294,6 +11109,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10302,9 +11118,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `BTreeInsert` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoBTreeNodeMergeEventDto": {
         "properties": {
@@ -10328,31 +11146,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10360,6 +11183,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10368,6 +11192,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10376,6 +11201,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10384,9 +11210,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `BTreeNodeMerge` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoBTreeNodeSplitEventDto": {
         "properties": {
@@ -10410,31 +11238,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10442,6 +11275,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10450,6 +11284,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10458,6 +11293,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10466,9 +11302,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `BTreeNodeSplit` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoCheckpointCollectEventDto": {
         "properties": {
@@ -10492,31 +11330,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10524,6 +11367,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10532,6 +11376,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10540,6 +11385,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10548,9 +11394,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `CheckpointCollect` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoCheckpointCycleEventDto": {
         "properties": {
@@ -10574,6 +11422,7 @@
               "integer",
               "string"
             ],
+            "description": "`CheckpointCycle` event payload — target lsn.",
             "format": "int64"
           },
           "reason": {
@@ -10582,6 +11431,7 @@
               "integer",
               "string"
             ],
+            "description": "`CheckpointCycle` event payload — reason.",
             "format": "uint8"
           },
           "dirtyPageCount": {
@@ -10591,6 +11441,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `CheckpointCycle` event payload — dirty page count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -10599,31 +11450,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10631,6 +11487,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10639,6 +11496,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10647,6 +11505,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10655,9 +11514,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `CheckpointCycle` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoCheckpointFsyncEventDto": {
         "properties": {
@@ -10681,31 +11542,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10713,6 +11579,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10721,6 +11588,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10729,6 +11597,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10737,9 +11606,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `CheckpointFsync` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoCheckpointRecycleEventDto": {
         "properties": {
@@ -10764,6 +11635,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `CheckpointRecycle` event payload — recycled count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -10772,31 +11644,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10804,6 +11681,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10812,6 +11690,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10820,6 +11699,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10828,9 +11708,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `CheckpointRecycle` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoCheckpointTransitionEventDto": {
         "properties": {
@@ -10855,6 +11737,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `CheckpointTransition` event payload — transitioned count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -10863,31 +11746,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10895,6 +11783,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10903,6 +11792,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -10911,6 +11801,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -10919,9 +11810,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `CheckpointTransition` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoCheckpointWriteEventDto": {
         "properties": {
@@ -10946,6 +11839,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `CheckpointWrite` event payload — written count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -10954,31 +11848,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -10986,6 +11885,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -10994,6 +11894,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11002,6 +11903,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11010,9 +11912,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `CheckpointWrite` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoClusterMigrationEventDto": {
         "properties": {
@@ -11036,6 +11940,7 @@
               "integer",
               "string"
             ],
+            "description": "`ClusterMigration` event payload — archetype id.",
             "format": "uint16"
           },
           "migrationCount": {
@@ -11044,6 +11949,7 @@
               "integer",
               "string"
             ],
+            "description": "`ClusterMigration` event payload — migration count.",
             "format": "int32"
           },
           "componentCount": {
@@ -11052,6 +11958,7 @@
               "integer",
               "string"
             ],
+            "description": "`ClusterMigration` event payload — component count.",
             "format": "int32"
           },
           "durationUs": {
@@ -11060,31 +11967,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -11092,6 +12004,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11100,6 +12013,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11108,6 +12022,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11116,9 +12031,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `ClusterMigration` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoConcurrencyAccessControlContentionEventDto": {
         "properties": {
@@ -11142,6 +12059,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11150,6 +12068,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11158,6 +12077,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11166,9 +12086,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlContention`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlExclusiveAcquireEventDto": {
         "properties": {
@@ -11192,10 +12114,12 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlExclusiveAcquire` event payload — thread id.",
             "format": "uint16"
           },
           "hadToWait": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyAccessControlExclusiveAcquire` event payload — had to wait."
           },
           "elapsedUs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -11203,6 +12127,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlExclusiveAcquire` event payload — elapsed us.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11211,6 +12136,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11219,6 +12145,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11227,6 +12154,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11235,9 +12163,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlExclusiveAcquire`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlExclusiveReleaseEventDto": {
         "properties": {
@@ -11261,6 +12191,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlExclusiveRelease` event payload — thread id.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11269,6 +12200,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11277,6 +12209,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11285,6 +12218,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11293,9 +12227,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlExclusiveRelease`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlPromotionEventDto": {
         "properties": {
@@ -11319,6 +12255,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlPromotion` event payload — elapsed us.",
             "format": "uint16"
           },
           "variant": {
@@ -11327,6 +12264,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlPromotion` event payload — variant.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -11335,6 +12273,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11343,6 +12282,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11351,6 +12291,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11359,9 +12300,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlPromotion`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlSharedAcquireEventDto": {
         "properties": {
@@ -11385,10 +12328,12 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlSharedAcquire` event payload — thread id.",
             "format": "uint16"
           },
           "hadToWait": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyAccessControlSharedAcquire` event payload — had to wait."
           },
           "elapsedUs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -11396,6 +12341,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlSharedAcquire` event payload — elapsed us.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11404,6 +12350,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11412,6 +12359,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11420,6 +12368,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11428,9 +12377,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlSharedAcquire`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlSharedReleaseEventDto": {
         "properties": {
@@ -11454,6 +12405,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlSharedRelease` event payload — thread id.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11462,6 +12414,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11470,6 +12423,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11478,6 +12432,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11486,9 +12441,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlSharedRelease`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlSmallContentionEventDto": {
         "properties": {
@@ -11512,6 +12469,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11520,6 +12478,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11528,6 +12487,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11536,9 +12496,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlSmallContention`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlSmallExclusiveAcquireEventDto": {
         "properties": {
@@ -11562,6 +12524,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlSmallExclusiveAcquire` event payload — thread id.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11570,6 +12533,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11578,6 +12542,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11586,6 +12551,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11594,9 +12560,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlSmallExclusiveAcquire`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlSmallExclusiveReleaseEventDto": {
         "properties": {
@@ -11620,6 +12588,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlSmallExclusiveRelease` event payload — thread id.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11628,6 +12597,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11636,6 +12606,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11644,6 +12615,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11652,9 +12624,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlSmallExclusiveRelease`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlSmallSharedAcquireEventDto": {
         "properties": {
@@ -11678,6 +12652,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlSmallSharedAcquire` event payload — thread id.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11686,6 +12661,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11694,6 +12670,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11702,6 +12679,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11710,9 +12688,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlSmallSharedAcquire`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAccessControlSmallSharedReleaseEventDto": {
         "properties": {
@@ -11736,6 +12716,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAccessControlSmallSharedRelease` event payload — thread id.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -11744,6 +12725,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11752,6 +12734,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11760,6 +12743,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11768,9 +12752,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAccessControlSmallSharedRelease`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyAdaptiveWaiterYieldOrSleepEventDto": {
         "properties": {
@@ -11794,9 +12780,11 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyAdaptiveWaiterYieldOrSleep` event payload — spin count before.",
             "format": "uint16"
           },
           "transitionKind": {
+            "description": "`ConcurrencyAdaptiveWaiterYieldOrSleep` event payload — transition kind.",
             "$ref": "#/components/schemas/AdaptiveWaiterTransitionKind"
           },
           "threadSlot": {
@@ -11805,6 +12793,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11813,6 +12802,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11821,6 +12811,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11829,9 +12820,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyAdaptiveWaiterYieldOrSleep`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyEpochAdvanceEventDto": {
         "properties": {
@@ -11855,6 +12848,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochAdvance` event payload — new epoch.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -11863,6 +12857,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11871,6 +12866,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11879,6 +12875,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11887,9 +12884,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyEpochAdvance`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyEpochRefreshEventDto": {
         "properties": {
@@ -11913,6 +12912,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochRefresh` event payload — old epoch.",
             "format": "uint32"
           },
           "newEpoch": {
@@ -11921,6 +12921,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochRefresh` event payload — new epoch.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -11929,6 +12930,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -11937,6 +12939,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -11945,6 +12948,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -11953,9 +12957,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyEpochRefresh`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyEpochScopeEnterEventDto": {
         "properties": {
@@ -11979,6 +12985,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochScopeEnter` event payload — epoch.",
             "format": "uint32"
           },
           "depthBefore": {
@@ -11987,10 +12994,12 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochScopeEnter` event payload — depth before.",
             "format": "uint8"
           },
           "isDormantToActive": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyEpochScopeEnter` event payload — is dormant to active."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -11998,6 +13007,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12006,6 +13016,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12014,6 +13025,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12022,9 +13034,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyEpochScopeEnter`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyEpochScopeExitEventDto": {
         "properties": {
@@ -12048,10 +13062,12 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochScopeExit` event payload — epoch.",
             "format": "uint32"
           },
           "isOutermost": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyEpochScopeExit` event payload — is outermost."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -12059,6 +13075,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12067,6 +13084,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12075,6 +13093,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12083,9 +13102,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyEpochScopeExit`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyEpochSlotClaimEventDto": {
         "properties": {
@@ -12109,6 +13130,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochSlotClaim` event payload — slot index.",
             "format": "uint16"
           },
           "threadId": {
@@ -12117,6 +13139,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochSlotClaim` event payload — thread id.",
             "format": "uint16"
           },
           "activeCount": {
@@ -12125,6 +13148,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochSlotClaim` event payload — active count.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -12133,6 +13157,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12141,6 +13166,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12149,6 +13175,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12157,9 +13184,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyEpochSlotClaim`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyEpochSlotReclaimEventDto": {
         "properties": {
@@ -12183,6 +13212,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochSlotReclaim` event payload — slot index.",
             "format": "uint16"
           },
           "oldOwner": {
@@ -12191,6 +13221,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochSlotReclaim` event payload — old owner.",
             "format": "uint16"
           },
           "newOwner": {
@@ -12199,6 +13230,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyEpochSlotReclaim` event payload — new owner.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -12207,6 +13239,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12215,6 +13248,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12223,6 +13257,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12231,9 +13266,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyEpochSlotReclaim`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyOlcLatchMarkObsoleteEventDto": {
         "properties": {
@@ -12257,6 +13294,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyOlcLatchMarkObsolete` event payload — version.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -12265,6 +13303,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12273,6 +13312,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12281,6 +13321,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12289,9 +13330,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyOlcLatchMarkObsolete`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyOlcLatchValidationFailEventDto": {
         "properties": {
@@ -12315,6 +13358,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyOlcLatchValidationFail` event payload — expected version.",
             "format": "uint32"
           },
           "actualVersion": {
@@ -12323,6 +13367,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyOlcLatchValidationFail` event payload — actual version.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -12331,6 +13376,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12339,6 +13385,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12347,6 +13394,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12355,9 +13403,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyOlcLatchValidationFail`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyOlcLatchWriteLockAttemptEventDto": {
         "properties": {
@@ -12381,10 +13431,12 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyOlcLatchWriteLockAttempt` event payload — version before.",
             "format": "uint32"
           },
           "success": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyOlcLatchWriteLockAttempt` event payload — success."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -12392,6 +13444,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12400,6 +13453,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12408,6 +13462,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12416,9 +13471,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyOlcLatchWriteLockAttempt`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyOlcLatchWriteUnlockEventDto": {
         "properties": {
@@ -12442,6 +13499,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyOlcLatchWriteUnlock` event payload — old version.",
             "format": "uint32"
           },
           "newVersion": {
@@ -12450,6 +13508,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyOlcLatchWriteUnlock` event payload — new version.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -12458,6 +13517,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12466,6 +13526,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12474,6 +13535,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12482,9 +13544,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyOlcLatchWriteUnlock`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyResourceAccessingEventDto": {
         "properties": {
@@ -12503,7 +13567,8 @@
             "format": "uint8"
           },
           "success": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyResourceAccessing` event payload — success."
           },
           "accessingCount": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -12511,6 +13576,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyResourceAccessing` event payload — accessing count.",
             "format": "uint8"
           },
           "elapsedUs": {
@@ -12519,6 +13585,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyResourceAccessing` event payload — elapsed us.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -12527,6 +13594,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12535,6 +13603,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12543,6 +13612,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12551,9 +13621,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyResourceAccessing`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyResourceContentionEventDto": {
         "properties": {
@@ -12577,6 +13649,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12585,6 +13658,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12593,6 +13667,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12601,9 +13676,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyResourceContention`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyResourceDestroyEventDto": {
         "properties": {
@@ -12622,7 +13699,8 @@
             "format": "uint8"
           },
           "success": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyResourceDestroy` event payload — success."
           },
           "elapsedUs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -12630,6 +13708,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyResourceDestroy` event payload — elapsed us.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -12638,6 +13717,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12646,6 +13726,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12654,6 +13735,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12662,9 +13744,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyResourceDestroy`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyResourceModifyEventDto": {
         "properties": {
@@ -12683,7 +13767,8 @@
             "format": "uint8"
           },
           "success": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ConcurrencyResourceModify` event payload — success."
           },
           "threadId": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -12691,6 +13776,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyResourceModify` event payload — thread id.",
             "format": "uint16"
           },
           "elapsedUs": {
@@ -12699,6 +13785,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyResourceModify` event payload — elapsed us.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -12707,6 +13794,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12715,6 +13803,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12723,6 +13812,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12731,9 +13821,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyResourceModify`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoConcurrencyResourceModifyPromotionEventDto": {
         "properties": {
@@ -12757,6 +13849,7 @@
               "integer",
               "string"
             ],
+            "description": "`ConcurrencyResourceModifyPromotion` event payload — elapsed us.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -12765,6 +13858,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12773,6 +13867,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12781,6 +13876,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12789,9 +13885,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ConcurrencyResourceModifyPromotion`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataIndexBTreeBulkInsertEventDto": {
         "properties": {
@@ -12815,6 +13913,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeBulkInsert` event payload — buffer id.",
             "format": "int32"
           },
           "entryCount": {
@@ -12823,6 +13922,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeBulkInsert` event payload — entry count.",
             "format": "int32"
           },
           "durationUs": {
@@ -12831,31 +13931,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -12863,6 +13968,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12871,6 +13977,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12879,6 +13986,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12887,9 +13995,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DataIndexBTreeBulkInsert` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDataIndexBTreeNodeCowEventDto": {
         "properties": {
@@ -12913,6 +14023,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeNodeCow` event payload — src chunk id.",
             "format": "int32"
           },
           "dstChunkId": {
@@ -12921,6 +14032,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeNodeCow` event payload — dst chunk id.",
             "format": "int32"
           },
           "threadSlot": {
@@ -12929,6 +14041,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -12937,6 +14050,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -12945,6 +14059,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -12953,9 +14068,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DataIndexBTreeNodeCow`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataIndexBTreeRangeScanEventDto": {
         "properties": {
@@ -12979,6 +14096,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeRangeScan` event payload — result count.",
             "format": "int32"
           },
           "restartCount": {
@@ -12987,6 +14105,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeRangeScan` event payload — restart count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -12995,31 +14114,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -13027,6 +14151,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13035,6 +14160,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13043,6 +14169,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13051,9 +14178,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DataIndexBTreeRangeScan` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDataIndexBTreeRangeScanRevalidateEventDto": {
         "properties": {
@@ -13077,6 +14206,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeRangeScanRevalidate` event payload — restart count.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -13085,6 +14215,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13093,6 +14224,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13101,6 +14233,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13109,9 +14242,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DataIndexBTreeRangeScanRevalidate`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataIndexBTreeRebalanceFallbackEventDto": {
         "properties": {
@@ -13135,6 +14270,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeRebalanceFallback` event payload — reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -13143,6 +14279,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13151,6 +14288,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13159,6 +14297,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13167,9 +14306,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DataIndexBTreeRebalanceFallback`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataIndexBTreeRootEventDto": {
         "properties": {
@@ -13193,6 +14334,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeRoot` event payload — op.",
             "format": "uint8"
           },
           "rootChunkId": {
@@ -13201,6 +14343,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeRoot` event payload — root chunk id.",
             "format": "int32"
           },
           "height": {
@@ -13209,6 +14352,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeRoot` event payload — height.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -13217,6 +14361,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13225,6 +14370,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13233,6 +14379,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13241,9 +14388,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DataIndexBTreeRoot`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataIndexBTreeSearchEventDto": {
         "properties": {
@@ -13267,6 +14416,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeSearch` event payload — retry reason.",
             "format": "uint8"
           },
           "restartCount": {
@@ -13275,6 +14425,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataIndexBTreeSearch` event payload — restart count.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -13283,6 +14434,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13291,6 +14443,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13299,6 +14452,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13307,9 +14461,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DataIndexBTreeSearch`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataMvccChainWalkEventDto": {
         "properties": {
@@ -13333,6 +14489,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataMvccChainWalk` event payload — tsn.",
             "format": "int64"
           },
           "chainLen": {
@@ -13341,6 +14498,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataMvccChainWalk` event payload — chain len.",
             "format": "uint8"
           },
           "visibility": {
@@ -13349,6 +14507,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataMvccChainWalk` event payload — visibility.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -13357,6 +14516,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13365,6 +14525,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13373,6 +14534,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13381,9 +14543,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DataMvccChainWalk`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataMvccVersionCleanupEventDto": {
         "properties": {
@@ -13407,6 +14571,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataMvccVersionCleanup` event payload — pk.",
             "format": "int64"
           },
           "entriesFreed": {
@@ -13415,6 +14580,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataMvccVersionCleanup` event payload — entries freed.",
             "format": "uint16"
           },
           "durationUs": {
@@ -13423,31 +14589,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -13455,6 +14626,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13463,6 +14635,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13471,6 +14644,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13479,9 +14653,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DataMvccVersionCleanup` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDataTransactionCleanupEventDto": {
         "properties": {
@@ -13505,6 +14681,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionCleanup` event payload — tsn.",
             "format": "int64"
           },
           "entityCount": {
@@ -13513,6 +14690,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionCleanup` event payload — entity count.",
             "format": "int32"
           },
           "durationUs": {
@@ -13521,31 +14699,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -13553,6 +14736,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13561,6 +14745,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13569,6 +14754,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13577,9 +14763,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DataTransactionCleanup` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDataTransactionConflictEventDto": {
         "properties": {
@@ -13603,6 +14791,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionConflict` event payload — tsn.",
             "format": "int64"
           },
           "pk": {
@@ -13611,6 +14800,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionConflict` event payload — pk.",
             "format": "int64"
           },
           "componentTypeId": {
@@ -13619,6 +14809,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionConflict` event payload — component type id.",
             "format": "int32"
           },
           "conflictType": {
@@ -13627,6 +14818,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionConflict` event payload — conflict type.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -13635,6 +14827,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13643,6 +14836,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13651,6 +14845,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13659,9 +14854,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DataTransactionConflict`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDataTransactionInitEventDto": {
         "properties": {
@@ -13685,6 +14882,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionInit` event payload — tsn.",
             "format": "int64"
           },
           "uowId": {
@@ -13693,6 +14891,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionInit` event payload — uow id.",
             "format": "uint16"
           },
           "durationUs": {
@@ -13701,31 +14900,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -13733,6 +14937,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13741,6 +14946,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13749,6 +14955,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13757,9 +14964,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DataTransactionInit` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDataTransactionPrepareEventDto": {
         "properties": {
@@ -13783,6 +14992,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionPrepare` event payload — tsn.",
             "format": "int64"
           },
           "durationUs": {
@@ -13791,31 +15001,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -13823,6 +15038,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13831,6 +15047,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13839,6 +15056,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13847,9 +15065,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DataTransactionPrepare` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDataTransactionValidateEventDto": {
         "properties": {
@@ -13873,6 +15093,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionValidate` event payload — tsn.",
             "format": "int64"
           },
           "entryCount": {
@@ -13881,6 +15102,7 @@
               "integer",
               "string"
             ],
+            "description": "`DataTransactionValidate` event payload — entry count.",
             "format": "int32"
           },
           "durationUs": {
@@ -13889,31 +15111,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -13921,6 +15148,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -13929,6 +15157,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -13937,6 +15166,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -13945,9 +15175,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DataTransactionValidate` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityCheckpointBackpressureEventDto": {
         "properties": {
@@ -13971,6 +15203,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityCheckpointBackpressure` event payload — wait ms.",
             "format": "uint32"
           },
           "exhausted": {
@@ -13979,6 +15212,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityCheckpointBackpressure` event payload — exhausted.",
             "format": "uint8"
           },
           "durationUs": {
@@ -13987,31 +15221,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14019,6 +15258,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14027,6 +15267,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14035,6 +15276,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14043,9 +15285,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityCheckpointBackpressure` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityCheckpointSleepEventDto": {
         "properties": {
@@ -14069,6 +15313,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityCheckpointSleep` event payload — sleep ms.",
             "format": "uint32"
           },
           "wakeReason": {
@@ -14077,6 +15322,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityCheckpointSleep` event payload — wake reason.",
             "format": "uint8"
           },
           "durationUs": {
@@ -14085,31 +15331,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14117,6 +15368,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14125,6 +15377,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14133,6 +15386,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14141,9 +15395,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityCheckpointSleep` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityCheckpointWriteBatchEventDto": {
         "properties": {
@@ -14167,6 +15423,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityCheckpointWriteBatch` event payload — write batch size.",
             "format": "int32"
           },
           "stagingAllocated": {
@@ -14175,6 +15432,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityCheckpointWriteBatch` event payload — staging allocated.",
             "format": "int32"
           },
           "durationUs": {
@@ -14183,31 +15441,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14215,6 +15478,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14223,6 +15487,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14231,6 +15496,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14239,9 +15505,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityCheckpointWriteBatch` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityRecoveryDiscoverEventDto": {
         "properties": {
@@ -14265,6 +15533,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryDiscover` event payload — seg count.",
             "format": "int32"
           },
           "totalBytes": {
@@ -14273,6 +15542,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryDiscover` event payload — total bytes.",
             "format": "int64"
           },
           "firstSegId": {
@@ -14281,6 +15551,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryDiscover` event payload — first seg id.",
             "format": "int32"
           },
           "durationUs": {
@@ -14289,31 +15560,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14321,6 +15597,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14329,6 +15606,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14337,6 +15615,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14345,115 +15624,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
-      },
-      "TraceEventDtoDurabilityRecoveryFpiEventDto": {
-        "properties": {
-          "kind": {
-            "enum": [
-              "durabilityRecoveryFpi"
-            ],
-            "type": "string"
-          },
-          "kindByte": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "uint8"
-          },
-          "fpiCount": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "repairedCount": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "mismatches": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "durationUs": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": [
-              "number",
-              "string"
-            ],
-            "format": "double"
-          },
-          "spanId": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "parentSpanId": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "traceIdHi": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "traceIdLo": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "threadSlot": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "uint8"
-          },
-          "tickNumber": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "int32"
-          },
-          "timestampUs": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": [
-              "number",
-              "string"
-            ],
-            "format": "double"
-          },
-          "sourceLocationId": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": [
-              "integer",
-              "string"
-            ],
-            "format": "uint16"
-          }
-        }
+        },
+        "description": "Generated DTO for `DurabilityRecoveryDiscover` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityRecoveryRecordEventDto": {
         "properties": {
@@ -14477,6 +15652,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryRecord` event payload — chunk type.",
             "format": "uint8"
           },
           "lsn": {
@@ -14485,6 +15661,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryRecord` event payload — lsn.",
             "format": "int64"
           },
           "size": {
@@ -14493,6 +15670,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryRecord` event payload — size.",
             "format": "int32"
           },
           "threadSlot": {
@@ -14501,6 +15679,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14509,6 +15688,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14517,6 +15697,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14525,9 +15706,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DurabilityRecoveryRecord`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDurabilityRecoveryRedoEventDto": {
         "properties": {
@@ -14551,6 +15734,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryRedo` event payload — records replayed.",
             "format": "int32"
           },
           "uowsReplayed": {
@@ -14559,6 +15743,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryRedo` event payload — uows replayed.",
             "format": "int32"
           },
           "durUs": {
@@ -14567,6 +15752,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryRedo` event payload — dur us.",
             "format": "uint32"
           },
           "durationUs": {
@@ -14575,31 +15761,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14607,6 +15798,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14615,6 +15807,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14623,6 +15816,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14631,9 +15825,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityRecoveryRedo` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityRecoverySegmentEventDto": {
         "properties": {
@@ -14657,6 +15853,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoverySegment` event payload — seg id.",
             "format": "int32"
           },
           "recCount": {
@@ -14665,6 +15862,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoverySegment` event payload — rec count.",
             "format": "int32"
           },
           "bytes": {
@@ -14673,6 +15871,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoverySegment` event payload — bytes.",
             "format": "int64"
           },
           "truncated": {
@@ -14681,6 +15880,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoverySegment` event payload — truncated.",
             "format": "uint8"
           },
           "durationUs": {
@@ -14689,31 +15889,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14721,6 +15926,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14729,6 +15935,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14737,6 +15944,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14745,9 +15953,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityRecoverySegment` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityRecoveryStartEventDto": {
         "properties": {
@@ -14771,6 +15981,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryStart` event payload — checkpoint lsn.",
             "format": "int64"
           },
           "reason": {
@@ -14779,6 +15990,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryStart` event payload — reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -14787,6 +15999,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14795,6 +16008,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14803,6 +16017,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14811,9 +16026,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DurabilityRecoveryStart`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDurabilityRecoveryTickFenceEventDto": {
         "properties": {
@@ -14837,6 +16054,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryTickFence` event payload — tick fence count.",
             "format": "int32"
           },
           "entries": {
@@ -14845,6 +16063,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryTickFence` event payload — entries.",
             "format": "int32"
           },
           "tickNumberPayload": {
@@ -14853,6 +16072,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryTickFence` event payload — tick number.",
             "format": "int64"
           },
           "durationUs": {
@@ -14861,31 +16081,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14893,6 +16118,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14901,6 +16127,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14909,6 +16136,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -14917,9 +16145,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityRecoveryTickFence` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityRecoveryUndoEventDto": {
         "properties": {
@@ -14943,6 +16173,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityRecoveryUndo` event payload — voided uow count.",
             "format": "int32"
           },
           "durationUs": {
@@ -14951,31 +16182,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -14983,6 +16219,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -14991,6 +16228,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -14999,6 +16237,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15007,9 +16246,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityRecoveryUndo` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityUowDeadlineEventDto": {
         "properties": {
@@ -15033,6 +16274,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityUowDeadline` event payload — deadline.",
             "format": "int64"
           },
           "remaining": {
@@ -15041,6 +16283,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityUowDeadline` event payload — remaining.",
             "format": "int64"
           },
           "expired": {
@@ -15049,6 +16292,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityUowDeadline` event payload — expired.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -15057,6 +16301,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15065,6 +16310,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15073,6 +16319,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15081,9 +16328,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DurabilityUowDeadline`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDurabilityUowStateEventDto": {
         "properties": {
@@ -15107,6 +16356,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityUowState` event payload — from.",
             "format": "uint8"
           },
           "to": {
@@ -15115,6 +16365,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityUowState` event payload — to.",
             "format": "uint8"
           },
           "uowId": {
@@ -15123,6 +16374,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityUowState` event payload — uow id.",
             "format": "uint16"
           },
           "reason": {
@@ -15131,6 +16383,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityUowState` event payload — reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -15139,6 +16392,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15147,6 +16401,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15155,6 +16410,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15163,9 +16419,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DurabilityUowState`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDurabilityWalBackpressureEventDto": {
         "properties": {
@@ -15189,6 +16447,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalBackpressure` event payload — wait us.",
             "format": "uint32"
           },
           "producerThread": {
@@ -15197,7 +16456,17 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalBackpressure` event payload — producer thread.",
             "format": "int32"
+          },
+          "retries": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "`DurabilityWalBackpressure` event payload — retries.",
+            "format": "uint16"
           },
           "durationUs": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
@@ -15205,31 +16474,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -15237,6 +16511,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15245,6 +16520,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15253,6 +16529,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15261,9 +16538,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityWalBackpressure` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityWalBufferEventDto": {
         "properties": {
@@ -15287,6 +16566,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalBuffer` event payload — bytes aligned.",
             "format": "int32"
           },
           "pad": {
@@ -15295,6 +16575,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalBuffer` event payload — pad.",
             "format": "int32"
           },
           "durationUs": {
@@ -15303,31 +16584,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -15335,6 +16621,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15343,6 +16630,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15351,6 +16639,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15359,9 +16648,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityWalBuffer` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityWalFrameEventDto": {
         "properties": {
@@ -15385,6 +16676,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalFrame` event payload — frame count.",
             "format": "uint16"
           },
           "crcStart": {
@@ -15393,6 +16685,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalFrame` event payload — crc start.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -15401,6 +16694,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15409,6 +16703,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15417,6 +16712,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15425,9 +16721,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DurabilityWalFrame`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDurabilityWalGroupCommitEventDto": {
         "properties": {
@@ -15451,6 +16749,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalGroupCommit` event payload — trigger ms.",
             "format": "uint16"
           },
           "producerThread": {
@@ -15459,6 +16758,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalGroupCommit` event payload — producer thread.",
             "format": "int32"
           },
           "threadSlot": {
@@ -15467,6 +16767,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15475,6 +16776,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15483,6 +16785,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15491,9 +16794,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DurabilityWalGroupCommit`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDurabilityWalOsWriteEventDto": {
         "properties": {
@@ -15517,6 +16822,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalOsWrite` event payload — bytes aligned.",
             "format": "int32"
           },
           "frameCount": {
@@ -15525,6 +16831,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalOsWrite` event payload — frame count.",
             "format": "int32"
           },
           "highLsn": {
@@ -15533,6 +16840,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalOsWrite` event payload — high lsn.",
             "format": "int64"
           },
           "durationUs": {
@@ -15541,31 +16849,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -15573,6 +16886,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15581,6 +16895,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15589,6 +16904,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15597,9 +16913,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityWalOsWrite` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityWalQueueDrainEventDto": {
         "properties": {
@@ -15623,6 +16941,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalQueueDrain` event payload — bytes aligned.",
             "format": "int32"
           },
           "frameCount": {
@@ -15631,6 +16950,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalQueueDrain` event payload — frame count.",
             "format": "int32"
           },
           "durationUs": {
@@ -15639,31 +16959,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -15671,6 +16996,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15679,6 +17005,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15687,6 +17014,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15695,9 +17023,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityWalQueueDrain` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoDurabilityWalQueueEventDto": {
         "properties": {
@@ -15721,6 +17051,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalQueue` event payload — drain attempt.",
             "format": "uint8"
           },
           "dataLen": {
@@ -15729,6 +17060,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalQueue` event payload — data len.",
             "format": "int32"
           },
           "waitReason": {
@@ -15737,6 +17069,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalQueue` event payload — wait reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -15745,6 +17078,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15753,6 +17087,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15761,6 +17096,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15769,9 +17105,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `DurabilityWalQueue`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoDurabilityWalSignalEventDto": {
         "properties": {
@@ -15795,6 +17133,7 @@
               "integer",
               "string"
             ],
+            "description": "`DurabilityWalSignal` event payload — high lsn.",
             "format": "int64"
           },
           "durationUs": {
@@ -15803,31 +17142,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -15835,6 +17179,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15843,6 +17188,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15851,6 +17197,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15859,9 +17206,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `DurabilityWalSignal` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsDestroyEventDto": {
         "properties": {
@@ -15885,6 +17234,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsDestroy` event payload — entity id.",
             "format": "uint64"
           },
           "cascadeCount": {
@@ -15894,6 +17244,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsDestroy` event payload — cascade count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "tsn": {
@@ -15903,6 +17254,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsDestroy` event payload — tsn. `null` when the wire record omits it.",
             "format": "int64"
           },
           "durationUs": {
@@ -15911,31 +17263,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -15943,6 +17300,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -15951,6 +17309,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -15959,6 +17318,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -15967,9 +17327,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsDestroy` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsQueryAnyEventDto": {
         "properties": {
@@ -15993,13 +17355,15 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryAny` event payload — archetype type id.",
             "format": "uint16"
           },
           "found": {
             "type": [
               "null",
               "boolean"
-            ]
+            ],
+            "description": "Optional `EcsQueryAny` event payload — found. `null` when the wire record omits it."
           },
           "scanMode": {
             "oneOf": [
@@ -16007,6 +17371,7 @@
                 "type": "null"
               },
               {
+                "description": "Optional `EcsQueryAny` event payload — scan mode. `null` when the wire record omits it.",
                 "$ref": "#/components/schemas/EcsQueryScanMode"
               }
             ]
@@ -16017,31 +17382,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -16049,6 +17419,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16057,6 +17428,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16065,6 +17437,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16073,9 +17446,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsQueryAny` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsQueryConstraintEnabledEventDto": {
         "properties": {
@@ -16099,6 +17474,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryConstraintEnabled` event payload — type id.",
             "format": "uint16"
           },
           "enableBit": {
@@ -16107,6 +17483,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryConstraintEnabled` event payload — enable bit.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -16115,6 +17492,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16123,6 +17501,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16131,6 +17510,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16139,9 +17519,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsQueryConstraintEnabled`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsQueryConstructEventDto": {
         "properties": {
@@ -16165,6 +17547,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryConstruct` event payload — target arch id.",
             "format": "uint16"
           },
           "polymorphic": {
@@ -16173,6 +17556,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryConstruct` event payload — polymorphic.",
             "format": "uint8"
           },
           "maskSize": {
@@ -16181,6 +17565,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryConstruct` event payload — mask size.",
             "format": "uint8"
           },
           "durationUs": {
@@ -16189,31 +17574,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -16221,6 +17611,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16229,6 +17620,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16237,6 +17629,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16245,9 +17638,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsQueryConstruct` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsQueryCountEventDto": {
         "properties": {
@@ -16271,6 +17666,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryCount` event payload — archetype type id.",
             "format": "uint16"
           },
           "resultCount": {
@@ -16280,6 +17676,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsQueryCount` event payload — result count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "scanMode": {
@@ -16288,6 +17685,7 @@
                 "type": "null"
               },
               {
+                "description": "Optional `EcsQueryCount` event payload — scan mode. `null` when the wire record omits it.",
                 "$ref": "#/components/schemas/EcsQueryScanMode"
               }
             ]
@@ -16298,31 +17696,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -16330,6 +17733,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16338,6 +17742,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16346,6 +17751,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16354,9 +17760,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsQueryCount` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsQueryExecuteEventDto": {
         "properties": {
@@ -16380,6 +17788,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryExecute` event payload — archetype type id.",
             "format": "uint16"
           },
           "resultCount": {
@@ -16389,6 +17798,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsQueryExecute` event payload — result count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "scanMode": {
@@ -16397,6 +17807,7 @@
                 "type": "null"
               },
               {
+                "description": "Optional `EcsQueryExecute` event payload — scan mode. `null` when the wire record omits it.",
                 "$ref": "#/components/schemas/EcsQueryScanMode"
               }
             ]
@@ -16407,31 +17818,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -16439,6 +17855,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16447,6 +17864,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16455,6 +17873,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16463,9 +17882,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsQueryExecute` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsQueryMaskAndEventDto": {
         "properties": {
@@ -16489,6 +17910,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryMaskAnd` event payload — bits before.",
             "format": "uint16"
           },
           "bitsAfter": {
@@ -16497,6 +17919,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryMaskAnd` event payload — bits after.",
             "format": "uint16"
           },
           "opType": {
@@ -16505,6 +17928,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQueryMaskAnd` event payload — op type.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -16513,6 +17937,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16521,6 +17946,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16529,6 +17955,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16537,9 +17964,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsQueryMaskAnd`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsQuerySpatialAttachEventDto": {
         "properties": {
@@ -16563,6 +17992,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQuerySpatialAttach` event payload — spatial type.",
             "format": "uint8"
           },
           "qbX1": {
@@ -16571,6 +18001,7 @@
               "number",
               "string"
             ],
+            "description": "`EcsQuerySpatialAttach` event payload — qb x1.",
             "format": "float"
           },
           "qbY1": {
@@ -16579,6 +18010,7 @@
               "number",
               "string"
             ],
+            "description": "`EcsQuerySpatialAttach` event payload — qb y1.",
             "format": "float"
           },
           "qbX2": {
@@ -16587,6 +18019,7 @@
               "number",
               "string"
             ],
+            "description": "`EcsQuerySpatialAttach` event payload — qb x2.",
             "format": "float"
           },
           "qbY2": {
@@ -16595,6 +18028,7 @@
               "number",
               "string"
             ],
+            "description": "`EcsQuerySpatialAttach` event payload — qb y2.",
             "format": "float"
           },
           "threadSlot": {
@@ -16603,6 +18037,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16611,6 +18046,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16619,6 +18055,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16627,9 +18064,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsQuerySpatialAttach`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsQuerySubtreeExpandEventDto": {
         "properties": {
@@ -16653,6 +18092,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQuerySubtreeExpand` event payload — subtree count.",
             "format": "uint16"
           },
           "rootId": {
@@ -16661,6 +18101,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsQuerySubtreeExpand` event payload — root id.",
             "format": "uint16"
           },
           "durationUs": {
@@ -16669,31 +18110,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -16701,6 +18147,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16709,6 +18156,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16717,6 +18165,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16725,9 +18174,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsQuerySubtreeExpand` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsSpawnEventDto": {
         "properties": {
@@ -16751,6 +18202,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsSpawn` event payload — archetype id.",
             "format": "uint16"
           },
           "entityId": {
@@ -16760,6 +18212,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsSpawn` event payload — entity id. `null` when the wire record omits it.",
             "format": "uint64"
           },
           "tsn": {
@@ -16769,6 +18222,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsSpawn` event payload — tsn. `null` when the wire record omits it.",
             "format": "int64"
           },
           "durationUs": {
@@ -16777,31 +18231,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -16809,6 +18268,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16817,6 +18277,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16825,6 +18286,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16833,9 +18295,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsSpawn` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsViewDeltaBufferOverflowEventDto": {
         "properties": {
@@ -16859,6 +18323,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewDeltaBufferOverflow` event payload — current tsn.",
             "format": "int64"
           },
           "tailTsn": {
@@ -16867,6 +18332,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewDeltaBufferOverflow` event payload — tail tsn.",
             "format": "int64"
           },
           "marginPagesLost": {
@@ -16875,6 +18341,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewDeltaBufferOverflow` event payload — margin pages lost.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -16883,6 +18350,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16891,6 +18359,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16899,6 +18368,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16907,9 +18377,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsViewDeltaBufferOverflow`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsViewDeltaCacheMissEventDto": {
         "properties": {
@@ -16933,6 +18405,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewDeltaCacheMiss` event payload — pk.",
             "format": "int64"
           },
           "reason": {
@@ -16941,6 +18414,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewDeltaCacheMiss` event payload — reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -16949,6 +18423,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -16957,6 +18432,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -16965,6 +18441,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -16973,9 +18450,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsViewDeltaCacheMiss`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsViewIncrementalDrainEventDto": {
         "properties": {
@@ -16999,6 +18478,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewIncrementalDrain` event payload — delta count.",
             "format": "int32"
           },
           "overflow": {
@@ -17007,6 +18487,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewIncrementalDrain` event payload — overflow.",
             "format": "uint8"
           },
           "durationUs": {
@@ -17015,31 +18496,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -17047,6 +18533,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17055,6 +18542,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17063,6 +18551,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17071,9 +18560,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsViewIncrementalDrain` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsViewProcessEntryEventDto": {
         "properties": {
@@ -17097,6 +18588,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewProcessEntry` event payload — pk.",
             "format": "int64"
           },
           "fieldIdx": {
@@ -17105,6 +18597,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewProcessEntry` event payload — field idx.",
             "format": "uint16"
           },
           "pass": {
@@ -17113,6 +18606,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewProcessEntry` event payload — pass.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -17121,6 +18615,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17129,6 +18624,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17137,6 +18633,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17145,9 +18642,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsViewProcessEntry`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsViewProcessEntryOrEventDto": {
         "properties": {
@@ -17171,6 +18670,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewProcessEntryOr` event payload — pk.",
             "format": "int64"
           },
           "branchCount": {
@@ -17179,6 +18679,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewProcessEntryOr` event payload — branch count.",
             "format": "uint8"
           },
           "bitmapDelta": {
@@ -17187,6 +18688,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewProcessEntryOr` event payload — bitmap delta.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -17195,6 +18697,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17203,6 +18706,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17211,6 +18715,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17219,9 +18724,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsViewProcessEntryOr`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsViewRefreshEventDto": {
         "properties": {
@@ -17245,6 +18752,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefresh` event payload — archetype type id.",
             "format": "uint16"
           },
           "mode": {
@@ -17253,6 +18761,7 @@
                 "type": "null"
               },
               {
+                "description": "Optional `EcsViewRefresh` event payload — mode. `null` when the wire record omits it.",
                 "$ref": "#/components/schemas/EcsViewRefreshMode"
               }
             ]
@@ -17264,6 +18773,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsViewRefresh` event payload — result count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "deltaCount": {
@@ -17273,6 +18783,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `EcsViewRefresh` event payload — delta count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -17281,31 +18792,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -17313,6 +18829,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17321,6 +18838,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17329,6 +18847,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17337,9 +18856,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsViewRefresh` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsViewRefreshFullEventDto": {
         "properties": {
@@ -17363,6 +18884,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshFull` event payload — old count.",
             "format": "int32"
           },
           "newCount": {
@@ -17371,6 +18893,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshFull` event payload — new count.",
             "format": "int32"
           },
           "requeryNs": {
@@ -17379,6 +18902,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshFull` event payload — requery ns.",
             "format": "uint32"
           },
           "durationUs": {
@@ -17387,31 +18911,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -17419,6 +18948,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17427,6 +18957,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17435,6 +18966,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17443,9 +18975,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsViewRefreshFull` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsViewRefreshFullOrEventDto": {
         "properties": {
@@ -17469,6 +19003,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshFullOr` event payload — old count.",
             "format": "int32"
           },
           "newCount": {
@@ -17477,6 +19012,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshFullOr` event payload — new count.",
             "format": "int32"
           },
           "branchCount": {
@@ -17485,6 +19021,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshFullOr` event payload — branch count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -17493,31 +19030,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -17525,6 +19067,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17533,6 +19076,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17541,6 +19085,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17549,9 +19094,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsViewRefreshFullOr` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsViewRefreshPullEventDto": {
         "properties": {
@@ -17575,6 +19122,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshPull` event payload — query ns.",
             "format": "uint32"
           },
           "archetypeMaskBits": {
@@ -17583,6 +19131,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRefreshPull` event payload — archetype mask bits.",
             "format": "uint16"
           },
           "durationUs": {
@@ -17591,31 +19140,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -17623,6 +19177,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17631,6 +19186,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17639,6 +19195,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17647,9 +19204,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `EcsViewRefreshPull` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoEcsViewRegistryDeregisterEventDto": {
         "properties": {
@@ -17673,6 +19232,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRegistryDeregister` event payload — view id.",
             "format": "uint16"
           },
           "fieldIdx": {
@@ -17681,6 +19241,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRegistryDeregister` event payload — field idx.",
             "format": "uint16"
           },
           "regCount": {
@@ -17689,6 +19250,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRegistryDeregister` event payload — reg count.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -17697,6 +19259,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17705,6 +19268,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17713,6 +19277,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17721,9 +19286,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsViewRegistryDeregister`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoEcsViewRegistryRegisterEventDto": {
         "properties": {
@@ -17747,6 +19314,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRegistryRegister` event payload — view id.",
             "format": "uint16"
           },
           "fieldIdx": {
@@ -17755,6 +19323,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRegistryRegister` event payload — field idx.",
             "format": "uint16"
           },
           "regCount": {
@@ -17763,6 +19332,7 @@
               "integer",
               "string"
             ],
+            "description": "`EcsViewRegistryRegister` event payload — reg count.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -17771,6 +19341,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17779,6 +19350,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17787,6 +19359,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17795,9 +19368,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `EcsViewRegistryRegister`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoGcEndEventDto": {
         "properties": {
@@ -17821,6 +19396,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — generation.",
             "format": "uint8"
           },
           "count": {
@@ -17829,6 +19405,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — count.",
             "format": "uint32"
           },
           "pauseDurationTicks": {
@@ -17837,6 +19414,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — pause duration ticks.",
             "format": "int64"
           },
           "promotedBytes": {
@@ -17845,6 +19423,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — promoted bytes.",
             "format": "uint64"
           },
           "gen0SizeAfter": {
@@ -17853,6 +19432,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — gen0 size after.",
             "format": "uint64"
           },
           "gen1SizeAfter": {
@@ -17861,6 +19441,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — gen1 size after.",
             "format": "uint64"
           },
           "gen2SizeAfter": {
@@ -17869,6 +19450,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — gen2 size after.",
             "format": "uint64"
           },
           "lohSizeAfter": {
@@ -17877,6 +19459,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — loh size after.",
             "format": "uint64"
           },
           "pohSizeAfter": {
@@ -17885,6 +19468,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — poh size after.",
             "format": "uint64"
           },
           "totalCommittedBytes": {
@@ -17893,6 +19477,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcEnd` event payload — total committed bytes.",
             "format": "uint64"
           },
           "threadSlot": {
@@ -17901,6 +19486,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17909,6 +19495,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17917,6 +19504,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17925,9 +19513,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `GcEnd`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoGcStartEventDto": {
         "properties": {
@@ -17951,12 +19541,15 @@
               "integer",
               "string"
             ],
+            "description": "`GcStart` event payload — generation.",
             "format": "uint8"
           },
           "reason": {
+            "description": "`GcStart` event payload — reason.",
             "$ref": "#/components/schemas/GcReason"
           },
           "type": {
+            "description": "`GcStart` event payload — type.",
             "$ref": "#/components/schemas/GcType"
           },
           "count": {
@@ -17965,6 +19558,7 @@
               "integer",
               "string"
             ],
+            "description": "`GcStart` event payload — count.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -17973,6 +19567,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -17981,6 +19576,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -17989,6 +19585,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -17997,9 +19594,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `GcStart`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoGcSuspensionEventDto": {
         "properties": {
@@ -18018,6 +19617,7 @@
             "format": "uint8"
           },
           "reason": {
+            "description": "`GcSuspension` event payload — reason.",
             "$ref": "#/components/schemas/GcSuspendReason"
           },
           "durationUs": {
@@ -18026,31 +19626,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -18058,6 +19663,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18066,6 +19672,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18074,6 +19681,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18082,9 +19690,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `GcSuspension` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoMemoryAlignmentWasteEventDto": {
         "properties": {
@@ -18108,6 +19718,7 @@
               "integer",
               "string"
             ],
+            "description": "`MemoryAlignmentWaste` event payload — size.",
             "format": "int32"
           },
           "alignment": {
@@ -18116,6 +19727,7 @@
               "integer",
               "string"
             ],
+            "description": "`MemoryAlignmentWaste` event payload — alignment.",
             "format": "int32"
           },
           "wastePctHundredths": {
@@ -18124,6 +19736,7 @@
               "integer",
               "string"
             ],
+            "description": "`MemoryAlignmentWaste` event payload — waste pct hundredths.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -18132,6 +19745,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18140,6 +19754,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18148,6 +19763,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18156,9 +19772,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `MemoryAlignmentWaste`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoMemoryAllocEventDto": {
         "properties": {
@@ -18177,6 +19795,7 @@
             "format": "uint8"
           },
           "direction": {
+            "description": "`MemoryAllocEvent` event payload — direction.",
             "$ref": "#/components/schemas/MemoryAllocDirection"
           },
           "sourceTag": {
@@ -18185,6 +19804,7 @@
               "integer",
               "string"
             ],
+            "description": "`MemoryAllocEvent` event payload — source tag.",
             "format": "uint16"
           },
           "sizeBytes": {
@@ -18193,6 +19813,7 @@
               "integer",
               "string"
             ],
+            "description": "`MemoryAllocEvent` event payload — size bytes.",
             "format": "uint64"
           },
           "totalAfterBytes": {
@@ -18201,6 +19822,7 @@
               "integer",
               "string"
             ],
+            "description": "`MemoryAllocEvent` event payload — total after bytes.",
             "format": "uint64"
           },
           "threadSlot": {
@@ -18209,6 +19831,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18217,6 +19840,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18225,6 +19849,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18233,9 +19858,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `MemoryAllocEvent`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoOtherTraceEventDto": {
         "properties": {
@@ -18251,10 +19878,12 @@
               "integer",
               "string"
             ],
+            "description": "Numeric TraceEventKind value of the underlying record.",
             "format": "int32"
           },
           "isSpan": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when the record carried the span-header extension (i.e., was a span, not an instant)."
           },
           "durationUs": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
@@ -18263,6 +19892,7 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds, when bool OtherTraceEventDto.IsSpan is true.",
             "format": "double"
           },
           "kindByte": {
@@ -18279,6 +19909,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18287,6 +19918,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18295,6 +19927,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18303,9 +19936,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Catch-all DTO for trace records whose kind doesn't map to a generator-emitted derived type. Used for\r\ninstant-shape records (TickStart, TickEnd, PhaseStart/End, etc.) that lack a `[TraceEvent]`\r\ndeclaration — they go through the generic `InstantEventCodec` and don't carry typed payload —\r\nand as forward-compat for kinds added to the wire after this consumer was built. Wire JSON has\r\n`kind: \"other\"` as the discriminator and the numeric kind value in int OtherTraceEventDto.OriginalKind."
       },
       "TraceEventDtoPageCacheAllocatePageEventDto": {
         "properties": {
@@ -18329,6 +19964,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheAllocatePage` event payload — file page index.",
             "format": "int32"
           },
           "durationUs": {
@@ -18337,31 +19973,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -18369,6 +20010,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18377,6 +20019,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18385,6 +20028,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18393,9 +20037,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `PageCacheAllocatePage` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoPageCacheBackpressureEventDto": {
         "properties": {
@@ -18419,6 +20065,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheBackpressure` event payload — retry count.",
             "format": "int32"
           },
           "dirtyCount": {
@@ -18427,6 +20074,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheBackpressure` event payload — dirty count.",
             "format": "int32"
           },
           "epochCount": {
@@ -18435,6 +20083,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheBackpressure` event payload — epoch count.",
             "format": "int32"
           },
           "durationUs": {
@@ -18443,31 +20092,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -18475,6 +20129,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18483,6 +20138,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18491,6 +20147,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18499,9 +20156,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `PageCacheBackpressure` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoPageCacheDiskReadEventDto": {
         "properties": {
@@ -18525,6 +20184,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheDiskRead` event payload — file page index.",
             "format": "int32"
           },
           "durationUs": {
@@ -18533,31 +20193,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -18565,6 +20230,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18573,6 +20239,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18581,6 +20248,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18589,9 +20257,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `PageCacheDiskRead` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoPageCacheDiskWriteEventDto": {
         "properties": {
@@ -18615,6 +20285,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheDiskWrite` event payload — file page index.",
             "format": "int32"
           },
           "pageCount": {
@@ -18624,6 +20295,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `PageCacheDiskWrite` event payload — page count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -18632,31 +20304,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -18664,6 +20341,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18672,6 +20350,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18680,6 +20359,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18688,9 +20368,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `PageCacheDiskWrite` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoPageCacheFetchEventDto": {
         "properties": {
@@ -18714,6 +20396,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheFetch` event payload — file page index.",
             "format": "int32"
           },
           "durationUs": {
@@ -18722,31 +20405,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -18754,6 +20442,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18762,6 +20451,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18770,6 +20460,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18778,9 +20469,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `PageCacheFetch` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoPageCacheFlushEventDto": {
         "properties": {
@@ -18804,6 +20497,7 @@
               "integer",
               "string"
             ],
+            "description": "`PageCacheFlush` event payload — page count.",
             "format": "int32"
           },
           "durationUs": {
@@ -18812,31 +20506,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -18844,6 +20543,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18852,6 +20552,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18860,6 +20561,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18868,9 +20570,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `PageCacheFlush` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoPhaseEndEventDto": {
         "properties": {
@@ -18894,6 +20598,7 @@
               "integer",
               "string"
             ],
+            "description": "`PhaseEnd` event payload — phase.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -18902,6 +20607,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18910,6 +20616,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18918,6 +20625,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18926,9 +20634,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `PhaseEnd`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoPhaseStartEventDto": {
         "properties": {
@@ -18952,6 +20662,7 @@
               "integer",
               "string"
             ],
+            "description": "`PhaseStart` event payload — phase.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -18960,6 +20671,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -18968,6 +20680,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -18976,6 +20689,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -18984,9 +20698,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `PhaseStart`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoQueryArgsEventDto": {
         "properties": {
@@ -19016,7 +20732,8 @@
                 "string"
               ],
               "format": "int64"
-            }
+            },
+            "description": "Widened i64 threshold constants, one per evaluator."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19024,6 +20741,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19032,6 +20750,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19040,6 +20759,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19048,9 +20768,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Decoded DTO for a TraceEventKind.QueryArgs instant record (#342, v9)."
       },
       "TraceEventDtoQueryCountEventDto": {
         "properties": {
@@ -19074,6 +20796,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryCount` event payload — result count.",
             "format": "int32"
           },
           "durationUs": {
@@ -19082,31 +20805,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19114,6 +20842,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19122,6 +20851,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19130,6 +20860,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19138,9 +20869,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryCount` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryDefinitionDescribeEventDto": {
         "properties": {
@@ -19164,6 +20897,7 @@
               "integer",
               "string"
             ],
+            "description": "0 = View, 1 = EcsQuery — discriminator for the (Kind, LocalId) identity pair. Serialized as `queryKind`: the camelCase of the CLR name (`kind`)\r\ncollides with the polymorphic type-discriminator property the `TraceEventDto` hierarchy already uses, which makes System.Text.Json reject the whole\r\nhierarchy at metadata-resolution time.",
             "format": "uint8"
           },
           "localId": {
@@ -19172,6 +20906,7 @@
               "integer",
               "string"
             ],
+            "description": "ViewId or EcsQueryId — the runtime-assigned identity within its Kind's namespace.",
             "format": "uint32"
           },
           "targetComponentType": {
@@ -19207,6 +20942,7 @@
               "integer",
               "string"
             ],
+            "description": "ID into the trace's `QuerySourceStringTable` for the file path. 0 = unattributed.",
             "format": "uint16"
           },
           "definitionSourceLine": {
@@ -19223,6 +20959,7 @@
               "integer",
               "string"
             ],
+            "description": "ID into the trace's `QuerySourceStringTable` for the method name. 0 = unattributed.",
             "format": "uint16"
           },
           "evaluators": {
@@ -19254,6 +20991,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19262,6 +21000,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19270,6 +21009,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19278,9 +21018,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Decoded DTO for a TraceEventKind.QueryDefinitionDescribe instant record (#342, v9)."
       },
       "TraceEventDtoQueryEstimateEventDto": {
         "properties": {
@@ -19304,6 +21046,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryEstimate` event payload — field idx.",
             "format": "uint16"
           },
           "cardinality": {
@@ -19312,6 +21055,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryEstimate` event payload — cardinality.",
             "format": "int64"
           },
           "durationUs": {
@@ -19320,31 +21064,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19352,6 +21101,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19360,6 +21110,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19368,6 +21119,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19376,9 +21128,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryEstimate` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryExecuteFilterEventDto": {
         "properties": {
@@ -19402,6 +21156,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecuteFilter` event payload — filter count.",
             "format": "uint8"
           },
           "rejectedCount": {
@@ -19410,6 +21165,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecuteFilter` event payload — rejected count.",
             "format": "int32"
           },
           "durationUs": {
@@ -19418,31 +21174,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19450,6 +21211,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19458,6 +21220,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19466,6 +21229,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19474,9 +21238,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryExecuteFilter` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryExecuteIndexScanEventDto": {
         "properties": {
@@ -19500,6 +21266,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecuteIndexScan` event payload — primary field idx.",
             "format": "uint16"
           },
           "mode": {
@@ -19508,6 +21275,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecuteIndexScan` event payload — mode.",
             "format": "uint8"
           },
           "durationUs": {
@@ -19516,31 +21284,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19548,6 +21321,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19556,6 +21330,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19564,6 +21339,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19572,9 +21348,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryExecuteIndexScan` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryExecuteIterateEventDto": {
         "properties": {
@@ -19598,6 +21376,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecuteIterate` event payload — chunk count.",
             "format": "int32"
           },
           "entryCount": {
@@ -19606,6 +21385,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecuteIterate` event payload — entry count.",
             "format": "int32"
           },
           "durationUs": {
@@ -19614,31 +21394,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19646,6 +21431,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19654,6 +21440,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19662,6 +21449,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19670,9 +21458,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryExecuteIterate` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryExecutePaginationEventDto": {
         "properties": {
@@ -19696,6 +21486,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecutePagination` event payload — skip.",
             "format": "int32"
           },
           "take": {
@@ -19704,6 +21495,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecutePagination` event payload — take.",
             "format": "int32"
           },
           "earlyTerm": {
@@ -19712,6 +21504,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecutePagination` event payload — early term.",
             "format": "uint8"
           },
           "durationUs": {
@@ -19720,31 +21513,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19752,6 +21550,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19760,6 +21559,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19768,6 +21568,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19776,9 +21577,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryExecutePagination` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryExecuteStorageModeEventDto": {
         "properties": {
@@ -19802,6 +21605,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryExecuteStorageMode` event payload — mode.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -19810,6 +21614,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19818,6 +21623,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19826,6 +21632,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19834,9 +21641,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `QueryExecuteStorageMode`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoQueryParseDnfEventDto": {
         "properties": {
@@ -19860,6 +21669,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryParseDnf` event payload — in branches.",
             "format": "uint16"
           },
           "outBranches": {
@@ -19868,6 +21678,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryParseDnf` event payload — out branches.",
             "format": "uint16"
           },
           "durationUs": {
@@ -19876,31 +21687,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -19908,6 +21724,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -19916,6 +21733,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -19924,6 +21742,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -19932,9 +21751,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryParseDnf` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryParseEventDto": {
         "properties": {
@@ -19958,6 +21779,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryParse` event payload — predicate count.",
             "format": "uint16"
           },
           "branchCount": {
@@ -19966,6 +21788,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryParse` event payload — branch count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -19974,31 +21797,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20006,6 +21834,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20014,6 +21843,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20022,6 +21852,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20030,9 +21861,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryParse` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryPlanEventDto": {
         "properties": {
@@ -20056,6 +21889,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlan` event payload — evaluator count.",
             "format": "uint8"
           },
           "indexFieldIdx": {
@@ -20064,6 +21898,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlan` event payload — index field idx.",
             "format": "uint16"
           },
           "rangeMin": {
@@ -20072,6 +21907,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlan` event payload — range min.",
             "format": "int64"
           },
           "rangeMax": {
@@ -20080,6 +21916,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlan` event payload — range max.",
             "format": "int64"
           },
           "queryInstanceKind": {
@@ -20089,6 +21926,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `QueryPlan` event payload — query instance kind. `null` when the wire record omits it.",
             "format": "uint8"
           },
           "queryInstanceLocalId": {
@@ -20098,6 +21936,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `QueryPlan` event payload — query instance local id. `null` when the wire record omits it.",
             "format": "uint32"
           },
           "executionSourceFileId": {
@@ -20107,6 +21946,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `QueryPlan` event payload — execution source file id. `null` when the wire record omits it.",
             "format": "uint16"
           },
           "executionSourceLine": {
@@ -20116,6 +21956,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `QueryPlan` event payload — execution source line. `null` when the wire record omits it.",
             "format": "int32"
           },
           "executionSourceMethodId": {
@@ -20125,6 +21966,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `QueryPlan` event payload — execution source method id. `null` when the wire record omits it.",
             "format": "uint16"
           },
           "ownerSystemIdx": {
@@ -20134,6 +21976,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `QueryPlan` event payload — owner system idx. `null` when the wire record omits it.",
             "format": "uint16"
           },
           "durationUs": {
@@ -20142,31 +21985,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20174,6 +22022,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20182,6 +22031,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20190,6 +22040,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20198,9 +22049,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryPlan` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoQueryPlanPrimarySelectEventDto": {
         "properties": {
@@ -20224,6 +22077,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlanPrimarySelect` event payload — candidates.",
             "format": "uint8"
           },
           "winnerIdx": {
@@ -20232,6 +22086,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlanPrimarySelect` event payload — winner idx.",
             "format": "uint8"
           },
           "reason": {
@@ -20240,6 +22095,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlanPrimarySelect` event payload — reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -20248,6 +22104,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20256,6 +22113,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20264,6 +22122,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20272,9 +22131,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `QueryPlanPrimarySelect`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoQueryPlanSortEventDto": {
         "properties": {
@@ -20298,6 +22159,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlanSort` event payload — evaluator count.",
             "format": "uint8"
           },
           "sortNs": {
@@ -20306,6 +22168,7 @@
               "integer",
               "string"
             ],
+            "description": "`QueryPlanSort` event payload — sort ns.",
             "format": "uint32"
           },
           "durationUs": {
@@ -20314,31 +22177,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20346,6 +22214,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20354,6 +22223,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20362,6 +22232,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20370,9 +22241,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `QueryPlanSort` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimePhaseSpanEventDto": {
         "properties": {
@@ -20396,6 +22269,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimePhaseSpan` event payload — phase.",
             "format": "uint8"
           },
           "durationUs": {
@@ -20404,31 +22278,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20436,6 +22315,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20444,6 +22324,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20452,6 +22333,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20460,9 +22342,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimePhaseSpan` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimePhaseUoWCreateEventDto": {
         "properties": {
@@ -20486,6 +22370,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimePhaseUoWCreate` event payload — tick.",
             "format": "int64"
           },
           "threadSlot": {
@@ -20494,6 +22379,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20502,6 +22388,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20510,6 +22397,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20518,9 +22406,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `RuntimePhaseUoWCreate`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoRuntimePhaseUoWFlushEventDto": {
         "properties": {
@@ -20544,6 +22434,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimePhaseUoWFlush` event payload — tick.",
             "format": "int64"
           },
           "changeCount": {
@@ -20552,6 +22443,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimePhaseUoWFlush` event payload — change count.",
             "format": "int32"
           },
           "threadSlot": {
@@ -20560,6 +22452,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20568,6 +22461,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20576,6 +22470,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20584,9 +22479,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `RuntimePhaseUoWFlush`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoRuntimeSubscriptionDeltaBuildEventDto": {
         "properties": {
@@ -20610,6 +22507,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaBuild` event payload — view id.",
             "format": "uint16"
           },
           "added": {
@@ -20618,6 +22516,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaBuild` event payload — added.",
             "format": "int32"
           },
           "removed": {
@@ -20626,6 +22525,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaBuild` event payload — removed.",
             "format": "int32"
           },
           "modified": {
@@ -20634,6 +22534,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaBuild` event payload — modified.",
             "format": "int32"
           },
           "durationUs": {
@@ -20642,31 +22543,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20674,6 +22580,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20682,6 +22589,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20690,6 +22598,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20698,9 +22607,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeSubscriptionDeltaBuild` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimeSubscriptionDeltaDirtyBitmapSupplementEventDto": {
         "properties": {
@@ -20724,6 +22635,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaDirtyBitmapSupplement` event payload — modified from ring.",
             "format": "int32"
           },
           "supplementCount": {
@@ -20732,6 +22644,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaDirtyBitmapSupplement` event payload — supplement count.",
             "format": "int32"
           },
           "unionSize": {
@@ -20740,6 +22653,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaDirtyBitmapSupplement` event payload — union size.",
             "format": "int32"
           },
           "durationUs": {
@@ -20748,31 +22662,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20780,6 +22699,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20788,6 +22708,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20796,6 +22717,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20804,9 +22726,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeSubscriptionDeltaDirtyBitmapSupplement` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimeSubscriptionDeltaSerializeEventDto": {
         "properties": {
@@ -20830,6 +22754,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaSerialize` event payload — client id.",
             "format": "uint32"
           },
           "viewId": {
@@ -20838,6 +22763,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaSerialize` event payload — view id.",
             "format": "uint16"
           },
           "bytes": {
@@ -20846,6 +22772,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaSerialize` event payload — bytes.",
             "format": "int32"
           },
           "format": {
@@ -20854,6 +22781,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionDeltaSerialize` event payload — format.",
             "format": "uint8"
           },
           "durationUs": {
@@ -20862,31 +22790,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20894,6 +22827,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -20902,6 +22836,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -20910,6 +22845,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -20918,9 +22854,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeSubscriptionDeltaSerialize` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimeSubscriptionOutputCleanupEventDto": {
         "properties": {
@@ -20944,6 +22882,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputCleanup` event payload — dead count.",
             "format": "int32"
           },
           "deregCount": {
@@ -20952,6 +22891,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputCleanup` event payload — dereg count.",
             "format": "int32"
           },
           "durationUs": {
@@ -20960,31 +22900,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -20992,6 +22937,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21000,6 +22946,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21008,6 +22955,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21016,9 +22964,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeSubscriptionOutputCleanup` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimeSubscriptionOutputExecuteEventDto": {
         "properties": {
@@ -21042,6 +22992,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputExecute` event payload — tick.",
             "format": "int64"
           },
           "level": {
@@ -21050,6 +23001,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputExecute` event payload — level.",
             "format": "uint8"
           },
           "clientCount": {
@@ -21058,6 +23010,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputExecute` event payload — client count.",
             "format": "uint16"
           },
           "viewsRefreshed": {
@@ -21066,6 +23019,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputExecute` event payload — views refreshed.",
             "format": "uint16"
           },
           "deltasPushed": {
@@ -21074,6 +23028,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputExecute` event payload — deltas pushed.",
             "format": "uint32"
           },
           "overflowCount": {
@@ -21082,6 +23037,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionOutputExecute` event payload — overflow count.",
             "format": "uint16"
           },
           "durationUs": {
@@ -21090,31 +23046,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -21122,6 +23083,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21130,6 +23092,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21138,6 +23101,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21146,9 +23110,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeSubscriptionOutputExecute` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimeSubscriptionSubscriberEventDto": {
         "properties": {
@@ -21172,6 +23138,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionSubscriber` event payload — subscriber id.",
             "format": "uint32"
           },
           "viewId": {
@@ -21180,6 +23147,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionSubscriber` event payload — view id.",
             "format": "uint16"
           },
           "deltaCount": {
@@ -21188,6 +23156,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionSubscriber` event payload — delta count.",
             "format": "int32"
           },
           "durationUs": {
@@ -21196,31 +23165,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -21228,6 +23202,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21236,6 +23211,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21244,6 +23220,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21252,9 +23229,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeSubscriptionSubscriber` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimeSubscriptionTransitionBeginSyncEventDto": {
         "properties": {
@@ -21278,6 +23257,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionTransitionBeginSync` event payload — client id.",
             "format": "uint32"
           },
           "viewId": {
@@ -21286,6 +23266,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionTransitionBeginSync` event payload — view id.",
             "format": "uint16"
           },
           "entitySnapshot": {
@@ -21294,6 +23275,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeSubscriptionTransitionBeginSync` event payload — entity snapshot.",
             "format": "int32"
           },
           "durationUs": {
@@ -21302,31 +23284,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -21334,6 +23321,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21342,6 +23330,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21350,6 +23339,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21358,9 +23348,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeSubscriptionTransitionBeginSync` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoRuntimeTransactionLifecycleEventDto": {
         "properties": {
@@ -21384,6 +23376,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeTransactionLifecycle` event payload — sys idx.",
             "format": "uint16"
           },
           "txDurUs": {
@@ -21392,6 +23385,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeTransactionLifecycle` event payload — tx dur us.",
             "format": "uint32"
           },
           "success": {
@@ -21400,6 +23394,7 @@
               "integer",
               "string"
             ],
+            "description": "`RuntimeTransactionLifecycle` event payload — success.",
             "format": "uint8"
           },
           "durationUs": {
@@ -21408,31 +23403,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -21440,6 +23440,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21448,6 +23449,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21456,6 +23458,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21464,9 +23467,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `RuntimeTransactionLifecycle` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerChunkEventDto": {
         "properties": {
@@ -21490,6 +23495,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerChunk` event payload — system index.",
             "format": "uint16"
           },
           "chunkIndex": {
@@ -21498,6 +23504,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerChunk` event payload — chunk index.",
             "format": "uint16"
           },
           "totalChunks": {
@@ -21506,6 +23513,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerChunk` event payload — total chunks.",
             "format": "uint16"
           },
           "entitiesProcessed": {
@@ -21514,6 +23522,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerChunk` event payload — entities processed.",
             "format": "int32"
           },
           "durationUs": {
@@ -21522,31 +23531,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -21554,6 +23568,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21562,6 +23577,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21570,6 +23586,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21578,9 +23595,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerChunk` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerDependencyFanOutEventDto": {
         "properties": {
@@ -21604,6 +23623,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDependencyFanOut` event payload — completing sys idx.",
             "format": "uint16"
           },
           "succCount": {
@@ -21612,6 +23632,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDependencyFanOut` event payload — succ count.",
             "format": "uint16"
           },
           "skippedCount": {
@@ -21620,6 +23641,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDependencyFanOut` event payload — skipped count.",
             "format": "uint16"
           },
           "durationUs": {
@@ -21628,31 +23650,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -21660,6 +23687,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21668,6 +23696,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21676,6 +23705,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21684,9 +23714,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerDependencyFanOut` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerDependencyReadyEventDto": {
         "properties": {
@@ -21710,6 +23742,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDependencyReady` event payload — from sys idx.",
             "format": "uint16"
           },
           "toSysIdx": {
@@ -21718,6 +23751,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDependencyReady` event payload — to sys idx.",
             "format": "uint16"
           },
           "fanOut": {
@@ -21726,6 +23760,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDependencyReady` event payload — fan out.",
             "format": "uint16"
           },
           "predRemain": {
@@ -21734,6 +23769,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDependencyReady` event payload — pred remain.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -21742,6 +23778,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21750,6 +23787,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21758,6 +23796,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21766,9 +23805,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerDependencyReady`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerDispenseEventDto": {
         "properties": {
@@ -21792,6 +23833,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDispense` event payload — sys idx.",
             "format": "uint16"
           },
           "chunkIdx": {
@@ -21800,6 +23842,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDispense` event payload — chunk idx.",
             "format": "int32"
           },
           "workerId": {
@@ -21808,6 +23851,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerDispense` event payload — worker id.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -21816,6 +23860,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21824,6 +23869,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21832,6 +23878,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21840,9 +23887,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerDispense`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerGraphBuildEventDto": {
         "properties": {
@@ -21866,6 +23915,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerGraphBuild` event payload — sys count.",
             "format": "uint16"
           },
           "edgeCount": {
@@ -21874,6 +23924,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerGraphBuild` event payload — edge count.",
             "format": "uint16"
           },
           "topoLen": {
@@ -21882,6 +23933,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerGraphBuild` event payload — topo len.",
             "format": "uint16"
           },
           "durationUs": {
@@ -21890,31 +23942,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -21922,6 +23979,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -21930,6 +23988,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -21938,6 +23997,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -21946,9 +24006,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerGraphBuild` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerGraphRebuildEventDto": {
         "properties": {
@@ -21972,6 +24034,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerGraphRebuild` event payload — old sys count.",
             "format": "uint16"
           },
           "newSysCount": {
@@ -21980,6 +24043,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerGraphRebuild` event payload — new sys count.",
             "format": "uint16"
           },
           "reason": {
@@ -21988,6 +24052,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerGraphRebuild` event payload — reason.",
             "format": "uint8"
           },
           "durationUs": {
@@ -21996,31 +24061,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -22028,6 +24098,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22036,6 +24107,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22044,6 +24116,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22052,9 +24125,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerGraphRebuild` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerOverloadDetectorEventDto": {
         "properties": {
@@ -22078,6 +24153,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — tick.",
             "format": "int64"
           },
           "overrunRatio": {
@@ -22086,6 +24162,7 @@
               "number",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — overrun ratio.",
             "format": "float"
           },
           "consecutiveOverrun": {
@@ -22094,6 +24171,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — consecutive overrun.",
             "format": "uint16"
           },
           "consecutiveUnderrun": {
@@ -22102,6 +24180,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — consecutive underrun.",
             "format": "uint16"
           },
           "consecutiveQueueGrowth": {
@@ -22110,6 +24189,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — consecutive queue growth.",
             "format": "uint16"
           },
           "queueDepth": {
@@ -22118,6 +24198,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — queue depth.",
             "format": "int32"
           },
           "level": {
@@ -22126,6 +24207,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — level.",
             "format": "uint8"
           },
           "multiplier": {
@@ -22134,6 +24216,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadDetector` event payload — multiplier.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -22142,6 +24225,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22150,6 +24234,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22158,6 +24243,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22166,9 +24252,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerOverloadDetector`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerOverloadLevelChangeEventDto": {
         "properties": {
@@ -22192,6 +24280,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadLevelChange` event payload — prev lvl.",
             "format": "uint8"
           },
           "newLvl": {
@@ -22200,6 +24289,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadLevelChange` event payload — new lvl.",
             "format": "uint8"
           },
           "ratio": {
@@ -22208,6 +24298,7 @@
               "number",
               "string"
             ],
+            "description": "`SchedulerOverloadLevelChange` event payload — ratio.",
             "format": "float"
           },
           "queueDepth": {
@@ -22216,6 +24307,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadLevelChange` event payload — queue depth.",
             "format": "int32"
           },
           "oldMul": {
@@ -22224,6 +24316,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadLevelChange` event payload — old mul.",
             "format": "uint8"
           },
           "newMul": {
@@ -22232,6 +24325,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadLevelChange` event payload — new mul.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -22240,6 +24334,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22248,6 +24343,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22256,6 +24352,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22264,9 +24361,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerOverloadLevelChange`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerOverloadSystemShedEventDto": {
         "properties": {
@@ -22290,6 +24389,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadSystemShed` event payload — sys idx.",
             "format": "uint16"
           },
           "level": {
@@ -22298,6 +24398,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadSystemShed` event payload — level.",
             "format": "uint8"
           },
           "divisor": {
@@ -22306,6 +24407,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadSystemShed` event payload — divisor.",
             "format": "uint16"
           },
           "decision": {
@@ -22314,6 +24416,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadSystemShed` event payload — decision.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -22322,6 +24425,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22330,6 +24434,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22338,6 +24443,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22346,9 +24452,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerOverloadSystemShed`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerOverloadTickMultiplierEventDto": {
         "properties": {
@@ -22372,6 +24480,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadTickMultiplier` event payload — tick.",
             "format": "int64"
           },
           "multiplier": {
@@ -22380,6 +24489,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadTickMultiplier` event payload — multiplier.",
             "format": "uint8"
           },
           "intervalTicks": {
@@ -22388,6 +24498,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerOverloadTickMultiplier` event payload — interval ticks.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -22396,6 +24507,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22404,6 +24516,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22412,6 +24525,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22420,9 +24534,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerOverloadTickMultiplier`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerSystemArchetypeEventDto": {
         "properties": {
@@ -22446,6 +24562,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemArchetype` event payload — system index.",
             "format": "uint16"
           },
           "archetypeId": {
@@ -22454,6 +24571,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemArchetype` event payload — archetype id.",
             "format": "uint16"
           },
           "entityCount": {
@@ -22462,6 +24580,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemArchetype` event payload — entity count.",
             "format": "int32"
           },
           "chunkCount": {
@@ -22470,6 +24589,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemArchetype` event payload — chunk count.",
             "format": "int32"
           },
           "durationUs": {
@@ -22478,31 +24598,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -22510,6 +24635,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22518,6 +24644,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22526,6 +24653,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22534,9 +24662,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerSystemArchetype` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerSystemCompletionEventDto": {
         "properties": {
@@ -22560,6 +24690,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemCompletion` event payload — sys idx.",
             "format": "uint16"
           },
           "reason": {
@@ -22568,6 +24699,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemCompletion` event payload — reason.",
             "format": "uint8"
           },
           "durationUsPayload": {
@@ -22576,6 +24708,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemCompletion` event payload — duration us.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -22584,6 +24717,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22592,6 +24726,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22600,6 +24735,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22608,9 +24744,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerSystemCompletion`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerSystemQueueWaitEventDto": {
         "properties": {
@@ -22634,6 +24772,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemQueueWait` event payload — sys idx.",
             "format": "uint16"
           },
           "queueWaitUs": {
@@ -22642,6 +24781,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemQueueWait` event payload — queue wait us.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -22650,6 +24790,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22658,6 +24799,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22666,6 +24808,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22674,9 +24817,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerSystemQueueWait`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerSystemSingleThreadedEventDto": {
         "properties": {
@@ -22700,6 +24845,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemSingleThreaded` event payload — sys idx.",
             "format": "uint16"
           },
           "isParallelQuery": {
@@ -22708,6 +24854,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemSingleThreaded` event payload — is parallel query.",
             "format": "uint8"
           },
           "chunkCount": {
@@ -22716,6 +24863,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemSingleThreaded` event payload — chunk count.",
             "format": "uint16"
           },
           "durationUs": {
@@ -22724,31 +24872,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -22756,6 +24909,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22764,6 +24918,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22772,6 +24927,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22780,9 +24936,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerSystemSingleThreaded` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerSystemStartExecutionEventDto": {
         "properties": {
@@ -22806,6 +24964,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerSystemStartExecution` event payload — sys idx.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -22814,6 +24973,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22822,6 +24982,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22830,6 +24991,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22838,9 +25000,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerSystemStartExecution`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSchedulerWorkerBetweenTickEventDto": {
         "properties": {
@@ -22864,6 +25028,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerBetweenTick` event payload — worker id.",
             "format": "uint8"
           },
           "waitUs": {
@@ -22872,6 +25037,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerBetweenTick` event payload — wait us.",
             "format": "uint32"
           },
           "wakeReason": {
@@ -22880,6 +25046,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerBetweenTick` event payload — wake reason.",
             "format": "uint8"
           },
           "durationUs": {
@@ -22888,31 +25055,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -22920,6 +25092,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -22928,6 +25101,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -22936,6 +25110,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -22944,9 +25119,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerWorkerBetweenTick` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerWorkerIdleEventDto": {
         "properties": {
@@ -22970,6 +25147,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerIdle` event payload — worker id.",
             "format": "uint8"
           },
           "spinCount": {
@@ -22978,6 +25156,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerIdle` event payload — spin count.",
             "format": "uint16"
           },
           "idleUs": {
@@ -22986,6 +25165,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerIdle` event payload — idle us.",
             "format": "uint32"
           },
           "durationUs": {
@@ -22994,31 +25174,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -23026,6 +25211,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23034,6 +25220,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23042,6 +25229,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23050,9 +25238,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SchedulerWorkerIdle` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSchedulerWorkerWakeEventDto": {
         "properties": {
@@ -23076,6 +25266,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerWake` event payload — worker id.",
             "format": "uint8"
           },
           "delayUs": {
@@ -23084,6 +25275,7 @@
               "integer",
               "string"
             ],
+            "description": "`SchedulerWorkerWake` event payload — delay us.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -23092,6 +25284,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23100,6 +25293,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23108,6 +25302,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23116,9 +25311,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SchedulerWorkerWake`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialCellIndexAddEventDto": {
         "properties": {
@@ -23142,6 +25339,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexAdd` event payload — cell key.",
             "format": "int32"
           },
           "slot": {
@@ -23150,6 +25348,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexAdd` event payload — slot.",
             "format": "int32"
           },
           "clusterChunkId": {
@@ -23158,6 +25357,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexAdd` event payload — cluster chunk id.",
             "format": "int32"
           },
           "capacity": {
@@ -23166,6 +25366,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexAdd` event payload — capacity.",
             "format": "int32"
           },
           "threadSlot": {
@@ -23174,6 +25375,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23182,6 +25384,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23190,6 +25393,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23198,9 +25402,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialCellIndexAdd`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialCellIndexRemoveEventDto": {
         "properties": {
@@ -23224,6 +25430,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexRemove` event payload — cell key.",
             "format": "int32"
           },
           "slot": {
@@ -23232,6 +25439,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexRemove` event payload — slot.",
             "format": "int32"
           },
           "swappedClusterId": {
@@ -23240,6 +25448,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexRemove` event payload — swapped cluster id.",
             "format": "int32"
           },
           "threadSlot": {
@@ -23248,6 +25457,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23256,6 +25466,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23264,6 +25475,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23272,9 +25484,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialCellIndexRemove`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialCellIndexUpdateEventDto": {
         "properties": {
@@ -23298,6 +25512,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexUpdate` event payload — cell key.",
             "format": "int32"
           },
           "slot": {
@@ -23306,6 +25521,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialCellIndexUpdate` event payload — slot.",
             "format": "int32"
           },
           "threadSlot": {
@@ -23314,6 +25530,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23322,6 +25539,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23330,6 +25548,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23338,9 +25557,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialCellIndexUpdate`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialClusterAabbRefreshEventDto": {
         "properties": {
@@ -23364,6 +25585,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterAabbRefresh` event payload — archetype id.",
             "format": "uint16"
           },
           "clusterScanned": {
@@ -23372,6 +25594,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterAabbRefresh` event payload — cluster scanned.",
             "format": "int32"
           },
           "aabbsChanged": {
@@ -23381,6 +25604,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `SpatialClusterAabbRefresh` event payload — aabbs changed. `null` when the wire record omits it.",
             "format": "int32"
           },
           "slotsScanned": {
@@ -23390,6 +25614,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `SpatialClusterAabbRefresh` event payload — slots scanned. `null` when the wire record omits it.",
             "format": "int32"
           },
           "outlierGuardFires": {
@@ -23399,6 +25624,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `SpatialClusterAabbRefresh` event payload — outlier guard fires. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -23407,31 +25633,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -23439,6 +25670,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23447,6 +25679,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23455,6 +25688,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23463,9 +25697,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialClusterAabbRefresh` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialClusterMigrationDetectEventDto": {
         "properties": {
@@ -23489,6 +25725,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationDetect` event payload — archetype id.",
             "format": "uint16"
           },
           "clusterChunkId": {
@@ -23497,6 +25734,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationDetect` event payload — cluster chunk id.",
             "format": "int32"
           },
           "oldCellKey": {
@@ -23505,6 +25743,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationDetect` event payload — old cell key.",
             "format": "int32"
           },
           "newCellKey": {
@@ -23513,6 +25752,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationDetect` event payload — new cell key.",
             "format": "int32"
           },
           "threadSlot": {
@@ -23521,6 +25761,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23529,6 +25770,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23537,6 +25779,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23545,9 +25788,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialClusterMigrationDetect`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialClusterMigrationDetectScanEventDto": {
         "properties": {
@@ -23571,6 +25816,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationDetectScan` event payload — archetype id.",
             "format": "uint16"
           },
           "scanSlotCount": {
@@ -23579,6 +25825,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationDetectScan` event payload — scan slot count.",
             "format": "int32"
           },
           "migrationsQueued": {
@@ -23588,6 +25835,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `SpatialClusterMigrationDetectScan` event payload — migrations queued. `null` when the wire record omits it.",
             "format": "int32"
           },
           "hysteresisAbsorbed": {
@@ -23597,6 +25845,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `SpatialClusterMigrationDetectScan` event payload — hysteresis absorbed. `null` when the wire record omits it.",
             "format": "int32"
           },
           "clustersTouched": {
@@ -23606,6 +25855,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `SpatialClusterMigrationDetectScan` event payload — clusters touched. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -23614,31 +25864,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -23646,6 +25901,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23654,6 +25910,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23662,6 +25919,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23670,9 +25928,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialClusterMigrationDetectScan` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialClusterMigrationHysteresisEventDto": {
         "properties": {
@@ -23696,6 +25956,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationHysteresis` event payload — archetype id.",
             "format": "uint16"
           },
           "clusterChunkId": {
@@ -23704,6 +25965,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationHysteresis` event payload — cluster chunk id.",
             "format": "int32"
           },
           "escapeDistSq": {
@@ -23712,6 +25974,7 @@
               "number",
               "string"
             ],
+            "description": "`SpatialClusterMigrationHysteresis` event payload — escape dist sq.",
             "format": "float"
           },
           "threadSlot": {
@@ -23720,6 +25983,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23728,6 +25992,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23736,6 +26001,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23744,9 +26010,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialClusterMigrationHysteresis`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialClusterMigrationQueueEventDto": {
         "properties": {
@@ -23770,6 +26038,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationQueue` event payload — archetype id.",
             "format": "uint16"
           },
           "clusterChunkId": {
@@ -23778,6 +26047,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationQueue` event payload — cluster chunk id.",
             "format": "int32"
           },
           "queueLen": {
@@ -23786,6 +26056,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialClusterMigrationQueue` event payload — queue len.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -23794,6 +26065,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23802,6 +26074,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23810,6 +26083,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23818,9 +26092,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialClusterMigrationQueue`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialGridCellTierChangeEventDto": {
         "properties": {
@@ -23844,6 +26120,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridCellTierChange` event payload — cell key.",
             "format": "int32"
           },
           "oldTier": {
@@ -23852,6 +26129,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridCellTierChange` event payload — old tier.",
             "format": "uint8"
           },
           "newTier": {
@@ -23860,6 +26138,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridCellTierChange` event payload — new tier.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -23868,6 +26147,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23876,6 +26156,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23884,6 +26165,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23892,9 +26174,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialGridCellTierChange`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialGridClusterCellAssignEventDto": {
         "properties": {
@@ -23918,6 +26202,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridClusterCellAssign` event payload — cluster chunk id.",
             "format": "int32"
           },
           "cellKey": {
@@ -23926,6 +26211,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridClusterCellAssign` event payload — cell key.",
             "format": "int32"
           },
           "archetypeId": {
@@ -23934,6 +26220,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridClusterCellAssign` event payload — archetype id.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -23942,6 +26229,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -23950,6 +26238,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -23958,6 +26247,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -23966,9 +26256,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialGridClusterCellAssign`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialGridOccupancyChangeEventDto": {
         "properties": {
@@ -23992,6 +26284,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridOccupancyChange` event payload — cell key.",
             "format": "int32"
           },
           "delta": {
@@ -23999,7 +26292,8 @@
             "type": [
               "integer",
               "string"
-            ]
+            ],
+            "description": "`SpatialGridOccupancyChange` event payload — delta."
           },
           "occBefore": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24007,6 +26301,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridOccupancyChange` event payload — occ before.",
             "format": "uint16"
           },
           "occAfter": {
@@ -24015,6 +26310,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialGridOccupancyChange` event payload — occ after.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -24023,6 +26319,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24031,6 +26328,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24039,6 +26337,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24047,9 +26346,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialGridOccupancyChange`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialMaintainAabbValidateEventDto": {
         "properties": {
@@ -24073,6 +26374,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainAabbValidate` event payload — entity pk.",
             "format": "int64"
           },
           "componentTypeId": {
@@ -24081,6 +26383,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainAabbValidate` event payload — component type id.",
             "format": "uint16"
           },
           "opcode": {
@@ -24089,6 +26392,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainAabbValidate` event payload — opcode.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -24097,6 +26401,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24105,6 +26410,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24113,6 +26419,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24121,9 +26428,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialMaintainAabbValidate`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialMaintainBackPointerWriteEventDto": {
         "properties": {
@@ -24147,6 +26456,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainBackPointerWrite` event payload — component chunk id.",
             "format": "int32"
           },
           "leafChunkId": {
@@ -24155,6 +26465,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainBackPointerWrite` event payload — leaf chunk id.",
             "format": "int32"
           },
           "slotIndex": {
@@ -24163,6 +26474,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainBackPointerWrite` event payload — slot index.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -24171,6 +26483,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24179,6 +26492,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24187,6 +26501,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24195,9 +26510,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialMaintainBackPointerWrite`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialMaintainInsertEventDto": {
         "properties": {
@@ -24221,6 +26538,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainInsert` event payload — entity pk.",
             "format": "int64"
           },
           "componentTypeId": {
@@ -24229,6 +26547,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainInsert` event payload — component type id.",
             "format": "uint16"
           },
           "didDegenerate": {
@@ -24237,6 +26556,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainInsert` event payload — did degenerate.",
             "format": "uint8"
           },
           "durationUs": {
@@ -24245,31 +26565,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24277,6 +26602,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24285,6 +26611,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24293,6 +26620,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24301,9 +26629,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialMaintainInsert` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialMaintainUpdateSlowPathEventDto": {
         "properties": {
@@ -24327,6 +26657,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainUpdateSlowPath` event payload — entity pk.",
             "format": "int64"
           },
           "componentTypeId": {
@@ -24335,6 +26666,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialMaintainUpdateSlowPath` event payload — component type id.",
             "format": "uint16"
           },
           "escapeDistSq": {
@@ -24343,6 +26675,7 @@
               "number",
               "string"
             ],
+            "description": "`SpatialMaintainUpdateSlowPath` event payload — escape dist sq.",
             "format": "float"
           },
           "durationUs": {
@@ -24351,31 +26684,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24383,6 +26721,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24391,6 +26730,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24399,6 +26739,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24407,9 +26748,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialMaintainUpdateSlowPath` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialQueryAabbEventDto": {
         "properties": {
@@ -24433,6 +26776,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryAabb` event payload — nodes visited.",
             "format": "uint16"
           },
           "leavesEntered": {
@@ -24441,6 +26785,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryAabb` event payload — leaves entered.",
             "format": "uint16"
           },
           "resultCount": {
@@ -24449,6 +26794,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryAabb` event payload — result count.",
             "format": "uint16"
           },
           "restartCount": {
@@ -24457,6 +26803,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryAabb` event payload — restart count.",
             "format": "uint8"
           },
           "categoryMask": {
@@ -24465,6 +26812,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryAabb` event payload — category mask.",
             "format": "uint32"
           },
           "durationUs": {
@@ -24473,31 +26821,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24505,6 +26858,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24513,6 +26867,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24521,6 +26876,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24529,9 +26885,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialQueryAabb` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialQueryCountEventDto": {
         "properties": {
@@ -24555,6 +26913,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryCount` event payload — variant.",
             "format": "uint8"
           },
           "nodesVisited": {
@@ -24563,6 +26922,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryCount` event payload — nodes visited.",
             "format": "uint16"
           },
           "resultCount": {
@@ -24571,6 +26931,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryCount` event payload — result count.",
             "format": "int32"
           },
           "durationUs": {
@@ -24579,31 +26940,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24611,6 +26977,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24619,6 +26986,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24627,6 +26995,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24635,9 +27004,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialQueryCount` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialQueryFrustumEventDto": {
         "properties": {
@@ -24661,6 +27032,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryFrustum` event payload — nodes visited.",
             "format": "uint16"
           },
           "resultCount": {
@@ -24669,6 +27041,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryFrustum` event payload — result count.",
             "format": "uint16"
           },
           "planeCount": {
@@ -24677,6 +27050,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryFrustum` event payload — plane count.",
             "format": "uint8"
           },
           "restartCount": {
@@ -24685,6 +27059,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryFrustum` event payload — restart count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -24693,31 +27068,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24725,6 +27105,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24733,6 +27114,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24741,6 +27123,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24749,9 +27132,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialQueryFrustum` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialQueryKnnEventDto": {
         "properties": {
@@ -24775,6 +27160,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryKnn` event payload — k.",
             "format": "uint16"
           },
           "iterCount": {
@@ -24783,6 +27169,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryKnn` event payload — iter count.",
             "format": "uint8"
           },
           "finalRadius": {
@@ -24791,6 +27178,7 @@
               "number",
               "string"
             ],
+            "description": "`SpatialQueryKnn` event payload — final radius.",
             "format": "float"
           },
           "resultCount": {
@@ -24799,6 +27187,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryKnn` event payload — result count.",
             "format": "uint16"
           },
           "durationUs": {
@@ -24807,31 +27196,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24839,6 +27233,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24847,6 +27242,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24855,6 +27251,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24863,9 +27260,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialQueryKnn` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialQueryRadiusEventDto": {
         "properties": {
@@ -24889,6 +27288,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryRadius` event payload — nodes visited.",
             "format": "uint16"
           },
           "resultCount": {
@@ -24897,6 +27297,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryRadius` event payload — result count.",
             "format": "uint16"
           },
           "radius": {
@@ -24905,6 +27306,7 @@
               "number",
               "string"
             ],
+            "description": "`SpatialQueryRadius` event payload — radius.",
             "format": "float"
           },
           "restartCount": {
@@ -24913,6 +27315,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryRadius` event payload — restart count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -24921,31 +27324,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -24953,6 +27361,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -24961,6 +27370,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -24969,6 +27379,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -24977,9 +27388,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialQueryRadius` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialQueryRayEventDto": {
         "properties": {
@@ -25003,6 +27416,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryRay` event payload — nodes visited.",
             "format": "uint16"
           },
           "resultCount": {
@@ -25011,6 +27425,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryRay` event payload — result count.",
             "format": "uint16"
           },
           "maxDist": {
@@ -25019,6 +27434,7 @@
               "number",
               "string"
             ],
+            "description": "`SpatialQueryRay` event payload — max dist.",
             "format": "float"
           },
           "restartCount": {
@@ -25027,6 +27443,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialQueryRay` event payload — restart count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -25035,31 +27452,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -25067,6 +27489,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25075,6 +27498,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25083,6 +27507,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25091,9 +27516,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialQueryRay` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialRTreeBulkLoadEventDto": {
         "properties": {
@@ -25117,6 +27544,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeBulkLoad` event payload — entity count.",
             "format": "int32"
           },
           "leafCount": {
@@ -25125,6 +27553,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeBulkLoad` event payload — leaf count.",
             "format": "int32"
           },
           "durationUs": {
@@ -25133,31 +27562,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -25165,6 +27599,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25173,6 +27608,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25181,6 +27617,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25189,9 +27626,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialRTreeBulkLoad` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialRTreeInsertEventDto": {
         "properties": {
@@ -25215,6 +27654,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeInsert` event payload — entity id.",
             "format": "int64"
           },
           "depth": {
@@ -25223,6 +27663,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeInsert` event payload — depth.",
             "format": "uint8"
           },
           "didSplit": {
@@ -25231,6 +27672,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeInsert` event payload — did split.",
             "format": "uint8"
           },
           "restartCount": {
@@ -25239,6 +27681,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeInsert` event payload — restart count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -25247,31 +27690,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -25279,6 +27727,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25287,6 +27736,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25295,6 +27745,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25303,9 +27754,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialRTreeInsert` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialRTreeNodeSplitEventDto": {
         "properties": {
@@ -25329,6 +27782,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeNodeSplit` event payload — depth.",
             "format": "uint8"
           },
           "splitAxis": {
@@ -25337,6 +27791,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeNodeSplit` event payload — split axis.",
             "format": "uint8"
           },
           "leftCount": {
@@ -25345,6 +27800,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeNodeSplit` event payload — left count.",
             "format": "uint8"
           },
           "rightCount": {
@@ -25353,6 +27809,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeNodeSplit` event payload — right count.",
             "format": "uint8"
           },
           "durationUs": {
@@ -25361,31 +27818,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -25393,6 +27855,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25401,6 +27864,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25409,6 +27873,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25417,9 +27882,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialRTreeNodeSplit` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialRTreeRemoveEventDto": {
         "properties": {
@@ -25443,6 +27910,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeRemove` event payload — entity id.",
             "format": "int64"
           },
           "leafCollapse": {
@@ -25451,6 +27919,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialRTreeRemove` event payload — leaf collapse.",
             "format": "uint8"
           },
           "durationUs": {
@@ -25459,31 +27928,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -25491,6 +27965,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25499,6 +27974,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25507,6 +27983,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25515,9 +27992,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialRTreeRemove` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialTierIndexRebuildEventDto": {
         "properties": {
@@ -25541,6 +28020,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTierIndexRebuild` event payload — archetype id.",
             "format": "uint16"
           },
           "clusterCount": {
@@ -25549,6 +28029,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTierIndexRebuild` event payload — cluster count.",
             "format": "int32"
           },
           "oldVersion": {
@@ -25557,6 +28038,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTierIndexRebuild` event payload — old version.",
             "format": "int32"
           },
           "newVersion": {
@@ -25565,6 +28047,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTierIndexRebuild` event payload — new version.",
             "format": "int32"
           },
           "durationUs": {
@@ -25573,31 +28056,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -25605,6 +28093,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25613,6 +28102,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25621,6 +28111,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25629,9 +28120,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialTierIndexRebuild` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialTierIndexVersionSkipEventDto": {
         "properties": {
@@ -25655,6 +28148,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTierIndexVersionSkip` event payload — archetype id.",
             "format": "uint16"
           },
           "version": {
@@ -25663,6 +28157,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTierIndexVersionSkip` event payload — version.",
             "format": "int32"
           },
           "reason": {
@@ -25671,6 +28166,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTierIndexVersionSkip` event payload — reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -25679,6 +28175,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25687,6 +28184,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25695,6 +28193,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25703,9 +28202,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialTierIndexVersionSkip`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialTriggerCacheInvalidateEventDto": {
         "properties": {
@@ -25729,6 +28230,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerCacheInvalidate` event payload — region id.",
             "format": "uint16"
           },
           "oldVersion": {
@@ -25737,6 +28239,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerCacheInvalidate` event payload — old version.",
             "format": "int32"
           },
           "newVersion": {
@@ -25745,6 +28248,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerCacheInvalidate` event payload — new version.",
             "format": "int32"
           },
           "threadSlot": {
@@ -25753,6 +28257,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25761,6 +28266,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25769,6 +28275,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25777,9 +28284,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialTriggerCacheInvalidate`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialTriggerEvalEventDto": {
         "properties": {
@@ -25803,6 +28312,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerEval` event payload — region id.",
             "format": "uint16"
           },
           "occupantCount": {
@@ -25811,6 +28321,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerEval` event payload — occupant count.",
             "format": "uint16"
           },
           "enterCount": {
@@ -25819,6 +28330,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerEval` event payload — enter count.",
             "format": "uint16"
           },
           "leaveCount": {
@@ -25827,6 +28339,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerEval` event payload — leave count.",
             "format": "uint16"
           },
           "durationUs": {
@@ -25835,31 +28348,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -25867,6 +28385,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25875,6 +28394,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25883,6 +28403,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25891,9 +28412,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `SpatialTriggerEval` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoSpatialTriggerOccupantDiffEventDto": {
         "properties": {
@@ -25917,6 +28440,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerOccupantDiff` event payload — region id.",
             "format": "uint16"
           },
           "prevCount": {
@@ -25925,6 +28449,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerOccupantDiff` event payload — prev count.",
             "format": "uint16"
           },
           "currCount": {
@@ -25933,6 +28458,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerOccupantDiff` event payload — curr count.",
             "format": "uint16"
           },
           "enterCount": {
@@ -25941,6 +28467,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerOccupantDiff` event payload — enter count.",
             "format": "uint16"
           },
           "leaveCount": {
@@ -25949,6 +28476,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerOccupantDiff` event payload — leave count.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -25957,6 +28485,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -25965,6 +28494,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -25973,6 +28503,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -25981,9 +28512,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialTriggerOccupantDiff`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSpatialTriggerRegionEventDto": {
         "properties": {
@@ -26007,6 +28540,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerRegion` event payload — op.",
             "format": "uint8"
           },
           "regionId": {
@@ -26015,6 +28549,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerRegion` event payload — region id.",
             "format": "uint16"
           },
           "categoryMask": {
@@ -26023,6 +28558,7 @@
               "integer",
               "string"
             ],
+            "description": "`SpatialTriggerRegion` event payload — category mask.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -26031,6 +28567,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26039,6 +28576,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26047,6 +28585,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26055,9 +28594,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SpatialTriggerRegion`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoStatisticsRebuildEventDto": {
         "properties": {
@@ -26081,6 +28622,7 @@
               "integer",
               "string"
             ],
+            "description": "`StatisticsRebuild` event payload — entity count.",
             "format": "int32"
           },
           "mutationCount": {
@@ -26089,6 +28631,7 @@
               "integer",
               "string"
             ],
+            "description": "`StatisticsRebuild` event payload — mutation count.",
             "format": "int32"
           },
           "samplingInterval": {
@@ -26097,6 +28640,7 @@
               "integer",
               "string"
             ],
+            "description": "`StatisticsRebuild` event payload — sampling interval.",
             "format": "int32"
           },
           "durationUs": {
@@ -26105,31 +28649,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -26137,6 +28686,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26145,6 +28695,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26153,6 +28704,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26161,9 +28713,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `StatisticsRebuild` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoStorageChunkSegmentGrowEventDto": {
         "properties": {
@@ -26187,6 +28741,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageChunkSegmentGrow` event payload — stride.",
             "format": "int32"
           },
           "oldCap": {
@@ -26195,6 +28750,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageChunkSegmentGrow` event payload — old cap.",
             "format": "int32"
           },
           "newCap": {
@@ -26203,6 +28759,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageChunkSegmentGrow` event payload — new cap.",
             "format": "int32"
           },
           "threadSlot": {
@@ -26211,6 +28768,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26219,6 +28777,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26227,6 +28786,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26235,9 +28795,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `StorageChunkSegmentGrow`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoStorageFileHandleEventDto": {
         "properties": {
@@ -26261,6 +28823,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageFileHandle` event payload — op.",
             "format": "uint8"
           },
           "filePathId": {
@@ -26269,6 +28832,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageFileHandle` event payload — file path id.",
             "format": "int32"
           },
           "modeOrReason": {
@@ -26277,6 +28841,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageFileHandle` event payload — mode or reason.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -26285,6 +28850,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26293,6 +28859,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26301,6 +28868,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26309,9 +28877,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `StorageFileHandle`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoStorageOccupancyMapGrowEventDto": {
         "properties": {
@@ -26335,6 +28905,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageOccupancyMapGrow` event payload — old cap.",
             "format": "int32"
           },
           "newCap": {
@@ -26343,6 +28914,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageOccupancyMapGrow` event payload — new cap.",
             "format": "int32"
           },
           "threadSlot": {
@@ -26351,6 +28923,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26359,6 +28932,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26367,6 +28941,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26375,9 +28950,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `StorageOccupancyMapGrow`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoStoragePageCacheDirtyWalkEventDto": {
         "properties": {
@@ -26401,6 +28978,7 @@
               "integer",
               "string"
             ],
+            "description": "`StoragePageCacheDirtyWalk` event payload — range start.",
             "format": "int32"
           },
           "rangeLen": {
@@ -26409,6 +28987,7 @@
               "integer",
               "string"
             ],
+            "description": "`StoragePageCacheDirtyWalk` event payload — range len.",
             "format": "int32"
           },
           "dirtyMs": {
@@ -26417,6 +28996,7 @@
               "integer",
               "string"
             ],
+            "description": "`StoragePageCacheDirtyWalk` event payload — dirty ms.",
             "format": "int32"
           },
           "durationUs": {
@@ -26425,31 +29005,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -26457,6 +29042,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26465,6 +29051,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26473,6 +29060,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26481,9 +29069,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `StoragePageCacheDirtyWalk` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoStorageSegmentCreateEventDto": {
         "properties": {
@@ -26507,6 +29097,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageSegmentCreate` event payload — segment id.",
             "format": "int32"
           },
           "pageCount": {
@@ -26515,6 +29106,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageSegmentCreate` event payload — page count.",
             "format": "int32"
           },
           "threadSlot": {
@@ -26523,6 +29115,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26531,6 +29124,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26539,6 +29133,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26547,9 +29142,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `StorageSegmentCreate`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoStorageSegmentGrowEventDto": {
         "properties": {
@@ -26573,6 +29170,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageSegmentGrow` event payload — segment id.",
             "format": "int32"
           },
           "oldLen": {
@@ -26581,6 +29179,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageSegmentGrow` event payload — old len.",
             "format": "int32"
           },
           "newLen": {
@@ -26589,6 +29188,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageSegmentGrow` event payload — new len.",
             "format": "int32"
           },
           "threadSlot": {
@@ -26597,6 +29197,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26605,6 +29206,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26613,6 +29215,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26621,9 +29224,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `StorageSegmentGrow`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoStorageSegmentLoadEventDto": {
         "properties": {
@@ -26647,6 +29252,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageSegmentLoad` event payload — segment id.",
             "format": "int32"
           },
           "pageCount": {
@@ -26655,6 +29261,7 @@
               "integer",
               "string"
             ],
+            "description": "`StorageSegmentLoad` event payload — page count.",
             "format": "int32"
           },
           "threadSlot": {
@@ -26663,6 +29270,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26671,6 +29279,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26679,6 +29288,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26687,9 +29297,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `StorageSegmentLoad`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSystemReadyEventDto": {
         "properties": {
@@ -26713,6 +29325,7 @@
               "integer",
               "string"
             ],
+            "description": "`SystemReady` event payload — system idx.",
             "format": "uint16"
           },
           "predecessorCount": {
@@ -26721,6 +29334,7 @@
               "integer",
               "string"
             ],
+            "description": "`SystemReady` event payload — predecessor count.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -26729,6 +29343,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26737,6 +29352,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26745,6 +29361,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26753,9 +29370,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SystemReady`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoSystemSkippedEventDto": {
         "properties": {
@@ -26779,6 +29398,7 @@
               "integer",
               "string"
             ],
+            "description": "`SystemSkipped` event payload — system idx.",
             "format": "uint16"
           },
           "skipReason": {
@@ -26787,6 +29407,7 @@
               "integer",
               "string"
             ],
+            "description": "`SystemSkipped` event payload — skip reason.",
             "format": "uint8"
           },
           "wouldBeChunkCount": {
@@ -26795,6 +29416,7 @@
               "integer",
               "string"
             ],
+            "description": "`SystemSkipped` event payload — would be chunk count.",
             "format": "uint16"
           },
           "successorsUnblocked": {
@@ -26803,6 +29425,7 @@
               "integer",
               "string"
             ],
+            "description": "`SystemSkipped` event payload — successors unblocked.",
             "format": "uint16"
           },
           "threadSlot": {
@@ -26811,6 +29434,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26819,6 +29443,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26827,6 +29452,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26835,9 +29461,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `SystemSkipped`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoThreadContextSwitchEventDto": {
         "properties": {
@@ -26861,6 +29489,7 @@
               "integer",
               "string"
             ],
+            "description": "`ThreadContextSwitch` event payload — target slot idx.",
             "format": "uint8"
           },
           "processorNumber": {
@@ -26869,9 +29498,11 @@
               "integer",
               "string"
             ],
+            "description": "`ThreadContextSwitch` event payload — processor number.",
             "format": "uint8"
           },
           "waitReason": {
+            "description": "`ThreadContextSwitch` event payload — wait reason.",
             "$ref": "#/components/schemas/ThreadWaitReason"
           },
           "threadState": {
@@ -26880,10 +29511,12 @@
               "integer",
               "string"
             ],
+            "description": "`ThreadContextSwitch` event payload — thread state.",
             "format": "uint8"
           },
           "gettingIdle": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`ThreadContextSwitch` event payload — getting idle."
           },
           "durationQpc": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -26891,6 +29524,7 @@
               "integer",
               "string"
             ],
+            "description": "`ThreadContextSwitch` event payload — duration qpc.",
             "format": "uint32"
           },
           "readyTimeQpc": {
@@ -26899,6 +29533,7 @@
               "integer",
               "string"
             ],
+            "description": "`ThreadContextSwitch` event payload — ready time qpc.",
             "format": "uint32"
           },
           "threadSlot": {
@@ -26907,6 +29542,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26915,6 +29551,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26923,6 +29560,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26931,9 +29569,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `ThreadContextSwitch`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoTickEndEventDto": {
         "properties": {
@@ -26957,6 +29597,7 @@
               "integer",
               "string"
             ],
+            "description": "`TickEnd` event payload — overload level.",
             "format": "uint8"
           },
           "tickMultiplier": {
@@ -26965,6 +29606,7 @@
               "integer",
               "string"
             ],
+            "description": "`TickEnd` event payload — tick multiplier.",
             "format": "uint8"
           },
           "threadSlot": {
@@ -26973,6 +29615,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -26981,6 +29624,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -26989,6 +29633,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -26997,9 +29642,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `TickEnd`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoTickStartEventDto": {
         "properties": {
@@ -27023,6 +29670,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27031,6 +29679,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27039,6 +29688,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27047,9 +29697,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated instant-event DTO for `TickStart`. 12-byte header + payload; no span fields."
       },
       "TraceEventDtoTransactionCommitComponentEventDto": {
         "properties": {
@@ -27073,6 +29725,7 @@
               "integer",
               "string"
             ],
+            "description": "`TransactionCommitComponent` event payload — tsn.",
             "format": "int64"
           },
           "componentTypeId": {
@@ -27081,6 +29734,7 @@
               "integer",
               "string"
             ],
+            "description": "`TransactionCommitComponent` event payload — component type id.",
             "format": "int32"
           },
           "rowCount": {
@@ -27090,6 +29744,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `TransactionCommitComponent` event payload — row count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -27098,31 +29753,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27130,6 +29790,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27138,6 +29799,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27146,6 +29808,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27154,9 +29817,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `TransactionCommitComponent` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoTransactionCommitEventDto": {
         "properties": {
@@ -27180,6 +29845,7 @@
               "integer",
               "string"
             ],
+            "description": "`TransactionCommit` event payload — tsn.",
             "format": "int64"
           },
           "componentCount": {
@@ -27189,13 +29855,15 @@
               "integer",
               "string"
             ],
+            "description": "Optional `TransactionCommit` event payload — component count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "conflictDetected": {
             "type": [
               "null",
               "boolean"
-            ]
+            ],
+            "description": "Optional `TransactionCommit` event payload — conflict detected. `null` when the wire record omits it."
           },
           "durationUs": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
@@ -27203,31 +29871,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27235,6 +29908,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27243,6 +29917,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27251,6 +29926,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27259,9 +29935,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `TransactionCommit` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoTransactionPersistEventDto": {
         "properties": {
@@ -27285,6 +29963,7 @@
               "integer",
               "string"
             ],
+            "description": "`TransactionPersist` event payload — tsn.",
             "format": "int64"
           },
           "walLsn": {
@@ -27294,6 +29973,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `TransactionPersist` event payload — wal lsn. `null` when the wire record omits it.",
             "format": "int64"
           },
           "durationUs": {
@@ -27302,31 +29982,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27334,6 +30019,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27342,6 +30028,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27350,6 +30037,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27358,9 +30046,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `TransactionPersist` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoTransactionRollbackEventDto": {
         "properties": {
@@ -27384,6 +30074,7 @@
               "integer",
               "string"
             ],
+            "description": "`TransactionRollback` event payload — tsn.",
             "format": "int64"
           },
           "componentCount": {
@@ -27393,6 +30084,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `TransactionRollback` event payload — component count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "reason": {
@@ -27401,6 +30093,7 @@
                 "type": "null"
               },
               {
+                "description": "Optional `TransactionRollback` event payload — reason. `null` when the wire record omits it.",
                 "$ref": "#/components/schemas/TransactionRollbackReason"
               }
             ]
@@ -27411,31 +30104,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27443,6 +30141,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27451,6 +30150,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27459,6 +30159,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27467,9 +30168,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `TransactionRollback` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWalFlushEventDto": {
         "properties": {
@@ -27493,6 +30196,7 @@
               "integer",
               "string"
             ],
+            "description": "`WalFlush` event payload — batch byte count.",
             "format": "int32"
           },
           "frameCount": {
@@ -27501,6 +30205,7 @@
               "integer",
               "string"
             ],
+            "description": "`WalFlush` event payload — frame count.",
             "format": "int32"
           },
           "highLsn": {
@@ -27509,6 +30214,7 @@
               "integer",
               "string"
             ],
+            "description": "`WalFlush` event payload — high lsn.",
             "format": "int64"
           },
           "durationUs": {
@@ -27517,31 +30223,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27549,6 +30260,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27557,6 +30269,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27565,6 +30278,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27573,9 +30287,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WalFlush` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWalSegmentRotateEventDto": {
         "properties": {
@@ -27599,6 +30315,7 @@
               "integer",
               "string"
             ],
+            "description": "`WalSegmentRotate` event payload — new segment index.",
             "format": "int32"
           },
           "durationUs": {
@@ -27607,31 +30324,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27639,6 +30361,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27647,6 +30370,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27655,6 +30379,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27663,9 +30388,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WalSegmentRotate` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWalWaitEventDto": {
         "properties": {
@@ -27689,6 +30416,7 @@
               "integer",
               "string"
             ],
+            "description": "`WalWait` event payload — target lsn.",
             "format": "int64"
           },
           "durationUs": {
@@ -27697,31 +30425,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27729,6 +30462,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27737,6 +30471,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27745,6 +30480,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27753,9 +30489,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WalWait` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWriteTickFenceClusterEventDto": {
         "properties": {
@@ -27779,6 +30517,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceCluster` event payload — archetype id.",
             "format": "uint16"
           },
           "dirtyClusterCount": {
@@ -27788,6 +30527,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceCluster` event payload — dirty cluster count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "entryCount": {
@@ -27797,6 +30537,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceCluster` event payload — entry count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "hasShadow": {
@@ -27806,6 +30547,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceCluster` event payload — has shadow. `null` when the wire record omits it.",
             "format": "uint8"
           },
           "hasSpatial": {
@@ -27815,6 +30557,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceCluster` event payload — has spatial. `null` when the wire record omits it.",
             "format": "uint8"
           },
           "walPublished": {
@@ -27824,6 +30567,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceCluster` event payload — wal published. `null` when the wire record omits it.",
             "format": "uint8"
           },
           "durationUs": {
@@ -27832,31 +30576,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27864,6 +30613,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27872,6 +30622,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27880,6 +30631,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27888,9 +30640,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WriteTickFenceCluster` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWriteTickFenceClusterShadowEventDto": {
         "properties": {
@@ -27914,6 +30668,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceClusterShadow` event payload — archetype id.",
             "format": "uint16"
           },
           "dirtyClusterCount": {
@@ -27922,6 +30677,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceClusterShadow` event payload — dirty cluster count.",
             "format": "int32"
           },
           "totalShadowEntries": {
@@ -27931,6 +30687,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceClusterShadow` event payload — total shadow entries. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -27939,31 +30696,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -27971,6 +30733,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -27979,6 +30742,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -27987,6 +30751,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -27995,9 +30760,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WriteTickFenceClusterShadow` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWriteTickFenceClusterSpatialEventDto": {
         "properties": {
@@ -28021,6 +30788,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceClusterSpatial` event payload — archetype id.",
             "format": "uint16"
           },
           "dirtyClusterCount": {
@@ -28029,6 +30797,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceClusterSpatial` event payload — dirty cluster count.",
             "format": "int32"
           },
           "migrationsExecuted": {
@@ -28038,6 +30807,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceClusterSpatial` event payload — migrations executed. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -28046,31 +30816,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -28078,6 +30853,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -28086,6 +30862,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -28094,6 +30871,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -28102,9 +30880,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WriteTickFenceClusterSpatial` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWriteTickFenceShadowEventDto": {
         "properties": {
@@ -28128,6 +30908,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceShadow` event payload — component type id.",
             "format": "uint16"
           },
           "indexedFieldCount": {
@@ -28136,6 +30917,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceShadow` event payload — indexed field count.",
             "format": "int32"
           },
           "totalShadowEntries": {
@@ -28145,6 +30927,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceShadow` event payload — total shadow entries. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -28153,31 +30936,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -28185,6 +30973,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -28193,6 +30982,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -28201,6 +30991,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -28209,9 +31000,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WriteTickFenceShadow` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWriteTickFenceSpatialEventDto": {
         "properties": {
@@ -28235,6 +31028,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceSpatial` event payload — component type id.",
             "format": "uint16"
           },
           "dirtyEntryCount": {
@@ -28243,6 +31037,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceSpatial` event payload — dirty entry count.",
             "format": "int32"
           },
           "escapedCount": {
@@ -28252,6 +31047,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceSpatial` event payload — escaped count. `null` when the wire record omits it.",
             "format": "int32"
           },
           "durationUs": {
@@ -28260,31 +31056,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -28292,6 +31093,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -28300,6 +31102,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -28308,6 +31111,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -28316,9 +31120,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WriteTickFenceSpatial` trace events. Wire format mirrors the encoder partial."
       },
       "TraceEventDtoWriteTickFenceTableEventDto": {
         "properties": {
@@ -28342,6 +31148,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceTable` event payload — component type id.",
             "format": "uint16"
           },
           "dirtyEntryCount": {
@@ -28350,6 +31157,7 @@
               "integer",
               "string"
             ],
+            "description": "`WriteTickFenceTable` event payload — dirty entry count.",
             "format": "int32"
           },
           "walPublished": {
@@ -28359,6 +31167,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceTable` event payload — wal published. `null` when the wire record omits it.",
             "format": "uint8"
           },
           "hasShadow": {
@@ -28368,6 +31177,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceTable` event payload — has shadow. `null` when the wire record omits it.",
             "format": "uint8"
           },
           "hasSpatial": {
@@ -28377,6 +31187,7 @@
               "integer",
               "string"
             ],
+            "description": "Optional `WriteTickFenceTable` event payload — has spatial. `null` when the wire record omits it.",
             "format": "uint8"
           },
           "durationUs": {
@@ -28385,31 +31196,36 @@
               "number",
               "string"
             ],
+            "description": "Span duration in microseconds. Computed as `DurationTicks / ticksPerUs`.",
             "format": "double"
           },
           "spanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "This span's id as a decimal string (JS-safe — JavaScript `Number` can't represent the full `ulong` range)."
           },
           "parentSpanId": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Enclosing span's id as a decimal string (zero ⇒ top-level span ⇒ \"0\")."
           },
           "traceIdHi": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Upper 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "traceIdLo": {
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "description": "Lower 64 bits of the OpenTelemetry trace id, decimal string. Empty / null when no trace context attached."
           },
           "threadSlot": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -28417,6 +31233,7 @@
               "integer",
               "string"
             ],
+            "description": "Producer thread slot (0..255). Indexes `ThreadSlotRegistry`.",
             "format": "uint8"
           },
           "tickNumber": {
@@ -28425,6 +31242,7 @@
               "integer",
               "string"
             ],
+            "description": "Tick number stamped by the consumer thread from the most recent `TickStart` marker.",
             "format": "int32"
           },
           "timestampUs": {
@@ -28433,6 +31251,7 @@
               "number",
               "string"
             ],
+            "description": "Wall-clock timestamp in microseconds since trace start. Computed as `StartTimestamp / ticksPerUs`.",
             "format": "double"
           },
           "sourceLocationId": {
@@ -28441,9 +31260,11 @@
               "integer",
               "string"
             ],
+            "description": "Source-location id from the `SourceLocationGenerator` (#302) — non-zero when the event was emitted via an\r\nintercepted `BeginXxx` call that baked in the literal site id. Resolves through\r\n`RuntimeSourceLocationManifest` to file + line on the consumer side.",
             "format": "uint16"
           }
-        }
+        },
+        "description": "Generated DTO for `WriteTickFenceTable` trace events. Wire format mirrors the encoder partial."
       },
       "TraceStatusDto": {
         "required": [
@@ -28676,6 +31497,9 @@
     },
     {
       "name": "Health"
+    },
+    {
+      "name": "Integrity"
     },
     {
       "name": "QueryConsole"

--- a/tools/Typhon.Workbench/ClientApp/src/App.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/App.tsx
@@ -2,12 +2,15 @@ import Shell from '@/shell/Shell';
 import ThemeProvider from '@/shell/ThemeProvider';
 import { useInitialDbAutoOpen } from '@/hooks/useInitialDbAutoOpen';
 import { useInitialTraceAutoOpen } from '@/hooks/useInitialTraceAutoOpen';
+import { useInitialIntegrityOpen } from '@/hooks/useInitialIntegrityOpen';
 
 export default function App() {
   // `typhon ui <db>` auto-opens the given database on first load (#429). No-op otherwise.
   useInitialDbAutoOpen();
   // `typhon ui --trace <path>` / `--open-latest` auto-opens the given profiler trace (#543). No-op otherwise.
   useInitialTraceAutoOpen();
+  // `#integrity=<bundle>` opens the Integrity view WITHOUT opening a session (#729). No-op otherwise.
+  useInitialIntegrityOpen();
 
   return (
     <ThemeProvider>

--- a/tools/Typhon.Workbench/ClientApp/src/api/bootstrapToken.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/api/bootstrapToken.ts
@@ -15,6 +15,7 @@ const BOOTSTRAP_TOKEN_KEY = 'wb.bootstrapToken';
 let initialDbPath: string | null = null;
 let initialSchemaPaths: string[] = [];
 let initialTracePath: string | null = null;
+let initialIntegrityPath: string | null = null;
 // Fallback when sessionStorage is unavailable (private mode / storage disabled): keep the token for this page load only.
 let inMemoryToken: string | null = null;
 
@@ -33,8 +34,12 @@ export function captureLaunchParamsFromUrl(): void {
   const db = params.get('db');
   const schema = params.get('schema');
   const trace = params.get('trace');
+  // #729 — `typhon check --ui <bundle>` hands the Workbench a database to *inspect* rather than open. Distinct
+  // from `db` on purpose: `db` means "open this", which is exactly what must not happen to a database someone
+  // is checking because it would not open, or because they are about to repair it and need it unlocked.
+  const integrity = params.get('integrity');
 
-  if (!token && !db && !trace) {
+  if (!token && !db && !trace && !integrity) {
     return;
   }
 
@@ -59,6 +64,10 @@ export function captureLaunchParamsFromUrl(): void {
 
   if (trace) {
     initialTracePath = trace;
+  }
+
+  if (integrity) {
+    initialIntegrityPath = integrity;
   }
 
   // Strip the fragment so the token/db/schema/trace never persist in the address bar, browser history, or referrer.
@@ -90,6 +99,15 @@ export function getInitialSchemaPaths(): string[] {
 /** The trace path passed via `typhon ui --trace <path>` / `--open-latest` (URL fragment), or null. Consumed once at startup. */
 export function getInitialTracePath(): string | null {
   return initialTracePath;
+}
+
+/**
+ * A bundle to open the Integrity view on, passed via the launch URL's `integrity=` fragment, or null.
+ * Consumed once at startup. Unlike {@link getInitialDbPath} this must NOT open a session — the point of
+ * arriving here is that opening is either impossible or undesirable.
+ */
+export function getInitialIntegrityPath(): string | null {
+  return initialIntegrityPath;
 }
 
 /**

--- a/tools/Typhon.Workbench/ClientApp/src/api/client.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/api/client.ts
@@ -5,6 +5,11 @@ import { applyWorkbenchAuthHeaders } from '@/api/bootstrapToken';
  * Error raised by {@link customFetch} for any non-2xx response. Carries the parsed RFC 7807
  * ProblemDetails body (or a `{ status }` synthetic when the body wasn't JSON) so callers and
  * the global query-cache logger can surface `title`/`detail` instead of `[object Object]`.
+ *
+ * Several controllers (Integrity, Options, Profiler, ProfilerSource, Resources) return a bare
+ * `{ error: "…" }` object rather than ProblemDetails. Without the `error` fallback below, every one of
+ * those carefully-worded messages collapsed to `HTTP 409` at the client boundary — the caller saw a
+ * status code where the server had written a sentence explaining what to do about it.
  */
 export class FetchError extends Error {
   readonly status: number;
@@ -13,7 +18,8 @@ export class FetchError extends Error {
   constructor(status: number, problem: Record<string, unknown>) {
     const title = typeof problem.title === 'string' ? problem.title : undefined;
     const detail = typeof problem.detail === 'string' ? problem.detail : undefined;
-    const message = detail ?? title ?? `HTTP ${status}`;
+    const plain = typeof problem.error === 'string' ? problem.error : undefined;
+    const message = detail ?? title ?? plain ?? `HTTP ${status}`;
     super(message);
     this.name = 'FetchError';
     this.status = status;

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/integrity/useIntegrityActions.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/integrity/useIntegrityActions.ts
@@ -1,0 +1,87 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, useRef } from 'react';
+import {
+  postApiIntegrityApply,
+  postApiIntegrityPlan,
+  postApiIntegrityScan,
+} from '@/api/generated/integrity/integrity';
+import { normalizeOutcome, normalizePlan, normalizeReport, type ScanDepth } from '@/panels/Integrity/integrityModel';
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+
+/**
+ * The three integrity actions, each a mutation rather than a query.
+ *
+ * Scan *looks* like a query — it is read-only and idempotent — but modelling it as one would mean
+ * TanStack Query deciding when it runs: on mount, on window focus, on reconnect. A scan is an explicit
+ * operator act with a real cost (a Deep scan reads the whole file), and its result is a diagnosis that
+ * a repair plan is then bound to. Refetching it behind the operator's back would silently invalidate
+ * a plan they were in the middle of reading. So: it runs when the button is pressed, never otherwise.
+ */
+
+/** Runs a scan and stores the normalized report. Supports cancellation — a Deep scan on a large file is slow. */
+export function useIntegrityScan() {
+  const setReport = useIntegrityStore((s) => s.setReport);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async (vars: { path: string; depth: ScanDepth }) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const res = await postApiIntegrityScan(
+        { path: vars.path, depth: vars.depth },
+        { signal: controller.signal },
+      );
+      return normalizeReport(res.data);
+    },
+    onSuccess: (report) => setReport(report),
+  });
+
+  const cancel = useCallback(() => abortRef.current?.abort(), []);
+  return { ...mutation, cancel };
+}
+
+/**
+ * Derives a repair plan. Read-only on the server — it re-scans at Deep depth and describes what it *would*
+ * do. Nothing is written, so this is safe to run on a database the operator has not decided to repair.
+ */
+export function useRepairPlan() {
+  const setPlan = useIntegrityStore((s) => s.setPlan);
+
+  return useMutation({
+    mutationFn: async (vars: { path: string }) => {
+      const res = await postApiIntegrityPlan({ path: vars.path, depth: 'deep' });
+      return normalizePlan(res.data);
+    },
+    onSuccess: (plan) => setPlan(plan),
+  });
+}
+
+/**
+ * Applies a repair — the only mutating call in the feature.
+ *
+ * `fingerprint` is mandatory and is not defaulted anywhere in this path: the server refuses without it, and
+ * a client that could synthesize one would be able to repair against a diagnosis nobody reviewed. `dryRun`
+ * results are deliberately *not* written to the store's outcome slot by the caller when they represent a
+ * rehearsal — see the panel, which keeps them in local state so a rehearsal can't be mistaken for a receipt.
+ */
+export function useRepairApply() {
+  return useMutation({
+    mutationFn: async (vars: {
+      path: string;
+      fingerprint: string;
+      allowLoss: boolean;
+      backupFirst: boolean;
+      dryRun: boolean;
+    }) => {
+      const res = await postApiIntegrityApply({
+        path: vars.path,
+        fingerprint: vars.fingerprint,
+        allowLoss: vars.allowLoss,
+        backupFirst: vars.backupFirst,
+        dryRun: vars.dryRun,
+      });
+      return normalizeOutcome(res.data);
+    },
+  });
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/integrity/useSpineVerdict.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/integrity/useSpineVerdict.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { postApiIntegrityScan } from '@/api/generated/integrity/integrity';
+import { normalizeReport, type Report } from '@/panels/Integrity/integrityModel';
+
+/**
+ * A cheap `Spine`-depth scan of one bundle, for the Storage Health verdict strip.
+ *
+ * Unlike the full scan this *is* modelled as a query, because the cost profile is completely different:
+ * Spine follows the bootstrap and segment roots only, so it is bounded by segment count rather than
+ * database size. It is the same tier the engine runs on every open. Re-running it when the panel mounts
+ * costs a few dozen page reads, so it can behave like any other dashboard metric.
+ *
+ * The database is live when this runs (a session holds it), so findings come back with `Suspected`
+ * confidence. That is why the strip links to the full view rather than pronouncing a verdict as final —
+ * a scan of a database someone is writing to cannot confirm anything.
+ */
+export function useSpineVerdict(path: string | null) {
+  return useQuery<Report>({
+    queryKey: ['integrity', 'spine', path],
+    enabled: !!path,
+    // A verdict is not a live metric — the operator refreshes Storage Health when they want a new one.
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: false,
+    queryFn: async () => {
+      const res = await postApiIntegrityScan({ path: path as string, depth: 'spine' });
+      return normalizeReport(res.data);
+    },
+  });
+}

--- a/tools/Typhon.Workbench/ClientApp/src/hooks/useInitialIntegrityOpen.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/hooks/useInitialIntegrityOpen.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { getInitialIntegrityPath } from '@/api/bootstrapToken';
+import { openIntegrity } from '@/shell/commands/openIntegrity';
+
+/**
+ * On first mount, if the launch URL carried `integrity=<bundle>`, open the Integrity view on it.
+ *
+ * The sibling of {@link useInitialDbAutoOpen}, with one deliberate difference: it does **not** open a session.
+ * `db=` means "open this database"; `integrity=` means "look at this file without opening it". Auto-opening a
+ * session here would take the exclusive lock — blocking the repair the operator arrived to perform, and
+ * failing outright on the database that would not open, which is the whole reason for arriving this way.
+ *
+ * Runs exactly once, guarded against StrictMode's double-invoke.
+ */
+export function useInitialIntegrityOpen(): void {
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) {
+      return;
+    }
+    const bundle = getInitialIntegrityPath();
+    if (!bundle) {
+      return;
+    }
+    startedRef.current = true;
+    openIntegrity(bundle);
+  }, []);
+}

--- a/tools/Typhon.Workbench/ClientApp/src/libs/dbmap/dbMapRenderer.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/dbmap/dbMapRenderer.ts
@@ -67,6 +67,7 @@ import {
   type DbMapLens,
   type DbMapPageOrder,
   type DbPageDetail,
+  type IntegrityMark,
 } from './types';
 import type { PathologyFlag } from './dbMapPathology';
 import type { DbMapRegion } from './dbMapRegions';
@@ -297,6 +298,12 @@ export class DbMapRenderer {
   private _selectionCell: { page: number; chunkInPage: number; cellIndex: number } | null = null;
   private _searchHits: readonly number[] = [];
   private _searchCurrent = -1;
+  /**
+   * Integrity-lens markers (#729): one per damaged page, coloured by finding severity. Separate from the lens
+   * *mask* because the mask only says which pages stay bright — it carries no severity, and "this page is
+   * damaged" and "this page loses data" need to be distinguishable at a glance.
+   */
+  private _integrityMarks: readonly IntegrityMark[] = [];
 
   // A2 detail-tier inputs, fed by the panel as the viewport changes.
   private _tiles: Map<number, DbDetailTile> = new Map();
@@ -413,6 +420,8 @@ export class DbMapRenderer {
     this._filterMask = null;
     this._searchHits = [];
     this._searchCurrent = -1;
+    // Markers name page indices in the *previous* map — stale ones would outline unrelated pages.
+    this._integrityMarks = [];
     this._hoverChunk = null;
     this._selectionChunk = null;
     this._hoverCell = null;
@@ -577,6 +586,14 @@ export class DbMapRenderer {
   setSearchHits(pages: readonly number[], current: number): void {
     this._searchHits = pages;
     this._searchCurrent = current;
+  }
+
+  /**
+   * Sets the integrity-lens page markers (#729). Cheap: the array is one entry per *damaged* page, not per
+   * page, so on a healthy database it is empty and the draw pass costs a zero-iteration loop.
+   */
+  setIntegrityMarks(marks: readonly IntegrityMark[]): void {
+    this._integrityMarks = marks;
   }
 
   setTheme(theme: DbMapTheme): void {
@@ -1232,6 +1249,13 @@ export class DbMapRenderer {
     // a stray box floating over the stripes when the user zooms back out to L0. drawCellHighlight clamps the
     // outline to a 3 px minimum, so without this gate the box stays visible even at sub-pixel cell sizes.
     if (l1Alpha > 0) {
+      // Integrity markers (#729) — drawn *under* search hits and the hover/selection outline so an explicit
+      // interaction always wins visually over a background annotation. Two-pixel outline: enough to read at a
+      // glance on a dimmed map without being mistaken for a selection.
+      for (let i = 0; i < this._integrityMarks.length; i++) {
+        const mark = this._integrityMarks[i];
+        this.drawCellHighlight(ctx, mark.page, mark.color, 2, l1Alpha);
+      }
       // Search-match markers — every hit gets a thin amber outline; the current match a thicker one (§4.5).
       for (let i = 0; i < this._searchHits.length; i++) {
         this.drawCellHighlight(ctx, this._searchHits[i], SEARCH_HIT_COLOR, i === this._searchCurrent ? 3 : 1, l1Alpha);

--- a/tools/Typhon.Workbench/ClientApp/src/libs/dbmap/types.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/libs/dbmap/types.ts
@@ -308,7 +308,21 @@ export function isDetailEncoding(encoding: DbMapEncoding): encoding is DbMapDeta
 }
 
 /** The active analytical lens (A3, §4.3) — a focused dim/highlight overlay on top of the base encoding. */
-export type DbMapLens = 'none' | 'fragmentation' | 'freeSpace' | 'pathology';
+export type DbMapLens = 'none' | 'fragmentation' | 'freeSpace' | 'pathology' | 'integrity';
+
+/**
+ * One damaged page to outline under the integrity lens (#729).
+ *
+ * Carries a resolved colour rather than a severity so the renderer stays independent of the integrity
+ * domain model — it draws what it is told, and the mapping from severity to colour lives with the other
+ * severity semantics.
+ */
+export interface IntegrityMark {
+  /** Physical page index, straight from a finding's `Locus.FilePageIndex`. */
+  page: number;
+  /** Canvas stroke colour for this page's worst severity. */
+  color: string;
+}
 
 /**
  * How file pages are laid out on the 2D grid. `hilbert` (default) preserves byte-offset locality in 2D — adjacent

--- a/tools/Typhon.Workbench/ClientApp/src/panels/DbMap/DbMapPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/DbMap/DbMapPanel.tsx
@@ -38,6 +38,9 @@ import {
 } from '@/libs/dbmap/types';
 import { buildRegions } from '@/libs/dbmap/dbMapRegions';
 import { findUnderFilledPages, LOW_FILL_THRESHOLD } from '@/libs/dbmap/dbMapPathology';
+import type { IntegrityMark } from '@/libs/dbmap/types';
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+import { SEVERITY_CANVAS_COLOR, severityByPage } from '@/panels/Integrity/integrityModel';
 import {
   contiguousRuns,
   fillDensity,
@@ -152,6 +155,7 @@ interface L0HoverInfo {
  */
 export default function DbMapPanel(_props: IDockviewPanelProps) {
   const sessionId = useSessionStore((s) => s.sessionId);
+  const sessionFilePath = useSessionStore((s) => s.filePath);
   const encoding = useDbMapStore((s) => s.encoding);
   const pageOrder = useDbMapStore((s) => s.pageOrder);
   const segmentOverlay = useDbMapStore((s) => s.segmentOverlay);
@@ -164,6 +168,7 @@ export default function DbMapPanel(_props: IDockviewPanelProps) {
   const lensSegmentId = useDbMapStore((s) => s.lensSegmentId);
   const filter = useDbMapStore((s) => s.filter);
   const pendingFocusType = useDbMapStore((s) => s.pendingFocusType);
+  const pendingFocusPage = useDbMapStore((s) => s.pendingFocusPage);
   const clearPendingFocus = useDbMapStore((s) => s.clearPendingFocus);
   const select = useSelectionStore((s) => s.select);
   const clearLeaf = useSelectionStore((s) => s.clearLeaf);
@@ -272,6 +277,29 @@ export default function DbMapPanel(_props: IDockviewPanelProps) {
 
   const regions = useMemo(() => (data ? buildRegions(data, tiles) : []), [data, tiles]);
   const pathologyFlags = useMemo(() => (data ? findUnderFilledPages(data, tiles) : []), [data, tiles]);
+
+  // #729 integrity lens — the worst severity per damaged page, from the last scan run in the Integrity view.
+  //
+  // Guarded on the report describing *this* database. The Integrity view is path-scoped and can be pointed at
+  // any bundle on disk, so without this check a scan of some other file would paint damage markers over the
+  // open database's map — page indices are just integers and would land somewhere plausible-looking.
+  const integrityReport = useIntegrityStore((s) => s.report);
+  const integrityForThisDb =
+    integrityReport && sessionFilePath && integrityReport.source.toLowerCase().includes(sessionFilePath.toLowerCase())
+      ? integrityReport
+      : null;
+  const integrityMarks = useMemo<IntegrityMark[]>(() => {
+    if (!integrityForThisDb || !data) {
+      return [];
+    }
+    const marks: IntegrityMark[] = [];
+    for (const [page, severity] of severityByPage(integrityForThisDb.findings)) {
+      if (page < data.pageCount) {
+        marks.push({ page, color: SEVERITY_CANVAS_COLOR[severity] });
+      }
+    }
+    return marks;
+  }, [integrityForThisDb, data]);
   const composition = useMemo(() => (data ? freeSpaceComposition(data) : null), [data]);
   const searchMatches = useMemo(() => (data ? searchDbMap(searchQuery, data, shortLabel) : []), [searchQuery, data, shortLabel]);
   const filterMask = useMemo(() => (data ? buildFilterMask(data, filter) : null), [data, filter]);
@@ -647,6 +675,29 @@ export default function DbMapPanel(_props: IDockviewPanelProps) {
     }
   }, [data, pendingFocusType, clearPendingFocus, flyToRegion, select, pulseSegment]);
 
+  // #729 — an integrity finding asked to reveal one damaged page. Unlike the component reveal above there is
+  // no segment to frame: the target is a single cell, and the interesting context is its neighbours (damage
+  // is often contiguous). So the fly-to spans a small window around it rather than the page alone, which at
+  // full zoom would fill the viewport with one featureless square.
+  useEffect(() => {
+    if (!data || pendingFocusPage == null) {
+      return;
+    }
+    const page = pendingFocusPage;
+    clearPendingFocus();
+    if (page < 0 || page >= data.pageCount) {
+      return;
+    }
+    const window = 64;
+    const first = Math.max(0, page - window / 2);
+    flyToRegion(first, Math.min(window, data.pageCount - first), {
+      label: `Page ${page.toLocaleString()}`,
+      fillFraction: 0.5,
+      startFromDatabaseFit: true,
+    });
+    select('page', { kind: 'page', pageIndex: page });
+  }, [data, pendingFocusPage, clearPendingFocus, flyToRegion, select]);
+
   // Construct the renderer once the canvas element exists.
   useLayoutEffect(() => {
     if (!canvasRef.current) {
@@ -813,7 +864,15 @@ export default function DbMapPanel(_props: IDockviewPanelProps) {
     }
     // The fragmentation lens needs a focused segment; without one (e.g. restored from a persisted session where
     // the segment id no longer applies) treat it as no lens so the map isn't dimmed-to-nothing on open.
-    if (!data || lens === 'none' || (lens === 'fragmentation' && lensSegmentId == null)) {
+    // The integrity lens with no report for this database is the same shape of problem as the fragmentation
+    // lens with no segment — a persisted lens choice that no longer applies. Dimming the whole map to nothing
+    // would read as "everything is damaged", the worst possible false reading, so fall back to no lens.
+    if (
+      !data ||
+      lens === 'none' ||
+      (lens === 'fragmentation' && lensSegmentId == null) ||
+      (lens === 'integrity' && !integrityForThisDb)
+    ) {
       renderer.setLens('none', null);
       scheduleRender();
       return;
@@ -845,10 +904,26 @@ export default function DbMapPanel(_props: IDockviewPanelProps) {
       for (const flag of pathologyFlags) {
         mask[flag.pageIndex] = 1;
       }
+    } else if (lens === 'integrity') {
+      for (const mark of integrityMarks) {
+        mask[mark.page] = 1;
+      }
     }
     renderer.setLens(lens, mask);
     scheduleRender();
-  }, [lens, lensSegmentId, data, tiles, pathologyFlags, scheduleRender]);
+  }, [lens, lensSegmentId, data, tiles, pathologyFlags, integrityMarks, integrityForThisDb, scheduleRender]);
+
+  // Integrity markers are fed independently of the lens so a finding revealed from the report outlines its
+  // page even before the user switches lens — the reveal is a jump to a specific page, and arriving at an
+  // unmarked cell would leave them hunting for what they were sent to see.
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      return;
+    }
+    renderer.setIntegrityMarks(integrityMarks);
+    scheduleRender();
+  }, [integrityMarks, scheduleRender]);
 
   // Filter-to-dim changed — hand the renderer the new pass/fail mask (§4.6). The mask is O(pageCount) but
   // recomputed only on a filter / data change, and composes on top of the active lens inside the renderer.

--- a/tools/Typhon.Workbench/ClientApp/src/panels/DbMap/DbMapToolbar.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/DbMap/DbMapToolbar.tsx
@@ -83,6 +83,10 @@ export function DbMapToolbar(props: DbMapToolbarProps) {
         <option value="fragmentation">Fragmentation</option>
         <option value="freeSpace">Free space</option>
         <option value="pathology">Pathology</option>
+        {/* #729 — dims to the pages an integrity scan flagged and outlines each in its severity colour.
+            Selectable even with no report: the lens then falls back to no dimming and the Legend tab says
+            why, which is more useful than an option that silently isn't there. */}
+        <option value="integrity">Integrity</option>
       </select>
 
       <button

--- a/tools/Typhon.Workbench/ClientApp/src/panels/DbMap/sidebar/LegendTab.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/DbMap/sidebar/LegendTab.tsx
@@ -1,4 +1,7 @@
 import { useDbMapStore } from '@/stores/useDbMapStore';
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+import { SEVERITY_CANVAS_COLOR, severityByPage } from '@/panels/Integrity/integrityModel';
+import { openIntegrityForSession } from '@/shell/commands/openIntegrity';
 import { formatFileSize } from '@/lib/formatters';
 import { useComponentNames } from '@/hooks/queryConsole/useComponentNames';
 import {
@@ -102,7 +105,69 @@ export function LegendTab(props: LegendTabProps) {
           <PathologyList flags={props.pathologies} segments={props.segments} onFlyToPage={props.onFlyToPage} />
         </section>
       )}
+
+      {lens === 'integrity' && <IntegrityLegend />}
     </div>
+  );
+}
+
+/**
+ * The integrity lens key (#729).
+ *
+ * Also the lens's empty state, because the two are the same surface: with no scan for this database the map
+ * shows nothing and the only useful thing to say is where a scan comes from. A silent unlit lens would read
+ * as "no damage found", which is a claim no one has made.
+ */
+function IntegrityLegend() {
+  const report = useIntegrityStore((s) => s.report);
+  const damagedPages = report ? severityByPage(report.findings).size : 0;
+
+  if (!report) {
+    return (
+      <section className="flex flex-col gap-1" data-testid="dbmap-integrity-legend">
+        <h3 className="text-fs-xs font-semibold uppercase tracking-wide text-muted-foreground">Integrity</h3>
+        <p className="text-fs-sm text-muted-foreground">
+          No scan yet — this lens paints the result of one. Run it from{' '}
+          <button
+            type="button"
+            onClick={openIntegrityForSession}
+            className="text-foreground underline underline-offset-2 hover:text-primary"
+          >
+            Check Database Integrity
+          </button>
+          .
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-1" data-testid="dbmap-integrity-legend">
+      <h3 className="text-fs-xs font-semibold uppercase tracking-wide text-muted-foreground">Integrity</h3>
+      <p className="text-fs-sm text-muted-foreground">
+        {damagedPages === 0
+          ? 'The last scan flagged no page. Nothing to paint.'
+          : `${damagedPages.toLocaleString()} page${damagedPages === 1 ? '' : 's'} flagged by the last scan, outlined by worst severity.`}
+      </p>
+      {damagedPages > 0 && (
+        <div className="mt-0.5 flex flex-col gap-0.5">
+          {(['Fatal', 'DataLoss', 'Divergence', 'Leak', 'Advisory'] as const).map((s) => (
+            <span key={s} className="flex items-center gap-1.5 text-fs-sm text-muted-foreground">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-sm border-2"
+                style={{ borderColor: SEVERITY_CANVAS_COLOR[s] }}
+              />
+              {s}
+            </span>
+          ))}
+        </div>
+      )}
+      {/* Same reasoning as the report's Limits block: the map can only paint what a scan found, and a scan
+          verifies internal consistency only. An unmarked page is not a page proven good. */}
+      <p className="mt-1 text-fs-xs text-muted-foreground">
+        Unmarked means "nothing found here", not "verified good".
+      </p>
+    </section>
   );
 }
 

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/FindingsTable.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/FindingsTable.tsx
@@ -1,0 +1,140 @@
+import { Fragment, useState } from 'react';
+import { ChevronDown, ChevronRight, MapPin } from 'lucide-react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { StatusBadge } from '@/components/ui/status-badge';
+import { severityTone, type Finding } from './integrityModel';
+
+interface Props {
+  findings: Finding[];
+  /** Present only when a live session holds this same bundle — the File Map needs an engine. */
+  onReveal?: (finding: Finding) => void;
+}
+
+/**
+ * Findings, worst first, each expandable to its evidence.
+ *
+ * The finding **code** gets its own monospace column rather than being folded into the summary, because a
+ * code is an API: alerts key on `CHK-PHY-01`, and someone reading this table is often here *because* an
+ * alert fired. It has to be greppable by eye and copyable without selecting prose around it.
+ *
+ * The collapsed row carries the summary (one sentence, no jargon); the expanded row carries `detail` (the
+ * evidence), the violated rule id, and — when repairing this finding would cost something — the loss.
+ */
+export default function FindingsTable({ findings, onReveal }: Props) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggle = (key: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(key)) {
+        next.add(key);
+      }
+      return next;
+    });
+
+  if (findings.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4">
+        <p className="text-fs-base text-muted-foreground">No findings. Nothing in this database contradicts anything else in it.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <Table className="text-fs-base">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-6" />
+            <TableHead className="text-fs-sm">Severity</TableHead>
+            <TableHead className="text-fs-sm">Code</TableHead>
+            <TableHead className="text-fs-sm">Summary</TableHead>
+            <TableHead className="text-fs-sm">Where</TableHead>
+            <TableHead className="text-right text-fs-sm">Count</TableHead>
+            <TableHead className="text-fs-sm">Repair</TableHead>
+            <TableHead className="w-8" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {findings.map((f, i) => {
+            // Findings are not individually identified by the server, and the same code can legitimately
+            // fire on several pages — so the row key is the tuple that actually distinguishes them.
+            const key = `${f.code}@${f.locus.filePageIndex}#${i}`;
+            const isOpen = expanded.has(key);
+            return (
+              <Fragment key={key}>
+                <TableRow
+                  className="cursor-pointer hover:bg-accent"
+                  data-testid="integrity-finding-row"
+                  data-finding-code={f.code}
+                  data-severity={f.severity}
+                  onClick={() => toggle(key)}
+                >
+                  <TableCell className="text-muted-foreground">
+                    {isOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge tone={severityTone(f.severity)}>{f.severity}</StatusBadge>
+                  </TableCell>
+                  <TableCell className="font-mono text-fs-sm">{f.code}</TableCell>
+                  <TableCell>{f.summary}</TableCell>
+                  <TableCell className="font-mono text-fs-sm text-muted-foreground">{f.locus.text}</TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {f.occurrences > 1 ? f.occurrences.toLocaleString() : ''}
+                  </TableCell>
+                  <TableCell className="text-fs-sm text-muted-foreground">{f.repair}</TableCell>
+                  <TableCell className="text-right">
+                    {onReveal && f.locus.filePageIndex >= 0 && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onReveal(f);
+                        }}
+                        data-testid="integrity-finding-reveal"
+                        title="Reveal this page in the File Map"
+                        className="rounded border border-border px-1 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                      >
+                        <MapPin className="h-3 w-3" />
+                      </button>
+                    )}
+                  </TableCell>
+                </TableRow>
+
+                {isOpen && (
+                  <TableRow className="bg-muted/30 hover:bg-muted/30">
+                    <TableCell />
+                    <TableCell colSpan={7} className="py-2">
+                      <div className="flex flex-col gap-1.5 text-fs-sm">
+                        <p className="select-text whitespace-pre-wrap text-foreground">{f.detail}</p>
+                        <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-muted-foreground">
+                          {f.ruleId && (
+                            <span>
+                              Rule <span className="font-mono text-foreground">{f.ruleId}</span>
+                            </span>
+                          )}
+                          <span>
+                            Confidence <span className="text-foreground">{f.confidence}</span>
+                            {f.confidence !== 'Confirmed' && ' — the database was not quiescent when this was observed'}
+                          </span>
+                        </div>
+                        {f.loss.kind !== 'None' && (
+                          <p className="mt-0.5 rounded border border-border bg-background px-2 py-1">
+                            <span className="text-foreground">Repairing this costs: </span>
+                            {f.loss.count} {f.loss.kind}
+                            {f.loss.component ? ` · ${f.loss.component}` : ''}
+                            {f.loss.explanation ? ` — ${f.loss.explanation}` : ''}
+                          </p>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/IntegrityPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/IntegrityPanel.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react';
+import { FolderOpen, ShieldCheck, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import FileBrowser from '@/shell/components/FileBrowser';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { useIntegrityStore, integrityStage } from '@/stores/useIntegrityStore';
+import { useIntegrityScan } from '@/hooks/integrity/useIntegrityActions';
+import { revealPageInDbMap } from '@/shell/commands/openDbMap';
+import { DEPTH_BLURB, SCAN_DEPTHS, type Finding, type ScanDepth } from './integrityModel';
+import VerdictBanner from './VerdictBanner';
+import ScanTotals from './ScanTotals';
+import FindingsTable from './FindingsTable';
+import LimitsBlock from './LimitsBlock';
+import RepairFlow from './RepairFlow';
+import RepairFooter from './RepairFooter';
+
+/**
+ * Props are deliberately looser than `IDockviewPanelProps`.
+ *
+ * The view has two homes — a dock panel when a session exists, and the main area when one does not (see
+ * {@link useIntegrityStore.standaloneOpen}) — so it cannot require the dockview panel context. dockview's
+ * props structurally satisfy this, so the same component serves both without a wrapper or a branch.
+ */
+interface IntegrityPanelProps {
+  params?: { path?: string };
+}
+
+/**
+ * The Integrity view — scan a database, read the verdict, plan and apply a repair.
+ *
+ * **Path-scoped, not session-scoped**, and that is the whole reason it is a view of its own rather than a
+ * tab inside Storage Health. Every other storage surface introspects the live engine of an open session.
+ * This one must work on a database that will not open — the case that most justifies the feature — and on
+ * one that is locked by another process, and it must survive the session being closed so a repair can take
+ * the exclusive access it requires. A session-keyed host could do none of those.
+ */
+export default function IntegrityPanel(props: IntegrityPanelProps) {
+  const sessionPath = useSessionStore((s) => s.filePath);
+  const sessionId = useSessionStore((s) => s.sessionId);
+
+  const path = useIntegrityStore((s) => s.path);
+  const depth = useIntegrityStore((s) => s.depth);
+  const report = useIntegrityStore((s) => s.report);
+  const plan = useIntegrityStore((s) => s.plan);
+  const outcome = useIntegrityStore((s) => s.outcome);
+  const setPath = useIntegrityStore((s) => s.setPath);
+  const setDepth = useIntegrityStore((s) => s.setDepth);
+
+  const scan = useIntegrityScan();
+  const [browseOpen, setBrowseOpen] = useState(false);
+  const [draft, setDraft] = useState(path);
+
+  // Panel params carry a path when opened from a deep link or a "check this database" handoff. The open
+  // session is the fallback seed — convenient, and it makes the common case one click.
+  const paramPath = props.params?.path;
+  useEffect(() => {
+    const seed = paramPath ?? (path || sessionPath || '');
+    if (seed && seed !== path) {
+      setPath(seed);
+      setDraft(seed);
+    } else if (!draft && seed) {
+      setDraft(seed);
+    }
+    // Seeding is a mount/param concern; re-running it on every keystroke would fight the input.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paramPath, sessionPath]);
+
+  const effectivePath = draft.trim().replace(/^"(.*)"$/, '$1');
+  const canScan = effectivePath.length > 0 && !scan.isPending;
+  const stage = integrityStage({ report, plan, outcome });
+
+  const runScan = () => {
+    if (!canScan) {
+      return;
+    }
+    if (effectivePath !== path) {
+      setPath(effectivePath);
+    }
+    scan.mutate({ path: effectivePath, depth });
+  };
+
+  // The File Map needs a live engine, so revealing is only offered when the open session is looking at the
+  // same bundle this report describes. Comparison is case-insensitive because Windows paths reach us with
+  // inconsistent casing depending on whether they came from a picker, a deep link, or the session.
+  const sameAsSession =
+    !!sessionId && !!sessionPath && sessionPath.toLowerCase() === (report?.source ?? path).toLowerCase();
+  const onReveal = sameAsSession ? (f: Finding) => revealPageInDbMap(f.locus.filePageIndex) : undefined;
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-background" data-testid="integrity">
+      {/* Target + depth + run */}
+      <div className="wb-pane-header flex shrink-0 flex-col gap-1.5 border-b border-border px-3 py-2">
+        <div className="flex items-center gap-2">
+          <Input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && runScan()}
+            placeholder="C:\path\to\database.typhon"
+            spellCheck={false}
+            autoComplete="off"
+            data-testid="integrity-path"
+            className="h-7 flex-1 font-mono text-fs-base"
+          />
+          <Button
+            variant="outline"
+            onClick={() => setBrowseOpen(true)}
+            title="Browse for a .typhon bundle"
+            data-testid="integrity-browse"
+            className="h-7 gap-1 px-2 text-fs-base"
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+            Browse
+          </Button>
+          {scan.isPending ? (
+            <Button
+              variant="outline"
+              onClick={() => scan.cancel()}
+              data-testid="integrity-cancel"
+              className="h-7 gap-1 px-2 text-fs-base"
+            >
+              <X className="h-3.5 w-3.5" />
+              Cancel
+            </Button>
+          ) : (
+            <Button onClick={runScan} disabled={!canScan} data-testid="integrity-scan" className="h-7 gap-1 px-3 text-fs-base">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Scan
+            </Button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="text-fs-sm text-muted-foreground">Depth</span>
+          <div className="flex overflow-hidden rounded border border-border" role="radiogroup" aria-label="Scan depth">
+            {SCAN_DEPTHS.map((d) => (
+              <button
+                key={d}
+                type="button"
+                role="radio"
+                aria-checked={depth === d}
+                onClick={() => setDepth(d)}
+                data-testid={`integrity-depth-${d}`}
+                className={`px-2 py-0.5 text-fs-sm capitalize ${
+                  depth === d ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-muted/60'
+                }`}
+              >
+                {d}
+              </button>
+            ))}
+          </div>
+          <span className="text-fs-sm text-muted-foreground">{DEPTH_BLURB[depth as ScanDepth]}</span>
+        </div>
+      </div>
+
+      {/* Report */}
+      {scan.isError && (
+        <div className="shrink-0 border-b border-border bg-destructive/10 px-3 py-2 text-fs-base text-destructive" data-testid="integrity-error">
+          {(scan.error as Error)?.message ?? 'Scan failed.'}
+        </div>
+      )}
+
+      {scan.isPending && (
+        <div className="flex flex-1 items-center justify-center" data-testid="integrity-scanning">
+          <p className="text-fs-base text-muted-foreground">Scanning…</p>
+        </div>
+      )}
+
+      {!scan.isPending && !report && (
+        <div className="flex flex-1 items-center justify-center p-4">
+          <p className="max-w-md text-center text-fs-base text-muted-foreground">
+            Point this at a <span className="font-mono">.typhon</span> bundle and scan it. Reading is always safe — it
+            opens the file directly, without starting the engine, so it works on a database that will not open and on
+            one another process is using.
+          </p>
+        </div>
+      )}
+
+      {!scan.isPending && report && (
+        <>
+          <VerdictBanner report={report} />
+          <ScanTotals totals={report.totals} />
+          {stage === 'scanned' ? (
+            <>
+              <FindingsTable findings={report.findings} onReveal={onReveal} />
+              {/* Immediately above the action bar: the last thing read before deciding to act, never
+                  something scrolled past on the way to a button. The repair stages render their own copy
+                  in the same position — the block is passed down rather than stacked after the flow, which
+                  would leave it *below* the Repair button and defeat the point. */}
+              <LimitsBlock limits={report.limits} />
+              <RepairFooter report={report} />
+            </>
+          ) : (
+            <RepairFlow limits={report.limits} />
+          )}
+        </>
+      )}
+
+      <Dialog open={browseOpen} onOpenChange={setBrowseOpen}>
+        <DialogContent className="flex h-[70vh] max-w-3xl flex-col">
+          <DialogHeader>
+            <DialogTitle>Select a database bundle</DialogTitle>
+          </DialogHeader>
+          <div className="min-h-0 flex-1">
+            <FileBrowser
+              extensionFilter={['.typhon']}
+              recentKind="db"
+              onSelectionChange={(paths) => paths[0] && setDraft(paths[0])}
+              onActivate={(p) => {
+                setDraft(p);
+                setBrowseOpen(false);
+              }}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/IntegrityStandalone.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/IntegrityStandalone.tsx
@@ -1,0 +1,41 @@
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+import IntegrityPanel from './IntegrityPanel';
+
+/**
+ * The Integrity view rendered full-bleed in the no-session shell, with a way back to the Welcome screen.
+ *
+ * The established pattern for a panel that must be reachable before a session exists is a modal fallback
+ * (`DevFixtureModal`). This deviates from it, on purpose. Dev Fixture is a short form; the Integrity view
+ * ends in a consent list that can run to thousands of rows, and a dialog that scrolls internally trains the
+ * eye to reach past its content for the button beneath. Consent that was scrolled past is not consent. The
+ * view therefore takes the full main area — the same real estate it gets when docked — rather than being
+ * squeezed into a container whose shape works against the one interaction that matters most here.
+ */
+export default function IntegrityStandalone() {
+  const closeStandalone = useIntegrityStore((s) => s.closeStandalone);
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-background" data-testid="integrity-standalone">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-1.5">
+        <Button
+          variant="ghost"
+          onClick={closeStandalone}
+          data-testid="integrity-standalone-back"
+          className="h-6 gap-1 px-1.5 text-fs-sm"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Back
+        </Button>
+        <span className="text-fs-base font-medium text-foreground">Database integrity</span>
+        <span className="text-fs-sm text-muted-foreground">
+          No database needs to be open — this reads the file directly.
+        </span>
+      </div>
+      <div className="min-h-0 flex-1">
+        <IntegrityPanel />
+      </div>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/LimitsBlock.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/LimitsBlock.tsx
@@ -1,0 +1,54 @@
+import { Info } from 'lucide-react';
+import type { Limits } from './integrityModel';
+
+/**
+ * What the scan could not have detected.
+ *
+ * **This component has no collapse control, no `defaultOpen`, and no caller-supplied way to hide it, and
+ * that is deliberate** ([04 §6](claude/design/Durability/Integrity/04-report-and-loss.md)). It renders on a
+ * fully green report exactly as it renders on a catastrophic one.
+ *
+ * The reasoning is worth stating because the product instinct is the opposite. A scan verifies that a
+ * database is *internally consistent*. It cannot verify that the database matches what was committed —
+ * committed updates lost in a prior recovery, or entities a prior recovery resurrected, leave a perfectly
+ * self-consistent file behind. A green verdict therefore means "nothing here contradicts anything else
+ * here", which is a narrower claim than the word *Sound* suggests. The moment that gap is most likely to
+ * mislead is precisely when everything passed and the operator stops reading — so that is the moment the
+ * block must not be suppressible.
+ */
+export default function LimitsBlock({ limits }: { limits: Limits }) {
+  const hasDetail = limits.checksSkipped.length > 0 || limits.caveats.length > 0;
+
+  return (
+    <div
+      className="shrink-0 border-t border-border bg-muted/30 px-3 py-2 text-fs-sm text-muted-foreground"
+      data-testid="integrity-limits"
+    >
+      <div className="flex items-start gap-2">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+        <div className="min-w-0">
+          <p className="font-medium text-foreground">Limits of this scan</p>
+          <p className="mt-0.5">{limits.structural}</p>
+
+          {hasDetail && (
+            <div className="mt-1.5 flex flex-col gap-1">
+              {limits.checksSkipped.length > 0 && (
+                <div>
+                  <span className="text-foreground">Checks not run at this depth: </span>
+                  <span data-testid="integrity-limits-skipped">{limits.checksSkipped.join(' · ')}</span>
+                </div>
+              )}
+              {limits.caveats.length > 0 && (
+                <ul className="list-inside list-disc" data-testid="integrity-limits-caveats">
+                  {limits.caveats.map((c) => (
+                    <li key={c}>{c}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/LossManifest.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/LossManifest.tsx
@@ -1,0 +1,70 @@
+import { useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { LossEstimate } from './integrityModel';
+
+/**
+ * The complete enumeration of what a repair destroys.
+ *
+ * **This list is the consent.** A dialog reading *"47 entities will be affected — OK?"* is not consent; it
+ * is a number standing in for the thing the operator is supposed to be agreeing to. So every entry the
+ * server sent is rendered — never a summary, never a "first 100 shown", never a count.
+ *
+ * It is virtualized rather than truncated precisely to keep that literal. A manifest can run to thousands
+ * of rows, and the alternative to windowing is a cap — which would turn "here is everything you are about
+ * to lose" into "here is some of it", quietly, exactly where quiet is most expensive. The row count is
+ * printed in the header so a reader can verify nothing was dropped between the server and the screen.
+ */
+export default function LossManifest({ entries }: { entries: LossEstimate[] }) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: entries.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 40,
+    overscan: 16,
+  });
+
+  if (entries.length === 0) {
+    return (
+      <p className="px-3 py-2 text-fs-base text-muted-foreground" data-testid="integrity-loss-empty">
+        This repair destroys nothing. Every step regenerates a derived structure from data that survives.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-baseline gap-2 border-b border-border px-3 py-1.5">
+        <span className="text-fs-base font-medium text-destructive">What this repair destroys</span>
+        <span className="text-fs-sm tabular-nums text-muted-foreground" data-testid="integrity-loss-count">
+          {entries.length.toLocaleString()} {entries.length === 1 ? 'entry' : 'entries'}
+        </span>
+        <span className="text-fs-sm text-muted-foreground">— all of them listed, none summarised</span>
+      </div>
+
+      <div ref={parentRef} className="min-h-0 flex-1 overflow-auto" data-testid="integrity-loss-manifest">
+        <div style={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+          {virtualizer.getVirtualItems().map((row) => {
+            const e = entries[row.index];
+            return (
+              <div
+                key={row.key}
+                data-testid="integrity-loss-row"
+                className="absolute left-0 top-0 w-full border-b border-border/50 px-3 py-1"
+                style={{ height: row.size, transform: `translateY(${row.start}px)` }}
+              >
+                <div className="flex items-baseline gap-2 text-fs-base">
+                  <span className="tabular-nums text-destructive">{e.count}</span>
+                  <span className="text-foreground">{e.kind}</span>
+                  {e.component && <span className="font-mono text-fs-sm text-muted-foreground">{e.component}</span>}
+                  {e.archetype && <span className="font-mono text-fs-sm text-muted-foreground">{e.archetype}</span>}
+                </div>
+                {e.explanation && <p className="truncate text-fs-sm text-muted-foreground" title={e.explanation}>{e.explanation}</p>}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/RepairFlow.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/RepairFlow.tsx
@@ -1,0 +1,263 @@
+import { useState } from 'react';
+import { AlertTriangle, ArrowLeft, FlaskConical, Lock, Wrench } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { StatusBadge } from '@/components/ui/status-badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { deleteApiSessionsId } from '@/api/generated/sessions/sessions';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+import { useRepairApply } from '@/hooks/integrity/useIntegrityActions';
+import type { Limits, RepairOutcome, RepairPlan } from './integrityModel';
+import LimitsBlock from './LimitsBlock';
+import LossManifest from './LossManifest';
+import RepairReceipt from './RepairReceipt';
+
+/**
+ * Plan review → consent → apply, in the panel rather than a modal.
+ *
+ * A modal was the obvious shape and is the wrong one. The loss manifest can run to thousands of rows, and a
+ * modal that scrolls internally trains the eye to reach past the content for the button underneath it. In
+ * the panel the manifest occupies the view, and the action bar sits below the thing it is consenting to.
+ */
+export default function RepairFlow({ limits }: { limits: Limits }) {
+  const path = useIntegrityStore((s) => s.path);
+  const plan = useIntegrityStore((s) => s.plan);
+  const outcome = useIntegrityStore((s) => s.outcome);
+  const allowLoss = useIntegrityStore((s) => s.allowLoss);
+  const backupFirst = useIntegrityStore((s) => s.backupFirst);
+  const setAllowLoss = useIntegrityStore((s) => s.setAllowLoss);
+  const setBackupFirst = useIntegrityStore((s) => s.setBackupFirst);
+  const setPlan = useIntegrityStore((s) => s.setPlan);
+  const setOutcome = useIntegrityStore((s) => s.setOutcome);
+
+  const sessionId = useSessionStore((s) => s.sessionId);
+  const sessionPath = useSessionStore((s) => s.filePath);
+  const clearSession = useSessionStore((s) => s.clearSession);
+
+  const apply = useRepairApply();
+  // A rehearsal is kept out of the store's outcome slot on purpose: `outcome` means "this database was
+  // repaired", and a dry run must never be able to render as that receipt.
+  const [rehearsal, setRehearsal] = useState<RepairOutcome | null>(null);
+  const [closing, setClosing] = useState(false);
+
+  if (outcome) {
+    return (
+      <>
+        <RepairReceipt outcome={outcome} />
+        <LimitsBlock limits={limits} />
+      </>
+    );
+  }
+  if (!plan) {
+    return null;
+  }
+
+  // The Workbench holds databases open; repair needs exclusive access. The server independently refuses
+  // (409 on a held lock) — this is the same rule stated early enough that the operator isn't surprised
+  // by it after reading a manifest.
+  const sessionHoldsTarget =
+    !!sessionId && !!sessionPath && sessionPath.toLowerCase() === path.toLowerCase();
+
+  const blocked = sessionHoldsTarget || (plan.requiresLossyConsent && !allowLoss);
+
+  const run = (dryRun: boolean) => {
+    apply.mutate(
+      { path, fingerprint: plan.fingerprint, allowLoss, backupFirst, dryRun },
+      {
+        onSuccess: (result) => (dryRun ? setRehearsal(result) : setOutcome(result)),
+      },
+    );
+  };
+
+  const closeSessionThenStay = async () => {
+    if (!sessionId) {
+      return;
+    }
+    setClosing(true);
+    try {
+      await deleteApiSessionsId(sessionId);
+    } catch {
+      /* the local clear must happen regardless — the session is gone from this client's perspective */
+    } finally {
+      clearSession();
+      setClosing(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col" data-testid="integrity-repair">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-1.5">
+        <Button
+          variant="ghost"
+          onClick={() => setPlan(null)}
+          data-testid="integrity-repair-back"
+          className="h-6 gap-1 px-1.5 text-fs-sm"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Back to report
+        </Button>
+        <span className="text-fs-base font-medium text-foreground">Repair plan</span>
+        <span
+          className="select-text font-mono text-fs-xs text-muted-foreground"
+          title="Binds this plan to the exact database state it was built for. Applying refuses if the database moved."
+        >
+          {plan.fingerprint.slice(0, 16)}…
+        </span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <StepsTable plan={plan} />
+
+        {plan.unaddressed.length > 0 && (
+          <div className="border-t border-border px-3 py-2" data-testid="integrity-unaddressed">
+            {/* Part of the diagnosis, not a footnote: what the tool cannot fix is what determines whether
+                the operator should be reaching for a backup instead. */}
+            <p className="text-fs-base font-medium text-foreground">This repair will not address</p>
+            <ul className="mt-1 list-inside list-disc text-fs-sm text-muted-foreground">
+              {plan.unaddressed.map((u) => (
+                <li key={u}>{u}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="flex min-h-0 flex-col border-t border-border">
+          <LossManifest entries={plan.loss} />
+        </div>
+
+        {rehearsal && (
+          <div className="border-t border-border" data-testid="integrity-rehearsal">
+            <div className="flex items-center gap-2 bg-sky-500/10 px-3 py-1.5">
+              <FlaskConical className="h-3.5 w-3.5 text-sky-500" />
+              <span className="text-fs-base text-foreground">Dry run — nothing was written</span>
+            </div>
+            <RepairReceipt outcome={rehearsal} rehearsal />
+          </div>
+        )}
+      </div>
+
+      {/* What the scan could not see, immediately above the decision it bears on. */}
+      <LimitsBlock limits={limits} />
+
+      {/* Action bar — below the manifest, never floating above it */}
+      <div className="shrink-0 border-t border-border px-3 py-2">
+        {sessionHoldsTarget && (
+          <div className="mb-2 flex items-center gap-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1.5" data-testid="integrity-lock-block">
+            <Lock className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+            <span className="text-fs-base text-foreground">
+              This database is open in the Workbench. Repair needs exclusive access.
+            </span>
+            <Button
+              variant="outline"
+              onClick={() => void closeSessionThenStay()}
+              disabled={closing}
+              data-testid="integrity-close-session"
+              className="ml-auto h-6 px-2 text-fs-sm"
+            >
+              {closing ? 'Closing…' : 'Close the session'}
+            </Button>
+          </div>
+        )}
+
+        {plan.requiresLossyConsent && (
+          <label
+            className="mb-2 flex cursor-pointer items-start gap-2 rounded border border-destructive/40 bg-destructive/10 px-2 py-1.5"
+            data-testid="integrity-consent"
+          >
+            <input
+              type="checkbox"
+              checked={allowLoss}
+              onChange={(e) => setAllowLoss(e.target.checked)}
+              data-testid="integrity-consent-checkbox"
+              className="mt-0.5"
+            />
+            <span className="text-fs-base text-foreground">
+              <AlertTriangle className="mr-1 inline h-3.5 w-3.5 text-destructive" />
+              I have read the {plan.loss.length.toLocaleString()}-entry list above and accept losing what it names.
+            </span>
+          </label>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex cursor-pointer items-center gap-1.5 text-fs-base text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={backupFirst}
+              onChange={(e) => setBackupFirst(e.target.checked)}
+              data-testid="integrity-backup-first"
+            />
+            Copy the bundle before the first write
+          </label>
+
+          <div className="ml-auto flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => run(true)}
+              disabled={apply.isPending || sessionHoldsTarget}
+              data-testid="integrity-dry-run"
+              className="h-7 gap-1 px-2 text-fs-base"
+              title="Execute every step in rehearsal and report what would happen. Writes nothing."
+            >
+              <FlaskConical className="h-3.5 w-3.5" />
+              Dry run
+            </Button>
+            <Button
+              onClick={() => run(false)}
+              disabled={blocked || apply.isPending}
+              data-testid="integrity-apply"
+              className="h-7 gap-1 px-3 text-fs-base"
+            >
+              <Wrench className="h-3.5 w-3.5" />
+              {apply.isPending ? 'Repairing…' : 'Repair'}
+            </Button>
+          </div>
+        </div>
+
+        {apply.isError && (
+          <p className="mt-2 text-fs-base text-destructive" data-testid="integrity-apply-error">
+            {(apply.error as Error)?.message ?? 'Repair failed.'}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepsTable({ plan }: { plan: RepairPlan }) {
+  if (plan.steps.length === 0) {
+    return <p className="px-3 py-2 text-fs-base text-muted-foreground">Nothing to do — this database needs no repair.</p>;
+  }
+
+  return (
+    <Table className="text-fs-base">
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-8 text-right text-fs-sm">#</TableHead>
+          <TableHead className="text-fs-sm">Action</TableHead>
+          <TableHead className="text-fs-sm">Class</TableHead>
+          <TableHead className="text-fs-sm">What it does</TableHead>
+          <TableHead className="text-fs-sm">Why</TableHead>
+          <TableHead className="text-fs-sm">Addresses</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {plan.steps.map((s) => (
+          <TableRow key={s.order} data-testid="integrity-step-row">
+            {/* Order is a correctness constraint (RB-02), not a display preference — indexes rebuilt over
+                un-scrubbed chains are confidently wrong rather than merely stale. Shown, never sortable. */}
+            <TableCell className="text-right tabular-nums text-muted-foreground">{s.order}</TableCell>
+            <TableCell className="font-mono text-fs-sm">{s.action}</TableCell>
+            <TableCell>
+              <StatusBadge tone={s.class === 'Excise' ? 'error' : s.class === 'Regenerate' ? 'success' : 'neutral'}>
+                {s.class}
+              </StatusBadge>
+            </TableCell>
+            <TableCell>{s.description}</TableCell>
+            <TableCell className="text-fs-sm text-muted-foreground">{s.rationale}</TableCell>
+            <TableCell className="font-mono text-fs-sm text-muted-foreground">{s.addresses.join(' ')}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/RepairFooter.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/RepairFooter.tsx
@@ -1,0 +1,47 @@
+import { ClipboardList } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+import { useRepairPlan } from '@/hooks/integrity/useIntegrityActions';
+import { verdictIsDamage, type Report } from './integrityModel';
+
+/**
+ * The entry to the repair flow, shown under a finished report.
+ *
+ * Planning is offered as a separate, explicitly read-only step rather than a "Repair" button that does
+ * everything. The friction is the feature: the cost of one extra click is seconds, and the cost of a wrong
+ * automatic repair is unbounded and unrecoverable. The button says *Plan* because that is all it does — it
+ * re-scans at Deep depth and describes what it would do, writing nothing.
+ */
+export default function RepairFooter({ report }: { report: Report }) {
+  const path = useIntegrityStore((s) => s.path);
+  const planMutation = useRepairPlan();
+
+  // A leaks-only database is not damaged. Offering repair here would push someone toward a mutation they
+  // don't need — reclaiming space is a maintenance task, not a correctness one.
+  const needsRepair = verdictIsDamage(report.verdict);
+
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-t border-border px-3 py-2" data-testid="integrity-repair-footer">
+      <span className="text-fs-base text-muted-foreground">
+        {needsRepair
+          ? 'Planning is read-only — it describes what a repair would do and what it would cost.'
+          : 'Nothing here needs repairing.'}
+      </span>
+      <Button
+        onClick={() => planMutation.mutate({ path })}
+        disabled={planMutation.isPending || !path}
+        variant={needsRepair ? 'default' : 'outline'}
+        data-testid="integrity-plan"
+        className="ml-auto h-7 gap-1 px-3 text-fs-base"
+      >
+        <ClipboardList className="h-3.5 w-3.5" />
+        {planMutation.isPending ? 'Planning…' : 'Plan a repair'}
+      </Button>
+      {planMutation.isError && (
+        <span className="text-fs-sm text-destructive" data-testid="integrity-plan-error">
+          {(planMutation.error as Error)?.message ?? 'Planning failed.'}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/RepairReceipt.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/RepairReceipt.tsx
@@ -1,0 +1,96 @@
+import { Check, CircleSlash, X } from 'lucide-react';
+import { StatusBadge } from '@/components/ui/status-badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { verdictTone, type RepairOutcome } from './integrityModel';
+
+/**
+ * What actually happened, step by step.
+ *
+ * The receipt reports the *actual* result rather than restating the plan, because the two legitimately
+ * differ: a step can be skipped when its finding turns out to have healed, and the realised loss can be
+ * **smaller** than the estimate. A receipt that echoed the plan would hide both.
+ *
+ * The post-repair verification scan is embedded rather than linked. A repair tool that says "done" without
+ * re-reading what it wrote is asking to be trusted on exactly the operation least deserving of trust.
+ */
+export default function RepairReceipt({ outcome, rehearsal }: { outcome: RepairOutcome; rehearsal?: boolean }) {
+  const v = outcome.verification;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-auto" data-testid={rehearsal ? 'integrity-receipt-dry' : 'integrity-receipt'}>
+      {!rehearsal && (
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+          <StatusBadge tone={outcome.succeeded ? 'success' : 'error'}>
+            {outcome.succeeded ? 'Repair completed' : 'Repair incomplete'}
+          </StatusBadge>
+          {outcome.backupPath && (
+            <span className="select-text text-fs-sm text-muted-foreground" title={outcome.backupPath}>
+              Pre-repair copy: <span className="font-mono text-foreground">{outcome.backupPath}</span>
+            </span>
+          )}
+        </div>
+      )}
+
+      <Table className="text-fs-base">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-8 text-right text-fs-sm">#</TableHead>
+            <TableHead className="text-fs-sm">Action</TableHead>
+            <TableHead className="text-fs-sm">Outcome</TableHead>
+            <TableHead className="text-fs-sm">Detail</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {outcome.results.map((r) => (
+            <TableRow key={r.order} data-testid="integrity-result-row" data-outcome={r.outcome}>
+              <TableCell className="text-right tabular-nums text-muted-foreground">{r.order}</TableCell>
+              <TableCell className="font-mono text-fs-sm">{r.action}</TableCell>
+              <TableCell>
+                <span className="flex items-center gap-1">
+                  <OutcomeIcon outcome={r.outcome} />
+                  {r.outcome}
+                </span>
+              </TableCell>
+              <TableCell className="text-fs-sm text-muted-foreground">{r.detail}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {v && (
+        <div className="mt-2 shrink-0 border-t border-border px-3 py-2" data-testid="integrity-verification">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-fs-base font-medium text-foreground">
+              {rehearsal ? 'Verification the repair would produce' : 'Verified after repair'}
+            </span>
+            <StatusBadge tone={verdictTone(v.verdict)}>{v.verdict}</StatusBadge>
+            <span className="text-fs-sm tabular-nums text-muted-foreground">
+              {v.findings.length} finding{v.findings.length === 1 ? '' : 's'} · {v.totals.pagesScanned.toLocaleString()} pages
+              re-read
+            </span>
+          </div>
+          {v.findings.length > 0 && (
+            <ul className="mt-1 list-inside list-disc text-fs-sm text-muted-foreground">
+              {v.findings.slice(0, 8).map((f, i) => (
+                <li key={`${f.code}-${i}`}>
+                  <span className="font-mono text-foreground">{f.code}</span> {f.summary}
+                </li>
+              ))}
+              {v.findings.length > 8 && <li>… re-scan for the full list</li>}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OutcomeIcon({ outcome }: { outcome: string }) {
+  if (outcome === 'Succeeded') {
+    return <Check className="h-3.5 w-3.5 text-emerald-500" />;
+  }
+  if (outcome === 'Skipped') {
+    return <CircleSlash className="h-3.5 w-3.5 text-muted-foreground" />;
+  }
+  return <X className="h-3.5 w-3.5 text-destructive" />;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/ScanTotals.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/ScanTotals.tsx
@@ -1,0 +1,50 @@
+import { formatBytes } from '@/libs/formatBytes';
+import type { Totals } from './integrityModel';
+
+/**
+ * What the scan actually looked at.
+ *
+ * This exists so a green verdict is falsifiable. "Sound" from a scan that walked 4 segments and read 12
+ * pages means something very different from "Sound" after 4,318 pages and 82 segments, and without these
+ * numbers the two are indistinguishable on screen. A reader who suspects the scan did nothing should be
+ * able to confirm or dismiss that here rather than by taking the verdict on faith.
+ */
+export default function ScanTotals({ totals }: { totals: Totals }) {
+  return (
+    <div
+      className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-0.5 border-b border-border px-3 py-1 text-fs-sm text-muted-foreground"
+      data-testid="integrity-totals"
+    >
+      <Metric label="pages scanned" value={totals.pagesScanned.toLocaleString()} />
+      <Metric label="allocated" value={totals.pagesAllocated.toLocaleString()} />
+      <Metric label="segments" value={totals.segmentsWalked.toLocaleString()} />
+      <Metric
+        label="sector-verified"
+        value={totals.pagesWithSectorFooters.toLocaleString()}
+        title="Pages carrying per-sector CRCs (format v6+). Older pages verify whole-page only."
+      />
+      <Metric
+        label="checksum failures"
+        value={totals.checksumFailures.toLocaleString()}
+        tone={totals.checksumFailures > 0 ? 'bad' : undefined}
+      />
+      <Metric
+        label="sector failures"
+        value={totals.sectorFailures.toLocaleString()}
+        tone={totals.sectorFailures > 0 ? 'bad' : undefined}
+      />
+      {totals.bytesLeaked > 0 && (
+        <Metric label="leaked" value={formatBytes(totals.bytesLeaked)} title="Allocated but unreachable — reclaimable, not damage." />
+      )}
+    </div>
+  );
+}
+
+function Metric({ label, value, title, tone }: { label: string; value: string; title?: string; tone?: 'bad' }) {
+  return (
+    <span title={title}>
+      <span className={`tabular-nums ${tone === 'bad' ? 'text-destructive' : 'text-foreground'}`}>{value}</span>{' '}
+      {label}
+    </span>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/VerdictBanner.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/VerdictBanner.tsx
@@ -1,0 +1,88 @@
+import { StatusBadge } from '@/components/ui/status-badge';
+import { formatBytes } from '@/libs/formatBytes';
+import {
+  countBySeverity,
+  severityTone,
+  verdictBlurb,
+  verdictTone,
+  SEVERITY_RANK,
+  type Report,
+  type Severity,
+} from './integrityModel';
+
+/**
+ * The one-word answer, its gloss, and the identity of what was scanned.
+ *
+ * The verdict is the headline because that is the first question an operator has — but the "clean shutdown"
+ * flag sits right beside it deliberately. A `Sound` verdict on a database that did *not* shut down cleanly
+ * means recovery worked; the same verdict after a clean close means nothing was ever at risk. Same word,
+ * different amount of reassurance, and the flag is what distinguishes them.
+ */
+export default function VerdictBanner({ report }: { report: Report }) {
+  const counts = countBySeverity(report.findings);
+  const present = (Object.keys(SEVERITY_RANK) as Severity[])
+    .filter((s) => counts[s] > 0)
+    .sort((a, b) => SEVERITY_RANK[a] - SEVERITY_RANK[b]);
+
+  const id = report.identity;
+
+  return (
+    <div className="shrink-0 border-b border-border px-3 py-2" data-testid="integrity-verdict">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span data-testid="integrity-verdict-badge">
+          <StatusBadge tone={verdictTone(report.verdict)} className="text-fs-lg">
+            {report.verdict}
+          </StatusBadge>
+        </span>
+
+        {present.length === 0 ? (
+          <span className="text-fs-base text-muted-foreground">no findings</span>
+        ) : (
+          <span className="flex flex-wrap items-center gap-1">
+            {present.map((s) => (
+              <StatusBadge key={s} tone={severityTone(s)} title={`${counts[s]} ${s} finding(s)`}>
+                {counts[s]} {s}
+              </StatusBadge>
+            ))}
+          </span>
+        )}
+
+        <span className="ml-auto text-fs-sm tabular-nums text-muted-foreground">
+          {report.depth} scan · {report.durationMs.toFixed(0)} ms
+        </span>
+      </div>
+
+      <p className="mt-1 text-fs-base text-muted-foreground">{verdictBlurb(report.verdict)}</p>
+
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-fs-sm text-muted-foreground">
+        <span className="font-mono text-foreground" title={report.source}>
+          {id.name || '(unnamed)'}
+        </span>
+        <span>·</span>
+        <span>format v{id.formatRevision}</span>
+        <span>·</span>
+        <span className="tabular-nums">{id.pageCount.toLocaleString()} pages</span>
+        <span>·</span>
+        <span className="tabular-nums">{formatBytes(id.sizeBytes)}</span>
+        <span>·</span>
+        <span className="tabular-nums" title="Last checkpoint LSN">
+          LSN {id.checkpointLsn.toLocaleString()}
+        </span>
+        <span>·</span>
+        {/* Not a finding on its own — an unclean flag is normal after a crash and the whole point of recovery.
+            It is shown because it changes how much a green verdict is worth. */}
+        <span className={id.cleanShutdown ? '' : 'text-amber-500'}>
+          clean shutdown: {id.cleanShutdown ? 'yes' : 'NO'}
+        </span>
+        {id.walSegmentCount > 0 && (
+          <>
+            <span>·</span>
+            <span className="tabular-nums">
+              WAL {id.walSegmentCount} seg / {formatBytes(id.walBytes)}
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/__tests__/integrityModel.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/__tests__/integrityModel.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import type { IntegrityFindingDto, IntegrityReportDto } from '@/api/generated/model';
+import {
+  countBySeverity,
+  normalizeReport,
+  severityByPage,
+  sortFindings,
+  verdictIsDamage,
+  type Finding,
+  type Severity,
+} from '../integrityModel';
+
+function finding(severity: Severity, page: number, code = 'CHK-X-01'): Finding {
+  return {
+    code,
+    severity,
+    confidence: 'Confirmed',
+    summary: '',
+    detail: '',
+    ruleId: '',
+    repair: '',
+    occurrences: 1,
+    locus: { filePageIndex: page, segmentRootPage: -1, kind: '', archetype: '', component: '', text: '' },
+    loss: { kind: 'None', count: '', archetype: '', component: '', explanation: '' },
+  };
+}
+
+describe('sortFindings', () => {
+  it('ranks by severity before page, so the worst thing is always the first row', () => {
+    const sorted = sortFindings([finding('Leak', 1), finding('Fatal', 900), finding('Divergence', 2)]);
+    expect(sorted.map((f) => f.severity)).toEqual(['Fatal', 'Divergence', 'Leak']);
+  });
+
+  it('groups equal severities by page, so contiguous damage reads as one region', () => {
+    const sorted = sortFindings([finding('Leak', 40), finding('Leak', 8), finding('Leak', 12)]);
+    expect(sorted.map((f) => f.locus.filePageIndex)).toEqual([8, 12, 40]);
+  });
+});
+
+describe('severityByPage', () => {
+  it('keeps the worst severity when several findings hit one page', () => {
+    const map = severityByPage([finding('Leak', 7), finding('DataLoss', 7), finding('Divergence', 7)]);
+    expect(map.get(7)).toBe('DataLoss');
+  });
+
+  it('drops findings with no page, because the map has no cell to paint for them', () => {
+    // A database-wide finding carries filePageIndex -1. Painting it would have to pick an arbitrary cell,
+    // which is worse than not painting it: it would accuse a page that is fine.
+    const map = severityByPage([finding('Fatal', -1), finding('Leak', 3)]);
+    expect(map.has(-1)).toBe(false);
+    expect([...map.keys()]).toEqual([3]);
+  });
+});
+
+describe('countBySeverity', () => {
+  it('counts every severity, including the ones with no findings', () => {
+    const counts = countBySeverity([finding('Leak', 1), finding('Leak', 2), finding('Fatal', 3)]);
+    expect(counts.Leak).toBe(2);
+    expect(counts.Fatal).toBe(1);
+    expect(counts.Advisory).toBe(0);
+  });
+});
+
+describe('verdictIsDamage', () => {
+  it('does not treat leaks as damage', () => {
+    // Leaks waste space; they are not a correctness problem. Calling them damage would push someone into a
+    // repair they do not need — the exact over-reaction the separate verdict exists to prevent.
+    expect(verdictIsDamage('SoundWithLeaks')).toBe(false);
+    expect(verdictIsDamage('Sound')).toBe(false);
+    expect(verdictIsDamage('Divergent')).toBe(true);
+    expect(verdictIsDamage('DataLoss')).toBe(true);
+    expect(verdictIsDamage('Unopenable')).toBe(true);
+  });
+});
+
+describe('normalizeReport', () => {
+  const bare: IntegrityReportDto = {
+    verdict: 'Sound',
+    exitCode: '0',
+    source: 'C:\\db.typhon',
+    mode: 'Offline',
+    depth: 'Standard',
+    durationMs: '12.5',
+    identity: {
+      name: 'db',
+      formatRevision: 6,
+      pageCount: 100,
+      sizeBytes: '819200',
+      checkpointLsn: '42',
+      cleanShutdown: true,
+      walSegmentCount: 0,
+      walBytes: '0',
+    },
+    totals: {
+      pagesScanned: 100,
+      pagesAllocated: 90,
+      checksumFailures: 0,
+      pagesWithSectorFooters: 100,
+      sectorFailures: 0,
+      segmentsWalked: 4,
+      bytesLeaked: '0',
+    },
+    findings: [],
+    limits: { structural: 'internal consistency only', checksSkipped: [], caveats: [] },
+  };
+
+  it('coerces the string-typed numerics ASP.NET emits for int64/double', () => {
+    const r = normalizeReport(bare);
+    expect(r.identity.sizeBytes).toBe(819200);
+    expect(r.identity.checkpointLsn).toBe(42);
+    expect(r.durationMs).toBe(12.5);
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('sorts findings on the way in, so no view can render them out of order', () => {
+    const raw: IntegrityFindingDto[] = [
+      { ...rawFinding('Leak', 1) },
+      { ...rawFinding('DataLoss', 50) },
+    ];
+    const r = normalizeReport({ ...bare, verdict: 'DataLoss', findings: raw });
+    expect(r.findings.map((f) => f.severity)).toEqual(['DataLoss', 'Leak']);
+  });
+
+  it('degrades an unknown severity to Advisory rather than throwing', () => {
+    // A checker that grows a sixth severity should under-rank one row on an old client, not blank the report.
+    const r = normalizeReport({ ...bare, findings: [rawFinding('Apocalyptic' as string, 5)] });
+    expect(r.findings[0].severity).toBe('Advisory');
+  });
+
+  it('degrades an unknown verdict to Divergent, never to Sound', () => {
+    // Failing toward "look at this" is the only safe direction: an unrecognised verdict rendered as Sound
+    // would be the client inventing a clean bill of health the server never gave.
+    const r = normalizeReport({ ...bare, verdict: 'Whatever' });
+    expect(r.verdict).toBe('Divergent');
+  });
+
+  it('survives null collections, which ASP.NET emits for empty ones', () => {
+    const r = normalizeReport({ ...bare, findings: null, limits: { structural: null, checksSkipped: null, caveats: null } });
+    expect(r.findings).toEqual([]);
+    expect(r.limits.checksSkipped).toEqual([]);
+    expect(r.limits.structural).toBe('');
+  });
+
+  function rawFinding(severity: string, page: number): IntegrityFindingDto {
+    return {
+      code: 'CHK-X-01',
+      severity,
+      confidence: 'Confirmed',
+      summary: 's',
+      detail: 'd',
+      ruleId: 'RB-01',
+      repair: 'Rebuild',
+      occurrences: 1,
+      locus: { filePageIndex: page, segmentRootPage: -1, kind: 'k', archetype: '', component: '', text: `page ${page}` },
+      loss: { kind: 'None', count: '', archetype: '', component: '', explanation: '' },
+    };
+  }
+});

--- a/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/integrityModel.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/Integrity/integrityModel.ts
@@ -1,0 +1,404 @@
+import type {
+  IntegrityFindingDto,
+  IntegrityLimitsDto,
+  IntegrityLocusDto,
+  IntegrityLossDto,
+  IntegrityReportDto,
+  RepairOutcomeDto,
+  RepairPlanDto,
+  RepairStepDto,
+  RepairStepResultDto,
+} from '@/api/generated/model';
+import type { StatusTone } from '@/components/ui/status-badge';
+
+/**
+ * Normalized mirrors of the integrity DTOs, plus the ordering and tone rules the views share.
+ *
+ * Orval emits `string | null` for every C# string and `number | string` for every int64/double, because
+ * ASP.NET Core doesn't propagate non-nullable reference types into OpenAPI. Panels can't `switch` on
+ * `string | null`, so severity and verdict are narrowed to real unions here — at the one boundary where an
+ * unrecognized value can be handled deliberately rather than crashing a render three components deep.
+ */
+
+/** How bad a finding is. Ordering matters — see {@link SEVERITY_RANK}. */
+export type Severity = 'Fatal' | 'DataLoss' | 'Divergence' | 'Leak' | 'Advisory';
+
+/** The one-word answer to "is this database sound?". */
+export type Verdict = 'Sound' | 'SoundWithLeaks' | 'Divergent' | 'DataLoss' | 'Unopenable';
+
+/** How much work a scan does. `spine` is the open-time tier — O(segments), not O(pages). */
+export type ScanDepth = 'spine' | 'quick' | 'standard' | 'deep';
+
+/** Whether the source was quiescent when the finding was observed. */
+export type Confidence = 'Confirmed' | 'Suspected' | 'Sampled';
+
+/** Whether a repair step regenerates (lossless) or excises (lossy). */
+export type RepairClass = 'Regenerate' | 'Excise' | 'Advisory';
+
+export const SCAN_DEPTHS: readonly ScanDepth[] = ['spine', 'quick', 'standard', 'deep'];
+
+/** Human blurb for each depth, shown in the picker so the cost/coverage trade is explicit. */
+export const DEPTH_BLURB: Readonly<Record<ScanDepth, string>> = {
+  spine: 'Bootstrap + segment roots only. Bounded by segment count, not database size.',
+  quick: 'Adds the occupancy bitmap and per-segment structure.',
+  standard: 'Full page sweep with checksum and sector verification.',
+  deep: 'Everything, including WAL inspection. The depth repair planning uses.',
+};
+
+/**
+ * Severity ordering, worst first. Findings sort by this and never alphabetically — an operator scanning a
+ * report reads top-down and must hit the thing that loses data before the thing that wastes space.
+ */
+export const SEVERITY_RANK: Readonly<Record<Severity, number>> = {
+  Fatal: 0,
+  DataLoss: 1,
+  Divergence: 2,
+  Leak: 3,
+  Advisory: 4,
+};
+
+const SEVERITY_TONE: Readonly<Record<Severity, StatusTone>> = {
+  Fatal: 'error',
+  DataLoss: 'error',
+  Divergence: 'warn',
+  Leak: 'info',
+  Advisory: 'neutral',
+};
+
+const VERDICT_TONE: Readonly<Record<Verdict, StatusTone>> = {
+  Sound: 'success',
+  SoundWithLeaks: 'info',
+  Divergent: 'warn',
+  DataLoss: 'error',
+  Unopenable: 'error',
+};
+
+/**
+ * One-line gloss per verdict. `SoundWithLeaks` is deliberately reassuring: leaks are not correctness
+ * problems and must not scare anyone into running a repair they don't need.
+ */
+const VERDICT_BLURB: Readonly<Record<Verdict, string>> = {
+  Sound: 'No damage found.',
+  SoundWithLeaks: 'No damage. Some space is allocated but unreachable — reclaimable, nothing is wrong.',
+  Divergent: 'Derived structures disagree with the data they are derived from. Rebuildable without loss.',
+  DataLoss: 'Damage that cannot be repaired without losing something. Read the loss manifest before repairing.',
+  Unopenable: 'The database cannot be opened. Repair may recover part of it.',
+};
+
+/**
+ * Canvas colours for the File Map integrity lens, keyed to the same semantics as the badge tones.
+ *
+ * Literal `rgb()` rather than CSS custom properties because the map renders to a canvas: it cannot inherit a
+ * token, and reading computed styles per frame is exactly the cost the renderer is built to avoid. These
+ * track the Tailwind palette the tones resolve to (red-400 / amber-400 / sky-400 / slate-400).
+ */
+export const SEVERITY_CANVAS_COLOR: Readonly<Record<Severity, string>> = {
+  Fatal: 'rgb(248, 113, 113)',
+  DataLoss: 'rgb(248, 113, 113)',
+  Divergence: 'rgb(251, 191, 36)',
+  Leak: 'rgb(56, 189, 248)',
+  Advisory: 'rgb(148, 163, 184)',
+};
+
+export function severityTone(severity: Severity): StatusTone {
+  return SEVERITY_TONE[severity] ?? 'neutral';
+}
+
+export function verdictTone(verdict: Verdict): StatusTone {
+  return VERDICT_TONE[verdict] ?? 'neutral';
+}
+
+export function verdictBlurb(verdict: Verdict): string {
+  return VERDICT_BLURB[verdict] ?? '';
+}
+
+/** True when the verdict means something is actually wrong (as opposed to merely wasteful). */
+export function verdictIsDamage(verdict: Verdict): boolean {
+  return verdict === 'Divergent' || verdict === 'DataLoss' || verdict === 'Unopenable';
+}
+
+export interface Locus {
+  filePageIndex: number;
+  segmentRootPage: number;
+  kind: string;
+  archetype: string;
+  component: string;
+  /** Server-rendered human form — always prefer this over recomposing the parts. */
+  text: string;
+}
+
+export interface LossEstimate {
+  kind: string;
+  /** Rendered count: an exact number or an honest range. Never parse it back into a number. */
+  count: string;
+  archetype: string;
+  component: string;
+  explanation: string;
+}
+
+export interface Finding {
+  code: string;
+  severity: Severity;
+  confidence: Confidence;
+  summary: string;
+  detail: string;
+  ruleId: string;
+  repair: string;
+  occurrences: number;
+  locus: Locus;
+  loss: LossEstimate;
+}
+
+export interface Identity {
+  name: string;
+  formatRevision: number;
+  pageCount: number;
+  sizeBytes: number;
+  checkpointLsn: number;
+  cleanShutdown: boolean;
+  walSegmentCount: number;
+  walBytes: number;
+}
+
+export interface Totals {
+  pagesScanned: number;
+  pagesAllocated: number;
+  checksumFailures: number;
+  pagesWithSectorFooters: number;
+  sectorFailures: number;
+  segmentsWalked: number;
+  bytesLeaked: number;
+}
+
+export interface Limits {
+  structural: string;
+  checksSkipped: string[];
+  caveats: string[];
+}
+
+export interface Report {
+  verdict: Verdict;
+  exitCode: number;
+  source: string;
+  mode: string;
+  depth: string;
+  durationMs: number;
+  identity: Identity;
+  totals: Totals;
+  findings: Finding[];
+  limits: Limits;
+}
+
+export interface RepairStep {
+  order: number;
+  action: string;
+  class: RepairClass;
+  description: string;
+  rationale: string;
+  addresses: string[];
+}
+
+export interface RepairPlan {
+  source: string;
+  /** Binds the plan to the exact database state it was built for. Apply refuses on drift. */
+  fingerprint: string;
+  verdict: Verdict;
+  requiresLossyConsent: boolean;
+  steps: RepairStep[];
+  /** The full enumeration. This *is* the consent — never render a count in its place. */
+  loss: LossEstimate[];
+  unaddressed: string[];
+}
+
+export interface RepairStepResult {
+  order: number;
+  action: string;
+  outcome: string;
+  detail: string;
+}
+
+export interface RepairOutcome {
+  succeeded: boolean;
+  backupPath: string;
+  results: RepairStepResult[];
+  verification: Report | null;
+}
+
+const num = (v: number | string | null | undefined, fallback = 0): number =>
+  v == null ? fallback : typeof v === 'number' ? v : Number(v);
+
+const str = (v: string | null | undefined, fallback = ''): string => v ?? fallback;
+
+const list = <T,>(v: T[] | null | undefined): T[] => v ?? [];
+
+/**
+ * Narrows a server severity string. An unknown value degrades to `Advisory` rather than throwing:
+ * a checker that grows a sixth severity should make an old client under-rank one row, not blank the
+ * whole report.
+ */
+function toSeverity(v: string | null | undefined): Severity {
+  return v != null && v in SEVERITY_RANK ? (v as Severity) : 'Advisory';
+}
+
+/** Unknown verdicts degrade to `Divergent` — the "something is off, look at it" bucket, never to `Sound`. */
+function toVerdict(v: string | null | undefined): Verdict {
+  return v != null && v in VERDICT_TONE ? (v as Verdict) : 'Divergent';
+}
+
+function normalizeLocus(raw: IntegrityLocusDto | null | undefined): Locus {
+  return {
+    filePageIndex: num(raw?.filePageIndex, -1),
+    segmentRootPage: num(raw?.segmentRootPage, -1),
+    kind: str(raw?.kind),
+    archetype: str(raw?.archetype),
+    component: str(raw?.component),
+    text: str(raw?.text),
+  };
+}
+
+function normalizeLoss(raw: IntegrityLossDto | null | undefined): LossEstimate {
+  return {
+    kind: str(raw?.kind, 'None'),
+    count: str(raw?.count),
+    archetype: str(raw?.archetype),
+    component: str(raw?.component),
+    explanation: str(raw?.explanation),
+  };
+}
+
+export function normalizeFinding(raw: IntegrityFindingDto): Finding {
+  return {
+    code: str(raw.code),
+    severity: toSeverity(raw.severity),
+    confidence: (str(raw.confidence, 'Suspected') as Confidence),
+    summary: str(raw.summary),
+    detail: str(raw.detail),
+    ruleId: str(raw.ruleId),
+    repair: str(raw.repair),
+    occurrences: num(raw.occurrences),
+    locus: normalizeLocus(raw.locus),
+    loss: normalizeLoss(raw.loss),
+  };
+}
+
+function normalizeLimits(raw: IntegrityLimitsDto | null | undefined): Limits {
+  return {
+    structural: str(raw?.structural),
+    checksSkipped: list(raw?.checksSkipped),
+    caveats: list(raw?.caveats),
+  };
+}
+
+export function normalizeReport(raw: IntegrityReportDto): Report {
+  return {
+    verdict: toVerdict(raw.verdict),
+    exitCode: num(raw.exitCode),
+    source: str(raw.source),
+    mode: str(raw.mode),
+    depth: str(raw.depth),
+    durationMs: num(raw.durationMs),
+    identity: {
+      name: str(raw.identity?.name),
+      formatRevision: num(raw.identity?.formatRevision),
+      pageCount: num(raw.identity?.pageCount),
+      sizeBytes: num(raw.identity?.sizeBytes),
+      checkpointLsn: num(raw.identity?.checkpointLsn),
+      cleanShutdown: raw.identity?.cleanShutdown ?? false,
+      walSegmentCount: num(raw.identity?.walSegmentCount),
+      walBytes: num(raw.identity?.walBytes),
+    },
+    totals: {
+      pagesScanned: num(raw.totals?.pagesScanned),
+      pagesAllocated: num(raw.totals?.pagesAllocated),
+      checksumFailures: num(raw.totals?.checksumFailures),
+      pagesWithSectorFooters: num(raw.totals?.pagesWithSectorFooters),
+      sectorFailures: num(raw.totals?.sectorFailures),
+      segmentsWalked: num(raw.totals?.segmentsWalked),
+      bytesLeaked: num(raw.totals?.bytesLeaked),
+    },
+    findings: sortFindings(list(raw.findings).map(normalizeFinding)),
+    limits: normalizeLimits(raw.limits),
+  };
+}
+
+function normalizeStep(raw: RepairStepDto): RepairStep {
+  return {
+    order: num(raw.order),
+    action: str(raw.action),
+    class: (str(raw.class, 'Advisory') as RepairClass),
+    description: str(raw.description),
+    rationale: str(raw.rationale),
+    addresses: list(raw.addresses),
+  };
+}
+
+export function normalizePlan(raw: RepairPlanDto): RepairPlan {
+  return {
+    source: str(raw.source),
+    fingerprint: str(raw.fingerprint),
+    verdict: toVerdict(raw.verdict),
+    requiresLossyConsent: raw.requiresLossyConsent ?? false,
+    // Step order is a correctness constraint (RB-02), not a display preference — sort by it explicitly
+    // rather than trusting array order to survive serialization.
+    steps: list(raw.steps).map(normalizeStep).sort((a, b) => a.order - b.order),
+    loss: list(raw.loss).map(normalizeLoss),
+    unaddressed: list(raw.unaddressed),
+  };
+}
+
+export function normalizeOutcome(raw: RepairOutcomeDto): RepairOutcome {
+  return {
+    succeeded: raw.succeeded ?? false,
+    backupPath: str(raw.backupPath),
+    results: list(raw.results as RepairStepResultDto[] | null).map((r) => ({
+      order: num(r.order),
+      action: str(r.action),
+      outcome: str(r.outcome),
+      detail: str(r.detail),
+    })),
+    verification: raw.verification ? normalizeReport(raw.verification) : null,
+  };
+}
+
+/**
+ * Worst first, then by page so a run of damage in one region reads as one region. Stable within a
+ * (severity, page) pair by falling back to the finding code.
+ */
+export function sortFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort((a, b) => {
+    const bySeverity = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (bySeverity !== 0) {
+      return bySeverity;
+    }
+    const byPage = a.locus.filePageIndex - b.locus.filePageIndex;
+    return byPage !== 0 ? byPage : a.code.localeCompare(b.code);
+  });
+}
+
+/** Counts per severity, for the banner's chip row. Zero-count severities are omitted by the caller. */
+export function countBySeverity(findings: Finding[]): Record<Severity, number> {
+  const counts: Record<Severity, number> = { Fatal: 0, DataLoss: 0, Divergence: 0, Leak: 0, Advisory: 0 };
+  for (const f of findings) {
+    counts[f.severity]++;
+  }
+  return counts;
+}
+
+/**
+ * Worst severity per physical page, for the File Map integrity lens. Findings with no page locus
+ * (`filePageIndex < 0` — database-wide findings) are excluded: the map has no cell to paint for them.
+ */
+export function severityByPage(findings: Finding[]): Map<number, Severity> {
+  const byPage = new Map<number, Severity>();
+  for (const f of findings) {
+    const page = f.locus.filePageIndex;
+    if (page < 0) {
+      continue;
+    }
+    const current = byPage.get(page);
+    if (current === undefined || SEVERITY_RANK[f.severity] < SEVERITY_RANK[current]) {
+      byPage.set(page, f.severity);
+    }
+  }
+  return byPage;
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/StorageHealth/IntegrityStrip.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/StorageHealth/IntegrityStrip.tsx
@@ -1,0 +1,76 @@
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
+import { StatusBadge } from '@/components/ui/status-badge';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { useSpineVerdict } from '@/hooks/integrity/useSpineVerdict';
+import { openIntegrityForSession } from '@/shell/commands/openIntegrity';
+import { verdictIsDamage, verdictTone } from '@/panels/Integrity/integrityModel';
+
+/**
+ * Storage Health's integrity presence: a one-line verdict for the open database, and the way into the full view.
+ *
+ * This is the compromise that keeps [06 §3](claude/design/Durability/Integrity/06-surfaces.md)'s intent — "Storage
+ * Health is the primary host for aggregate integrity" — without making the feature session-captive. The verdict
+ * belongs here, next to the other whole-database aggregates. The *view* cannot live here, because Storage Health
+ * needs a live engine and the cases integrity exists for are the ones where there isn't one.
+ *
+ * It runs the `Spine` tier only: bounded by segment count rather than database size, the same tier the engine
+ * runs on every open. Cheap enough to be a dashboard metric. It deliberately stops short of pronouncing —
+ * the database is live while this runs, so nothing it sees can be `Confirmed`, and the link exists because the
+ * real answer needs a deeper scan the operator asks for explicitly.
+ */
+export default function IntegrityStrip() {
+  const filePath = useSessionStore((s) => s.filePath);
+  const { data, isLoading, isError } = useSpineVerdict(filePath);
+
+  if (!filePath || isLoading) {
+    return null;
+  }
+
+  // A failed spine scan is itself worth surfacing — quietly hiding it would leave the strip looking like a
+  // clean bill of health when it is actually an absence of information.
+  if (isError || !data) {
+    return (
+      <StripShell>
+        <span className="text-fs-sm text-muted-foreground">Integrity: could not read the bundle.</span>
+      </StripShell>
+    );
+  }
+
+  const damaged = verdictIsDamage(data.verdict);
+
+  return (
+    <StripShell>
+      {damaged ? (
+        <ShieldAlert className="h-3.5 w-3.5 text-destructive" />
+      ) : (
+        <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" />
+      )}
+      <span className="text-fs-sm text-muted-foreground">Integrity</span>
+      <StatusBadge tone={verdictTone(data.verdict)}>{data.verdict}</StatusBadge>
+      <span className="text-fs-sm text-muted-foreground">
+        {damaged
+          ? 'from a shallow scan of a live database — run a full scan to confirm'
+          : 'spine only; a full scan checks every page'}
+      </span>
+      <button
+        type="button"
+        onClick={openIntegrityForSession}
+        data-testid="storage-health-integrity-link"
+        className="ml-auto rounded border border-border px-1.5 py-0.5 text-fs-xs text-foreground hover:bg-accent"
+      >
+        Full scan →
+      </button>
+    </StripShell>
+  );
+}
+
+function StripShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-0.5 border-b border-border px-3 py-1"
+      data-testid="storage-health-integrity"
+    >
+      {children}
+    </div>
+  );
+}

--- a/tools/Typhon.Workbench/ClientApp/src/panels/StorageHealth/StorageHealthPanel.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/panels/StorageHealth/StorageHealthPanel.tsx
@@ -10,6 +10,7 @@ import { openDbMapForComponent } from '@/shell/commands/openDbMap';
 import { segmentRgb, rgbCss } from '@/libs/dbmap/dbMapColors';
 import { sortHealthSegments, type HealthSortKey } from './storageHealthModel';
 import { formatBytes } from '@/libs/formatBytes';
+import IntegrityStrip from './IntegrityStrip';
 
 /**
  * Storage Health (Stage 2 Phase 3, GAP-16) — the *aggregate* storage dashboard, the non-spatial complement to
@@ -80,6 +81,9 @@ export default function StorageHealthPanel(_props: IDockviewPanelProps) {
           <RefreshCw className={`h-3 w-3 ${isFetching ? 'animate-spin' : ''}`} />
         </button>
       </div>
+
+      {/* #729 — the aggregate integrity verdict, sitting with the other whole-database aggregates. */}
+      <IntegrityStrip />
 
       {/* Per-segment table */}
       <div className="min-h-0 flex-1 overflow-auto">

--- a/tools/Typhon.Workbench/ClientApp/src/shell/DockHost.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/DockHost.tsx
@@ -145,6 +145,9 @@ const components: Record<string, React.FC<IDockviewPanelProps>> = {
   PaletteDebug: lazyPanel(() => import('@/panels/PaletteDebug')),
   DbMap: lazyPanel(() => import('@/panels/DbMap/DbMapPanel')),
   StorageHealth: lazyPanel(() => import('@/panels/StorageHealth/StorageHealthPanel')),
+  // #729 Integrity: the docked home of the scan/plan/repair view. It also renders full-bleed in the
+  // no-session shell (Shell.tsx) because a database that will not open has no session to dock into.
+  Integrity: lazyPanel(() => import('@/panels/Integrity/IntegrityPanel')),
   DataBrowserEntities: lazyPanel(() => import('@/panels/DataBrowser/EntityListPanel')),
   // #386 Phase 1: Query Console (chip-mode authoring + DSL editor + result grid + saved queries / history).
   QueryConsole: lazyPanel(() => import('@/panels/QueryConsole/QueryConsolePanel')),

--- a/tools/Typhon.Workbench/ClientApp/src/shell/MenuBar.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/MenuBar.tsx
@@ -43,6 +43,7 @@ import {
 } from './commands/openSchemaBrowser';
 import { toggleViewCallTree, toggleViewCriticalPath, toggleViewProfiler, toggleViewTopSpans, toggleViewQueryAnalyzer, toggleViewEngineLiveHealth, registerOpenSaveReplay } from './commands/profilerCommands';
 import { toggleViewQueryConsole } from './commands/openQueryConsole';
+import { openIntegrity } from './commands/openIntegrity';
 import { registerOpenConnect } from './commands/baseCommands';
 import { ANY_ZONE_D_VIEW_ACTIVE, isViewVisible } from './viewRegistry';
 import { logError, logInfo } from '@/stores/useLogStore';
@@ -114,6 +115,12 @@ export default function MenuBar() {
  </MenubarItem>
  <MenubarSeparator />
  <MenubarItem onClick={() => openConnect('recent')}>Recent Files…</MenubarItem>
+ <MenubarSeparator />
+ {/* #729 — deliberately in File rather than View. Every View entry opens a panel onto *the current
+     session*; this one acts on a database file, needs no session, and is most useful when the file
+     cannot be opened at all. Filing it under View would put the recovery tool behind the very thing
+     that is broken. */}
+ <MenubarItem onClick={() => openIntegrity()}>Check Database Integrity…</MenubarItem>
  </MenubarContent>
  </MenubarMenu>
 

--- a/tools/Typhon.Workbench/ClientApp/src/shell/Shell.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/Shell.tsx
@@ -3,6 +3,8 @@ import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { useSelectionBootstrap } from '@/hooks/useSelectionBootstrap';
 import { useSessionStore } from '@/stores/useSessionStore';
 import { useDensityStore } from '@/stores/useDensityStore';
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+import IntegrityStandalone from '@/panels/Integrity/IntegrityStandalone';
 import ContextBar from './ContextBar';
 import DevFixtureModal from './dialogs/DevFixtureModal';
 import DockHost from './DockHost';
@@ -14,6 +16,9 @@ export default function Shell() {
   const kind = useSessionStore((s) => s.kind);
   const sessionId = useSessionStore((s) => s.sessionId);
   const density = useDensityStore((s) => s.mode);
+  // The Integrity view's no-session home. It replaces the Welcome screen rather than overlaying it, because
+  // it is a full working surface — scan, plan, consent, repair — not a dialog interrupting one.
+  const integrityStandalone = useIntegrityStore((s) => s.standaloneOpen);
 
   useKeyboardShortcuts();
   useSelectionBootstrap();
@@ -28,7 +33,11 @@ export default function Shell() {
       <MenuBar />
       {kind !== 'none' && <ContextBar />}
       <main className="min-h-0 flex-1">
-        {kind === 'none' ? <WelcomeScreen /> : <DockHost key={sessionId ?? 'none'} />}
+        {kind === 'none' ? (
+          integrityStandalone ? <IntegrityStandalone /> : <WelcomeScreen />
+        ) : (
+          <DockHost key={sessionId ?? 'none'} />
+        )}
       </main>
       <StatusBar />
       {/* Modal fallback for the Dev Fixture surface when there's no dockview to dock into (Welcome state).

--- a/tools/Typhon.Workbench/ClientApp/src/shell/WelcomeScreen.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/WelcomeScreen.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { customFetch } from '@/api/client';
 import ConnectDialog, { type ConnectTab } from './dialogs/ConnectDialog';
 import { toggleViewDevFixture } from './commands/openSchemaBrowser';
+import { openIntegrity } from './commands/openIntegrity';
 
 export default function WelcomeScreen() {
  const [dialogOpen, setDialogOpen] = useState(false);
@@ -88,6 +89,21 @@ export default function WelcomeScreen() {
  </Button>
  )}
  </div>
+
+ {/* #729 — a recovery path, not a primary one, so it reads as a sentence rather than competing with the
+     "get started" buttons above. Phrased around the symptom because that is what someone arriving here
+     with a broken database actually knows: the file won't open. They don't yet know the word "integrity". */}
+ <p className="text-fs-base text-muted-foreground">
+ Database won&apos;t open, or you suspect damage?{' '}
+ <button
+ type="button"
+ onClick={() => openIntegrity()}
+ data-testid="welcome-check-integrity"
+ className="rounded text-foreground underline underline-offset-2 hover:text-primary"
+ >
+ Check its integrity
+ </button>
+ </p>
 
  <ConnectDialog open={dialogOpen} initialTab={initialTab} onOpenChange={setDialogOpen} />
  </div>

--- a/tools/Typhon.Workbench/ClientApp/src/shell/__tests__/conformance.test.tsx
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/__tests__/conformance.test.tsx
@@ -19,6 +19,7 @@ import QueryAnalyzerPanel from '@/panels/QueryAnalyzer/QueryAnalyzerPanel';
 import QueryConsolePanel from '@/panels/QueryConsole/QueryConsolePanel';
 import EngineLiveHealthPanel from '@/panels/EngineLiveHealth/EngineLiveHealthPanel';
 import DevFixturePanel from '@/panels/DevFixture/DevFixturePanel';
+import IntegrityPanel from '@/panels/Integrity/IntegrityPanel';
 
 // AC2.11 / AC3.11 — per-view conformance, parameterized over the reintroduced Stage-2/3 views (the conformance
 // doc's suites D + E). Each view is rendered in its **cold** state (no session → hooks disabled → empty/loading)
@@ -70,6 +71,10 @@ const VIEWS: { id: string; label: string; render: () => React.JSX.Element }[] = 
   // Dev Fixture: pure DOM (form + buttons). Capability probe is async — the first render shows
   // "Checking capability…", satisfying PC-2. PC-6 (no broken Open in/Reveal in/Go to) holds trivially.
   { id: 'DevFixture', label: 'Dev Fixture', render: () => <DevFixturePanel {...NO_PROPS} /> },
+  // #729 Integrity: pure DOM (path input + depth radios + report tables). Its cold state — before any scan —
+  // is a sentence explaining what the view does and that reading is safe, which is the PC-2 shape. Enrolled
+  // in its *docked* form; the full-bleed no-session form wraps this same component, so it inherits both.
+  { id: 'Integrity', label: 'Integrity', render: () => <IntegrityPanel /> },
 ];
 
 function mount(view: (typeof VIEWS)[number]) {

--- a/tools/Typhon.Workbench/ClientApp/src/shell/__tests__/viewRegistry.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/__tests__/viewRegistry.test.ts
@@ -26,8 +26,10 @@ const ZONE_D_GATED_OFF = [] as const;
 // Out-of-stage: DevFixture — the standalone fixture-creation panel (formerly the Connect-dialog tab). DEBUG-only
 // on the server; client always-active so the View menu / palette entries render in dev builds, with the panel
 // itself handling the "not available" cold state when the server's #if DEBUG endpoints are absent.
+// `Integrity` (#729) is listed here even though it is the one zone-D view that is *also* reachable with no
+// session at all — the flag gates only its docked form, which is a plain zone-D panel like the rest.
 const ZONE_D_ACTIVE = [
-  'DataBrowserEntities', 'DbMap', 'StorageHealth', 'Profiler', 'TopSpans', 'CallTree', 'SourcePreview', 'DataFlow', 'SystemDag', 'CriticalPath', 'QueryAnalyzer', 'QueryConsole', 'EngineLiveHealth', 'DevFixture',
+  'DataBrowserEntities', 'DbMap', 'StorageHealth', 'Profiler', 'TopSpans', 'CallTree', 'SourcePreview', 'DataFlow', 'SystemDag', 'CriticalPath', 'QueryAnalyzer', 'QueryConsole', 'EngineLiveHealth', 'DevFixture', 'Integrity',
 ] as const;
 
 // The full registry key set = gated-off ∪ active. Used to assert the registry covers exactly the documented set.

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/baseCommands.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/baseCommands.ts
@@ -24,6 +24,7 @@ import {
 } from './openSchemaBrowser';
 import { buildProfilerPaletteCommands } from './profilerCommands';
 import { openQueryConsole, toggleViewQueryConsole } from './openQueryConsole';
+import { openIntegrity } from './openIntegrity';
 import { isViewVisible } from '@/shell/viewRegistry';
 import type { ConnectTab } from '@/shell/dialogs/ConnectDialog';
 
@@ -75,6 +76,7 @@ export function buildBaseCommands(): CommandItem[] {
     { id: 'toggle-view-dbmap',                label: 'Toggle View Database File Map',       keywords: 'database file map storage layout pages hilbert fragmentation disk', action: toggleViewDbMap, viewId: 'DbMap' },
     { id: 'toggle-view-storage-health',       label: 'Open Storage Health',                 keywords: 'storage health dashboard segments occupancy dirty reclaimable fragmentation wal disk aggregate', action: toggleViewStorageHealth, viewId: 'StorageHealth' },
     { id: 'toggle-view-dev-fixture',          label: 'Create sample database',              keywords: 'sample playground dev fixture database generate preset advanced destination folder', action: toggleViewDevFixture, viewId: 'DevFixture' },
+    { id: 'check-integrity',                  label: 'Check database integrity…',           keywords: 'integrity check scan repair corrupt damage checksum crc verify recover fix broken unopenable loss', action: () => openIntegrity(), viewId: 'Integrity' },
     { id: 'data-browser',                     label: 'Open Data Browser',                   keywords: 'data browser entities components values inspect crud rows', action: () => toggleViewDataBrowser(), viewId: 'DataBrowserEntities' },
     { id: 'open-query-console',               label: 'Open Query Console',                  keywords: 'query console author run dsl chip filter where archetype indexed', action: () => openQueryConsole(), viewId: 'QueryConsole' },
     { id: 'toggle-view-query-console',        label: 'Toggle View Query Console',           keywords: 'query console author run dsl chip filter where archetype indexed', action: toggleViewQueryConsole, viewId: 'QueryConsole' },

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/openDbMap.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/openDbMap.ts
@@ -17,6 +17,21 @@ export function openDbMapForComponent(typeName: string): void {
 }
 
 /**
+ * Integrity finding → map: switch to the integrity lens and centre on the damaged page.
+ *
+ * The lens is switched on as part of the reveal rather than left to the user, because arriving at a page
+ * coloured by ordinary page-type encoding tells you nothing about why you were sent there. The caller is
+ * responsible for only offering this when a live session holds the same bundle the report describes — the
+ * map reads a live engine, the report does not.
+ */
+export function revealPageInDbMap(pageIndex: number): void {
+  const store = useDbMapStore.getState();
+  store.setLens('integrity');
+  store.requestFocusPage(pageIndex);
+  ensureDockPanel('dbmap', 'DbMap', 'Database File Map');
+}
+
+/**
  * Inspector System card → System DAG: highlight the system on the bus, request the canvas to centre + fit its node
  * (the `pendingFocusSystem` reveal signal, distinct from the plain bus highlight so only an explicit reveal recentres),
  * and surface the DAG panel. The panel auto-enables "show engine tracks" if the target is an engine-internal system

--- a/tools/Typhon.Workbench/ClientApp/src/shell/commands/openIntegrity.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/commands/openIntegrity.ts
@@ -1,0 +1,37 @@
+import { useIntegrityStore } from '@/stores/useIntegrityStore';
+import { useSessionStore } from '@/stores/useSessionStore';
+import { ensureDockPanel } from './openSchemaBrowser';
+
+/**
+ * Opens the Integrity view, wherever it can live right now.
+ *
+ * The two-home dance is invisible to every caller: `DockHost` only mounts once a session exists, so with a
+ * session the view is a dock panel and without one it takes the main area. Callers — the Welcome card, the
+ * palette, the View menu, the Storage Health strip, the launch-URL deep link — say "open integrity" and
+ * this decides where that means. If it were the callers' problem, the no-session path (the one that matters
+ * most) would be the one each of them forgot.
+ *
+ * @param path Bundle to target. Omit to keep whatever the view was last looking at.
+ */
+export function openIntegrity(path?: string): void {
+  const store = useIntegrityStore.getState();
+
+  if (path) {
+    store.setPath(path);
+  }
+
+  if (useSessionStore.getState().kind === 'none') {
+    store.openStandalone(path);
+    return;
+  }
+
+  ensureDockPanel('integrity', 'Integrity', 'Database Integrity');
+}
+
+/**
+ * Opens the view targeting the session's own database — the Storage Health strip's "view report" action.
+ * Falls back to a bare open when the session has no file path (attach / trace sessions).
+ */
+export function openIntegrityForSession(): void {
+  openIntegrity(useSessionStore.getState().filePath ?? undefined);
+}

--- a/tools/Typhon.Workbench/ClientApp/src/shell/viewRegistry.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/shell/viewRegistry.ts
@@ -24,6 +24,10 @@ export const ZONE_D_VIEW_ACTIVE: Readonly<Record<string, boolean>> = {
   DbMap: true,
   // Stage 2 Phase 3: Storage Health — the aggregate dashboard complement to the File Map (GAP-16).
   StorageHealth: true,
+  // #729: Database Integrity — offline scan / repair-plan / repair. Unlike every other zone-D view this one
+  // is also reachable with no session at all (Shell renders it full-bleed over the Welcome screen), so this
+  // flag gates only its *docked* form.
+  Integrity: true,
   // Profile (P-B) — profiler deep views.
   // Stage 3 Phase 1: the Profiler timeline (the global time-scope owner) + Top Spans are reintroduced onto the
   // finished shell. Selection already mirrors to the unified bus (Stage 1); flipping these on mounts them into
@@ -115,6 +119,9 @@ const VIEW_SESSION_SCOPE: Readonly<Record<string, ViewSessionScope>> = {
   SystemsQueriesNav: 'profiler',
   // Session-independent (generates/opens regardless of the current session)
   DevFixture: 'any',
+  // Integrity reads the bundle off disk rather than through an engine, so it is not merely session-independent —
+  // it is most useful with *no* session, on a database that cannot be opened at all.
+  Integrity: 'any',
 };
 
 /** The session-kind scope of a view (or view-bound command). Unlisted / undefined ids are `any`. */

--- a/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useIntegrityStore.test.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/__tests__/useIntegrityStore.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { integrityStage, useIntegrityStore } from '../useIntegrityStore';
+import type { Report, RepairOutcome, RepairPlan } from '@/panels/Integrity/integrityModel';
+
+const report = { verdict: 'DataLoss', findings: [] } as unknown as Report;
+const plan = { fingerprint: 'abc123', loss: [], steps: [] } as unknown as RepairPlan;
+const outcome = { succeeded: true, results: [] } as unknown as RepairOutcome;
+
+describe('useIntegrityStore', () => {
+  beforeEach(() => {
+    useIntegrityStore.getState().reset();
+  });
+
+  it('starts with backups on and consent off', () => {
+    const s = useIntegrityStore.getState();
+    expect(s.backupFirst).toBe(true);
+    expect(s.allowLoss).toBe(false);
+    expect(s.depth).toBe('standard');
+  });
+
+  // ── The invalidation rules. These are the correctness properties of this store, not conveniences. ──
+
+  it('a new scan discards the plan built from the previous one', () => {
+    // A plan is bound to a database fingerprint. Leaving it on screen after a re-scan would invite applying
+    // it against a diagnosis that has since changed — the failure the server's fingerprint check exists to
+    // catch. Catch it here too, before the operator has invested attention in reading it.
+    const s = useIntegrityStore.getState();
+    s.setReport(report);
+    s.setPlan(plan);
+    expect(useIntegrityStore.getState().plan).not.toBeNull();
+
+    s.setReport(report);
+    expect(useIntegrityStore.getState().plan).toBeNull();
+    expect(useIntegrityStore.getState().outcome).toBeNull();
+  });
+
+  it('a new plan revokes consent given for the previous one', () => {
+    // Otherwise an operator could tick the box against one loss manifest and apply a different one.
+    const s = useIntegrityStore.getState();
+    s.setPlan(plan);
+    s.setAllowLoss(true);
+    expect(useIntegrityStore.getState().allowLoss).toBe(true);
+
+    s.setPlan(plan);
+    expect(useIntegrityStore.getState().allowLoss).toBe(false);
+  });
+
+  it('a new scan revokes consent too', () => {
+    const s = useIntegrityStore.getState();
+    s.setPlan(plan);
+    s.setAllowLoss(true);
+    s.setReport(report);
+    expect(useIntegrityStore.getState().allowLoss).toBe(false);
+  });
+
+  it('retargeting the path clears every downstream artefact', () => {
+    // A report about one database must never sit next to another database's path.
+    const s = useIntegrityStore.getState();
+    s.setReport(report);
+    s.setPlan(plan);
+    s.setAllowLoss(true);
+
+    s.setPath('C:\\other.typhon');
+    const next = useIntegrityStore.getState();
+    expect(next.report).toBeNull();
+    expect(next.plan).toBeNull();
+    expect(next.outcome).toBeNull();
+    expect(next.allowLoss).toBe(false);
+  });
+
+  it('openStandalone without a path keeps the loaded report, so reopening returns to it', () => {
+    const s = useIntegrityStore.getState();
+    s.setPath('C:\\db.typhon');
+    s.setReport(report);
+    s.closeStandalone();
+
+    s.openStandalone();
+    const next = useIntegrityStore.getState();
+    expect(next.standaloneOpen).toBe(true);
+    expect(next.report).not.toBeNull();
+  });
+
+  it('openStandalone with a different path invalidates like any other retarget', () => {
+    const s = useIntegrityStore.getState();
+    s.setReport(report);
+    s.openStandalone('C:\\other.typhon');
+    const next = useIntegrityStore.getState();
+    expect(next.path).toBe('C:\\other.typhon');
+    expect(next.report).toBeNull();
+  });
+});
+
+describe('integrityStage', () => {
+  it('derives the flow position from what is loaded', () => {
+    expect(integrityStage({ report: null, plan: null, outcome: null })).toBe('idle');
+    expect(integrityStage({ report, plan: null, outcome: null })).toBe('scanned');
+    expect(integrityStage({ report, plan, outcome: null })).toBe('planned');
+    expect(integrityStage({ report, plan, outcome })).toBe('applied');
+  });
+});

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useDbMapStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useDbMapStore.ts
@@ -40,6 +40,12 @@ interface DbMapStoreState {
    * (§13 A4 AC1) — cross-links identify components by type name. The panel consumes it once and clears it.
    */
   pendingFocusType: string | null;
+  /**
+   * A physical page index an integrity finding asked the map to reveal. Distinct from
+   * {@link pendingFocusType} because a finding identifies damage by page, not by component — a corrupt page
+   * may belong to a segment whose component type is exactly what the damage made unreadable.
+   */
+  pendingFocusPage: number | null;
   /** The active filter-to-dim predicate, or null when no filter is applied (§4.6). */
   filter: DbMapFilter | null;
   /** Saved viewports, keyed by database name — the only persisted slice (§13 A4 AC3). */
@@ -56,7 +62,9 @@ interface DbMapStoreState {
   setActiveTab: (tab: DbMapTab) => void;
   /** Requests the panel focus a component type's segment on its next render — the cross-link entry point. */
   requestFocusComponent: (typeName: string) => void;
-  /** Clears a consumed cross-link focus request. */
+  /** Requests the panel centre on a physical page — the integrity-finding entry point. */
+  requestFocusPage: (pageIndex: number) => void;
+  /** Clears a consumed cross-link focus request (both the type and page forms). */
   clearPendingFocus: () => void;
   /** Sets the filter-to-dim predicate; null clears it. */
   setFilter: (filter: DbMapFilter | null) => void;
@@ -89,6 +97,7 @@ export const useDbMapStore = create<DbMapStoreState>()(
       railCollapsed: false,
       activeTab: 'legend',
       pendingFocusType: null,
+      pendingFocusPage: null,
       filter: null,
       bookmarks: {},
       setEncoding: (encoding) => set({ encoding }),
@@ -102,7 +111,8 @@ export const useDbMapStore = create<DbMapStoreState>()(
       toggleRail: () => set((s) => ({ railCollapsed: !s.railCollapsed })),
       setActiveTab: (tab) => set({ activeTab: tab }),
       requestFocusComponent: (typeName) => set({ pendingFocusType: typeName }),
-      clearPendingFocus: () => set({ pendingFocusType: null }),
+      requestFocusPage: (pageIndex) => set({ pendingFocusPage: pageIndex }),
+      clearPendingFocus: () => set({ pendingFocusType: null, pendingFocusPage: null }),
       setFilter: (filter) => set({ filter }),
       addBookmark: (databaseName, bookmark) =>
         set((s) => ({
@@ -127,10 +137,11 @@ export const useDbMapStore = create<DbMapStoreState>()(
       name: 'workbench-dbmap',
       storage: safeStorage(),
       // Persist the view configuration so the panel reopens the way the user left it — encoding, lens, overlay
-      // toggles, filter, and rail layout — alongside the per-database bookmarks. `lensSegmentId` and
-      // `pendingFocusType` are deliberately NOT persisted: they reference a specific segment / cross-link that
-      // may not exist next session, so they reset (the panel guards a restored fragmentation lens with no
-      // segment so it doesn't dim the whole map on open).
+      // toggles, filter, and rail layout — alongside the per-database bookmarks. `lensSegmentId`,
+      // `pendingFocusType` and `pendingFocusPage` are deliberately NOT persisted: they reference a specific
+      // segment / cross-link / damaged page that may not exist next session, so they reset (the panel guards
+      // a restored fragmentation lens with no segment so it doesn't dim the whole map on open, and guards a
+      // restored integrity lens with no report the same way).
       partialize: (s) => ({
         bookmarks: s.bookmarks,
         encoding: s.encoding,

--- a/tools/Typhon.Workbench/ClientApp/src/stores/useIntegrityStore.ts
+++ b/tools/Typhon.Workbench/ClientApp/src/stores/useIntegrityStore.ts
@@ -1,0 +1,102 @@
+import { create } from 'zustand';
+import type { Report, RepairOutcome, RepairPlan, ScanDepth } from '@/panels/Integrity/integrityModel';
+
+/**
+ * State for the Integrity view — deliberately **path-scoped, not session-scoped**.
+ *
+ * Every other storage store keys on `sessionId`, because every other storage view introspects a live engine.
+ * This one cannot: the case that most justifies the feature is a database that will not open, where there is
+ * no session to key on. Keying this store on a session would make the feature unavailable in exactly the
+ * situation it exists for — the same argument that made the server API path-based.
+ */
+
+/** Which step of scan → plan → apply the view is showing. Derived, never stored, so it cannot disagree. */
+export type IntegrityStage = 'idle' | 'scanned' | 'planned' | 'applied';
+
+interface IntegrityState {
+  /** Bundle path under examination. Seeded from the open session, the file picker, or a deep link. */
+  path: string;
+  depth: ScanDepth;
+  report: Report | null;
+  plan: RepairPlan | null;
+  outcome: RepairOutcome | null;
+  /** Consent to lossy (Class B) steps. Always starts false — consent is never inherited across plans. */
+  allowLoss: boolean;
+  /** Copy the bundle before the first mutation. Mirrors the server default. */
+  backupFirst: boolean;
+  /**
+   * Whether the view is showing full-bleed in the no-session shell.
+   *
+   * `DockHost` only mounts once a session exists (`Shell.tsx`), so a dockview panel cannot serve the case
+   * this feature most needs to serve: a database that will not open, where there is no session to host a
+   * dock. The view therefore has two homes — a dock panel when a session exists, and the main area when one
+   * does not. This flag selects the second.
+   */
+  standaloneOpen: boolean;
+
+  setPath: (path: string) => void;
+  setDepth: (depth: ScanDepth) => void;
+  setReport: (report: Report | null) => void;
+  setPlan: (plan: RepairPlan | null) => void;
+  setOutcome: (outcome: RepairOutcome) => void;
+  setAllowLoss: (allow: boolean) => void;
+  setBackupFirst: (backup: boolean) => void;
+  /** Shows the view full-bleed in the no-session shell, optionally seeding the target path. */
+  openStandalone: (path?: string) => void;
+  closeStandalone: () => void;
+  reset: () => void;
+}
+
+const INITIAL = {
+  path: '',
+  depth: 'standard' as ScanDepth,
+  report: null,
+  plan: null,
+  outcome: null,
+  allowLoss: false,
+  backupFirst: true,
+  standaloneOpen: false,
+};
+
+export const useIntegrityStore = create<IntegrityState>()((set) => ({
+  ...INITIAL,
+
+  // Changing the target invalidates everything downstream — a report about one database must never be
+  // left on screen next to another database's path.
+  setPath: (path) => set({ path, report: null, plan: null, outcome: null, allowLoss: false }),
+
+  setDepth: (depth) => set({ depth }),
+
+  // A fresh scan invalidates the plan. The plan is bound to a database fingerprint, so a plan surviving
+  // a re-scan is a plan the operator might apply against a diagnosis that has since changed — which is
+  // precisely the failure the server's fingerprint check exists to catch. Catch it here too, before the
+  // operator has invested any attention in it.
+  setReport: (report) => set({ report, plan: null, outcome: null, allowLoss: false }),
+
+  // Consent resets with every new plan. Carrying a checked box across a re-plan would let an operator
+  // consent to one loss manifest and apply a different one.
+  setPlan: (plan) => set({ plan, outcome: null, allowLoss: false }),
+
+  setOutcome: (outcome) => set({ outcome }),
+  setAllowLoss: (allowLoss) => set({ allowLoss }),
+  setBackupFirst: (backupFirst) => set({ backupFirst }),
+
+  // A supplied path goes through the same invalidation as setPath; an omitted one keeps whatever was
+  // already loaded, so reopening the view returns to the report you were reading.
+  openStandalone: (path) =>
+    set(path ? { standaloneOpen: true, path, report: null, plan: null, outcome: null, allowLoss: false } : { standaloneOpen: true }),
+  closeStandalone: () => set({ standaloneOpen: false }),
+
+  reset: () => set({ ...INITIAL }),
+}));
+
+/** Derives the flow stage from what is loaded. Not stored, so it cannot drift from the data. */
+export function integrityStage(s: Pick<IntegrityState, 'report' | 'plan' | 'outcome'>): IntegrityStage {
+  if (s.outcome) {
+    return 'applied';
+  }
+  if (s.plan) {
+    return 'planned';
+  }
+  return s.report ? 'scanned' : 'idle';
+}

--- a/tools/Typhon.Workbench/Controllers/FixturesController.Integrity.cs
+++ b/tools/Typhon.Workbench/Controllers/FixturesController.Integrity.cs
@@ -1,0 +1,134 @@
+#if DEBUG
+using Microsoft.AspNetCore.Mvc;
+using Typhon.Engine;
+
+namespace Typhon.Workbench.Controllers;
+
+/// <summary>
+/// DEBUG-only damage injection for the integrity Playwright canaries (#729).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this the integrity e2e could only ever assert the green path — scan a healthy database, see
+/// <c>Sound</c>. That is the one outcome whose regression is least interesting, and the whole feature exists
+/// for the other outcomes. Every branch worth protecting (a verdict banner that isn't green, a findings table
+/// with rows in it, a repair plan with steps, a consent gate, an applied receipt) is unreachable from a
+/// healthy fixture.
+/// </para>
+/// <para>
+/// It damages an <b>existing</b> bundle rather than building one, so it composes with the sample-database
+/// endpoint instead of duplicating its generator. Gated by <c>#if DEBUG</c> for the obvious reason: an
+/// endpoint that corrupts a database on request has no business in a shipped binary.
+/// </para>
+/// </remarks>
+public sealed partial class FixturesController
+{
+    /// <summary>
+    /// Corrupts a bundle in a named, reproducible way and returns the verdict the damage produces.
+    /// </summary>
+    /// <param name="req">Which bundle, and which damage variant.</param>
+    [HttpPost("damaged")]
+    public ActionResult<DamagedFixtureResponseDto> CreateDamaged([FromBody] DamagedFixtureRequestDto req)
+    {
+        if (req == null || string.IsNullOrWhiteSpace(req.Path))
+        {
+            return BadRequest(new { error = "A bundle path is required." });
+        }
+
+        string bundle;
+        try
+        {
+            bundle = OfflineBundlePageSource.ResolveBundleDirectory(req.Path);
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+
+        var variant = string.IsNullOrWhiteSpace(req.Variant) ? "meta-slot" : req.Variant.Trim().ToLowerInvariant();
+
+        try
+        {
+            switch (variant)
+            {
+                // One meta slot clobbered. The A/B pair means the other slot still carries a valid image, so this
+                // is Class A repairable *without loss* — the flow the canary drives end to end (plan has steps,
+                // no consent gate, apply, verify green).
+                case "meta-slot":
+                    DamagePage(bundle, 0, page => page.AsSpan(200, 64).Fill(0xAB));
+                    break;
+
+                // A flipped byte inside a data page: fails its CRC, and the data it held is simply gone. Produces
+                // a DataLoss verdict — the canary for a report that is not green and a repair that costs something.
+                case "checksum":
+                {
+                    var lastPage = PageCount(bundle) - 1;
+                    if (lastPage < 2)
+                    {
+                        return BadRequest(new { error = "Bundle is too small to damage a data page." });
+                    }
+
+                    DamagePage(bundle, lastPage, page => page[IntegrityConstants.PageHeaderSize + 16] ^= 0xFF);
+                    break;
+                }
+
+                // Both meta slots gone — nothing left to recover identity from. The Unopenable verdict, and the
+                // case that most justifies the feature: no engine can open this, so no session-scoped view could
+                // ever show it.
+                case "unopenable":
+                    DamagePage(bundle, 0, page => page.AsSpan(200, 64).Fill(0xAB));
+                    DamagePage(bundle, 1, page => page.AsSpan(200, 64).Fill(0xCD));
+                    break;
+
+                default:
+                    return BadRequest(new { error = $"Unknown variant '{variant}'. Expected meta-slot, checksum or unopenable." });
+            }
+        }
+        catch (IOException ex)
+        {
+            // Almost always "the database is still open" — worth saying plainly, since the fix is to close it.
+            return Conflict(new { error = $"Could not write to the bundle: {ex.Message}" });
+        }
+
+        using var source = new OfflineBundlePageSource(bundle);
+        var report = IntegrityScanner.Scan(source, new IntegrityOptions { Depth = ScanDepth.Standard });
+
+        return Ok(new DamagedFixtureResponseDto(bundle, variant, report.Verdict.ToString(), report.Findings.Count));
+    }
+
+    private static int PageCount(string bundlePath)
+    {
+        var dataPath = Path.Combine(bundlePath, IntegrityConstants.DataFileName);
+        return (int)(new FileInfo(dataPath).Length / IntegrityConstants.PageSize);
+    }
+
+    /// <summary>
+    /// Read-modify-write of one whole page. Mirrors the engine tests' helper deliberately — the canary should be
+    /// damaging the database the same way the unit tests do, so a divergence in what "damaged" means cannot
+    /// hide behind two different corruption routines.
+    /// </summary>
+    private static void DamagePage(string bundlePath, int filePageIndex, Action<byte[]> mutate)
+    {
+        var dataPath = Path.Combine(bundlePath, IntegrityConstants.DataFileName);
+        var page = new byte[IntegrityConstants.PageSize];
+        using var fs = new FileStream(dataPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        fs.Seek(filePageIndex * (long)IntegrityConstants.PageSize, SeekOrigin.Begin);
+        fs.ReadExactly(page);
+        mutate(page);
+        fs.Seek(filePageIndex * (long)IntegrityConstants.PageSize, SeekOrigin.Begin);
+        fs.Write(page);
+    }
+}
+
+/// <summary>Request to damage a bundle for an integrity canary.</summary>
+/// <param name="Path">Bundle to damage, in place.</param>
+/// <param name="Variant">meta-slot (repairable, lossless) · checksum (data loss) · unopenable. Defaults to meta-slot.</param>
+public sealed record DamagedFixtureRequestDto(string Path, string Variant = "meta-slot");
+
+/// <summary>The damage that was applied, and what a scan makes of it.</summary>
+/// <param name="Path">Resolved bundle directory.</param>
+/// <param name="Variant">Variant applied.</param>
+/// <param name="Verdict">Verdict a Standard scan now returns — lets the canary assert its precondition.</param>
+/// <param name="FindingCount">How many findings the damage produced.</param>
+public sealed record DamagedFixtureResponseDto(string Path, string Variant, string Verdict, int FindingCount);
+#endif

--- a/tools/Typhon.Workbench/Controllers/IntegrityController.cs
+++ b/tools/Typhon.Workbench/Controllers/IntegrityController.cs
@@ -1,0 +1,220 @@
+using Microsoft.AspNetCore.Mvc;
+using Typhon.Engine;
+using Typhon.Workbench.Dtos.Storage;
+using Typhon.Workbench.Middleware;
+
+namespace Typhon.Workbench.Controllers;
+
+/// <summary>
+/// REST surface for database integrity: scan, plan a repair, apply one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately <b>path-based rather than session-based</b>. Every other storage endpoint introspects the live engine of
+/// an open session; these do not, and must not. A scan has to work on a database that will not open — that is the case
+/// that most justifies its existence — and a repair needs exclusive access, which by definition means no session holds
+/// the database. Routing these through a session would make the feature unavailable in exactly the situations it exists
+/// for.
+/// </para>
+/// <para>
+/// Scanning is read-only and therefore unrestricted. Applying a repair is guarded twice: the caller must present the
+/// fingerprint of the plan it reviewed, and the engine re-scans and refuses if the database moved since. Consent to lose
+/// data is a separate flag again, and the loss manifest is returned in full rather than summarised — a dialog that says
+/// "47 entities will be affected, OK?" is not consent; the list is.
+/// </para>
+/// </remarks>
+[ApiController]
+[Route("api/integrity")]
+[Tags("Integrity")]
+[RequireBootstrapToken]
+public sealed class IntegrityController : ControllerBase
+{
+    /// <summary>Scans a bundle and returns the report. Read-only and always safe to call.</summary>
+    /// <param name="request">Which bundle to scan, and how deeply.</param>
+    [HttpPost("scan")]
+    public ActionResult<IntegrityReportDto> Scan([FromBody] IntegrityScanRequestDto request)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.Path))
+        {
+            return BadRequest(new { error = "A bundle path is required." });
+        }
+
+        if (!TryParseDepth(request.Depth, out var depth))
+        {
+            return BadRequest(new { error = $"Unknown depth '{request.Depth}'. Expected spine, quick, standard or deep." });
+        }
+
+        try
+        {
+            using var source = new OfflineBundlePageSource(request.Path);
+            var report = IntegrityScanner.Scan(source, new IntegrityOptions { Depth = depth });
+            return Ok(Map(report));
+        }
+        catch (Exception ex) when (ex is IOException or DirectoryNotFoundException or FileNotFoundException or UnauthorizedAccessException)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>Derives a repair plan. Read-only: describes what would happen and changes nothing.</summary>
+    /// <param name="request">Which bundle to plan for.</param>
+    [HttpPost("plan")]
+    public ActionResult<RepairPlanDto> PlanRepair([FromBody] IntegrityScanRequestDto request)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.Path))
+        {
+            return BadRequest(new { error = "A bundle path is required." });
+        }
+
+        try
+        {
+            using var source = new OfflineBundlePageSource(request.Path);
+            var report = IntegrityScanner.Scan(source, IntegrityOptions.Deep);
+            return Ok(Map(DatabaseRepair.Plan(report)));
+        }
+        catch (Exception ex) when (ex is IOException or DirectoryNotFoundException or FileNotFoundException or UnauthorizedAccessException)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>Applies a repair. The only mutating endpoint in the surface.</summary>
+    /// <param name="request">Which bundle, which plan fingerprint, and what consent was given.</param>
+    [HttpPost("apply")]
+    public ActionResult<RepairOutcomeDto> ApplyRepair([FromBody] RepairApplyRequestDto request)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.Path))
+        {
+            return BadRequest(new { error = "A bundle path is required." });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Fingerprint))
+        {
+            return BadRequest(new
+            {
+                error = "A plan fingerprint is required. Applying without one would mean repairing against a diagnosis "
+                    + "nobody reviewed."
+            });
+        }
+
+        try
+        {
+            RepairPlan plan;
+            using (var source = new OfflineBundlePageSource(request.Path))
+            {
+                if (source.LockHeld)
+                {
+                    return Conflict(new
+                    {
+                        error = "This database is open in another process. Repair requires exclusive access — close every "
+                            + "session on it and retry."
+                    });
+                }
+
+                plan = DatabaseRepair.Plan(IntegrityScanner.Scan(source, IntegrityOptions.Deep));
+            }
+
+            if (!string.Equals(plan.DatabaseFingerprint, request.Fingerprint, StringComparison.Ordinal))
+            {
+                return Conflict(new
+                {
+                    error = "The database has changed since the plan was reviewed, so the plan no longer describes it. "
+                        + "Re-scan and review a fresh plan.",
+                    expected = request.Fingerprint,
+                    actual = plan.DatabaseFingerprint
+                });
+            }
+
+            var outcome = DatabaseRepair.Apply(request.Path, plan, request.AllowLoss, request.BackupFirst, request.DryRun);
+            return Ok(Map(outcome));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Conflict(new { error = ex.Message });
+        }
+        catch (Exception ex) when (ex is IOException or DirectoryNotFoundException or FileNotFoundException or UnauthorizedAccessException)
+        {
+            return NotFound(new { error = ex.Message });
+        }
+    }
+
+    private static bool TryParseDepth(string value, out ScanDepth depth)
+    {
+        depth = ScanDepth.Standard;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "spine": depth = ScanDepth.Spine; return true;
+            case "quick": depth = ScanDepth.Quick; return true;
+            case "standard": depth = ScanDepth.Standard; return true;
+            case "deep": depth = ScanDepth.Deep; return true;
+            default: return false;
+        }
+    }
+
+    private static IntegrityReportDto Map(IntegrityReport report)
+    {
+        var findings = new List<IntegrityFindingDto>(report.Findings.Count);
+        for (var i = 0; i < report.Findings.Count; i++)
+        {
+            var f = report.Findings[i];
+            findings.Add(new IntegrityFindingDto(f.Code, f.Severity.ToString(), f.Confidence.ToString(), f.Summary, f.Detail,
+                f.RuleId, f.Repair.ToString(), f.Occurrences, Map(f.Locus), Map(f.Loss)));
+        }
+
+        var id = report.Identity;
+        var t = report.Totals;
+
+        return new IntegrityReportDto(
+            report.Verdict.ToString(), report.ExitCode, report.Source, report.Mode.ToString(), report.Depth.ToString(),
+            report.Duration.TotalMilliseconds,
+            new IntegrityIdentityDto(id.Name, id.FormatRevision, id.PageCount, id.SizeBytes, id.CheckpointLsn, id.CleanShutdown,
+                id.WalSegmentCount, id.WalBytes),
+            new IntegrityTotalsDto(t.PagesScanned, t.PagesAllocated, t.ChecksumFailures, t.PagesWithSectorFooters,
+                t.SectorFailures, t.SegmentsWalked, t.BytesLeaked),
+            findings,
+            new IntegrityLimitsDto(ScanLimits.StructuralLimit, report.Limits.ChecksSkipped, report.Limits.Caveats));
+    }
+
+    private static IntegrityLocusDto Map(Locus locus)
+        => new(locus.FilePageIndex, locus.SegmentRootPage, locus.Kind.ToString(), locus.ArchetypeName, locus.ComponentName, locus.ToString());
+
+    private static IntegrityLossDto Map(LossEstimate loss)
+        => new(loss.Kind.ToString(), loss.CountText, loss.Archetype, loss.Component, loss.Explanation);
+
+    private static RepairPlanDto Map(RepairPlan plan)
+    {
+        var steps = new List<RepairStepDto>(plan.Steps.Count);
+        for (var i = 0; i < plan.Steps.Count; i++)
+        {
+            var s = plan.Steps[i];
+            steps.Add(new RepairStepDto(s.Order, s.Action.ToString(), s.Class.ToString(), s.Description, s.Rationale, s.Addresses));
+        }
+
+        var losses = new List<IntegrityLossDto>(plan.Loss.Entries.Count);
+        for (var i = 0; i < plan.Loss.Entries.Count; i++)
+        {
+            losses.Add(Map(plan.Loss.Entries[i]));
+        }
+
+        return new RepairPlanDto(plan.Source, plan.DatabaseFingerprint, plan.Verdict.ToString(), plan.RequiresLossyConsent,
+            steps, losses, plan.Unaddressed);
+    }
+
+    private static RepairOutcomeDto Map(RepairOutcome outcome)
+    {
+        var results = new List<RepairStepResultDto>(outcome.Results.Count);
+        for (var i = 0; i < outcome.Results.Count; i++)
+        {
+            var r = outcome.Results[i];
+            results.Add(new RepairStepResultDto(r.Step.Order, r.Step.Action.ToString(), r.Outcome.ToString(), r.Detail));
+        }
+
+        return new RepairOutcomeDto(outcome.Succeeded, outcome.BackupPath, results,
+            outcome.VerificationReport == null ? null : Map(outcome.VerificationReport));
+    }
+}

--- a/tools/Typhon.Workbench/Dtos/Storage/IntegrityDtos.cs
+++ b/tools/Typhon.Workbench/Dtos/Storage/IntegrityDtos.cs
@@ -1,0 +1,122 @@
+namespace Typhon.Workbench.Dtos.Storage;
+
+/// <summary>Request body for starting an integrity scan.</summary>
+/// <param name="Path">Path to the <c>.typhon</c> bundle directory.</param>
+/// <param name="Depth">spine | quick | standard | deep. Defaults to standard.</param>
+public sealed record IntegrityScanRequestDto(string Path, string Depth = "standard");
+
+/// <summary>Where a finding is, flattened for the client.</summary>
+/// <param name="FilePageIndex">Physical page index, or -1.</param>
+/// <param name="SegmentRootPage">Owning segment's root page, or -1.</param>
+/// <param name="Kind">Owning segment kind.</param>
+/// <param name="Archetype">Archetype name when resolvable.</param>
+/// <param name="Component">Component name when resolvable.</param>
+/// <param name="Text">Rendered, human-readable locus.</param>
+public sealed record IntegrityLocusDto(int FilePageIndex, int SegmentRootPage, string Kind, string Archetype, string Component, string Text);
+
+/// <summary>What a repair would cost, in user terms.</summary>
+/// <param name="Kind">Unit of loss.</param>
+/// <param name="Count">Rendered count — an exact number or an honest range.</param>
+/// <param name="Archetype">Archetype the loss falls in, when resolvable.</param>
+/// <param name="Component">Component the loss falls in, when resolvable.</param>
+/// <param name="Explanation">Plain-English statement of what is no longer there.</param>
+public sealed record IntegrityLossDto(string Kind, string Count, string Archetype, string Component, string Explanation);
+
+/// <summary>One thing that is wrong with the database.</summary>
+/// <param name="Code">Stable check code — treat it as an API, it is what an alert keys on.</param>
+/// <param name="Severity">How bad it is.</param>
+/// <param name="Confidence">Whether the source was quiescent when it was observed.</param>
+/// <param name="Summary">One sentence, no jargon.</param>
+/// <param name="Detail">The evidence.</param>
+/// <param name="RuleId">The invariant violated.</param>
+/// <param name="Repair">What can be done about it.</param>
+/// <param name="Occurrences">How many times this fired.</param>
+/// <param name="Locus">Where it is.</param>
+/// <param name="Loss">What repairing it would cost.</param>
+public sealed record IntegrityFindingDto(string Code, string Severity, string Confidence, string Summary, string Detail,
+    string RuleId, string Repair, long Occurrences, IntegrityLocusDto Locus, IntegrityLossDto Loss);
+
+/// <summary>Identity of the scanned database.</summary>
+/// <param name="Name">Database name from page 0.</param>
+/// <param name="FormatRevision">On-disk format revision.</param>
+/// <param name="PageCount">Pages in the data file.</param>
+/// <param name="SizeBytes">Data file size.</param>
+/// <param name="CheckpointLsn">Last checkpoint LSN.</param>
+/// <param name="CleanShutdown">Whether the last close set the clean flag.</param>
+/// <param name="WalSegmentCount">WAL segment files present.</param>
+/// <param name="WalBytes">Total WAL bytes.</param>
+public sealed record IntegrityIdentityDto(string Name, int FormatRevision, int PageCount, long SizeBytes, long CheckpointLsn,
+    bool CleanShutdown, int WalSegmentCount, long WalBytes);
+
+/// <summary>What the scan looked at.</summary>
+/// <param name="PagesScanned">Pages read and classified.</param>
+/// <param name="PagesAllocated">Pages the bitmap marks in use.</param>
+/// <param name="ChecksumFailures">Pages that failed verification.</param>
+/// <param name="PagesWithSectorFooters">Pages carrying per-sector verification.</param>
+/// <param name="SectorFailures">Sectors that failed across all pages.</param>
+/// <param name="SegmentsWalked">Segments discovered and walked.</param>
+/// <param name="BytesLeaked">Allocated-but-unreachable bytes.</param>
+public sealed record IntegrityTotalsDto(int PagesScanned, int PagesAllocated, int ChecksumFailures, int PagesWithSectorFooters,
+    int SectorFailures, int SegmentsWalked, long BytesLeaked);
+
+/// <summary>What the scan could not have detected. Never omitted, including on a green report.</summary>
+/// <param name="Structural">The always-true statement of the instrument's blind spot.</param>
+/// <param name="ChecksSkipped">Checks not run at this depth.</param>
+/// <param name="Caveats">Scan-specific caveats.</param>
+public sealed record IntegrityLimitsDto(string Structural, IReadOnlyList<string> ChecksSkipped, IReadOnlyList<string> Caveats);
+
+/// <summary>A complete integrity report.</summary>
+/// <param name="Verdict">The one-word answer.</param>
+/// <param name="ExitCode">The same verdict as a process exit code.</param>
+/// <param name="Source">What was scanned.</param>
+/// <param name="Mode">How the pages were reached.</param>
+/// <param name="Depth">How much work was done.</param>
+/// <param name="DurationMs">Wall-clock duration.</param>
+/// <param name="Identity">Identity of the database.</param>
+/// <param name="Totals">What the scan looked at.</param>
+/// <param name="Findings">Everything that is wrong, severity-ranked.</param>
+/// <param name="Limits">What the scan could not see.</param>
+public sealed record IntegrityReportDto(string Verdict, int ExitCode, string Source, string Mode, string Depth, double DurationMs,
+    IntegrityIdentityDto Identity, IntegrityTotalsDto Totals, IReadOnlyList<IntegrityFindingDto> Findings, IntegrityLimitsDto Limits);
+
+/// <summary>One step of a repair plan.</summary>
+/// <param name="Order">Execution position. The order is a correctness constraint.</param>
+/// <param name="Action">What the step does.</param>
+/// <param name="Class">Whether it regenerates or excises.</param>
+/// <param name="Description">What will happen.</param>
+/// <param name="Rationale">Why it is safe, or what it costs.</param>
+/// <param name="Addresses">Check codes it answers.</param>
+public sealed record RepairStepDto(int Order, string Action, string Class, string Description, string Rationale, IReadOnlyList<string> Addresses);
+
+/// <summary>A repair plan, ready for an operator to review.</summary>
+/// <param name="Source">The database it targets.</param>
+/// <param name="Fingerprint">Binds the plan to the exact state it was built for; applying refuses on drift.</param>
+/// <param name="Verdict">The diagnosis it addresses.</param>
+/// <param name="RequiresLossyConsent">Whether any step destroys something.</param>
+/// <param name="Steps">The ordered steps.</param>
+/// <param name="Loss">The full loss enumeration. This is the consent, not a summary of it.</param>
+/// <param name="Unaddressed">Findings this build cannot repair, with the reason and the escalation path.</param>
+public sealed record RepairPlanDto(string Source, string Fingerprint, string Verdict, bool RequiresLossyConsent,
+    IReadOnlyList<RepairStepDto> Steps, IReadOnlyList<IntegrityLossDto> Loss, IReadOnlyList<string> Unaddressed);
+
+/// <summary>Request body for applying a repair.</summary>
+/// <param name="Path">Path to the bundle.</param>
+/// <param name="Fingerprint">The plan's fingerprint. Must still match, or the request is refused.</param>
+/// <param name="AllowLoss">Consent to lossy steps.</param>
+/// <param name="BackupFirst">Copy the bundle before the first mutation.</param>
+/// <param name="DryRun">Describe every step and execute none.</param>
+public sealed record RepairApplyRequestDto(string Path, string Fingerprint, bool AllowLoss = false, bool BackupFirst = true, bool DryRun = false);
+
+/// <summary>What happened to one step.</summary>
+/// <param name="Order">The step's position.</param>
+/// <param name="Action">What it was going to do.</param>
+/// <param name="Outcome">What happened.</param>
+/// <param name="Detail">What it actually did, or why it did not.</param>
+public sealed record RepairStepResultDto(int Order, string Action, string Outcome, string Detail);
+
+/// <summary>The receipt for an applied repair.</summary>
+/// <param name="Succeeded">Whether every attempted step worked.</param>
+/// <param name="BackupPath">Where the pre-repair copy went, when one was taken.</param>
+/// <param name="Results">Per-step receipts.</param>
+/// <param name="Verification">The scan run after the repair.</param>
+public sealed record RepairOutcomeDto(bool Succeeded, string BackupPath, IReadOnlyList<RepairStepResultDto> Results, IntegrityReportDto Verification);


### PR DESCRIPTION
Implements the full [Integrity design series](https://github.com/log2n-io/Typhon-Claude/tree/feature/db-repair/design/Durability/Integrity) — all six phases in the planned order. Closes #730, #731, #732, #733, #734, #735.

## The problem

Typhon already repairs damaged databases. Module `RB` is a real, rule-governed, tested recovery net. What it cannot do is **say anything**: it runs only at open, only on the crash path, cannot be invoked, and reports into log lines. Its outcome is binary — the database opens, or it throws.

So the engine can silently repair a database and the operator learns nothing, or refuse to open one and the operator learns nothing useful either. This adds the missing half.

```
$ typhon check game.typhon --depth deep

  game.typhon · format v6 · 4,318 pages (33.7 MiB) · checkpoint LSN 31,613
  clean shutdown: yes

  VERDICT: SOUND                     no findings

  LIMITS OF THIS SCAN
    This scan verifies that the database is INTERNALLY CONSISTENT. It cannot verify that the
    database matches what was committed…

  4,318 pages scanned · 82 segments · 4,221 pages with per-sector verification · 69 ms
```

## It found a real bug on its first run

Against a **healthy** database.

> `SavePages` — the structural ChangeSet flush — guards its checksum stamping on `FilePageIndex > 0`. **The write was not guarded.** A flush carrying logical page 0 overwrote **meta slot 0** with an image whose stored checksum no longer matched its content.

The meta pair exists so a torn write can never destroy the only copy of the root metadata. Half of it was being destroyed on ordinary shutdowns. Nothing complained — the surviving slot still opened the database, and every structure was individually well-formed. It would have surfaced only later, as a **permanently unopenable** database after a second, unrelated tear. That is exactly what `CK-05` exists to prevent.

`CollectDirtyMemPageIndices` had the `IsExternallyPersisted` exclusion all along; `SavePages` is fed by a ChangeSet rather than that scan, so it never applied. Fixed by extending the partition that already existed there for CK-05 directory pages. Regression: `MetaPairStructuralFlushTests`.

This is the argument for the feature, made by the feature: a `[silent]` violation no amount of internal consistency checking could notice.

## What's in it

**Offline scanner** — reads a `.typhon` bundle as bytes. No engine, no lock, no replay. Not a preference: booting the engine destroys the evidence (the rebuild net re-derives the structures you wanted to inspect before you get a handle), cannot reach the case that most justifies a checker, and mutates. Every pointer is range-checked before it is followed; there is a test that overwrites the entire data file with random bytes and requires a *verdict* rather than an exception.

Segment discovery is **physical**, not bootstrap-driven — a root page says so in its own header, so the sweep finds every segment without trusting a dictionary that may itself be damaged. The trap is that an A/B twin is a byte copy of its primary, root flag included; the discriminator is self-reference, since a segment's directory names its own root as entry 0 and a twin's copy still names the primary.

**20 checks** across BOO / PHY / SEG / WAL, each naming the `rules/` invariant it enforces.

**Report** — findings carry a locus in every applicable addressing scheme, a severity, a **confidence** (a live scan sees a consistent page but never a consistent database, so its cross-structure conclusions are `Suspected` and repair never acts on them), and a loss estimate that never reports `0` when the answer is unknown. Text + JSON; the verdict is the exit code so it drops into cron or CI unparsed.

Every report carries a **limits block**, including a fully green one. That is the point of it: a recovery gap that discarded a committed update leaves a database that passes every check, because it *is* self-consistent — merely stale.

**Repair** — plan → consent → act. The plan is a file, not a flag: it records a fingerprint of the exact state it was built for, and applying re-scans and **refuses on drift**. The lossless repairs are implemented (restore a degraded pair slot from its verified sibling; re-derive the allocation bitmap). Findings whose data is genuinely gone are reported under `Unaddressed` with the escalation stated, never silently dropped — excising rows from a damaged page needs the archetype layout, and guessing is what the design forbids.

**Format revision 6** — one checksum over 8192 bytes becomes sixteen over 512-byte sectors, each with a currency stamp. Zero added bytes (the space was already reserved and already CRC-covered) and the checksum path gets **faster**:

| granularity | ns/page |
|---|---|
| 8192 B, 1 chain (before) | 602.5 |
| **16 × 512 B (shipped)** | **459.9** |

**−23.7 %**, because a single 8 KiB chain is latency-bound on `crc32`'s 3-cycle latency while 16 independent chains are not.

The generation stamp is what a checksum alone cannot do: a torn write leaves a *valid* image of the previous generation, so its CRC passes and only currency distinguishes it. The rule takes the **maximum** across the header and every sector — comparing each sector against the header inverts when sector 0 is the part that failed to persist, condemning the one sector that landed and accepting every stale one. There is a test for exactly that.

**Verify on open** — `Spine` tier, on by default. The clean-shutdown flag records that the last process closed properly, not that the bytes survived. A fatal finding refuses the open with the report attached; lesser findings open and log.

**Surfaces** — `typhon check`, `typhon repair`; `POST /api/integrity/{scan,plan,apply}`, path-based rather than session-based because a scan must work on a database that will not open and a repair needs exclusive access.

## Deviations from the design

Recorded in [08 §4](https://github.com/log2n-io/Typhon-Claude/blob/feature/db-repair/design/Durability/Integrity/08-implementation-report.md) rather than silently absorbed.

1. **The Workbench decode layer was not moved into the engine.** The design's premise was wrong about it: `StorageMapService` walks *in-memory engine structures* on a live healthy database, not disk bytes. Moving it would have produced a walker that crashes on the databases the scanner exists to diagnose. Written fresh instead; the Workbench is untouched and becomes a consumer.
2. **Cross-structure checks (CHN/CLU/IDX/MAP/ALO) deferred** — they need offline schema decode. Named in the report's `ChecksSkipped`.
3. **Class B excision planned but not executed** — same schema dependency; acting on a guess is forbidden.

## Testing

36 new tests. Full suite **5,106 passed / 5 failed** — the same 5 that fail on unmodified `main`, baselined 3× before and after (known ~1-in-3 flake band, #720). Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CWY311fU31yKmmkEkPWaM