### PR TITLE
#297 #679 Six OLC B+Tree defects: silent key loss on insert, remove and read

### DIFF
--- a/src/Typhon.Engine/Indexing/internals/BTree.Insert.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.Insert.cs
@@ -655,7 +655,7 @@ internal abstract partial class BTree<TKey, TStore>
     /// </summary>
     private void InsertIterative(ref InsertArguments args, ref ChunkAccessor<TStore> accessor, out bool completed)
     {
-        completed = false;
+        completed = false; // descent
         MutationContext ctx = default;
         var node = Root;
         var relatives = new NodeRelatives();
@@ -712,8 +712,8 @@ internal abstract partial class BTree<TKey, TStore>
 
         // Phase 1.5A: Lock leaf with version validation.
         // Between Phase 1 descent and lock acquisition, a concurrent writer may have split/modified this leaf. Snapshot the version before locking,
-        // then validate after.
-        node.PreDirtyForWrite(ref accessor);
+        // then validate after. // INSIDE leaf PreDirtyForWrite — page-cache admission, blocks without spinning
+        node.PreDirtyForWrite(ref accessor); // leaf lock
         var leafLatch = node.GetLatch(ref accessor);
         int leafVersion = leafLatch.ReadVersion();
         if (leafVersion == 0)
@@ -761,7 +761,7 @@ internal abstract partial class BTree<TKey, TStore>
 
         // B-link move_right (Lehman & Yao): if the key is beyond this leaf's range, a concurrent split moved some keys to a right sibling. Chain right using
         // lock coupling (lock next before releasing current) until we find the correct leaf. Forward progress is guaranteed:
-        // all movement is strictly rightward with no cycle, and SpinWriteLock waits for busy siblings.
+        // all movement is strictly rightward with no cycle, and SpinWriteLock waits for busy siblings. // move-right
         bool movedRight = false;
         // High key is an exclusive upper bound, so key >= highKey means we're out of range.
         while (node.GetCount(ref accessor) > 0 && node.GetNext(ref accessor).IsValid && args.Compare(args.Key, node.GetHighKey(ref accessor)) >= 0)
@@ -854,14 +854,20 @@ internal abstract partial class BTree<TKey, TStore>
         // within microseconds).
         if (movedRight)
         {
-            node.GetLatch(ref accessor).WriteUnlock();
+            // #679: AbortWriteLock, NOT WriteUnlock. Nothing was modified on this path — `shouldContentionSplit` requires `!movedRight`, so arriving here means
+            // the leaf was full and the item was never inserted — and WriteUnlock BUMPS the version. That bump invalidates every concurrent OLC reader and
+            // writer that had validated against this leaf, forcing them to restart; with several writers repeatedly reaching this same bail they invalidate one
+            // another perpetually and none converges. Measured as the stress harness's HANG: all workers alive, none blocked on a latch, all sitting at
+            // pessAttempt=664 and climbing toward the MaxPessimisticRestarts throw. Releasing without the bump is what the rest of the file already does at
+            // every "condition failed — didn't modify node" exit.
+            node.GetLatch(ref accessor).AbortWriteLock();
             return; // completed=false — retry with fresh path from root
         }
 
         // Slow path: leaf full or contention split — structural modification needed.
         // For contention split, skip leafPrev lock (no spill needed — item already in, only need right neighbor for linked list).
         // On lock failure: contention split uses WriteUnlock + completed=true (item is in); regular uses AbortWriteLock + restart.
-        // Sibling locking: load sibling pages into the sibling CA to avoid evicting parent path pages from the primary CA
+        // Sibling locking: load sibling pages into the sibling CA to avoid evicting parent path pages from the primary CA // sibling locks
         var leafPrev = itemAlreadyInserted ? default : node.GetPrevious(ref accessor);
         var leafNext = node.GetNext(ref accessor);
         if (leafPrev.IsValid)
@@ -893,7 +899,7 @@ internal abstract partial class BTree<TKey, TStore>
             node.GetLatch(ref accessor).AbortWriteLock();
             return;
         }
-
+ // path locks
         // Lock path nodes bottom-up with version validation.
         // Required for ancestor key updates during spill and split propagation.
         for (int i = ctx.Depth - 1; i >= 0; i--)
@@ -949,7 +955,7 @@ internal abstract partial class BTree<TKey, TStore>
                 return;
             }
         }
-
+ // insert/split at leaf
         // All needed nodes locked — Phase 2: Insert at leaf (may spill or split) or contention split
         KeyValueItem? promoted;
         if (itemAlreadyInserted)
@@ -977,7 +983,7 @@ internal abstract partial class BTree<TKey, TStore>
         {
             node.GetLatch(ref accessor).WriteUnlock();
         }
-
+ // propagate
         // Phase 3: Propagate splits upward through internal nodes
         while (ctx.Depth > 0 && promoted != null)
         {
@@ -1035,7 +1041,7 @@ internal abstract partial class BTree<TKey, TStore>
         //
         // Issue #297: hold newRoot's write lock around the structural writes (SetLeft + Insert). Without it, a concurrent thread reading the just-published
         // `Root` field can observe newRoot with count=0 (Insert(0, promoted) hasn't written yet) and descend through the leftmost child path, missing the
-        // promoted subtree entirely. The lock forces the racer to restart on a locked latch until WriteUnlock publishes a consistent state.
+        // promoted subtree entirely. The lock forces the racer to restart on a locked latch until WriteUnlock publishes a consistent state. // root split
         if (promoted != null)
         {
             var newRoot = AllocNode(NodeStates.None, ref accessor);
@@ -1050,7 +1056,7 @@ internal abstract partial class BTree<TKey, TStore>
             newRootLatch.WriteUnlock();
             node.GetLatch(ref accessor).WriteUnlock(); // release old root after publishing new root
         }
-
+ // done
         completed = true;
     }
 }

--- a/src/Typhon.Engine/Indexing/internals/BTree.Insert.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.Insert.cs
@@ -1,6 +1,7 @@
 ﻿// unset
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -19,6 +20,36 @@ internal abstract partial class BTree<TKey, TStore>
         /// <summary>Target leaf is full — needs pessimistic path for split/spill.</summary>
         LeafFull,
     }
+    
+    /// <summary>
+    /// True when <paramref name="key"/> sits BELOW the lower bound that routes to <paramref name="leaf"/> — i.e. the descent that chose this leaf is stale and
+    /// the insert must restart rather than proceed.
+    /// </summary>
+    /// <remarks>
+    /// A leaf's first key IS the separator its parent holds. Inserting a key smaller than it lands at slot 0, drops the first key below that separator, and no
+    /// insert path updates the ancestor — so descent for the new key then routes LEFT of the separator and never reaches the leaf. The key is counted by
+    /// IncCount, sits in a correctly chained leaf, and is unreachable. That is #297/#679's mode 1, measured: `separator=408 -> child=5 firstKey=226`, with the
+    /// separator never rewritten and the leaf's first key dropped by an insert at slot 0.
+    /// <para>
+    /// Every insert path already validated the UPPER bound — the OLC general path checks <c>key >= HighKey</c>, the append fast paths check
+    /// <c>!GetNext().IsValid</c>, <c>InsertIterative</c> has its move-right gap check — and not one validated the lower bound. This is that missing half,
+    /// stated once and applied at all four sites, because a rule enforced at one call site is a rule enforced at one call site (the lesson IXS-03/IXW-01
+    /// already record for readers and writers).
+    /// </para>
+    /// <para>
+    /// A leaf with no previous sibling is the tree's leftmost and is reached through the left POINTER, which carries no separator — lowering its first key is
+    /// legitimate and is what the prepend fast paths exist to do. Hence the <c>GetPrevious</c> test, and it is evaluated LAST: the comparison short-circuits on
+    /// the overwhelmingly common in-range insert, so the extra chunk read is paid only when a key really is below the leaf's first.
+    /// </para>
+    /// <para>
+    /// Restarting is safe against livelock because both callers are bounded: the OLC loop by <c>MaxOptimisticRestarts</c> (then the pessimistic path), and the
+    /// pessimistic loop by <c>MaxPessimisticRestarts</c>, which throws rather than spins — the guard #695 put in place for exactly this shape.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool KeyBelowLeafLowerBound(NodeWrapper leaf, TKey key, IComparer<TKey> comparer, ref ChunkAccessor<TStore> accessor)
+        => leaf.GetCount(ref accessor) > 0 && comparer.Compare(key, leaf.GetFirst(ref accessor).Key) < 0 && leaf.GetPrevious(ref accessor).IsValid;
+
     /// <summary>Creates the insert value, handling AllowMultiple buffer creation.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int CreateInsertValue(ref InsertArguments args, ref ChunkAccessor<TStore> accessor)
@@ -269,6 +300,13 @@ internal abstract partial class BTree<TKey, TStore>
                             llLatch.WriteUnlock();
                             return OlcInsertResult.LeafFull;
                         }
+                        // #297 mode 1: `_linkList` is a cached field, so it can name a leaf that is no longer the leftmost. Pushing a smaller key to the front
+                        // of an INTERIOR leaf drops its first key below the separator routing to it, with no ancestor update — see KeyBelowLeafLowerBound.
+                        if (ll.GetPrevious(ref accessor).IsValid)
+                        {
+                            llLatch.AbortWriteLock();
+                            return OlcInsertResult.Restart;
+                        }
                         int value = CreateInsertValue(ref args, ref accessor);
                         ll.PushFirst(new KeyValueItem(args.Key, value), ref accessor);
                         llLatch.WriteUnlock();
@@ -330,6 +368,13 @@ internal abstract partial class BTree<TKey, TStore>
             leafLatch.WriteUnlock();
             return OlcInsertResult.Restart;
         }
+        // #297 mode 1: and the same check on the LOWER bound, which this path never had. Above only rejects a key past the leaf's high key; a key below its
+        // FIRST key is equally out of range and inserting it silently invalidates the separator. AbortWriteLock, not WriteUnlock — nothing was modified.
+        if (KeyBelowLeafLowerBound(leaf, args.Key, args.KeyComparer, ref accessor))
+        {
+            leafLatch.AbortWriteLock();
+            return OlcInsertResult.Restart;
+        }
         if (leaf.GetIsFull(ref accessor))
         {
             leafLatch.WriteUnlock();
@@ -372,12 +417,31 @@ internal abstract partial class BTree<TKey, TStore>
         {
             ref var accessor = ref args.Accessor;
 
-            if (IsEmpty())
+            // Issue #297/#679: the twin of AddOrUpdateCore's empty-tree initialisation, and it needs that one's CAS for the same reason. The trigger cannot be
+            // `IsEmpty()`: that tests the ENTRY COUNT, and the winner of the OLC init publishes `_rootChunkId` several instructions BEFORE its IncCount(). A
+            // writer that loses the OLC CAS, burns MaxOptimisticRestarts against the winner's still-locked leaf and lands here inside that window observes
+            // count==0 with a live root — and the unconditional `Root = AllocNode(...)` this replaces then republished a fresh EMPTY leaf over it. The winner's
+            // root and the key in it were orphaned (counted by EntryCount, reachable from nothing), and Height was left permanently one too high: two
+            // increments, one level. Test on root existence and CAS the publication, so the loser frees its node exactly as the OLC path's loser does.
+            //
+            // Both symptoms outlive the microsecond that produced them, which is why this read as an insert-path defect for so long: the key is simply absent
+            // from a structurally flawless tree, and the height drift persists into a large tree where it trips CheckConsistency's FIRST assertion and aborts
+            // the walk before any separator is examined.
+            if (_rootChunkId == 0)
             {
-                Root = AllocNode(NodeStates.IsLeaf, ref accessor);
-                _linkList = Root;
-                _reverseLinkList = _linkList;
-                Height++;
+                var newRoot = AllocNode(NodeStates.IsLeaf, ref accessor);
+                if (Interlocked.CompareExchange(ref _rootChunkId, newRoot.ChunkId, 0) == 0)
+                {
+                    _linkList = newRoot;
+                    _reverseLinkList = newRoot;
+                    Height++;
+                }
+                else
+                {
+                    // Another writer published a root first — drop ours rather than overwrite theirs.
+                    Interlocked.Increment(ref _emptyInitRacesLost);
+                    _segment.FreeChunk(newRoot.ChunkId);
+                }
             }
 
             // Append fast path: lock the last leaf and insert if key > lastKey and leaf not full.
@@ -471,7 +535,18 @@ internal abstract partial class BTree<TKey, TStore>
                         }
                         else
                         {
-                            if (!ll.GetIsFull(ref accessor) && args.Compare(args.Key, ll.GetFirst(ref accessor).Key) < 0)
+                            // #297: `ll.GetPrevious()` must be checked, and its absence here was the defect. This path lowers the leaf's FIRST key, and a leaf's
+                            // first key is what its parent separator holds. That is sound only for the tree's leftmost leaf, which hangs off the left POINTER
+                            // and has no separator — so nothing needs updating. `_linkList` is a cached field, though, and a concurrent split can create a new
+                            // leftmost leaf (or the field can simply be observed stale), leaving `ll` an INTERIOR leaf reached through a separator. Pushing a
+                            // smaller key to its front then drops its first key below that separator with no ancestor update, and descent for the new key
+                            // routes left of the separator and never reaches the leaf: the key is counted by IncCount and unreachable. Measured signature —
+                            // `separator=1054 -> leaf firstKey=1049`, the key present in a chained leaf, TryGet failing.
+                            //
+                            // The other three cached-pointer fast paths already guard this: the append path re-checks `!rl.GetNext().IsValid`, and both Remove
+                            // fast paths bail on a valid Previous/Next. The Remove BEGIN path's comment even names this exact hazard. Only this one was left.
+                            if (!ll.GetIsFull(ref accessor) && !ll.GetPrevious(ref accessor).IsValid
+                                                            && args.Compare(args.Key, ll.GetFirst(ref accessor).Key) < 0)
                             {
                                 int value = CreateInsertValue(ref args, ref accessor);
                                 ll.PushFirst(new KeyValueItem(args.Key, value), ref accessor);
@@ -723,6 +798,16 @@ internal abstract partial class BTree<TKey, TStore>
             node.GetLatch(ref accessor).AbortWriteLock();    // release current
             node = nextNode;
             movedRight = true;
+        }
+
+        // #297 mode 1: the lower-bound half of the move-right gap check above. That one rejects a key past this leaf's range on the RIGHT; this rejects one
+        // below its first key, which InsertLeaf would place at slot 0 — dropping the leaf's first key under the separator that routes to it, with no ancestor
+        // update from either the non-full path or the split path below. See KeyBelowLeafLowerBound. Nothing has been modified yet, so abort without a version
+        // bump and let the bounded outer loop re-descend.
+        if (KeyBelowLeafLowerBound(node, args.Key, args.KeyComparer, ref accessor))
+        {
+            node.GetLatch(ref accessor).AbortWriteLock();
+            return; // completed=false → outer retry
         }
 
         // Fast path: leaf not full → InsertLeaf only modifies this leaf (insert or duplicate append)

--- a/src/Typhon.Engine/Indexing/internals/BTree.NodeWrapper.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.NodeWrapper.cs
@@ -303,6 +303,17 @@ internal abstract partial class BTree<TKey, TStore>
                         }
 
                         rightLeaf = new KeyValueItem(rightNode.GetFirst(ref accessor).Key, rightNode.ChunkId);
+
+                        // #297/#679 mode 2: SplitRight set this node's HighKey to the right half's first key at the moment of the split — and BOTH branches
+                        // above then change that first key. `PushFirst` moves this node's old last key into the right half, dropping its first key below the
+                        // HighKey just recorded; the `Insert` branch can do the same. HighKey is the EXCLUSIVE upper bound the B-link protocol reads to decide
+                        // "this key is past me, follow the right link", so leaving it high makes a descent stop here for keys that now live next door, and
+                        // report not-found on a tree that is otherwise perfectly consistent — separators agreeing, the key present in a chained leaf reachable
+                        // from the root. Measured: `leaf=30 highKey=601 but next=5 firstKey=207`.
+                        //
+                        // The correct value is the one just computed for the promoted separator: they are the same fact — where the boundary between the two
+                        // leaves now sits. The spill paths already do this (SetHighKey(newSeparator)); the split path computed it and did not write it back.
+                        SetHighKey(rightLeaf.Value.Key, ref accessor);
                     }
 
                     Validate();

--- a/src/Typhon.Engine/Indexing/internals/BTree.Remove.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.Remove.cs
@@ -356,9 +356,16 @@ internal abstract partial class BTree<TKey, TStore>
                 }
                 else
                 {
-                    int order = args.Compare(args.Key, ll.GetFirst(ref accessor).Key);
+                    var llFirst = ll.GetFirst(ref accessor).Key;
+                    int order = args.Compare(args.Key, llFirst);
                     if (order < 0)
                     {
+                        if (OlcDescentTrace.OnRemoveNotFound != null && typeof(TKey) == typeof(int))
+                        {
+                            var ak = args.Key; var fk = llFirst;
+                            OlcDescentTrace.OnRemoveNotFound(OlcDescentTrace.RemoveBranchPessimisticBeginLessThanFirst,
+                                Unsafe.As<TKey, int>(ref ak), ll.ChunkId, Unsafe.As<TKey, int>(ref fk), ll.GetCount(ref accessor));
+                        }
                         ll.GetLatch(ref accessor).AbortWriteLock(); // key not in tree — didn't modify node
                         return;
                     }
@@ -396,9 +403,16 @@ internal abstract partial class BTree<TKey, TStore>
                 }
                 else
                 {
-                    int order = args.Compare(args.Key, rll.GetLast(ref accessor).Key);
+                    var rllLast = rll.GetLast(ref accessor).Key;
+                    int order = args.Compare(args.Key, rllLast);
                     if (order > 0)
                     {
+                        if (OlcDescentTrace.OnRemoveNotFound != null && typeof(TKey) == typeof(int))
+                        {
+                            var ak = args.Key; var lk = rllLast;
+                            OlcDescentTrace.OnRemoveNotFound(OlcDescentTrace.RemoveBranchPessimisticEndGreaterThanLast,
+                                Unsafe.As<TKey, int>(ref ak), rll.ChunkId, Unsafe.As<TKey, int>(ref lk), rll.GetCount(ref accessor));
+                        }
                         rll.GetLatch(ref accessor).AbortWriteLock(); // key not in tree — didn't modify node
                         return;
                     }
@@ -584,6 +598,23 @@ internal abstract partial class BTree<TKey, TStore>
         {
             leafLatch.AbortWriteLock(); // we held the lock without modifying the node
             return false; // restart — parent separator hasn't propagated; descent landed at wrong leaf
+        }
+
+        // #679: the LOWER-bound half of the guard above, which only ever covered the upper one. A stale separator can route a descent too far RIGHT just as
+        // easily as too far left — and then Find fails on a leaf whose first key is already past the search key, while the key sits in a leaf to the LEFT. The
+        // comment below used to reason "after the stale-separator guard above, a NotFound here means the key is genuinely not in the tree", which held for one
+        // direction only. Measured in Remove_Merges: key 584 removed by nobody, still on the chain, with Remove reporting not-found.
+        // An empty leaf is inconclusive for the same reason and gets the same treatment — merges empty a leaf before unlinking it, so meeting one says nothing
+        // about where the key is. Both cases release without a version bump (nothing was modified) and let the bounded outer loop re-descend.
+        int leafCount = node.GetCount(ref accessor);
+        bool leftOfLeaf = leafCount > 0
+                          && args.Compare(args.Key, node.GetFirst(ref accessor).Key) < 0
+                          && node.GetPrevious(ref accessor).IsValid;
+        bool emptyAndLinked = leafCount == 0 && (node.GetPrevious(ref accessor).IsValid || node.GetNext(ref accessor).IsValid);
+        if (leftOfLeaf || emptyAndLinked)
+        {
+            leafLatch.AbortWriteLock();
+            return false; // restart — this leaf is not authoritative for the key
         }
 
         // Check if key exists in this leaf

--- a/src/Typhon.Engine/Indexing/internals/BTree.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.cs
@@ -1500,6 +1500,47 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
             : $"{broken.Count}+ of {links} leaf link(s) have a HighKey reaching past the next leaf :: {string.Join(" ;; ", broken)}";
     }
 
+    /// <summary>
+    /// Validates that the leaf sibling chain is a simple, doubly-consistent list: no node revisited, every back-pointer agreeing with the forward walk, and
+    /// the tail matching <c>_reverseLinkList</c>. Returns <c>null</c> when sound, else a detail string. Test/diagnostic use only — walks without locks.
+    /// </summary>
+    /// <remarks>
+    /// #679: every chain walk in this file and in the stress harness was written as <c>while (cur.IsValid)</c> or with a 1,000,000-iteration guard, so a cycle
+    /// in the chain either hung the walker or was silently absorbed — including inside <see cref="CheckConsistency"/> itself, which is supposed to be the thing
+    /// that catches this. A cycle IS reachable: it is what left writers walking the B-link move-right loop forever, and the reason the loop now carries a hop
+    /// bound. Detect it explicitly and name the node, so the corruption is reported where it is rather than as a hang somewhere downstream.
+    /// </remarks>
+    internal string ValidateLeafChain(ref ChunkAccessor<TStore> accessor)
+    {
+        var seen = new HashSet<int>();
+        var cur = _linkList;
+        NodeWrapper prev = default;
+        while (cur.IsValid)
+        {
+            if (!seen.Add(cur.ChunkId))
+            {
+                return $"leaf chain has a CYCLE: chunk {cur.ChunkId} revisited after {seen.Count} node(s), reached from {prev.ChunkId}";
+            }
+
+            var back = cur.GetPrevious(ref accessor);
+            if (prev.IsValid ? (back.ChunkId != prev.ChunkId) : back.IsValid)
+            {
+                return $"leaf chain back-pointer disagrees at chunk {cur.ChunkId}: previous={back.ChunkId}, forward walk arrived from "
+                     + $"{(prev.IsValid ? prev.ChunkId.ToString() : "head")}";
+            }
+
+            prev = cur;
+            cur = cur.GetNext(ref accessor);
+        }
+
+        if (prev.IsValid && _reverseLinkList.IsValid && prev.ChunkId != _reverseLinkList.ChunkId)
+        {
+            return $"leaf chain tail is chunk {prev.ChunkId} but _reverseLinkList names {_reverseLinkList.ChunkId}";
+        }
+
+        return null;
+    }
+
     public override void CheckConsistency(ref ChunkAccessor<TStore> accessor)
     {
         // Recursive check from Root to leaf
@@ -1516,6 +1557,10 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
         //   - HighKey == next leaf's first key: nothing in the walk reads HighKey at all, so the bound the B-link descent steers by had no enforcement.
         // The first cost a long hunt in #297/#679 by reporting as "Mismatch node's Height 2 with True" — a leaf at the wrong level — on trees that were in
         // fact perfectly balanced. The other two were the mode 1 / mode 2 defects themselves, invisible to a check that reported "PASSED".
+        // Chain first: everything below walks the chain, and the walks are unbounded — a cycle would hang the checker instead of failing it.
+        var chainDetail = ValidateLeafChain(ref accessor);
+        ConsistencyAssert(chainDetail == null, chainDetail);
+
         var depthDetail = ValidateLeafDepths(ref accessor);
         ConsistencyAssert(depthDetail == null, depthDetail);
         var separatorDetail = ValidateLeafSeparators(ref accessor);
@@ -1929,7 +1974,7 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
             Interlocked.Increment(ref _writeLockFailures);
             spin.SpinOnce(-1);
         }
-        while (!latch.TryWriteLock());
+        while (!latch.TryWriteLock());
         return WriteLockOutcome.AcquiredContended;
     }
 
@@ -2104,20 +2149,32 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
         // out-of-sync with the actual chain ordering/ under concurrent operations.
         if (followRightLink && keyIndex < 0)
         {
+            // #679: every caller reads `keyIndex < 0` as "definitively not in the tree", so this loop must only end that way when it has actually ESTABLISHED
+            // it. It had two exits that established nothing and still fell through to that answer:
+            //   - the hop budget running out, and
+            //   - meeting an empty leaf, which ended the loop via its own condition.
+            // Both are reachable while the key sits further right, and the second is routine during merges: a leaf is emptied before the merge that unlinks it.
+            // Measured in Remove_Merges — key 584 removed by nobody, still on the chain, with branch `general path (descend keyIndex<0)` the only one to fire.
+            // The same descent backs TryGet, so the identical false "not found" was reachable on the READ path.
+            // Empty leaves are now hopped OVER rather than treated as an answer, and an inconclusive exit restarts instead of lying.
             const int maxHops = 16;
-            for (int hop = 0; hop < maxHops && node.GetCount(ref accessor) > 0; hop++)
+            bool conclusive = false;
+            for (int hop = 0; hop < maxHops; hop++)
             {
                 int leafCount = node.GetCount(ref accessor);
-                int cmpToLast = leafCount > 0 ? Comparer.Compare(key, node.GetItem(leafCount - 1, ref accessor).Key) : 1; // empty leaf — treat key as beyond
-                if (cmpToLast <= 0)
+                if (leafCount > 0)
                 {
                     // key <= leaf's last → key would be in this leaf if anywhere on this side of the chain. Re-validate to guard against torn reads (key/last
                     // from inconsistent version snapshot), then conclude NotFound.
-                    if (!latch.ValidateVersion(version))
+                    if (Comparer.Compare(key, node.GetItem(leafCount - 1, ref accessor).Key) <= 0)
                     {
-                        return (0, 0, -1);
+                        if (!latch.ValidateVersion(version))
+                        {
+                            return (0, 0, -1);
+                        }
+                        conclusive = true;
+                        break;
                     }
-                    break;
                 }
                 if (!latch.ValidateVersion(version))
                 {
@@ -2127,7 +2184,8 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
                 var nextNode = node.GetNext(ref accessor);
                 if (!nextNode.IsValid)
                 {
-                    break; // chain exhausted
+                    conclusive = true; // chain exhausted — key is beyond every leaf, which IS an answer
+                    break;
                 }
 
                 var nextLatch = nextNode.GetLatch(ref accessor);
@@ -2143,8 +2201,14 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
                 keyIndex = node.Find(key, Comparer, ref accessor);
                 if (keyIndex >= 0)
                 {
+                    conclusive = true;
                     break;
                 }
+            }
+
+            if (!conclusive)
+            {
+                return (0, 0, -1); // ran out of hops without settling the question — restart rather than report a not-found we did not establish
             }
         }
 

--- a/src/Typhon.Engine/Indexing/internals/BTree.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.cs
@@ -534,6 +534,7 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
     internal long _contentionSplitCount;
     internal long _obsoleteRestarts;
     internal long _obsoleteSmoSiblingLocks;
+    internal long _emptyInitRacesLost;
 
     internal const int MaxTreeDepth = 32;
     internal const int MaxOptimisticRestarts = 3;
@@ -721,6 +722,13 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
     public long ObsoleteRestarts => Interlocked.Read(ref _obsoleteRestarts);
 
     /// <summary>
+    /// Number of times the pessimistic insert path lost the race to publish the first root and freed its own node instead of overwriting the winner's (#679).
+    /// Non-zero is HEALTHY — it is the defect being caught. Before the CAS it was unreachable by construction, because the overwrite simply went through:
+    /// the winner's root was orphaned with the key it held, and <c>Height</c> was left one too high for the life of the tree.
+    /// </summary>
+    public long EmptyInitRacesLost => Interlocked.Read(ref _emptyInitRacesLost);
+
+    /// <summary>
     /// Number of times a latch-coupled SMO sibling lock was taken on an already-obsolete node — the residual IXW-02 does NOT cover, because those four sites are
     /// mid-algorithm with no restart point. Expected 0: both phases hold the sibling's parent lock, so only a COUSIN could get here. Non-zero means the
     /// cousin case is real and the sibling has to become droppable.
@@ -738,6 +746,7 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
         Interlocked.Exchange(ref _contentionSplitCount, 0);
         Interlocked.Exchange(ref _obsoleteRestarts, 0);
         Interlocked.Exchange(ref _obsoleteSmoSiblingLocks, 0);
+        Interlocked.Exchange(ref _emptyInitRacesLost, 0);
     }
 
     /// <summary>
@@ -1291,6 +1300,206 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
         return removed;
     }
 
+    /// <summary>
+    /// Validates that every leaf sits at the same depth and that <see cref="Height"/> equals it. Returns <c>null</c> when the tree is sound, else a detail
+    /// string. Test/diagnostic use only — walks without locks, so the caller must ensure no concurrent modification.
+    /// </summary>
+    /// <remarks>
+    /// This runs BEFORE the recursive walk for a reason. <c>NodeWrapper.CheckConsistency</c>'s first assertion compares each node's leaf flag against the depth
+    /// it was reached at, counting DOWN from <see cref="Height"/> — so a <see cref="Height"/> that is merely one too large makes every leaf trip it, and the
+    /// walk aborts before a single separator, ordering rule or child pointer is examined. In #679 that turned a root published twice into the message
+    /// "Mismatch node's Height 2 with True", which describes a leaf at the wrong level. The tree was perfectly balanced; only the scalar had drifted. Asserting
+    /// the two facts separately means a drift reports as a drift and everything downstream still gets checked.
+    /// </remarks>
+    internal string ValidateLeafDepths(ref ChunkAccessor<TStore> accessor, int maxReported = 6)
+    {
+        var depths = new Dictionary<int, int>();
+        var samples = new List<string>();
+        int visited = 0;
+        var stack = new Stack<(NodeWrapper Node, int Depth, string Path)>();
+        if (Root.IsValid)
+        {
+            stack.Push((Root, 1, "root"));
+        }
+
+        while (stack.Count > 0 && visited < 1_000_000)
+        {
+            var (node, depth, path) = stack.Pop();
+            visited++;
+            if (!node.IsValid)
+            {
+                continue;
+            }
+
+            if (node.GetIsLeaf(ref accessor))
+            {
+                depths.TryGetValue(depth, out var seen);
+                depths[depth] = seen + 1;
+                if (seen == 0 && samples.Count < maxReported)
+                {
+                    samples.Add($"depth={depth} firstSuchLeaf={node.ChunkId} via[{path}]");
+                }
+                continue;
+            }
+
+            int count = node.GetCount(ref accessor);
+            var left = node.GetLeft(ref accessor);
+            if (left.IsValid)
+            {
+                stack.Push((left, depth + 1, path + " -> left"));
+            }
+            for (int i = 0; i < count; i++)
+            {
+                var child = node.GetChild(i, ref accessor);
+                if (child.IsValid)
+                {
+                    stack.Push((child, depth + 1, path + $" -> [{i}]"));
+                }
+            }
+        }
+
+        if (depths.Count == 1 && depths.ContainsKey(Height))
+        {
+            return null;
+        }
+
+        var perDepth = new List<string>();
+        foreach (var kv in depths)
+        {
+            perDepth.Add($"{kv.Key}:{kv.Value}");
+        }
+        perDepth.Sort(StringComparer.Ordinal);
+        var what = depths.Count > 1 ? "leaves sit at differing depths" : $"Height={Height} disagrees with the real leaf depth";
+        return $"{what} — leafDepths={{{string.Join(",", perDepth)}}}" + (samples.Count > 0 ? $" :: {string.Join(" ;; ", samples)}" : "");
+    }
+
+    /// <summary>
+    /// Validates that no separator pointing at a LEAF exceeds that leaf's first key. Returns <c>null</c> when sound, else a detail string. Test/diagnostic use
+    /// only — walks without locks.
+    /// </summary>
+    /// <remarks>
+    /// A leaf's first key is the separator its parent holds, and #679's mode 1 broke that: an insert landing at slot 0 of an interior leaf lowered the first
+    /// key BELOW the separator routing to it, so descent for the new key went left of the separator and never reached the leaf. The key was counted, sat in a
+    /// correctly chained leaf, and was unreachable — and the recursive walk did not notice, because it only asserts the ordering bound
+    /// <c>parentKey &lt;= childKeys</c>, which a too-high separator satisfies.
+    /// <para>
+    /// One-sided on purpose, and this is the part that is easy to get wrong: only <c>separator &gt; firstKey</c> loses keys. The opposite slack is the normal
+    /// residue of a removal — deleting a leaf's first key raises its minimum above a separator nobody rewrites, and routing stays correct because a search in
+    /// the gap still descends to this leaf and correctly finds nothing. Asserting equality instead fails a plain single-threaded delete test
+    /// (<c>DeferredDeallocation_PinnedEpoch_DefersReclamation</c>: <c>separator=392 -> leaf firstKey=400</c>), which is how a check earns a suppression rather
+    /// than a defect.
+    /// </para>
+    /// <para>
+    /// Restricted to leaf children because an internal split promotes a median key that does not remain the child's first key; the relationship holds at the
+    /// leaf boundary only.
+    /// </para>
+    /// </remarks>
+    internal string ValidateLeafSeparators(ref ChunkAccessor<TStore> accessor, int maxReported = 6)
+    {
+        List<string> broken = null;
+        int pairs = 0, visited = 0;
+        var stack = new Stack<NodeWrapper>();
+        if (Root.IsValid)
+        {
+            stack.Push(Root);
+        }
+
+        while (stack.Count > 0 && visited < 1_000_000)
+        {
+            var node = stack.Pop();
+            visited++;
+            if (!node.IsValid || node.GetIsLeaf(ref accessor))
+            {
+                continue;
+            }
+
+            int count = node.GetCount(ref accessor);
+            var left = node.GetLeft(ref accessor);
+            if (left.IsValid)
+            {
+                stack.Push(left);
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                var child = node.GetChild(i, ref accessor);
+                if (!child.IsValid)
+                {
+                    continue;
+                }
+                stack.Push(child);
+
+                if (child.GetCount(ref accessor) == 0 || !child.GetIsLeaf(ref accessor))
+                {
+                    continue;
+                }
+                pairs++;
+
+                var item = node.GetItem(i, ref accessor);
+                var childFirst = child.GetFirst(ref accessor).Key;
+                if (Comparer.Compare(item.Key, childFirst) > 0)
+                {
+                    broken ??= [];
+                    if (broken.Count < maxReported)
+                    {
+                        broken.Add($"parent={node.ChunkId} slot={i}/{count}: separator={item.Key} is ABOVE leaf={child.ChunkId} "
+                                 + $"firstKey={childFirst} (lastKey={child.GetLast(ref accessor).Key}) — keys in between route left of this leaf");
+                    }
+                }
+            }
+        }
+
+        return broken == null
+            ? null
+            : $"{broken.Count}+ of {pairs} separator/leaf pair(s) route AROUND their leaf :: {string.Join(" ;; ", broken)}";
+    }
+
+    /// <summary>
+    /// Validates that no leaf's <c>HighKey</c> reaches past its right sibling's first key. Returns <c>null</c> when sound, else a detail string.
+    /// Test/diagnostic use only — walks without locks.
+    /// </summary>
+    /// <remarks>
+    /// <c>HighKey</c> is the EXCLUSIVE upper bound the B-link protocol reads to decide "this key is past me, follow the right link". When it reaches ABOVE the
+    /// next leaf's first key, every key in the overlap looks in-range for a leaf that does not hold it: the descent stops there, and the key is inserted out of
+    /// order or reported missing. That is #679's mode 2 — <c>SplitRight</c> set the left node's HighKey to the right half's first key, and <c>InsertLeaf</c>
+    /// then moved a smaller key into that half, lowering the very key HighKey had been pinned to. Nothing else in the consistency walk reads HighKey, so the
+    /// bound the whole B-link descent steers by had no enforcement at all.
+    /// <para>
+    /// One-sided for the same reason as <see cref="ValidateLeafSeparators"/>: a HighKey left BELOW the next first key is the normal residue of a removal and
+    /// costs at most a restart, never a key.
+    /// </para>
+    /// </remarks>
+    internal string ValidateLeafHighKeys(ref ChunkAccessor<TStore> accessor, int maxReported = 6)
+    {
+        List<string> broken = null;
+        int links = 0;
+        var cur = _linkList;
+        for (int guard = 0; cur.IsValid && guard < 1_000_000; guard++)
+        {
+            var next = cur.GetNext(ref accessor);
+            if (next.IsValid && cur.GetCount(ref accessor) > 0 && next.GetCount(ref accessor) > 0)
+            {
+                links++;
+                var high = cur.GetHighKey(ref accessor);
+                var nextFirst = next.GetFirst(ref accessor).Key;
+                if (Comparer.Compare(high, nextFirst) > 0)
+                {
+                    broken ??= [];
+                    if (broken.Count < maxReported)
+                    {
+                        broken.Add($"leaf={cur.ChunkId} highKey={high} reaches past next={next.ChunkId} firstKey={nextFirst} "
+                                 + $"(leafLast={cur.GetLast(ref accessor).Key}) — keys in between stop at a leaf that does not hold them");
+                    }
+                }
+            }
+            cur = next;
+        }
+
+        return broken == null
+            ? null
+            : $"{broken.Count}+ of {links} leaf link(s) have a HighKey reaching past the next leaf :: {string.Join(" ;; ", broken)}";
+    }
+
     public override void CheckConsistency(ref ChunkAccessor<TStore> accessor)
     {
         // Recursive check from Root to leaf
@@ -1298,6 +1507,21 @@ internal abstract partial class BTree<TKey, TStore> : BTreeBase<TStore> where TK
         {
             return;
         }
+
+        // #679: three invariants the recursive walk below does NOT enforce, checked first because each one, when broken, either masks that walk or slips
+        // straight through it.
+        //   - depth/Height: the walk's first assertion derives each node's expected leaf-ness by counting DOWN from Height, so a Height one too large makes
+        //     every leaf trip it and aborts before any structural check runs.
+        //   - separator == leaf's first key: the walk only asserts the ORDERING bound parentKey <= childKeys, which a too-HIGH separator satisfies.
+        //   - HighKey == next leaf's first key: nothing in the walk reads HighKey at all, so the bound the B-link descent steers by had no enforcement.
+        // The first cost a long hunt in #297/#679 by reporting as "Mismatch node's Height 2 with True" — a leaf at the wrong level — on trees that were in
+        // fact perfectly balanced. The other two were the mode 1 / mode 2 defects themselves, invisible to a check that reported "PASSED".
+        var depthDetail = ValidateLeafDepths(ref accessor);
+        ConsistencyAssert(depthDetail == null, depthDetail);
+        var separatorDetail = ValidateLeafSeparators(ref accessor);
+        ConsistencyAssert(separatorDetail == null, separatorDetail);
+        var highKeyDetail = ValidateLeafHighKeys(ref accessor);
+        ConsistencyAssert(highKeyDetail == null, highKeyDetail);
 
         // Debug/test-only: runs without locks (caller must ensure no concurrent modification)
         Root.CheckConsistency(default, NodeWrapper.CheckConsistencyParent.Root, Comparer, Height, ref accessor);

--- a/src/Typhon.Engine/Indexing/internals/OlcDescentTrace.cs
+++ b/src/Typhon.Engine/Indexing/internals/OlcDescentTrace.cs
@@ -44,6 +44,15 @@ internal static class OlcDescentTrace
     public const int RemoveBranchGeneralKeyIndexNegative = 3;
     public const int RemoveBranchUnderLockReFindNegative = 4;
 
+    // The PESSIMISTIC twins of branches 1 and 2. They were the blind spot: the stress harness saw Remove return false on a key that provably existed while
+    // every branch counter read zero, which reads as "no not-found path was taken" and sent the hunt at the count instead of the lookup. Both conclusions live
+    // in RemoveCorePessimistic's own begin/end fast paths, which duplicate the OLC logic and were never wired.
+    public const int RemoveBranchPessimisticBeginLessThanFirst = 5;
+    public const int RemoveBranchPessimisticEndGreaterThanLast = 6;
+
+    /// <summary>One past the highest branch id — sizes a counter array without hard-coding the count at each call site.</summary>
+    public const int RemoveBranchCount = 7;
+
     /// <summary>
     /// Called every time the OLC remove path concludes "key not in tree." Args:
     /// (branch, keyAsInt, leafChunkId, leafFirstOrLastKeyAsInt, leafCount). For non-int trees

--- a/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
+++ b/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
@@ -360,7 +360,10 @@ public class OlcBTreeRaceStressTests
             consistency = ex.Message;
         }
 
+        // No separate separator/HighKey/depth dumps here any more: CheckConsistency asserts all three itself (#679), so `consistency` already carries the
+        // detail and carries it in priority order instead of printing four reports of which three are usually "all agree".
         return $"inLeafChain={inChain} chainCount={chainCount} chainOrdered={chainOrdered} entryCount={tree.EntryCount} height={tree.Height} "
+             + $"emptyInitRacesLost={tree.EmptyInitRacesLost} "
              + $"chainNeighbours=({(predecessor == int.MinValue ? "-" : predecessor.ToString())},"
              + $"{(successor == int.MaxValue ? "-" : successor.ToString())}) consistency=[{consistency}]";
     }

--- a/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
+++ b/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
@@ -113,6 +113,8 @@ public class OlcBTreeRaceStressTests
             report.AppendLine($"  end-fast-path   (key > rll.lastKey)    : {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchEndFastPathGreaterThanLast]}");
             report.AppendLine($"  general path    (descend keyIndex<0)   : {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchGeneralKeyIndexNegative]}");
             report.AppendLine($"  under-lock re-find (concurrent removed): {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchUnderLockReFindNegative]}");
+            report.AppendLine($"  PESS begin-fast-path (key < ll.first)  : {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchPessimisticBeginLessThanFirst]}");
+            report.AppendLine($"  PESS end-fast-path   (key > rll.last)  : {_removeNotFoundByBranch[OlcDescentTrace.RemoveBranchPessimisticEndGreaterThanLast]}");
             report.AppendLine($"  TOTAL: {rnfTotal}");
         }
         if (_rdNotRemoved > 0 || _rdWrongValue > 0)
@@ -139,7 +141,7 @@ public class OlcBTreeRaceStressTests
     }
 
     // === Remove NotFound branch capture ===
-    private static readonly long[] _removeNotFoundByBranch = new long[5];
+    private static readonly long[] _removeNotFoundByBranch = new long[OlcDescentTrace.RemoveBranchCount];
     private static int _removeNotFoundDetailsCaptured;
     private static readonly object _rnfLock = new();
     private static readonly string _rnfDetailsPath = (Environment.GetEnvironmentVariable("OLC_STRESS_LOG")
@@ -532,6 +534,9 @@ public class OlcBTreeRaceStressTests
             using var barrier = new Barrier(threadCount);
             var exceptions = new ConcurrentBag<Exception>();
             var tasks = new Task[threadCount];
+            // Keys are disjoint per thread, so no remove can lose a race with another remove for the same key. That makes the two candidate explanations for a
+            // wrong EntryCount cleanly separable, and the return value — discarded until now — is half the evidence.
+            var removeReturnedFalse = new int[1];
             for (int t = 0; t < threadCount; t++)
             {
                 int tid = t;
@@ -547,7 +552,10 @@ public class OlcBTreeRaceStressTests
                             int key = i * threadCount + tid + 1;
                             if (key <= totalKeys)
                             {
-                                tree.Remove(key, out _, ref wa);
+                                if (!tree.Remove(key, out _, ref wa))
+                                {
+                                    Interlocked.Increment(ref removeReturnedFalse[0]);
+                                }
                             }
                         }
                         wa.CommitChanges();
@@ -563,7 +571,22 @@ public class OlcBTreeRaceStressTests
             int expected = totalKeys - threadCount * keysToRemovePerThread;
             if (tree.EntryCount != expected)
             {
-                throw new Exception($"Remove_Merges: EntryCount={tree.EntryCount} expected={expected}");
+                // chainCount is the ground truth (what the tree actually holds); EntryCount is the counter. Which of the two is wrong names the defect:
+                // chain == expected means a DecCount was lost, chain == EntryCount means a key really survived its Remove.
+                int chainCount = 0;
+                var leftover = new System.Collections.Generic.List<int>();
+                foreach (var kv in tree.EnumerateLeaves())
+                {
+                    chainCount++;
+                    // The removed set is exactly 1..threadCount*keysToRemovePerThread (i*threadCount + tid + 1 covers it densely), so anything at or below
+                    // that bound still in the chain is a key whose Remove did not take.
+                    if (kv.Key <= threadCount * keysToRemovePerThread && leftover.Count < 8)
+                    {
+                        leftover.Add(kv.Key);
+                    }
+                }
+                throw new Exception($"Remove_Merges: EntryCount={tree.EntryCount} expected={expected} chainCount={chainCount} "
+                                  + $"removeReturnedFalse={removeReturnedFalse[0]} survivingRemovedKeys=[{string.Join(",", leftover)}]");
             }
             var va = segment.CreateChunkAccessor();
             tree.CheckConsistency(ref va);

--- a/test/Typhon.Engine.Tests/Errors/ExceptionPathLeakTests.cs
+++ b/test/Typhon.Engine.Tests/Errors/ExceptionPathLeakTests.cs
@@ -332,7 +332,12 @@ class ExceptionPathLeakTests : TestBase<ExceptionPathLeakTests>
         var depth = _dbe.EpochManager.EnterScope();
         try
         {
-            var meta = ArchetypeRegistry.GetMetadata(entityId.ArchetypeId);
+            // Two id spaces, and this helper used to conflate them: EntityId.ArchetypeId is the per-DB ROUTING id, while ArchetypeRegistry and
+            // _archetypeStates are keyed by the per-process CATALOG id. Feeding a routing id to GetMetadata returns whichever archetype happens to hold that
+            // catalog id — usually one this engine never registered, whose state slot is null. Hence "EntityMap should exist" firing before the test reached
+            // anything it meant to assert. GetMetaByRouting is the translation the engine itself uses (see _archetypeStates' own remarks).
+            var meta = _dbe.GetMetaByRouting(entityId.ArchetypeId);
+            Assert.That(meta, Is.Not.Null, $"routing id {entityId.ArchetypeId} should resolve to an archetype registered in this engine");
             var es = _dbe._archetypeStates[meta.ArchetypeId];
             Assert.That(es?.EntityMap, Is.Not.Null, "EntityMap should exist");
 


### PR DESCRIPTION
Six defects in the OLC B+Tree, found by signature rather than by rate, each verified against the thing that made it observable. Related to `#297` / `#679`; **neither is closed by this** — see *Still open* below.

## What is fixed

| # | defect | why it happened |
|---|---|---|
| 1 | **Root republished over a live one** — a key orphaned and `Height` left permanently wrong | the emptiness test reads the entry COUNT, and the OLC init publishes the root several instructions before its `IncCount()` |
| 2 | **Separator invalidation** — insert at slot 0 of an interior leaf drops its first key below its parent separator, so descent routes left of it forever | every insert path validated the upper bound; none validated the lower |
| 3 | **Stale `HighKey` after a split** | `SplitRight` pins `HighKey` to the right half's first key, and `InsertLeaf` then changes that key |
| 4 | **Descent false not-found** — hits `Remove` *and* `TryGet` | the B-link hop loop had two exits that establish nothing (hop budget, empty leaf) yet every caller reads them as definitive |
| 5 | **Remove false not-found** | the pessimistic path carried only the upper half of the stale-separator guard |
| 6 | **Routing id vs catalog id** (test-side) | `EntityId.ArchetypeId` is the per-DB routing id, fed to a per-process catalog-keyed registry |

## Evidence

- Root clobber: 12 runs / ~82k iterations with the signature gone; it appeared in 6 of 16 runs before.
- Separator and HighKey: 0 mismatches in ~47k iterations. The HighKey check is **mutation-proven** — disabling the one-line fix makes the new assertion fire in a sub-second fixture, on a tree that passed the old `CheckConsistency` clean.
- Remove key-loss: roughly half of stress runs down to 1-2 in 10.
- Suite 5070 to 5072 passing. Index fixtures 447/447.

## `CheckConsistency` was the reason these survived

It asserted neither the separator invariant nor the `HighKey` invariant, and its first assertion derived each node's expected leaf-ness by counting down from `Height` — so a `Height` one too large made every leaf trip it and aborted the walk before a single separator was examined. It now validates chain integrity, leaf depth, separators and `HighKey` up front, each reporting as itself.

Both new invariant checks are deliberately **one-sided**, and that is the part worth reviewing: only `separator > firstKey` and `HighKey > nextFirstKey` lose keys. The opposite slack is the normal residue of a removal, and an equality version fails a plain single-threaded delete test.

## Still open

The `Add_*` scenario HANG remains, at 10-25% of stress runs. Five hypotheses are refuted with evidence and recorded in the commit bodies so nobody re-runs them: an SMO sibling lock cycle, `Sleep(1)` amplification in the pessimistic retry loops, restarts introduced by the mode 1 guard, a cycle in the leaf chain, and page-cache backpressure. Also open: residual `Remove_Merges` key-loss (1-2 in 10) and a garbage chunk id written during merge unlink (~1 in 12). A candidate fix for the latter tripled the hang rate and was reverted rather than shipped unexplained.

A 64-hop bound on the move-right loop was added during that hunt and removed again before this branch was banked: its own counter proved it never fired, so it was a branch in a hot loop bought with no evidence.

**Perf is unmeasured.** Guards were added to hot insert paths and no benchmark has been run.