### PR TITLE
#740 Fix the lower-bound guard's surviving twin in RemoveIterative, and widen IXW-03 to cover it

### DIFF
--- a/rules/indexing.md
+++ b/rules/indexing.md
@@ -243,9 +243,18 @@ written for the read path; these are the write-path obligations that went unwrit
   enforce `BTree.KeyBelowLeafLowerBound` short-circuits on `count == 0` and on `key >= firstKey`, then reads the previous leaf and
           returns `key < previous.HighKey`. The two extra chunk reads are paid only after the first-key comparison has failed, so
           the common in-range insert still costs one `GetCount`, one `GetFirst` and one compare.
-  scope: BTree.Insert.cs (`KeyBelowLeafLowerBound` and its two call sites: the OLC general path, `InsertIterative`)
+  scope: BTree.Insert.cs (`KeyBelowLeafLowerBound` and its call sites), BTree.Remove.cs (`RemoveIterative`), BTree.Move.cs
+  gap BTree.Move.cs performs leaf inserts with NO lower-bound guard at all. It is not a drifted copy, it is a missing one, and
+      collapsing the five hand-maintained leaf-insert copies onto one authority is the only fix that scales - see the assessment
+      in claude/research/Indexing/.
   on_violation: every re-descent reaches the same leaf and fails the same test, so the bounded pessimistic loop of IXW-01 burns all
-                10,000 restarts and throws. Measured single-threaded, no contention of any kind: 2 m 34 s to the throw.
+                10,000 restarts and throws. Measured single-threaded on the INSERT side, no contention of any kind: 2 m 34 s to the
+                throw. On the REMOVE side it is concurrency-gated - `TryRemoveOlc` answers NotFound from the descent before its
+                count check, so an absent key never reaches the pessimistic guard; it needs the descent to find the key, an
+                underfull leaf, and a concurrent writer raising the leaf's first key in between.
+  note the first version of this rule scoped itself to BTree.Insert.cs alone, while the identical defective predicate stood
+       untouched in BTree.Remove.cs:610 - the rule written to stop the drift did not cover its own twin, and shipped that way for
+       a day. A scope line that names one of N copies is a rule that only holds in one of N places.
   rationale: `separator == leaf.firstKey` holds only immediately AFTER a split. Removing a leaf's first key raises the leaf's
              minimum and leaves the separator where it was, so `separator <= key < firstKey` is a legitimate destination - the leaf
              IS correct, and the insert lowers its minimum back toward a separator that already routes to it. This is the same

--- a/src/Typhon.Engine/Indexing/internals/BTree.Remove.cs
+++ b/src/Typhon.Engine/Indexing/internals/BTree.Remove.cs
@@ -606,10 +606,15 @@ internal abstract partial class BTree<TKey, TStore>
         // direction only. Measured in Remove_Merges: key 584 removed by nobody, still on the chain, with Remove reporting not-found.
         // An empty leaf is inconclusive for the same reason and gets the same treatment — merges empty a leaf before unlinking it, so meeting one says nothing
         // about where the key is. Both cases release without a version bump (nothing was modified) and let the bounded outer loop re-descend.
+        // #740 twin: this tested `key < leaf.firstKey`, the predicate KeyBelowLeafLowerBound was created to replace on the insert side and which was left
+        // standing here — one copy fixed, one forgotten, which is the drift IXW-03 exists to stop and which its own scope line originally failed to cover.
+        // A leaf's first key equals the separator routing to it only until something is removed from the front; after that the band
+        // `previousHighKey <= key < firstKey` is one this leaf IS authoritative for, and answering "not authoritative" there releases the latch and re-descends
+        // to the same leaf. Unlike the insert side this is NOT single-threaded reachable — TryRemoveOlc answers NotFound from the descent before the count
+        // check, so an absent key never arrives here; it needs the descent to FIND the key, the leaf to be underfull enough to defer to the pessimistic path,
+        // and a concurrent writer to raise the leaf's first key above it in between. Concurrency-gated, and the #738 class rather than #740's.
         int leafCount = node.GetCount(ref accessor);
-        bool leftOfLeaf = leafCount > 0
-                          && args.Compare(args.Key, node.GetFirst(ref accessor).Key) < 0
-                          && node.GetPrevious(ref accessor).IsValid;
+        bool leftOfLeaf = KeyBelowLeafLowerBound(node, args.Key, args.Comparer, ref accessor);
         bool emptyAndLinked = leafCount == 0 && (node.GetPrevious(ref accessor).IsValid || node.GetNext(ref accessor).IsValid);
         if (leftOfLeaf || emptyAndLinked)
         {

--- a/test/Typhon.Engine.Tests/Data/BTreeTests.cs
+++ b/test/Typhon.Engine.Tests/Data/BTreeTests.cs
@@ -499,6 +499,58 @@ class BtreeTests
         }
     }
 
+    /// <summary>
+    /// Removing an already-absent key that sits below its leaf's first key reports not-found, across every leaf boundary in a 2,000-key tree.
+    /// </summary>
+    /// <remarks>
+    /// Written while fixing the #740 twin in <c>RemoveIterative</c>, and it is worth stating plainly that it does NOT reach that guard — it passed before the
+    /// fix as well as after. <c>TryRemoveOlc</c> answers <c>NotFound</c> from the optimistic descent before its count check, so an absent key never arrives at
+    /// the pessimistic path at all; reaching the guard needs the descent to FIND the key, the leaf to be underfull enough to defer, and a concurrent writer to
+    /// raise the leaf's first key above it in between. That is concurrency-gated and this fixture is single-threaded.
+    /// <para>
+    /// It is kept because the coverage is real and was missing: double-remove across every leaf boundary, with a consistency check either side. What it must
+    /// not be mistaken for is evidence that the pessimistic lower-bound guard is correct — nothing single-threaded can be.
+    /// </para>
+    /// </remarks>
+    [Test]
+    [Property("MemPageCount", 8192)]
+    unsafe public void RemoveAbsentKeyBelowLeafFirstKey_ReportsNotFound()
+    {
+        const int Count = 2000;
+
+        using var pmmf = _serviceProvider.GetRequiredService<ManagedPagedMMF>();
+        using var epochManager = _serviceProvider.GetRequiredService<EpochManager>();
+        var segment = pmmf.AllocateChunkBasedSegment(PageBlockType.None, 10, sizeof(Index64Chunk));
+        var depth = epochManager.EnterScope();
+        try
+        {
+            var accessor = segment.CreateChunkAccessor();
+            var tree = new LongSingleBTree<PersistentStore>(segment);
+
+            for (long k = 1; k <= Count; k++)
+            {
+                tree.Add(k, (int)k, ref accessor);
+            }
+            tree.CheckConsistency(ref accessor);
+
+            // Removing k a second time is the case: k is now below its leaf's first key, and that leaf still routes it.
+            for (long k = 1; k <= Count; k++)
+            {
+                Assert.That(tree.Remove(k, out _, ref accessor), Is.True, () => $"First removal of {k} should succeed");
+                Assert.That(tree.Remove(k, out _, ref accessor), Is.False, () => $"Second removal of {k} should report not-found");
+            }
+
+            tree.CheckConsistency(ref accessor);
+            Assert.That(tree.EntryCount, Is.Zero);
+
+            accessor.Dispose();
+        }
+        finally
+        {
+            epochManager.ExitScope(depth);
+        }
+    }
+
     [Test]
     unsafe public void CheckRemoveString64()
     {


### PR DESCRIPTION
PR #745 replaced `key < leaf.firstKey` with a comparison against the previous leaf's `HighKey` on the insert side — and left the identical predicate standing in `RemoveIterative`. Both were written by the same change (#737); one was found wrong, one was fixed.

```
KeyBelowLeafLowerBound   BTree.Insert.cs: 5    BTree.Remove.cs: 0    BTree.Move.cs: 0
BTree.Remove.cs:610      count > 0 && key < firstKey && previous.IsValid   ← verbatim, until this commit
```

## Why it is wrong

A leaf's first key equals the separator routing to it only until something is removed from the front. After that, the band `prevHighKey <= key < firstKey` is one the leaf **is** authoritative for; answering "not authoritative" releases the latch and re-descends to the same leaf.

## Why it ships without a red-to-green test — read this part

It is **not** single-threaded reachable, and I asserted it was before testing it. `TryRemoveOlc` answers `NotFound` from the optimistic descent *before* its count check, so an absent key never arrives at the pessimistic guard. Reaching it needs the descent to **find** the key, the leaf underfull enough to defer, and a concurrent writer to raise the leaf's first key in between. Concurrency-gated — the #738 class, not #740's.

`RemoveAbsentKeyBelowLeafFirstKey_ReportsNotFound` is included because the coverage is real and was missing (double-remove across every leaf boundary of a 2,000-key tree, consistency-checked either side) — but **it passed before this change as well as after**, and its remarks say so in the source. Presenting it as proof would be the same "green means verified" error the assessment condemns. The justification is the invariant, not the test.

**Verified against the race harness instead:** 4 runs, 41,934 iterations, 0 hangs, 0 crashes, failure counts unchanged from baseline. Full suite 5,116 passed / 5 failed, all known flake band, none in indexing.

## IXW-03 did not cover its own twin

The rule written to stop this drift scoped itself to `BTree.Insert.cs` alone, and shipped that way for a day. Scope now names `Remove.cs` and `Move.cs`, plus an explicit gap note: **`Move.cs` performs leaf inserts with no lower-bound guard at all** — not a drifted copy but a missing one. Collapsing the five hand-maintained leaf-insert copies onto one authority is #765 step S2.

Assessment: #765.