### PR TITLE
#740 Compare the insert lower-bound guard against the previous leaf's HighKey, not the leaf's own first key

### DIFF
--- a/src/Typhon.Engine/Indexing/internals/BTree.Insert.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.Insert.cs
@@ -26,29 +26,45 @@ internal abstract partial class BTree<TKey, TStore>
     /// the insert must restart rather than proceed.
     /// </summary>
     /// <remarks>
-    /// A leaf's first key IS the separator its parent holds. Inserting a key smaller than it lands at slot 0, drops the first key below that separator, and no
-    /// insert path updates the ancestor — so descent for the new key then routes LEFT of the separator and never reaches the leaf. The key is counted by
-    /// IncCount, sits in a correctly chained leaf, and is unreachable. That is #297/#679's mode 1, measured: `separator=408 -> child=5 firstKey=226`, with the
-    /// separator never rewritten and the leaf's first key dropped by an insert at slot 0.
+    /// Inserting a key below the bound that routes to a leaf lands it at slot 0, drops the leaf's first key below that bound, and no insert path updates the
+    /// ancestor — so descent for the new key then routes LEFT of the separator and never reaches the leaf. The key is counted by IncCount, sits in a correctly
+    /// chained leaf, and is unreachable. That is #297/#679's mode 1, measured: `separator=408 -> child=5 firstKey=226`.
     /// <para>
     /// Every insert path already validated the UPPER bound — the OLC general path checks <c>key >= HighKey</c>, the append fast paths check
     /// <c>!GetNext().IsValid</c>, <c>InsertIterative</c> has its move-right gap check — and not one validated the lower bound. This is that missing half,
-    /// stated once and applied at all four sites, because a rule enforced at one call site is a rule enforced at one call site (the lesson IXS-03/IXW-01
-    /// already record for readers and writers).
+    /// stated once and applied at both sites, because a rule enforced at one call site is a rule enforced at one call site.
+    /// </para>
+    /// <para>
+    /// The bound is the PREVIOUS leaf's <c>HighKey</c>, not this leaf's first key. Those coincide only immediately after a split. Removing a leaf's first key
+    /// raises its minimum and leaves the separator where it was, so the band <c>prevHighKey &lt;= key &lt; firstKey</c> is a legitimate destination — the leaf
+    /// IS correct and the insert lowers its minimum back toward the separator that already routes to it. This is the same one-sided slack
+    /// <c>ValidateLeafSeparators</c> deliberately tolerates, and the first version of this guard contradicted it by testing <c>key &lt; firstKey</c>: a plain
+    /// single-threaded remove-then-reinsert of any leaf's first key restarted forever and died on <c>MaxPessimisticRestarts</c> with no contention involved
+    /// (<c>RemoveThenReinsertLeafFirstKey_DoesNotStallInsert</c>). <c>HighKey</c> is the exclusive upper bound the whole B-link descent already steers by, so
+    /// reading it here asks the same question the descent asked, rather than a stricter one.
     /// </para>
     /// <para>
     /// A leaf with no previous sibling is the tree's leftmost and is reached through the left POINTER, which carries no separator — lowering its first key is
-    /// legitimate and is what the prepend fast paths exist to do. Hence the <c>GetPrevious</c> test, and it is evaluated LAST: the comparison short-circuits on
-    /// the overwhelmingly common in-range insert, so the extra chunk read is paid only when a key really is below the leaf's first.
+    /// legitimate and is what the prepend fast paths exist to do. The two extra chunk reads (previous leaf + its HighKey) are paid only after the first-key
+    /// comparison has already failed, so the overwhelmingly common in-range insert still costs one <c>GetCount</c>, one <c>GetFirst</c> and one compare.
     /// </para>
     /// <para>
     /// Restarting is safe against livelock because both callers are bounded: the OLC loop by <c>MaxOptimisticRestarts</c> (then the pessimistic path), and the
-    /// pessimistic loop by <c>MaxPessimisticRestarts</c>, which throws rather than spins — the guard #695 put in place for exactly this shape.
+    /// pessimistic loop by <c>MaxPessimisticRestarts</c>, which throws rather than spins — the guard #695 put in place for exactly this shape. That bound is
+    /// what turned the defect above into a 2.5-minute throw instead of a hang, and it is why the message names liveness rather than contention.
     /// </para>
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool KeyBelowLeafLowerBound(NodeWrapper leaf, TKey key, IComparer<TKey> comparer, ref ChunkAccessor<TStore> accessor)
-        => leaf.GetCount(ref accessor) > 0 && comparer.Compare(key, leaf.GetFirst(ref accessor).Key) < 0 && leaf.GetPrevious(ref accessor).IsValid;
+    {
+        if (leaf.GetCount(ref accessor) == 0 || comparer.Compare(key, leaf.GetFirst(ref accessor).Key) >= 0)
+        {
+            return false;
+        }
+
+        var previous = leaf.GetPrevious(ref accessor);
+        return previous.IsValid && comparer.Compare(key, previous.GetHighKey(ref accessor)) < 0;
+    }
 
     /// <summary>Creates the insert value, handling AllowMultiple buffer creation.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/Typhon.Engine.Tests/Data/BTreeTests.cs
+++ b/test/Typhon.Engine.Tests/Data/BTreeTests.cs
@@ -442,6 +442,63 @@ class BtreeTests
         }
     }
 
+    /// <summary>
+    /// #737 regression guard: removing a leaf's FIRST key and re-inserting it must not stall the pessimistic insert loop.
+    /// </summary>
+    /// <remarks>
+    /// <c>KeyBelowLeafLowerBound</c> restarts the descent whenever the key sits below the target leaf's first key and that leaf has a previous sibling, on the
+    /// premise that such a leaf is reached through a separator equal to its first key — so lowering the first key would strand it under the separator. Removing
+    /// a leaf's first key breaks that premise: the separator stays where it was and is now BELOW the leaf's new minimum, which is legitimate and is exactly the
+    /// one-sided slack <c>ValidateLeafSeparators</c> deliberately tolerates. Re-inserting the removed key then lands in <c>separator &lt;= key &lt; firstKey</c>,
+    /// where the leaf IS the correct destination and the guard rejects it anyway. Single-threaded, nothing else mutates between attempts, so every re-descent
+    /// reaches the same leaf and fails the same test until <c>MaxPessimisticRestarts</c> throws. No contention is involved.
+    /// </remarks>
+    [Test]
+    [Property("MemPageCount", 8192)]
+    unsafe public void RemoveThenReinsertLeafFirstKey_DoesNotStallInsert()
+    {
+        const int Count = 2000;
+
+        using var pmmf = _serviceProvider.GetRequiredService<ManagedPagedMMF>();
+        using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
+        var segment = pmmf.AllocateChunkBasedSegment(PageBlockType.None, 10, sizeof(Index64Chunk));
+        var depth = epochManager.EnterScope();
+        try
+        {
+            var accessor = segment.CreateChunkAccessor();
+            var tree = new LongSingleBTree<PersistentStore>(segment);
+
+            for (long k = 1; k <= Count; k++)
+            {
+                tree.Add(k, (int)k, ref accessor);
+            }
+            tree.CheckConsistency(ref accessor);
+
+            // Every leaf boundary in the tree gets hit by this sweep, so the first key of each non-leftmost leaf is removed and re-inserted in turn.
+            for (long k = 1; k <= Count; k++)
+            {
+                Assert.That(tree.Remove(k, out var val, ref accessor), Is.True, () => $"Failed to remove key {k}");
+                tree.Add(k, val, ref accessor);
+            }
+
+            tree.CheckConsistency(ref accessor);
+            Assert.That(tree.EntryCount, Is.EqualTo(Count));
+
+            for (long k = 1; k <= Count; k++)
+            {
+                var result = tree.TryGet(k, ref accessor);
+                Assert.That(result.IsSuccess, Is.True, () => $"Key {k} should still be present");
+                Assert.That(result.Value, Is.EqualTo((int)k));
+            }
+
+            accessor.Dispose();
+        }
+        finally
+        {
+            epochManager.ExitScope(depth);
+        }
+    }
+
     [Test]
     unsafe public void CheckRemoveString64()
     {


### PR DESCRIPTION
Corrects a **P0 liveness regression shipped by PR #737**, live on `main` since `3958c154`. Addresses `#740`; deliberately not auto-closed, so the board flow stays in charge of closing it.

A plain **single-threaded** `Remove(k)` then `Add(k)`, where `k` is the first key of any non-leftmost leaf, burns all 10,000 pessimistic restarts over **2 m 34 s** and throws. No concurrency involved.

## The defect: a guard strictly stronger than the invariant it protects

`KeyBelowLeafLowerBound` restarted the descent whenever the key sat below the target leaf's **first key** and the leaf had a previous sibling. Its stated premise was *"a leaf's first key IS the separator its parent holds."*

That holds only immediately after a split. **Removing a leaf's first key raises the leaf's minimum and leaves the separator where it was**, so `separator <= key < firstKey` is a legitimate destination — the leaf is correct, and the insert lowers its minimum back toward a separator that already routes to it.

Mode 1 is a defect only when `key < separator`. Testing `key < firstKey` also rejects that whole band, on a path whose only other exit is a restart. Single-threaded there is nothing to mutate between attempts, so every re-descent reaches the same leaf and fails the same test until the bound throws.

**The guard and the consistency check contradicted each other.** That band is the same one-sided slack `ValidateLeafSeparators` was deliberately written to tolerate — in the same PR.

## The fix

Compare against the previous leaf's `HighKey`, the exclusive upper bound the whole B-link descent already steers by, so the guard asks the same question the descent asked rather than a stricter one.

```csharp
if (leaf.GetCount(ref accessor) == 0 || comparer.Compare(key, leaf.GetFirst(ref accessor).Key) >= 0)
{
    return false;
}
var previous = leaf.GetPrevious(ref accessor);
return previous.IsValid && comparer.Compare(key, previous.GetHighKey(ref accessor)) < 0;
```

Common path is unchanged — one `GetCount`, one `GetFirst`, one compare. The previous-leaf read happens only once the first-key comparison has already failed.

## Why 5,072 passing tests did not catch it

Nothing in the suite removed a leaf's first key and re-inserted it on a tree large enough to have interior leaves. It was found by **`BTreeMicroBenchmarks.Insert_Random` reporting `NA`** — BenchmarkDotNet for a process that exited on an error. That benchmark does exactly `Remove(key)` then `Add(key)` over a 10,000-key tree.

The benchmark that had been sitting unrun as the "perf is unmeasured" caveat on #297 was also the only thing in the repo exercising this shape.

`BtreeTests.RemoveThenReinsertLeafFirstKey_DoesNotStallInsert` now covers it, sweeping every leaf boundary: **2 m 34 s and failing before, 130 ms and green after.**

## Perf, since the guards went into hot insert paths and had never been benchmarked

Three `BTreeMicroBenchmarks` runs — one on pre-#737 `f664beed`, two on this branch, so the two same-build runs give a noise floor instead of leaving a single A/B uninterpretable.

| ns | pre-#737 | fixed (1) | fixed (2) | same-build spread | pre → fixed |
|---|---:|---:|---:|---:|---:|
| `Lookup_Hit` *(control)* | 182.9 | 189.9 | 193.9 | 4.0 | **+9.0** |
| `Lookup_Miss` *(control)* | 187.8 | 186.1 | 189.7 | 3.6 | +0.1 |
| `Insert_Sequential` | 227.3 | 204.1 | 212.8 | 8.7 | −18.8 |
| `Insert_Random` | 251.2 | 264.1 | 254.8 | 9.3 | +8.3 |
| `Delete_Reinsert` | 466.3 | 484.0 | 471.0 | 13.0 | +11.2 |
| `SequentialScan_100` | 143.9 | 143.2 | 143.9 | 0.7 | −0.3 |

**The two lookups are the control** — they execute none of this code by construction, and `Lookup_Hit` still moved +9.0 ns between builds. Every insert-path delta sits inside that band. `Insert_Sequential` reading 18.8 ns *faster* points the same way: adding a branch does not speed up a path, so that is layout or ambient load, and it sets the scale for how much of the rest to believe. **No regression attributable to the guards.**

Caveat rather than a buried footnote: another process was active on the box throughout, which is the likeliest source of what the control picked up. A clean absolute number needs a quiet machine; this conclusion does not, because the control bounds it either way.

## Verification

- Full suite on this branch alone: **5,073 passed, 3 failed.** Those three (`PayloadAxes_SurviveACrash`, `DirtyCounter_IsConservedAtQuiesce`, `ParallelOperations_AreLinearizable`) were baselined on unmodified `main` and fail identically there.
- All 70 B+Tree fixture tests green.

Docs: the invariant is recorded as `IXW-03` in the companion `typhon-claude` PR.
