### PR TITLE
#738 Stop the race harness calling slowness a hang, and leaking a locked database that poisons the next run

### DIFF
--- a/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
+++ b/test/Typhon.Engine.Tests/Data/OlcBTreeRaceStressTests.cs
@@ -21,10 +21,18 @@ namespace Typhon.Engine.Tests;
 ///   OLC_STRESS_SECONDS — wall duration of the run (default 30)
 ///   OLC_STRESS_NOISE   — count of CPU-saturating noise threads (default = ProcessorCount/2)
 /// One ManagedPagedMMF per scenario, reused across iterations (fresh segment per iter) — avoids per-iter file I/O cost.
+/// <para>
+/// [NonParallelizable] for the same reason <see cref="OlcBTreeStressTests"/> carries it, and it was missing here (#738). The assembly runs
+/// <c>Parallelizable(ParallelScope.Fixtures)</c> at <c>LevelOfParallelism(4)</c>, so without it this fixture — which already spawns five scenario tasks plus
+/// ProcessorCount/2 noise threads of its own — is one of FOUR heavy fixtures running at once. A nightly `Category=Nightly` run in that configuration took the
+/// test host down with it, alongside ChaosStressTests.UltimateStress_AllSubsystems and two others. A harness whose whole purpose is to reproduce one specific
+/// race cannot do that from inside uncontrolled oversubscription: whatever it then reports is a property of the tier, not of the tree.
+/// </para>
 /// </summary>
 [TestFixture]
 [Explicit("Long-running race-stress harness for issue #297")]
 [Category("Nightly")]
+[NonParallelizable]
 public class OlcBTreeRaceStressTests
 {
     private static int _scenarioId;
@@ -736,8 +744,15 @@ public class OlcBTreeRaceStressTests
                         var iterTask = Task.Factory.StartNew(() => s.Body(ctx), TaskCreationOptions.LongRunning);
                         if (!iterTask.Wait(IterationDeadline))
                         {
-                            s.Failures.Add(new FailureRecord(iter, $"HANG: scenario body did not complete within {IterationDeadline.TotalSeconds}s"));
-                            WriteProgress(s.Name, iter, "HANG");
+                            // DEADLINE, not "hang" — this detects nothing about the tree. It reports that one iteration exceeded a wall clock, while
+                            // OLC_STRESS_NOISE CPU-saturating threads run alongside five scenario loops. A slow iteration reaches here identically to a
+                            // deadlocked one: a bounded-but-glacial retry loop (the pessimistic paths allow MaxPessimisticRestarts = 10,000, measured at
+                            // 2m34s single-threaded in #740) trips it exactly as a genuine deadlock would. Reading the old "HANG" label as evidence of a
+                            // lock cycle is what sent five hypotheses to be refuted one at a time in #738. If you need to know which it was, the answer is
+                            // in the STACKS — run with `--blame-hang --blame-hang-timeout <n>` and read the dump; do not infer it from this counter.
+                            s.Failures.Add(new FailureRecord(iter, $"DEADLINE: scenario body exceeded {IterationDeadline.TotalSeconds}s (slow or stuck — "
+                                                                  + "this does not distinguish them; capture stacks to tell)"));
+                            WriteProgress(s.Name, iter, "DEADLINE");
                             // Workers may still be alive — touching the MMF after Dispose() would AV.
                             // Skip cleanup; let the orphan workers churn against live (epoch-protected) memory
                             // until the process exits. Memory leak across HANG iters is bounded by the stress
@@ -826,7 +841,12 @@ public class OlcBTreeRaceStressTests
 
     private static IServiceProvider BuildScenarioProvider()
     {
-        // Unique DB name per scenario invocation so concurrent loops don't collide on the file.
+        // Unique DB name per scenario invocation so concurrent loops don't collide on the file — and unique per PROCESS, which it was not (#738). `_scenarioId`
+        // restarts at 0 in every test host, so run N+1 walked the exact same name sequence as run N. That only matters because the HANG path in
+        // RunScenarioLoop deliberately skips cleanup and leaks the MMF with its file open, so a single deadline expiry left a locked `olcrs_<id>` behind that
+        // every subsequent run then tripped over at the same iteration — `EnsureFileDeleted` cannot remove a file another process still holds, and `LoadFile`
+        // throws IOException. Measured: three consecutive isolated runs failed identically at `olcrs_2397`, and 33,088 leaked database directories had
+        // accumulated under the test bin. Including the process id makes the leak self-contained instead of contagious.
         int id = Interlocked.Increment(ref _scenarioId);
         var sc = new ServiceCollection()
             .AddLogging()
@@ -835,7 +855,7 @@ public class OlcBTreeRaceStressTests
             .AddEpochManager()
             .AddScopedManagedPagedMemoryMappedFile(o =>
             {
-                o.DatabaseName = $"olcrs_{id:x}";
+                o.DatabaseName = $"olcrs_{Environment.ProcessId:x}_{id:x}";
                 // Generously sized — many segments per scenario over a long run.
                 o.DatabaseCacheSize = (ulong)(PagedMMF.MinimumMemPageCount * PagedMMF.PageSize);
                 o.PagesDebugPattern = true;


### PR DESCRIPTION
Repairs the OLC race-stress harness, which had been the primary evidence source for `#297` / `#679` / `#738` / `#739` while carrying four defects that produce the same signal as a tree bug. Addresses `#738`; deliberately not auto-closed — the tree-side defect it uncovered is still open.

Independent of [#745](https://github.com/Log2n-io/Typhon/pull/745); no file overlap, either order merges.

## What was wrong with the instrument

**1. "HANG" was a ten-second wall clock, not a detected deadlock.** `RunScenarioLoop` records it when `iterTask.Wait(IterationDeadline)` expires — default 10 s, against a scenario body running under `ProcessorCount/2` CPU-saturating noise threads plus four other scenario loops. A **bounded-but-glacial** iteration trips it identically to a stuck one, and the pessimistic paths allow `MaxPessimisticRestarts = 10,000`, measured at 2 m 34 s single-threaded in #740.

Reading that label as evidence of a lock cycle is what sent five hypotheses in #738 to be refuted one at a time — each looking for something that was never there. Relabelled `DEADLINE`, with the distinction stated at the site and a pointer to capture stacks rather than infer.

**2. The deadline path leaked the database, by design.** Its own comment: *"Skip cleanup; let the orphan workers churn... Memory leak across HANG iters is bounded by the stress duration."* It is not bounded by the stress duration — a `testhost.exe` from a **completed** run stayed alive holding the test DLL and had to be killed by PID before a rebuild could copy over it.

**3. So one deadline poisoned every later run, deterministically.** `_scenarioId` restarts at 0 in each test host and the name was `olcrs_{id:x}` — unique *within* a process, identical *across* them. A leaked lock therefore sat exactly where the next run would ask for it; `EnsureFileDeleted` cannot remove a file another process holds, and `LoadFile` throws.

Measured: three consecutive isolated runs failed **identically at `olcrs_2397`**, and **33,088** leaked `olcrs_*.typhon` directories had accumulated under the test bin. Now `olcrs_{ProcessId:x}_{id:x}` — the leak becomes self-contained instead of contagious.

**4. The fixture was never `[NonParallelizable]`.** The assembly runs `Parallelizable(ParallelScope.Fixtures)` at `LevelOfParallelism(4)`. `OlcBTreeStressTests` carries the attribute; this one did not — so a harness already spawning five scenario tasks plus ~16 noise threads ran as one of **four** concurrent heavy fixtures. That configuration took the **test host down**, with `ChaosStressTests.UltimateStress_AllSubsystems`, `SubscriptionStressTests.MultiClient_50Clients_SharedView_AllReceiveDeltas` and `WalCrashSweepTests.Exhaustive_PageAxis_SingleTxSpawn_N33` in flight alongside it.

## What a working instrument then showed

Six runs, **68,123 iterations**: no hangs, no crashes, **no missing keys in any scenario**.

| scenario | iterations | failures |
|---|---:|---:|
| `Add_Splits` | 6,001 | 6 |
| `Add_Disjoint` | 13,129 | 2 |
| `Remove_Disjoint` | 16,931 | 3 |
| `Remove_Merges` | 15,977 | 1 |
| `Remove_Mixed` | 16,085 | 0 |

**Read no rate published before this change as a property of the tree.**

### #738 is not a deadlock

The experiment that settles it — same build, same 60 s of stress, only the iteration deadline changes. If the iteration is *stuck*, no budget helps; if it is merely *slow*, a bigger budget lets it finish.

| iteration deadline | iterations | `DEADLINE` records |
|---|---:|---:|
| 10 s | 11,694 | 1 |
| 10 s | 19,972 | 2 |
| **300 s** | 19,445 | **0** |

At 300 s the deadlines vanish and are replaced by both `Add_*` scenarios reaching the bound and throwing:

```
InvalidOperationException: B+Tree insert made no progress in 10000 pessimistic retries.
  at BTree`2.AddOrUpdateCorePessimistic(InsertArguments&)   BTree.Insert.cs:620
```

Same event, two labels. It is the same defect class as #740 and a **different instance** — the `Add_*` scenarios never call `Remove`, and the #740 fix was already in that build. Left open: *which* restart in the pessimistic insert fails to make progress. The instrumentation shape that worked on the Remove side is per-exit counters, so a burn names its exit instead of leaving it to inference.

### #739 reproduces, and it is not garbage

`Remove_Disjoint` (not `Remove_Merges`), in `RemoveLeaf`'s merge-from-right branch:

```
GetChunkLocation: Computed page index 19027 >= segment length 50. ChunkId=589824
  at NodeWrapper.SetPrevious   BTree.NodeWrapper.cs:92
  at NodeWrapper.RemoveLeaf    BTree.NodeWrapper.cs:559
```

**Identical `ChunkId` and page index across two independent runs.** `589824` is `0x90000` — low 16 bits zero, the shape of a packed field read as a chunk id, not of corrupted memory.

## Scope

Test-fixture changes only; no engine code. Build verified standalone. Companion doc correction in `typhon-claude`.
